### PR TITLE
Add PerFieldAnalyzerWrapper and simplify SearchEngine API

### DIFF
--- a/examples/bm25_scorer.rs
+++ b/examples/bm25_scorer.rs
@@ -4,7 +4,7 @@ use sarissa::error::Result;
 use sarissa::index::index::IndexConfig;
 use sarissa::prelude::*;
 use sarissa::query::{BM25Scorer, Scorer};
-use sarissa::search::SearchEngine;
+use sarissa::search::{SearchEngine, SearchRequest};
 use tempfile::TempDir;
 
 fn main() -> Result<()> {
@@ -92,7 +92,9 @@ fn main() -> Result<()> {
 
     // Example 5: Real search with scoring
     println!("\n5. Real search results with BM25 scoring:");
-    let results = engine.search_str("programming", "body")?;
+    let parser = sarissa::query::QueryParser::new().with_default_field("body");
+    let query = parser.parse("programming")?;
+    let results = engine.search(SearchRequest::new(query))?;
     println!("   Search for 'programming' in body field:");
     println!("   Found {} results", results.total_hits);
 

--- a/examples/boolean_query.rs
+++ b/examples/boolean_query.rs
@@ -94,7 +94,7 @@ fn main() -> Result<()> {
     query.add_must(Box::new(TermQuery::new("body", "python")));
     query.add_must(Box::new(TermQuery::new("body", "programming")));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -119,7 +119,7 @@ fn main() -> Result<()> {
     query.add_should(Box::new(TermQuery::new("body", "python")));
     query.add_should(Box::new(TermQuery::new("body", "javascript")));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -144,7 +144,7 @@ fn main() -> Result<()> {
     query.add_must(Box::new(TermQuery::new("category", "programming")));
     query.add_must_not(Box::new(TermQuery::new("body", "javascript")));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -178,7 +178,7 @@ fn main() -> Result<()> {
         Some(50.0),
     )));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -216,7 +216,7 @@ fn main() -> Result<()> {
         vec!["machine".to_string(), "learning".to_string()],
     )));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -246,7 +246,7 @@ fn main() -> Result<()> {
     query.add_must(Box::new(language_query));
 
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -275,7 +275,7 @@ fn main() -> Result<()> {
     )));
     query.add_must_not(Box::new(TermQuery::new("body", "design")));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -310,7 +310,7 @@ fn main() -> Result<()> {
         None,
     )));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -365,7 +365,7 @@ fn main() -> Result<()> {
     )));
 
     let request = SearchRequest::new(Box::new(main_query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -424,7 +424,7 @@ fn main() -> Result<()> {
     )));
 
     let request = SearchRequest::new(Box::new(final_query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -453,7 +453,7 @@ fn main() -> Result<()> {
     let mut query = BooleanQuery::new();
     query.add_should(Box::new(TermQuery::new("category", "data-science")));
     query.add_should(Box::new(TermQuery::new("category", "web-development")));
-    let count = engine.count_mut(Box::new(query))?;
+    let count = engine.count(Box::new(query))?;
     println!("   Count: {count} books");
 
     engine.close()?;

--- a/examples/fuzzy_query.rs
+++ b/examples/fuzzy_query.rs
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
     println!("1. Fuzzy search for 'javascritp' (typo for 'javascript') with edit distance 1:");
     let query = FuzzyQuery::new("body", "javascritp").max_edits(1);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -123,7 +123,7 @@ fn main() -> Result<()> {
     println!("\n2. Fuzzy search for 'programing' (missing 'm') with edit distance 2:");
     let query = FuzzyQuery::new("body", "programing").max_edits(2);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -146,7 +146,7 @@ fn main() -> Result<()> {
     println!("\n3. Fuzzy search for 'machne' (missing 'i') in title with edit distance 1:");
     let query = FuzzyQuery::new("title", "machne").max_edits(1);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -169,7 +169,7 @@ fn main() -> Result<()> {
     println!("\n4. Fuzzy search for 'Jon' (should match 'John') in author with edit distance 1:");
     let query = FuzzyQuery::new("author", "Jon").max_edits(1);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -197,7 +197,7 @@ fn main() -> Result<()> {
     println!("\n5. Fuzzy search for 'algoritm' (missing 'h') with edit distance 2:");
     let query = FuzzyQuery::new("body", "algoritm").max_edits(2);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -220,7 +220,7 @@ fn main() -> Result<()> {
     println!("\n6. Fuzzy search for 'artifical' (missing 'i') in tags with edit distance 1:");
     let query = FuzzyQuery::new("tags", "artifical").max_edits(1);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -243,7 +243,7 @@ fn main() -> Result<()> {
     println!("\n7. Fuzzy search for exact 'python' with edit distance 0:");
     let query = FuzzyQuery::new("body", "python").max_edits(0);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -266,7 +266,7 @@ fn main() -> Result<()> {
     println!("\n8. Fuzzy search for 'databse' (missing 'a') with edit distance 3:");
     let query = FuzzyQuery::new("body", "databse").max_edits(3);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -289,14 +289,14 @@ fn main() -> Result<()> {
     println!("\n9. Fuzzy search for 'xyz123' (no similar terms) with edit distance 2:");
     let query = FuzzyQuery::new("body", "xyz123").max_edits(2);
     let request = SearchRequest::new(Box::new(query));
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
 
     // Example 10: Count fuzzy matches
     println!("\n10. Counting documents with fuzzy match for 'developement' (extra 'e'):");
     let query = FuzzyQuery::new("body", "developement").max_edits(2);
-    let count = engine.count_mut(Box::new(query))?;
+    let count = engine.count(Box::new(query))?;
     println!("    Count: {count} documents");
 
     engine.close()?;

--- a/examples/geo_query.rs
+++ b/examples/geo_query.rs
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
     println!("1. Locations within 5km of Times Square (40.7580° N, 73.9855° W):");
     let query = GeoQuery::within_radius("location", 40.7580, -73.9855, 5.0)?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
     println!("\n2. Locations within 10km of downtown San Francisco (37.7749° N, 122.4194° W):");
     let query = GeoQuery::within_radius("location", 37.7749, -122.4194, 10.0)?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -161,7 +161,7 @@ fn main() -> Result<()> {
     println!("   (33.9° N, 118.6° W) to (34.3° N, 118.1° W)");
     let query = GeoQuery::within_bounding_box("location", 33.9, -118.6, 34.3, -118.1)?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -189,7 +189,7 @@ fn main() -> Result<()> {
     println!("\n4. All West Coast locations within 1000km of San Francisco:");
     let query = GeoQuery::within_radius("location", 37.7749, -122.4194, 1000.0)?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -217,7 +217,7 @@ fn main() -> Result<()> {
     println!("\n5. Locations within 2km of downtown Seattle (47.6062° N, 122.3321° W):");
     let query = GeoQuery::within_radius("location", 47.6062, -122.3321, 2.0)?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -245,7 +245,7 @@ fn main() -> Result<()> {
     println!("\n6. Locations within 1km of a specific point in the ocean:");
     let query = GeoQuery::within_radius("location", 36.0, -125.0, 1.0)?; // Pacific Ocean
     let request = SearchRequest::new(Box::new(query));
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
 
@@ -254,7 +254,7 @@ fn main() -> Result<()> {
     println!("   (25° N, 125° W) to (49° N, 66° W)");
     let query = GeoQuery::within_bounding_box("location", 25.0, -125.0, 49.0, -66.0)?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -281,7 +281,7 @@ fn main() -> Result<()> {
     // Example 8: Count locations within a specific area
     println!("\n8. Counting locations within 50km of Los Angeles center:");
     let query = GeoQuery::within_radius("location", 34.0522, -118.2437, 50.0)?;
-    let count = engine.count_mut(Box::new(query))?;
+    let count = engine.count(Box::new(query))?;
     println!("   Count: {count} locations");
 
     engine.close()?;

--- a/examples/hybrid_search.rs
+++ b/examples/hybrid_search.rs
@@ -315,7 +315,7 @@ async fn main() -> Result<()> {
     println!("6. Pure keyword search comparison:");
     let keyword_query = Box::new(TermQuery::new("body", "programming"));
     let keyword_request = SearchRequest::new(keyword_query).load_documents(true);
-    let keyword_results = keyword_engine.search_mut(keyword_request)?;
+    let keyword_results = keyword_engine.search(keyword_request)?;
 
     println!(
         "   Pure keyword search found {} results",

--- a/examples/ml_enhanced_search.rs
+++ b/examples/ml_enhanced_search.rs
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
     search_request.config.load_documents = true;
     search_request.config.max_docs = 5;
 
-    let results = engine.search_mut(search_request)?;
+    let results = engine.search(search_request)?;
 
     println!("\nSearch results with query expansion:");
     for (i, hit) in results.hits.iter().enumerate() {
@@ -219,7 +219,7 @@ async fn main() -> Result<()> {
     search_request.config.load_documents = true;
     search_request.config.max_docs = 10;
 
-    let search_results = engine.search_mut(search_request)?;
+    let search_results = engine.search(search_request)?;
 
     println!("\nOriginal search results:");
     for (i, hit) in search_results.hits.iter().take(3).enumerate() {

--- a/examples/phrase_query.rs
+++ b/examples/phrase_query.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
     println!("1. Searching for phrase 'machine learning' in body:");
     let query = PhraseQuery::new("body", vec!["machine".to_string(), "learning".to_string()]);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
         ],
     );
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -113,7 +113,7 @@ fn main() -> Result<()> {
     println!("\n3. Searching for phrase 'deep learning' in title:");
     let query = PhraseQuery::new("title", vec!["deep".to_string(), "learning".to_string()]);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
         vec!["data".to_string(), "science".to_string()],
     );
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -162,7 +162,7 @@ fn main() -> Result<()> {
     println!("\n5. Searching for non-existent phrase 'quantum computing':");
     let query = PhraseQuery::new("body", vec!["quantum".to_string(), "computing".to_string()]);
     let request = SearchRequest::new(Box::new(query));
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
 
@@ -170,7 +170,7 @@ fn main() -> Result<()> {
     println!("\n6. Searching for single word phrase 'intelligence' in body:");
     let query = PhraseQuery::new("body", vec!["intelligence".to_string()]);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -201,7 +201,7 @@ fn main() -> Result<()> {
         ],
     );
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -223,7 +223,7 @@ fn main() -> Result<()> {
     // Example 8: Count phrase matches
     println!("\n8. Counting documents with phrase 'computer vision':");
     let query = PhraseQuery::new("body", vec!["computer".to_string(), "vision".to_string()]);
-    let count = engine.count_mut(Box::new(query))?;
+    let count = engine.count(Box::new(query))?;
     println!("   Count: {count} documents");
 
     engine.close()?;

--- a/examples/query_parser.rs
+++ b/examples/query_parser.rs
@@ -52,12 +52,12 @@ fn main() -> Result<()> {
 
     // Example 1: Simple OR query (with correct case)
     println!("1. Simple OR query (Mockingbird OR Gatsby):");
-    let parser = engine.query_parser_with_default("title");
+    let parser = sarissa::query::QueryParser::new().with_default_field("title");
     let query = parser.parse("Mockingbird OR Gatsby")?;
     println!("   Parsed query: {}", query.description());
 
     let request = SearchRequest::new(query).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
         println!(
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
     println!("   Parsed query: {}", query.description());
 
     let request = SearchRequest::new(query).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
         println!(
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
     println!("   Parsed query: {}", query.description());
 
     let request = SearchRequest::new(query).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
         println!(
@@ -134,7 +134,7 @@ fn main() -> Result<()> {
     println!("   Parsed query: {}", query.description());
 
     let request = SearchRequest::new(query).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
         println!(
@@ -158,7 +158,7 @@ fn main() -> Result<()> {
     println!("   Parsed query: {}", query.description());
 
     let request = SearchRequest::new(query).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
         println!(
@@ -178,12 +178,12 @@ fn main() -> Result<()> {
 
     // Example 6: Different default field
     println!("\n6. Using 'body' as default field (father OR brother):");
-    let body_parser = engine.query_parser_with_default("body");
+    let body_parser = sarissa::query::QueryParser::new().with_default_field("body");
     let query = body_parser.parse("father OR brother")?;
     println!("   Parsed query: {}", query.description());
 
     let request = SearchRequest::new(query).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
         println!(

--- a/examples/range_query.rs
+++ b/examples/range_query.rs
@@ -88,6 +88,7 @@ fn main() -> Result<()> {
 
     println!("Adding {} documents to the index...", documents.len());
     engine.add_documents(documents)?;
+    engine.commit()?;
 
     println!("\n=== RangeQuery Examples ===\n");
 
@@ -95,7 +96,7 @@ fn main() -> Result<()> {
     println!("1. Books with price between $50.00 and $70.00:");
     let query = NumericRangeQuery::f64_range("price", Some(50.0), Some(70.0));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -123,7 +124,7 @@ fn main() -> Result<()> {
     println!("\n2. Books with rating 4.5 or higher:");
     let query = NumericRangeQuery::f64_range("rating", Some(4.5), None);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -151,7 +152,7 @@ fn main() -> Result<()> {
     println!("\n3. Books published after 2010:");
     let query = NumericRangeQuery::i64_range("year", Some(2010), None);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -179,7 +180,7 @@ fn main() -> Result<()> {
     println!("\n4. Books with 400 pages or fewer:");
     let query = NumericRangeQuery::i64_range("pages", None, Some(400));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -207,7 +208,7 @@ fn main() -> Result<()> {
     println!("\n5. Books published between 2008 and 2009:");
     let query = NumericRangeQuery::i64_range("year", Some(2008), Some(2009));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -235,7 +236,7 @@ fn main() -> Result<()> {
     println!("\n6. Budget-friendly books (price under $50.00):");
     let query = NumericRangeQuery::f64_range_exclusive_upper("price", None, Some(50.0));
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -263,7 +264,7 @@ fn main() -> Result<()> {
     println!("\n7. Large books (more than 500 pages):");
     let query = NumericRangeQuery::i64_range("pages", Some(500), None);
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -290,14 +291,14 @@ fn main() -> Result<()> {
     // Example 8: Count books in price range
     println!("\n8. Counting books with price between $40.00 and $80.00:");
     let query = NumericRangeQuery::f64_range("price", Some(40.0), Some(80.0));
-    let count = engine.count_mut(Box::new(query))?;
+    let count = engine.count(Box::new(query))?;
     println!("   Count: {count} books");
 
     // Example 9: Empty range (no results expected)
     println!("\n9. Books with impossible price range ($200-$300):");
     let query = NumericRangeQuery::f64_range("price", Some(200.0), Some(300.0));
     let request = SearchRequest::new(Box::new(query));
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
 

--- a/examples/term_query.rs
+++ b/examples/term_query.rs
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
     println!("1. Searching for 'Rust' in title field:");
     let query = TermQuery::new("title", "Rust");
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
     println!("\n2. Searching for 'language' in body field:");
     let query = TermQuery::new("body", "language");
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -121,7 +121,7 @@ fn main() -> Result<()> {
     println!("\n3. Searching for 'programming' in category field:");
     let query = TermQuery::new("category", "programming");
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -144,7 +144,7 @@ fn main() -> Result<()> {
     println!("\n4. Searching for non-existent term 'golang':");
     let query = TermQuery::new("title", "golang");
     let request = SearchRequest::new(Box::new(query));
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
 
@@ -152,7 +152,7 @@ fn main() -> Result<()> {
     println!("\n5. Case sensitivity - searching for 'rust' (lowercase):");
     let query = TermQuery::new("title", "rust");
     let request = SearchRequest::new(Box::new(query));
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     println!("   Note: TermQuery is case-sensitive by default");
@@ -161,7 +161,7 @@ fn main() -> Result<()> {
     println!("\n6. Searching for exact author 'John Smith':");
     let query = TermQuery::new("author", "John Smith");
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -188,7 +188,7 @@ fn main() -> Result<()> {
     // Example 7: Count matching documents
     println!("\n7. Counting documents containing 'programming':");
     let query = TermQuery::new("body", "programming");
-    let count = engine.count_mut(Box::new(query))?;
+    let count = engine.count(Box::new(query))?;
     println!("   Count: {count} documents");
 
     engine.close()?;

--- a/examples/wildcard_query.rs
+++ b/examples/wildcard_query.rs
@@ -97,7 +97,7 @@ fn main() -> Result<()> {
     println!("1. Files starting with 'java' using 'java*' pattern:");
     let query = WildcardQuery::new("filename", "java*")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -120,7 +120,7 @@ fn main() -> Result<()> {
     println!("\n2. Files ending with '.pdf' using '*.pdf' pattern:");
     let query = WildcardQuery::new("filename", "*.pdf")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -143,7 +143,7 @@ fn main() -> Result<()> {
     println!("\n3. Files with 'web' followed by anything ending in '.txt' using 'web*.txt':");
     let query = WildcardQuery::new("filename", "web*.txt")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -166,7 +166,7 @@ fn main() -> Result<()> {
     println!("\n4. Extensions with pattern '?sx' (jsx, tsx, etc.):");
     let query = WildcardQuery::new("extension", "?sx")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -189,7 +189,7 @@ fn main() -> Result<()> {
     println!("\n5. Categories starting with 'prog' and ending with 'ing' using 'prog*ing':");
     let query = WildcardQuery::new("category", "prog*ing")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -212,7 +212,7 @@ fn main() -> Result<()> {
     println!("\n6. Filenames with pattern '*_*.????' (underscore and 4-char extension):");
     let query = WildcardQuery::new("filename", "*_*.????")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -235,7 +235,7 @@ fn main() -> Result<()> {
     println!("\n7. Titles containing 'Development' using '*Development*':");
     let query = WildcardQuery::new("title", "*Development*")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -258,7 +258,7 @@ fn main() -> Result<()> {
     println!("\n8. Extensions with exactly 3 characters using '???':");
     let query = WildcardQuery::new("extension", "???")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -281,7 +281,7 @@ fn main() -> Result<()> {
     println!("\n9. All files with any extension using '*.*':");
     let query = WildcardQuery::new("filename", "*.*")?;
     let request = SearchRequest::new(Box::new(query)).load_documents(true);
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
     for (i, hit) in results.hits.iter().enumerate() {
@@ -304,14 +304,14 @@ fn main() -> Result<()> {
     println!("\n10. Pattern with no matches using 'xyz*abc':");
     let query = WildcardQuery::new("filename", "xyz*abc")?;
     let request = SearchRequest::new(Box::new(query));
-    let results = engine.search_mut(request)?;
+    let results = engine.search(request)?;
 
     println!("   Found {} results", results.total_hits);
 
     // Example 11: Count matching documents
     println!("\n11. Counting files with 'data' in filename using '*data*':");
     let query = WildcardQuery::new("filename", "*data*")?;
-    let count = engine.count_mut(Box::new(query))?;
+    let count = engine.count(Box::new(query))?;
     println!("    Count: {count} files");
 
     engine.close()?;

--- a/src/analysis/analyzer/analyzer.rs
+++ b/src/analysis/analyzer/analyzer.rs
@@ -10,4 +10,7 @@ pub trait Analyzer: Send + Sync {
 
     /// Get the name of this analyzer (for debugging and configuration).
     fn name(&self) -> &'static str;
+
+    /// Provide access to the concrete type for downcasting (e.g., to PerFieldAnalyzerWrapper).
+    fn as_any(&self) -> &dyn std::any::Any;
 }

--- a/src/analysis/analyzer/keyword.rs
+++ b/src/analysis/analyzer/keyword.rs
@@ -43,6 +43,10 @@ impl Analyzer for KeywordAnalyzer {
     fn name(&self) -> &'static str {
         "keyword"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl std::fmt::Debug for KeywordAnalyzer {

--- a/src/analysis/analyzer/mod.rs
+++ b/src/analysis/analyzer/mod.rs
@@ -4,6 +4,7 @@
 mod analyzer;
 mod keyword;
 mod noop;
+mod per_field;
 mod pipeline;
 mod simple;
 mod standard;
@@ -11,6 +12,7 @@ mod standard;
 pub use analyzer::Analyzer;
 pub use keyword::KeywordAnalyzer;
 pub use noop::NoOpAnalyzer;
+pub use per_field::PerFieldAnalyzerWrapper;
 pub use pipeline::PipelineAnalyzer;
 pub use simple::SimpleAnalyzer;
 pub use standard::StandardAnalyzer;

--- a/src/analysis/analyzer/noop.rs
+++ b/src/analysis/analyzer/noop.rs
@@ -25,6 +25,10 @@ impl Analyzer for NoOpAnalyzer {
     fn name(&self) -> &'static str {
         "noop"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[cfg(test)]

--- a/src/analysis/analyzer/per_field.rs
+++ b/src/analysis/analyzer/per_field.rs
@@ -1,0 +1,140 @@
+//! Per-field analyzer wrapper (Lucene-compatible).
+
+use crate::analysis::analyzer::Analyzer;
+use crate::analysis::TokenStream;
+use crate::error::Result;
+use ahash::AHashMap;
+use std::sync::Arc;
+
+/// A wrapper analyzer that applies different analyzers to different fields.
+///
+/// This is similar to Lucene's PerFieldAnalyzerWrapper. It allows you to specify
+/// a different analyzer for each field, with a default analyzer for fields not
+/// explicitly configured.
+///
+/// # Example
+///
+/// ```
+/// use sarissa::analysis::{PerFieldAnalyzerWrapper, StandardAnalyzer, KeywordAnalyzer};
+/// use std::sync::Arc;
+///
+/// let mut wrapper = PerFieldAnalyzerWrapper::new(Arc::new(StandardAnalyzer::new()));
+/// wrapper.add_analyzer("id", Arc::new(KeywordAnalyzer));
+/// wrapper.add_analyzer("category", Arc::new(KeywordAnalyzer));
+/// // "title" and "body" will use StandardAnalyzer
+/// // "id" and "category" will use KeywordAnalyzer
+/// ```
+#[derive(Clone)]
+pub struct PerFieldAnalyzerWrapper {
+    /// Default analyzer for fields not in the map.
+    default_analyzer: Arc<dyn Analyzer>,
+
+    /// Map of field names to their specific analyzers.
+    field_analyzers: AHashMap<String, Arc<dyn Analyzer>>,
+}
+
+impl PerFieldAnalyzerWrapper {
+    /// Create a new per-field analyzer wrapper with a default analyzer.
+    pub fn new(default_analyzer: Arc<dyn Analyzer>) -> Self {
+        Self {
+            default_analyzer,
+            field_analyzers: AHashMap::new(),
+        }
+    }
+
+    /// Add a field-specific analyzer.
+    pub fn add_analyzer(&mut self, field: impl Into<String>, analyzer: Arc<dyn Analyzer>) {
+        self.field_analyzers.insert(field.into(), analyzer);
+    }
+
+    /// Get the analyzer for a specific field.
+    pub fn get_analyzer(&self, field: &str) -> &Arc<dyn Analyzer> {
+        self.field_analyzers
+            .get(field)
+            .unwrap_or(&self.default_analyzer)
+    }
+
+    /// Get the default analyzer.
+    pub fn default_analyzer(&self) -> &Arc<dyn Analyzer> {
+        &self.default_analyzer
+    }
+
+    /// Analyze text with the analyzer for the given field.
+    pub fn analyze_field(&self, field: &str, text: &str) -> Result<TokenStream> {
+        self.get_analyzer(field).analyze(text)
+    }
+}
+
+impl Analyzer for PerFieldAnalyzerWrapper {
+    fn analyze(&self, text: &str) -> Result<TokenStream> {
+        // When used as a regular Analyzer, use the default analyzer
+        self.default_analyzer.analyze(text)
+    }
+
+    fn name(&self) -> &'static str {
+        "PerFieldAnalyzerWrapper"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::{KeywordAnalyzer, StandardAnalyzer};
+
+    #[test]
+    fn test_per_field_analyzer_wrapper() {
+        let mut wrapper = PerFieldAnalyzerWrapper::new(Arc::new(StandardAnalyzer::new().unwrap()));
+        wrapper.add_analyzer("id", Arc::new(KeywordAnalyzer::new()));
+        wrapper.add_analyzer("category", Arc::new(KeywordAnalyzer::new()));
+
+        // Test that different fields use different analyzers
+        let text = "Hello World";
+
+        // Default analyzer (StandardAnalyzer) lowercases and tokenizes
+        let tokens: Vec<_> = wrapper.analyze_field("title", text).unwrap().collect();
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].text, "hello");
+        assert_eq!(tokens[1].text, "world");
+
+        // KeywordAnalyzer keeps as single token (not lowercased by default)
+        let tokens: Vec<_> = wrapper.analyze_field("id", text).unwrap().collect();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].text, "Hello World");
+
+        // Another field with KeywordAnalyzer
+        let tokens: Vec<_> = wrapper.analyze_field("category", text).unwrap().collect();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].text, "Hello World");
+    }
+
+    #[test]
+    fn test_default_analyzer_when_field_not_configured() {
+        let wrapper = PerFieldAnalyzerWrapper::new(Arc::new(StandardAnalyzer::new().unwrap()));
+
+        let text = "Hello World";
+        let tokens: Vec<_> = wrapper.analyze_field("unknown_field", text).unwrap().collect();
+
+        // Should use default StandardAnalyzer
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].text, "hello");
+        assert_eq!(tokens[1].text, "world");
+    }
+
+    #[test]
+    fn test_as_analyzer_trait() {
+        let mut wrapper = PerFieldAnalyzerWrapper::new(Arc::new(StandardAnalyzer::new().unwrap()));
+        wrapper.add_analyzer("id", Arc::new(KeywordAnalyzer::new()));
+
+        // When used as Analyzer trait, should use default analyzer
+        let text = "Hello World";
+        let tokens: Vec<_> = wrapper.analyze(text).unwrap().collect();
+
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].text, "hello");
+        assert_eq!(tokens[1].text, "world");
+    }
+}

--- a/src/analysis/analyzer/pipeline.rs
+++ b/src/analysis/analyzer/pipeline.rs
@@ -70,6 +70,10 @@ impl Analyzer for PipelineAnalyzer {
         // Instead, we'll use a default name
         "pipeline"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl std::fmt::Debug for PipelineAnalyzer {

--- a/src/analysis/analyzer/simple.rs
+++ b/src/analysis/analyzer/simple.rs
@@ -33,6 +33,10 @@ impl Analyzer for SimpleAnalyzer {
     fn name(&self) -> &'static str {
         "simple"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl std::fmt::Debug for SimpleAnalyzer {

--- a/src/analysis/analyzer/standard.rs
+++ b/src/analysis/analyzer/standard.rs
@@ -57,6 +57,10 @@ impl Analyzer for StandardAnalyzer {
     fn name(&self) -> &'static str {
         "standard"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl std::fmt::Debug for StandardAnalyzer {

--- a/src/document/document.rs
+++ b/src/document/document.rs
@@ -95,11 +95,6 @@ impl Document {
         &self.field_analyzers
     }
 
-    /// Set an analyzer for a specific field (internal use).
-    pub(crate) fn set_field_analyzer(&mut self, field_name: String, analyzer: Arc<dyn Analyzer>) {
-        self.field_analyzers.insert(field_name, analyzer);
-    }
-
     /// Get the number of fields.
     pub fn len(&self) -> usize {
         self.fields.len()

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -290,9 +290,9 @@ impl FileIndex {
         let mut segments = Vec::new();
 
         // Find all segment metadata files
-        for file in files {
+        for file in &files {
             if file.starts_with("segment_") && file.ends_with(".meta") {
-                let mut input = self.storage.open_input(&file)?;
+                let mut input = self.storage.open_input(file)?;
                 let mut data = Vec::new();
                 std::io::Read::read_to_end(&mut input, &mut data)?;
 

--- a/src/index/writer.rs
+++ b/src/index/writer.rs
@@ -52,4 +52,10 @@ pub trait IndexWriter: Send + std::fmt::Debug {
 
     /// Check if the writer is closed.
     fn is_closed(&self) -> bool;
+
+    /// Add a custom analyzer with the given name.
+    fn add_analyzer(&mut self, name: &str, analyzer: Box<dyn crate::analysis::Analyzer>);
+
+    /// Configure a field to use a specific analyzer by name.
+    fn set_field_analyzer(&mut self, field: &str, analyzer_name: &str);
 }


### PR DESCRIPTION
## Summary

This PR implements Lucene-compatible per-field analyzer support and simplifies the SearchEngine API by removing redundant convenience methods.

## Changes

### 1. PerFieldAnalyzerWrapper (Lucene-compatible)
- **New**: `PerFieldAnalyzerWrapper` class that allows different analyzers per field
- Supports default analyzer with field-specific overrides
- Automatically used by `QueryParser` when set as the analyzer
- Example usage:
  ```rust
  let mut wrapper = PerFieldAnalyzerWrapper::new(Arc::new(StandardAnalyzer::new()?));
  wrapper.add_analyzer("category", Arc::new(KeywordAnalyzer::new()));
  let parser = QueryParser::with_analyzer(Arc::new(wrapper));
2. QueryParser Enhancement
analyze_term() now accepts field name and automatically applies correct analyzer
Detects PerFieldAnalyzerWrapper via downcasting and uses field-specific analyzer
Added as_any() method to Analyzer trait for downcasting support
3. Index Writer Field Analyzer Support
Added field_analyzers map to AdvancedWriterConfig
analyze_document() now selects analyzer based on field name
New methods: add_analyzer() and set_field_analyzer() on IndexWriter trait
Exposed via SearchEngine::add_analyzer() and SearchEngine::set_field_analyzer()
4. SearchEngine API Simplification
Removed convenience methods: search_query(), search_str(), search_field(), query_parser(), query_parser_with_default()
Renamed: search_mut() → search(), count_mut() → count()
Simpler API with only essential methods
Users now use QueryParser directly for more flexibility
5. Bug Fixes
Fixed NumericRangeQuery to properly filter documents when BKD tree unavailable
Fixed AdvancedIndexReader::document() to correctly map global→local doc IDs
Fixed SegmentReader::document() to accept local doc IDs
Removed unused set_field_analyzer() method from Document