### PR TITLE
Fix panic in ML ranking and remove unused fields in parallel hybrid search

### DIFF
--- a/src/ml/ranking.rs
+++ b/src/ml/ranking.rs
@@ -281,7 +281,11 @@ impl LearningToRank {
         }
 
         // Sort by combined score
-        scored_results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        // Handle NaN values by treating them as equal (ordering doesn't matter for NaN)
+        scored_results.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         // Update metrics
         {

--- a/src/parallel_hybrid_search/engine.rs
+++ b/src/parallel_hybrid_search/engine.rs
@@ -39,21 +39,15 @@ pub struct HybridIndexHandle {
 struct IndexLoadStats {
     /// Number of active searches.
     active_searches: usize,
-    /// Total searches completed.
-    total_searches: u64,
     /// Average search time in milliseconds.
     avg_search_time_ms: f64,
-    /// Last update timestamp.
-    last_updated: Instant,
 }
 
 impl Default for IndexLoadStats {
     fn default() -> Self {
         Self {
             active_searches: 0,
-            total_searches: 0,
             avg_search_time_ms: 0.0,
-            last_updated: Instant::now(),
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes a panic in the ML ranking module and removes unused struct fields that were causing compiler warnings.

## Changes

### 1. Fix panic in `LearningToRank::rerank_results` 
**File:** `src/ml/ranking.rs:284`

**Problem:**
- Calling `.unwrap()` on `partial_cmp()` when comparing floating-point scores
- Panics when scores contain NaN values (e.g., from BM25 scoring)

**Solution:**
- Use `.unwrap_or(std::cmp::Ordering::Equal)` to safely handle NaN comparisons
- NaN values are now treated as equal during sorting

**Impact:**
- `ml_enhanced_search` example now runs without panicking
- All 40 example codes verified to work correctly

### 2. Remove unused fields in `IndexLoadStats`
**File:** `src/parallel_hybrid_search/engine.rs:43-47`

**Removed:**
- `total_searches: u64` (defined but never read)
- `last_updated: Instant` (defined but never read)

**Impact:**
- Eliminates compiler dead code warnings
- Cleaner codebase with no functional changes
- All tests pass (9/9 parallel_hybrid_search tests)