### PR TITLE
feat: index and query multi-valued numeric fields end-to-end (PR2/2 of #281)

### DIFF
--- a/laurus/src/lexical/core/analyzed.rs
+++ b/laurus/src/lexical/core/analyzed.rs
@@ -90,8 +90,17 @@ pub struct AnalyzedDocument {
     pub stored_fields: AHashMap<String, FieldValue>,
     /// Field name to field length (number of tokens) mapping.
     pub field_lengths: AHashMap<String, u32>,
-    /// Field name to numeric point values (for BKD tree).
-    pub point_values: AHashMap<String, Vec<f64>>,
+    /// Field name to numeric point values for the BKD tree.
+    ///
+    /// Each value in the map is a list of points for that field. A point is
+    /// itself a `Vec<f64>` whose length is the BKD dimensionality (1 for
+    /// integer/float/datetime, 2 for geo, etc.). A field can have multiple
+    /// points per document — single-valued numeric fields contribute one
+    /// point, multi-valued numeric fields contribute one point per element.
+    /// Each `(point, doc_id)` pair is emitted as a distinct BKD entry, and
+    /// the BKD reader deduplicates `doc_id`s during range search so a
+    /// document is reported at most once per query.
+    pub point_values: AHashMap<String, Vec<Vec<f64>>>,
 }
 
 /// An analyzed term with position and metadata.

--- a/laurus/src/lexical/core/parser.rs
+++ b/laurus/src/lexical/core/parser.rs
@@ -192,7 +192,7 @@ impl DocumentParser {
 
                     field_terms.insert(field_name.clone(), vec![analyzed_term]);
                     stored_fields.insert(field_name.clone(), FieldValue::Int64(num));
-                    point_values.insert(field_name.clone(), vec![num as f64]);
+                    point_values.insert(field_name.clone(), vec![vec![num as f64]]);
                 }
                 FieldValue::Float64(num) => {
                     // Convert float to text for indexing
@@ -207,7 +207,7 @@ impl DocumentParser {
 
                     field_terms.insert(field_name.clone(), vec![analyzed_term]);
                     stored_fields.insert(field_name.clone(), FieldValue::Float64(num));
-                    point_values.insert(field_name.clone(), vec![num]);
+                    point_values.insert(field_name.clone(), vec![vec![num]]);
                 }
                 FieldValue::Bool(b) => {
                     // Convert boolean to text
@@ -245,7 +245,7 @@ impl DocumentParser {
                     stored_fields.insert(field_name.clone(), FieldValue::DateTime(dt));
                     let ts = dt.timestamp() as f64
                         + dt.timestamp_subsec_nanos() as f64 / 1_000_000_000.0;
-                    point_values.insert(field_name.clone(), vec![ts]);
+                    point_values.insert(field_name.clone(), vec![vec![ts]]);
                 }
                 FieldValue::Geo(lat, lon) => {
                     // Convert geo point to string representation
@@ -260,7 +260,8 @@ impl DocumentParser {
 
                     field_terms.insert(field_name.clone(), vec![analyzed_term]);
                     stored_fields.insert(field_name.clone(), FieldValue::Geo(lat, lon));
-                    point_values.insert(field_name.clone(), vec![lat, lon]);
+                    // Geo is a single 2D point.
+                    point_values.insert(field_name.clone(), vec![vec![lat, lon]]);
                 }
                 FieldValue::Vector(v) => {
                     // Vectors are stored but not indexed in lexical
@@ -272,10 +273,10 @@ impl DocumentParser {
                 }
                 FieldValue::Int64Array(arr) => {
                     // Multi-valued integer: each element becomes its own
-                    // analyzed term and BKD point so range queries match
-                    // when any value satisfies the predicate.
+                    // analyzed term and a separate 1D BKD point so range
+                    // queries match when any value satisfies the predicate.
                     let mut terms: Vec<AnalyzedTerm> = Vec::with_capacity(arr.len());
-                    let mut points: Vec<f64> = Vec::with_capacity(arr.len());
+                    let mut points: Vec<Vec<f64>> = Vec::with_capacity(arr.len());
                     let mut offset = 0usize;
                     for (idx, num) in arr.iter().enumerate() {
                         let text = num.to_string();
@@ -287,7 +288,7 @@ impl DocumentParser {
                             offset: (offset, offset + len),
                         });
                         offset += len + 1;
-                        points.push(*num as f64);
+                        points.push(vec![*num as f64]);
                     }
                     field_terms.insert(field_name.clone(), terms);
                     stored_fields.insert(field_name.clone(), FieldValue::Int64Array(arr.clone()));
@@ -296,7 +297,7 @@ impl DocumentParser {
                 FieldValue::Float64Array(arr) => {
                     // Multi-valued float: same shape as Int64Array.
                     let mut terms: Vec<AnalyzedTerm> = Vec::with_capacity(arr.len());
-                    let mut points: Vec<f64> = Vec::with_capacity(arr.len());
+                    let mut points: Vec<Vec<f64>> = Vec::with_capacity(arr.len());
                     let mut offset = 0usize;
                     for (idx, num) in arr.iter().enumerate() {
                         let text = num.to_string();
@@ -308,7 +309,7 @@ impl DocumentParser {
                             offset: (offset, offset + len),
                         });
                         offset += len + 1;
-                        points.push(*num);
+                        points.push(vec![*num]);
                     }
                     field_terms.insert(field_name.clone(), terms);
                     stored_fields.insert(field_name.clone(), FieldValue::Float64Array(arr.clone()));

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -447,7 +447,7 @@ impl InvertedIndexWriter {
                         };
 
                         field_terms.insert(field_name.clone(), vec![analyzed_term]);
-                        point_values.insert(field_name.clone(), vec![*num as f64]);
+                        point_values.insert(field_name.clone(), vec![vec![*num as f64]]);
                     }
                     DataValue::Float64(num) => {
                         // ...
@@ -460,7 +460,7 @@ impl InvertedIndexWriter {
                                 offset: (0, num.to_string().len()),
                             }],
                         );
-                        point_values.insert(field_name.clone(), vec![*num]);
+                        point_values.insert(field_name.clone(), vec![vec![*num]]);
                     }
                     DataValue::DateTime(dt) => {
                         let ts = dt.timestamp() as f64;
@@ -473,7 +473,7 @@ impl InvertedIndexWriter {
                                 offset: (0, ts.to_string().len()),
                             }],
                         );
-                        point_values.insert(field_name.clone(), vec![ts]);
+                        point_values.insert(field_name.clone(), vec![vec![ts]]);
                     }
                     DataValue::Bool(b) => {
                         // bool is indexed as "true"/"false" text for lexical queries,
@@ -500,9 +500,52 @@ impl InvertedIndexWriter {
                                 offset: (0, format!("{},{}", lat, lon).len()),
                             }],
                         );
