### PR TITLE
Remove unused models_directory field from MLConfig

### DIFF
--- a/examples/ml_enhanced_search.rs
+++ b/examples/ml_enhanced_search.rs
@@ -32,7 +32,6 @@ async fn main() -> Result<()> {
     // Configure ML features
     let ml_config = MLConfig {
         enabled: true,
-        models_directory: temp_dir.path().join("models").to_str().unwrap().to_string(),
         ranking: RankingConfig {
             enabled: true,
             model_type: ModelType::GBDT,

--- a/src/ml/mod.rs
+++ b/src/ml/mod.rs
@@ -28,8 +28,6 @@ use serde::{Deserialize, Serialize};
 pub struct MLConfig {
     /// Enable machine learning features.
     pub enabled: bool,
-    /// Directory to store trained models.
-    pub models_directory: String,
     /// Learning to rank configuration.
     pub ranking: RankingConfig,
     /// Query expansion configuration.
@@ -46,7 +44,6 @@ impl Default for MLConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            models_directory: "./models".to_string(),
             ranking: RankingConfig::default(),
             query_expansion: QueryExpansionConfig::default(),
             recommendation: RecommendationConfig::default(),
@@ -170,7 +167,6 @@ mod tests {
     fn test_ml_config_default() {
         let config = MLConfig::default();
         assert!(config.enabled);
-        assert_eq!(config.models_directory, "./models");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove `models_directory` field from `MLConfig` struct
- Update example code to remove the unused field assignment
- Remove related default value and test assertion

## Changes
- **src/ml/mod.rs**: Removed `models_directory` field from `MLConfig` struct and its default implementation
- **examples/ml_enhanced_search.rs**: Removed `models_directory` initialization from example
- **tests**: Removed assertion for `models_directory` in default config test

## Rationale
The `models_directory` field was not being used in the ML configuration, so removing it simplifies the API and reduces confusion.