-                        point_values.insert(field_name.clone(), vec![*lat, *lon]);
+                        point_values.insert(field_name.clone(), vec![vec![*lat, *lon]]);
                     }
-                    // Handle other variants...
+                    DataValue::Int64Array(arr) => {
+                        // Multi-valued integer field. Each element is a
+                        // distinct analyzed term and a distinct 1D BKD
+                        // point so range queries match if any value falls
+                        // in range (Lucene "any match" semantics).
+                        let mut terms: Vec<AnalyzedTerm> = Vec::with_capacity(arr.len());
+                        let mut points: Vec<Vec<f64>> = Vec::with_capacity(arr.len());
+                        let mut offset = 0usize;
+                        for (idx, num) in arr.iter().enumerate() {
+                            let text = num.to_string();
+                            let len = text.len();
+                            terms.push(AnalyzedTerm {
+                                term: text,
+                                position: idx as u32,
+                                frequency: 1,
+                                offset: (offset, offset + len),
+                            });
+                            offset += len + 1;
+                            points.push(vec![*num as f64]);
+                        }
+                        field_terms.insert(field_name.clone(), terms);
+                        point_values.insert(field_name.clone(), points);
+                    }
+                    DataValue::Float64Array(arr) => {
+                        // Multi-valued float field. Same shape as Int64Array.
+                        let mut terms: Vec<AnalyzedTerm> = Vec::with_capacity(arr.len());
+                        let mut points: Vec<Vec<f64>> = Vec::with_capacity(arr.len());
+                        let mut offset = 0usize;
+                        for (idx, num) in arr.iter().enumerate() {
+                            let text = num.to_string();
+                            let len = text.len();
+                            terms.push(AnalyzedTerm {
+                                term: text,
+                                position: idx as u32,
+                                frequency: 1,
+                                offset: (offset, offset + len),
+                            });
+                            offset += len + 1;
+                            points.push(vec![*num]);
+                        }
+                        field_terms.insert(field_name.clone(), terms);
+                        point_values.insert(field_name.clone(), points);
+                    }
+                    // Handle other variants (Bytes, Vector, Null) — not lexically indexed.
                     _ => {}
                 }
             }
@@ -890,11 +933,16 @@ impl InvertedIndexWriter {
         let mut field_points: AHashMap<String, Vec<(Vec<f64>, u64)>> = AHashMap::new();
 
         for (doc_id, doc) in &self.buffered_docs {
-            for (field, values) in &doc.point_values {
-                field_points
-                    .entry(field.clone())
-                    .or_default()
-                    .push((values.clone(), *doc_id));
+            for (field, points) in &doc.point_values {
+                // Each `point` is one BKD entry. A single-valued field
+                // contributes one entry; a multi-valued field contributes
+                // one per element. The BKD reader's `range_search` already
+                // deduplicates `doc_id`s, so a multi-valued document is
+                // reported at most once per query.
+                let bucket = field_points.entry(field.clone()).or_default();
+                for point in points {
+                    bucket.push((point.clone(), *doc_id));
+                }
             }
         }
 

--- a/laurus/src/lexical/query/range.rs
+++ b/laurus/src/lexical/query/range.rs
@@ -464,158 +464,101 @@ impl NumericRangeQuery {
     }
 
     /// Count the number of documents that match this range query.
+    ///
+    /// For multi-valued fields, a document is counted at most once even
+    /// when several of its values fall in the range (Lucene-style "any
+    /// match" semantics).
     pub fn count_matching_documents(&self, reader: &dyn LexicalIndexReader) -> Result<u64> {
         let mut count = 0u64;
         let total_docs = reader.max_doc();
         for doc_id in 0..total_docs {
             if let Ok(Some(doc)) = reader.document(doc_id)
                 && let Some(val) = doc.get(&self.field)
+                && self.value_matches_any(val)
             {
-                let numeric_value = match val {
-                    crate::data::DataValue::Float64(f) => *f,
-                    crate::data::DataValue::Int64(i) => *i as f64,
-                    _ => continue, // Not a numeric field
-                };
-
-                if self.contains_numeric(numeric_value) {
-                    count += 1;
-                }
+                count += 1;
             }
         }
 
         Ok(count)
     }
+
+    /// Returns `true` if any numeric component of `val` is in this range.
+    ///
+    /// Single-valued fields contribute one numeric value; multi-valued
+    /// (`Int64Array` / `Float64Array`) fields are scanned for any element
+    /// that satisfies the predicate. Non-numeric variants return `false`.
+    fn value_matches_any(&self, val: &crate::data::DataValue) -> bool {
+        match val {
+            crate::data::DataValue::Int64(i) => self.contains_numeric(*i as f64),
+            crate::data::DataValue::Float64(f) => self.contains_numeric(*f),
+            crate::data::DataValue::Int64Array(arr) => {
+                arr.iter().any(|i| self.contains_numeric(*i as f64))
+            }
+            crate::data::DataValue::Float64Array(arr) => {
+                arr.iter().any(|f| self.contains_numeric(*f))
+            }
+            _ => false,
+        }
+    }
 }
 
 /// A scorer specialized for numeric range queries.
+///
+/// Range queries use Lucene-style **constant scoring**: every matching
+/// document receives the same score (`boost`), regardless of how close
+/// each value is to the range bounds or how many of a multi-valued
+/// document's values fall in range. The previous IDF + proximity scoring
+/// was removed when multi-valued numeric fields landed (#281), since per
+/// per-value weighting interacts poorly with "any match" semantics and
+/// produced surprising rankings.
 #[derive(Debug, Clone)]
 pub struct RangeScorer {
-    /// Lower bound value for proximity calculation.
-    lower_bound: Option<f64>,
-    /// Upper bound value for proximity calculation.
-    upper_bound: Option<f64>,
-    /// Range width for selectivity calculation.
-    range_width: f64,
-    /// Total number of documents.
-    total_docs: u64,
-    /// Number of documents matching the range.
+    /// Number of documents matching the range. Retained for `max_score`'s
+    /// "is anything matching?" check.
     matching_docs: u64,
-    /// Boost factor.
+    /// Boost factor; the per-document score is exactly this value.
     boost: f32,
 }
 
 impl RangeScorer {
     /// Create a new range scorer.
+    ///
+    /// Bounds and total document count were used by the legacy IDF /
+    /// proximity scorer; they are accepted (and ignored) so existing call
+    /// sites continue to compile.
     pub fn new(
-        lower_bound: Option<f64>,
-        upper_bound: Option<f64>,
+        _lower_bound: Option<f64>,
+        _upper_bound: Option<f64>,
         matching_docs: u64,
-        total_docs: u64,
+        _total_docs: u64,
         boost: f32,
     ) -> Self {
-        // Calculate range width for selectivity scoring
-        let range_width = match (lower_bound, upper_bound) {
-            (Some(lower), Some(upper)) => (upper - lower).abs(),
-            (Some(_), None) | (None, Some(_)) => 1000.0, // Large default for unbounded ranges
-            (None, None) => f64::INFINITY,               // Unbounded range
-        };
-
         RangeScorer {
-            lower_bound,
-            upper_bound,
-            range_width,
-            total_docs,
             matching_docs,
             boost,
-        }
-    }
-
-    /// Calculate selectivity-based IDF for the range.
-    fn range_idf(&self) -> f32 {
-        if self.matching_docs == 0 || self.total_docs == 0 {
-            // Return a default IDF for ranges with no matches
-            return 1.0;
-        }
-
-        let n = self.total_docs as f32;
-        let df = self.matching_docs as f32;
-
-        // Base IDF calculation using BM25 formula
-        let base_idf = ((n - df + 0.5) / (df + 0.5)).ln();
-
-        // Check for invalid values and ensure non-negative
-        let base_idf = if base_idf.is_nan() || base_idf.is_infinite() || base_idf < 0.0 {
-            // When most documents match (negative IDF), use a small positive value
-            // This maintains relative ranking while avoiding negative scores
-            0.5
-        } else {
-            base_idf
-        };
-
-        // Apply range selectivity bonus - narrower ranges get higher scores
-        let selectivity_multiplier = if self.range_width.is_finite() && self.range_width > 0.0 {
-            // Smaller range width = higher selectivity = higher score
-            1.0_f32 + (100.0_f32 / (self.range_width as f32 + 1.0_f32)).min(2.0_f32)
-        } else {
-            1.0_f32 // No bonus for unbounded ranges
-        };
-
-        // Ensure minimum meaningful score
-        let min_score = 0.5_f32;
-        (base_idf * selectivity_multiplier).max(min_score)
-    }
-
-    /// Calculate proximity-based score for a numeric value.
-    fn proximity_score(&self, value: f64) -> f32 {
-        match (self.lower_bound, self.upper_bound) {
-            (Some(lower), Some(upper)) => {
-                // For bounded ranges, calculate distance from range center
-                let center = (lower + upper) / 2.0;
-                let distance_from_center = (value - center).abs();
-                let max_distance = (upper - lower) / 2.0;
-
-                if max_distance > 0.0 {
-                    // Values closer to center get higher scores
-                    (1.0 + (1.0 - (distance_from_center / max_distance)).max(0.0)) as f32
-                } else {
-                    1.0_f32
-                }
-            }
-            (Some(bound), None) | (None, Some(bound)) => {
-                // For single-bounded ranges, closer to bound is better
-                let distance = (value - bound).abs();
-                (1.0 + (1.0 / (distance + 1.0)).min(1.0)) as f32
-            }
-            (None, None) => {
-                // Unbounded range - constant score
-                1.0_f32
-            }
         }
     }
 }
 
 impl Scorer for RangeScorer {
-    fn score(&self, _doc_id: u64, value: f32, _field_length: Option<f32>) -> f32 {
-        let idf = self.range_idf();
-
-        // If value is provided (non-zero), use it for proximity calculation
-        // Otherwise use a default score
-        let proximity = if value != 0.0 {
-            self.proximity_score(value as f64)
-        } else {
-            // Default proximity score when no value is provided
-            1.5
-        };
-
-        // Final score combines IDF with proximity bonus
-        let score = self.boost * idf * proximity;
-
-        // Ensure score is never NaN or infinite
-        if score.is_nan() || score.is_infinite() {
-            return self.boost * idf * 1.5; // Return reasonable default
-        }
-
-        score
+    /// Constant score for range matches.
+    ///
+    /// Matches Lucene's
+    /// [`PointRangeQuery`](https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/search/PointRangeQuery.html)
+    /// behaviour: a range query is a binary "in range / not in range"
+    /// predicate, scored uniformly by the boost factor. This applies to
+    /// both single-valued and multi-valued numeric fields — when several
+    /// of a multi-valued document's values fall in range, the document
+    /// still contributes a single constant-scored hit (the BKD reader
+    /// deduplicates `doc_id`s during range search).
+    ///
+    /// The previous IDF + proximity heuristic confused users when the same
+    /// query produced different scores for the same document depending on
+    /// surrounding queries; constant scoring keeps range query semantics
+    /// predictable and aligns with the dynamic-schema spec.
+    fn score(&self, _doc_id: u64, _value: f32, _field_length: Option<f32>) -> f32 {
+        self.boost
     }
 
     fn boost(&self) -> f32 {
@@ -630,10 +573,7 @@ impl Scorer for RangeScorer {
         if self.matching_docs == 0 {
             return 0.0;
         }
-
-        let idf = self.range_idf();
-        let max_proximity = 2.0; // Maximum proximity bonus
-        self.boost * idf * max_proximity
+        self.boost
     }
 
     fn name(&self) -> &'static str {
@@ -656,7 +596,10 @@ impl Query for NumericRangeQuery {
             return Ok(Box::new(PreComputedMatcher::new(doc_ids)));
         }
 
-        // Fallback: scan all documents and filter by numeric range
+        // Fallback: scan all documents and filter by numeric range.
+        // Multi-valued fields match if ANY value falls in the range
+        // (Lucene-style "any match"), and the document is recorded at
+        // most once per query.
         let mut matching_docs = Vec::new();
         let max_doc = reader.max_doc();
 
@@ -664,17 +607,25 @@ impl Query for NumericRangeQuery {
             if let Ok(Some(doc)) = reader.document(doc_id)
                 && let Some(val) = doc.get(&self.field)
             {
-                let numeric_value = match val {
-                    crate::data::DataValue::Float64(f) => Some(*f),
-                    crate::data::DataValue::Int64(i) => Some(*i as f64),
-                    // WORKAROUND: Parse text values as numbers (needed because stored docs lose type info)
-                    crate::data::DataValue::Text(s) => s.parse::<f64>().ok(),
-                    _ => None,
+                let matched = match val {
+                    crate::data::DataValue::Float64(f) => self.contains_numeric(*f),
+                    crate::data::DataValue::Int64(i) => self.contains_numeric(*i as f64),
+                    crate::data::DataValue::Int64Array(arr) => {
+                        arr.iter().any(|i| self.contains_numeric(*i as f64))
+                    }
+                    crate::data::DataValue::Float64Array(arr) => {
+                        arr.iter().any(|f| self.contains_numeric(*f))
+                    }
+                    // WORKAROUND: Parse text values as numbers (needed
+                    // because stored docs lose type info in some paths).
+                    crate::data::DataValue::Text(s) => s
+                        .parse::<f64>()
+                        .ok()
+                        .is_some_and(|n| self.contains_numeric(n)),
+                    _ => false,
                 };
 
-                if let Some(numeric_value) = numeric_value
-                    && self.contains_numeric(numeric_value)
-                {
+                if matched {
                     matching_docs.push(doc_id);
                 }
             }

--- a/laurus/tests/multi_valued_numeric_test.rs
+++ b/laurus/tests/multi_valued_numeric_test.rs
@@ -1,0 +1,237 @@
+//! End-to-end tests for multi-valued numeric fields.
+//!
+//! These tests drive the inverted index writer / reader pair the way
+//! production search does and verify the Lucene-style "any value
+//! matches" semantics for both `Int64Array` and `Float64Array` fields.
+
+use laurus::lexical::LexicalIndexWriter;
+use laurus::lexical::NumericRangeQuery;
+use laurus::lexical::NumericType;
+use laurus::lexical::Query;
+use laurus::lexical::{InvertedIndexWriter, InvertedIndexWriterConfig};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::{DataValue, Document};
+use std::sync::Arc;
+
+/// Drain a matcher into a Vec of doc IDs in iteration order.
+fn collect_matcher_results(mut m: Box<dyn laurus::lexical::query::matcher::Matcher>) -> Vec<u64> {
+    let mut docs = Vec::new();
+    while !m.is_exhausted() {
+        let doc_id = m.doc_id();
+        if doc_id == u64::MAX {
+            break;
+        }
+        docs.push(doc_id);
+        if !m.next().unwrap() {
+            break;
+        }
+    }
+    docs
+}
+
+#[test]
+fn int64_array_any_value_in_range() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut writer = InvertedIndexWriter::new(
+        storage.clone(),
+        InvertedIndexWriterConfig {
+            max_buffered_docs: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Doc 0: scores = [85, 72, 95]  (95 in [80, 100])
+    // Doc 1: scores = [60, 65]      (no value in [80, 100])
+    // Doc 2: scores = [88]          (88 in [80, 100])
+    writer
+        .add_document(
+            Document::builder()
+                .add_int64_array("scores", vec![85, 72, 95])
+                .build(),
+        )
+        .unwrap();
+    writer
+        .add_document(
+            Document::builder()
+                .add_int64_array("scores", vec![60, 65])
+                .build(),
+        )
+        .unwrap();
+    writer
+        .add_document(
+            Document::builder()
+                .add_int64_array("scores", vec![88])
+                .build(),
+        )
+        .unwrap();
+
+    writer.commit().unwrap();
+
+    let reader = writer.build_reader().unwrap();
+
+    // Range [80, 100] inclusive.
+    let q = NumericRangeQuery::new(
+        "scores",
+        NumericType::Integer,
+        Some(80.0),
+        Some(100.0),
+        true,
+        true,
+    );
+
+    let matched = collect_matcher_results(q.matcher(&*reader).unwrap());
+    assert_eq!(
+        matched,
+        vec![0, 2],
+        "doc 0 (95) and doc 2 (88) should match"
+    );
+
+    // Range [10, 20] — no document has any value in this range.
+    let q_low = NumericRangeQuery::new(
+        "scores",
+        NumericType::Integer,
+        Some(10.0),
+        Some(20.0),
+        true,
+        true,
+    );
+    let matched_low = collect_matcher_results(q_low.matcher(&*reader).unwrap());
+    assert!(
+        matched_low.is_empty(),
+        "no doc should match a disjoint range, got {matched_low:?}",
+    );
+}
+
+#[test]
+fn int64_array_dedups_doc_when_multiple_values_match() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut writer = InvertedIndexWriter::new(
+        storage.clone(),
+        InvertedIndexWriterConfig {
+            max_buffered_docs: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Doc 0 has THREE values inside [50, 100]: 60, 80, 90.
+    // The doc must be reported only once (Lucene dedup contract).
+    writer
+        .add_document(
+            Document::builder()
+                .add_int64_array("scores", vec![60, 80, 90])
+                .build(),
+        )
+        .unwrap();
+
+    writer.commit().unwrap();
+
+    let reader = writer.build_reader().unwrap();
+
+    let q = NumericRangeQuery::new(
+        "scores",
+        NumericType::Integer,
+        Some(50.0),
+        Some(100.0),
+        true,
+        true,
+    );
+    let matched = collect_matcher_results(q.matcher(&*reader).unwrap());
+    assert_eq!(matched, vec![0], "doc must be reported exactly once");
+}
+
+#[test]
+fn float64_array_any_value_in_range() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut writer = InvertedIndexWriter::new(
+        storage.clone(),
+        InvertedIndexWriterConfig {
+            max_buffered_docs: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Doc 0: prices = [12.5, 99.9, 7.0]  (99.9 in [50.0, 100.0])
+    // Doc 1: prices = [200.0, 250.0]     (none in range)
+    writer
+        .add_document(
+            Document::builder()
+                .add_float64_array("prices", vec![12.5, 99.9, 7.0])
+                .build(),
+        )
+        .unwrap();
+    writer
+        .add_document(
+            Document::builder()
+                .add_float64_array("prices", vec![200.0, 250.0])
+                .build(),
+        )
+        .unwrap();
+
+    writer.commit().unwrap();
+
+    let reader = writer.build_reader().unwrap();
+
+    let q = NumericRangeQuery::new(
+        "prices",
+        NumericType::Float,
+        Some(50.0),
+        Some(100.0),
+        true,
+        true,
+    );
+    let matched = collect_matcher_results(q.matcher(&*reader).unwrap());
+    assert_eq!(matched, vec![0]);
+}
+
+#[test]
+fn single_valued_field_unchanged_by_multi_valued_changes() {
+    // Regression: existing single-valued integer fields must keep their
+    // pre-existing behaviour after the multi-value plumbing change.
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut writer = InvertedIndexWriter::new(
+        storage.clone(),
+        InvertedIndexWriterConfig {
+            max_buffered_docs: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    writer
+        .add_document(
+            Document::builder()
+                .add_field("age", DataValue::Int64(30))
+                .build(),
+        )
+        .unwrap();
+    writer
+        .add_document(
+            Document::builder()
+                .add_field("age", DataValue::Int64(20))
+                .build(),
+        )
+        .unwrap();
+    writer
+        .add_document(
+            Document::builder()
+                .add_field("age", DataValue::Int64(40))
+                .build(),
+        )
+        .unwrap();
+    writer.commit().unwrap();
+
+    let reader = writer.build_reader().unwrap();
+    let q = NumericRangeQuery::new(
+        "age",
+        NumericType::Integer,
+        Some(25.0),
+        Some(35.0),
+        true,
+        true,
+    );
+    let matched = collect_matcher_results(q.matcher(&*reader).unwrap());
+    assert_eq!(matched, vec![0]);
+}


### PR DESCRIPTION
## Summary

- Plumb multi-valued numeric fields all the way through the lexical-store indexing pipeline. PR #286 put the data shape (`Int64Array` / `Float64Array`) and the `multi_valued` schema flag in place; this PR makes range queries actually match the right documents and Lucene-style constant scoring.
- `AnalyzedDocument::point_values` now carries a list of points per field. Single-valued fields contribute one point; multi-valued numeric fields contribute one 1D point per element. The BKD writer registers each as a distinct entry, and the BKD reader's `range_search` already deduplicates `doc_id`s, so a multi-valued document is reported at most once per query — the Lucene contract.
- Range query evaluation gains "any value matches" semantics on the fallback path and constant scoring on the scorer.

## Why

PR #286 documented a transitional state: Int64Array / Float64Array values round-tripped through the engine but range queries against multi-valued fields could not reliably match. PR2 closes that gap.

## What changed

### Storage / indexing pipeline

- `laurus/src/lexical/core/analyzed.rs` — `point_values` is now `AHashMap<String, Vec<Vec<f64>>>` (a list of multi-dimensional points per field).
- `laurus/src/lexical/core/parser.rs` — `DocumentParser::parse` emits a separate 1D point per `Int64Array` / `Float64Array` element (and an appropriately-shaped point for existing scalar / geo cases).
- `laurus/src/lexical/index/inverted/writer.rs`:
  - The inline parser path mirrors `DocumentParser`; the previous `_ => {}` wildcard that silently dropped `Int64Array` / `Float64Array` is replaced with explicit handlers that build N analyzed terms and N BKD points.
  - `write_bkd_trees` flattens the new structure: it pushes one `(point, doc_id)` per element into the `BKDWriter`, leaning on the existing `BKDReader::range_search` `dedup` step for unique-doc-id semantics.

### Range query (Lucene parity)

- `laurus/src/lexical/query/range.rs`:
  - `NumericRangeQuery::count_matching_documents` and the fallback matcher recognise `Int64Array` / `Float64Array` values via `arr.iter().any(...)`. The BKD path inherits "any match" from `dedup`.
  - `RangeScorer::score` returns `boost` unconditionally — Lucene's `PointRangeQuery` uses constant scoring, and per-value IDF / proximity weighting interacts poorly with multi-valued "any match" semantics. The legacy `range_idf` / `proximity_score` heuristics and the unused `lower_bound` / `upper_bound` / `range_width` / `total_docs` fields were removed; `RangeScorer::new` keeps its old signature so existing call sites continue to compile.

### doc_values (intentionally untouched)

A multi-valued document stores one `FieldValue::Int64Array(...)` or `Float64Array(...)` per `(doc_id, field)` — sufficient for retrieval and round-trip without restructuring storage. A Lucene-style `NumericDocValues` / `SortedNumericDocValues` split is only relevant for sort selectors (MIN / MAX / MEDIAN / SUM), which we left as a future enhancement (issue follow-up).

## Tests

`laurus/tests/multi_valued_numeric_test.rs` (new) exercises the full writer → BKD → reader → range query pipeline:

- `int64_array_any_value_in_range` — three docs with varied integer arrays; only those with any value in `[80, 100]` match (`vec![0, 2]`), and a disjoint range `[10, 20]` returns no matches.
- `int64_array_dedups_doc_when_multiple_values_match` — a single doc with three values inside `[50, 100]` is reported exactly once.
- `float64_array_any_value_in_range` — same shape for `Float64Array`.
- `single_valued_field_unchanged_by_multi_valued_changes` — regression for the existing single-valued integer path (range query still produces `vec![0]` for `age = 30` in `[25, 35]`).

All 698 unit tests + every existing integration test (including BKD / range / scoring) pass without modification.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p laurus -p laurus-server -p laurus-cli -p laurus-mcp -p laurus-python -p laurus-nodejs -p laurus-wasm --all-targets -- -D warnings`
- [x] `cargo test -p laurus -p laurus-server -p laurus-cli -p laurus-mcp` — 698 unit tests + new e2e tests + existing integration tests all pass

Closes #281