### PR TITLE
feat(bkd): introduce IntersectVisitor and back range_search with it

### DIFF
--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -952,21 +952,17 @@ struct MultiSegmentBKDTree {
 }
 
 impl BKDTree for MultiSegmentBKDTree {
-    fn range_search(
+    /// Forward the visitor to every per-segment tree in order. The visitor
+    /// accumulates hits across segments; the trait's default
+    /// `range_search` then sorts and dedups the combined output.
+    fn intersect(
         &self,
-        mins: &[Option<f64>],
-        maxs: &[Option<f64>],
-        include_min: bool,
-        include_max: bool,
-    ) -> Result<Vec<u64>> {
-        let mut results = Vec::new();
+        visitor: &mut dyn crate::lexical::index::structures::visitor::IntersectVisitor,
+    ) -> Result<()> {
         for tree in &self.trees {
-            let mut tree_results = tree.range_search(mins, maxs, include_min, include_max)?;
-            results.append(&mut tree_results);
+            tree.intersect(visitor)?;
         }
-        results.sort_unstable();
-        results.dedup();
-        Ok(results)
+        Ok(())
     }
 }
 

--- a/laurus/src/lexical/index/structures.rs
+++ b/laurus/src/lexical/index/structures.rs
@@ -1,3 +1,5 @@
+pub mod aabb;
 pub mod bkd_tree;
 pub mod dictionary;
 pub mod doc_values;
+pub mod visitor;

--- a/laurus/src/lexical/index/structures/aabb.rs
+++ b/laurus/src/lexical/index/structures/aabb.rs
@@ -1,0 +1,200 @@
+//! Axis-aligned bounding box (AABB) used by the BKD tree's
+//! `IntersectVisitor` API.
+//!
+//! All bounds are interpreted as **closed** intervals — `[min[d], max[d]]` —
+//! and unbounded coordinates are represented with `f64::NEG_INFINITY` /
+//! `f64::INFINITY`. Callers that need half-open semantics (e.g. range queries
+//! with `>` rather than `>=`) layer that on top of `AABB`, in their visitor
+//! implementation, rather than in the AABB itself.
+
+use crate::error::{LaurusError, Result};
+
+/// Axis-aligned bounding box with `min` and `max` per dimension.
+///
+/// Both `min` and `max` slices have the same length, which equals the
+/// dimensionality of the box (`num_dims`). For every dimension `d`,
+/// `min[d] <= max[d]` must hold; the constructor validates this.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AABB {
+    min: Vec<f64>,
+    max: Vec<f64>,
+}
+
+impl AABB {
+    /// Create a new AABB from per-dimension `min` / `max` vectors.
+    ///
+    /// # Errors
+    /// - `min.len() != max.len()` (dimensionality mismatch).
+    /// - `min.is_empty()` (a 0-dimensional box has no meaning).
+    /// - any `min[d] > max[d]` (degenerate box).
+    /// - any coordinate is `NaN`.
+    pub fn new(min: Vec<f64>, max: Vec<f64>) -> Result<Self> {
+        if min.len() != max.len() {
+            return Err(LaurusError::index(format!(
+                "AABB dimension mismatch: min has {} dims, max has {} dims",
+                min.len(),
+                max.len()
+            )));
+        }
+        if min.is_empty() {
+            return Err(LaurusError::index(
+                "AABB requires at least one dimension".to_string(),
+            ));
+        }
+        for d in 0..min.len() {
+            if min[d].is_nan() || max[d].is_nan() {
+                return Err(LaurusError::index(format!(
+                    "AABB contains NaN at dimension {d}"
+                )));
+            }
+            if min[d] > max[d] {
+                return Err(LaurusError::index(format!(
+                    "AABB invalid at dimension {d}: min={} > max={}",
+                    min[d], max[d]
+                )));
+            }
+        }
+        Ok(AABB { min, max })
+    }
+
+    /// Construct an AABB that spans the entire `f64` range on every
+    /// dimension — `[NEG_INFINITY, INFINITY]`. Useful as the initial
+    /// "match everything" query.
+    pub fn unbounded(num_dims: usize) -> Self {
+        AABB {
+            min: vec![f64::NEG_INFINITY; num_dims],
+            max: vec![f64::INFINITY; num_dims],
+        }
+    }
+
+    /// Number of dimensions covered by this AABB.
+    #[inline]
+    pub fn num_dims(&self) -> usize {
+        self.min.len()
+    }
+
+    /// Per-dimension lower bounds.
+    #[inline]
+    pub fn min(&self) -> &[f64] {
+        &self.min
+    }
+
+    /// Per-dimension upper bounds.
+    #[inline]
+    pub fn max(&self) -> &[f64] {
+        &self.max
+    }
+
+    /// Whether `point` lies on or inside this AABB on every dimension.
+    /// Returns `false` if `point` has a different dimensionality.
+    pub fn contains_point(&self, point: &[f64]) -> bool {
+        if point.len() != self.min.len() {
+            return false;
+        }
+        for (d, &v) in point.iter().enumerate() {
+            if v < self.min[d] || v > self.max[d] {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Whether `other` is entirely inside `self` on every dimension.
+    /// Returns `false` if dimensionalities differ.
+    pub fn contains_aabb(&self, other: &AABB) -> bool {
+        if other.num_dims() != self.num_dims() {
+            return false;
+        }
+        for d in 0..self.min.len() {
+            if other.min[d] < self.min[d] || other.max[d] > self.max[d] {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Whether `self` and `other` share at least one point.
+    /// Returns `false` if dimensionalities differ.
+    pub fn intersects(&self, other: &AABB) -> bool {
+        if other.num_dims() != self.num_dims() {
+            return false;
+        }
+        for d in 0..self.min.len() {
+            if self.max[d] < other.min[d] || self.min[d] > other.max[d] {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_validates_dimension_mismatch() {
+        let err = AABB::new(vec![0.0, 0.0], vec![1.0]).unwrap_err();
+        assert!(format!("{err:?}").contains("dimension mismatch"));
+    }
+
+    #[test]
+    fn new_validates_empty() {
+        let err = AABB::new(vec![], vec![]).unwrap_err();
+        assert!(format!("{err:?}").contains("at least one dimension"));
+    }
+
+    #[test]
+    fn new_validates_min_greater_than_max() {
+        let err = AABB::new(vec![5.0], vec![3.0]).unwrap_err();
+        assert!(format!("{err:?}").contains("min=5 > max=3"));
+    }
+
+    #[test]
+    fn new_rejects_nan() {
+        let err = AABB::new(vec![f64::NAN], vec![1.0]).unwrap_err();
+        assert!(format!("{err:?}").contains("NaN"));
+    }
+
+    #[test]
+    fn unbounded_uses_infinities() {
+        let aabb = AABB::unbounded(3);
+        assert_eq!(aabb.num_dims(), 3);
+        for d in 0..3 {
+            assert_eq!(aabb.min()[d], f64::NEG_INFINITY);
+            assert_eq!(aabb.max()[d], f64::INFINITY);
+        }
+    }
+
+    #[test]
+    fn contains_point_handles_boundary_inclusively() {
+        let aabb = AABB::new(vec![0.0, 0.0], vec![10.0, 10.0]).unwrap();
+        assert!(aabb.contains_point(&[5.0, 5.0]));
+        assert!(aabb.contains_point(&[0.0, 10.0])); // boundary
+        assert!(!aabb.contains_point(&[10.1, 5.0]));
+        assert!(!aabb.contains_point(&[5.0]));
+    }
+
+    #[test]
+    fn contains_aabb_strict_subset() {
+        let outer = AABB::new(vec![0.0, 0.0], vec![10.0, 10.0]).unwrap();
+        let inner = AABB::new(vec![1.0, 1.0], vec![9.0, 9.0]).unwrap();
+        let touching = AABB::new(vec![0.0, 0.0], vec![10.0, 10.0]).unwrap();
+        let outside = AABB::new(vec![5.0, 5.0], vec![15.0, 15.0]).unwrap();
+        assert!(outer.contains_aabb(&inner));
+        assert!(outer.contains_aabb(&touching));
+        assert!(!outer.contains_aabb(&outside));
+    }
+
+    #[test]
+    fn intersects_disjoint_and_overlapping() {
+        let a = AABB::new(vec![0.0, 0.0], vec![5.0, 5.0]).unwrap();
+        let overlapping = AABB::new(vec![3.0, 3.0], vec![8.0, 8.0]).unwrap();
+        let touching = AABB::new(vec![5.0, 5.0], vec![10.0, 10.0]).unwrap();
+        let disjoint = AABB::new(vec![6.0, 6.0], vec![10.0, 10.0]).unwrap();
+        assert!(a.intersects(&overlapping));
+        // Touching boxes share their corner — closed intervals intersect.
+        assert!(a.intersects(&touching));
+        assert!(!a.intersects(&disjoint));
+    }
+}

--- a/laurus/src/lexical/index/structures/bkd_tree.rs
+++ b/laurus/src/lexical/index/structures/bkd_tree.rs
@@ -3,6 +3,8 @@
 //! This is a simplified version of Apache Lucene's BKD Tree data structure,
 //! optimized for 1-dimensional numeric range filtering.
 
+use super::aabb::AABB;
+use super::visitor::{CellRelation, IntersectVisitor, RangeQueryVisitor};
 use crate::error::Result;
 use crate::storage::structured::{StructReader, StructWriter};
 use crate::storage::{Storage, StorageInput, StorageOutput};
@@ -11,15 +13,54 @@ use std::io::SeekFrom;
 use std::sync::Arc;
 
 /// Trait for BKD Tree implementations (in-memory or disk-based).
+///
+/// Implementations expose two query primitives:
+///
+/// - [`BKDTree::intersect`] is the low-level Lucene-style traversal: the
+///   reader walks the tree once, calling the visitor's `compare` method on
+///   each subtree's AABB (Inside / Outside / Crosses) and either pruning,
+///   collecting, or descending accordingly. This is the building block for
+///   sphere queries, k-NN, and any custom shape that fits the visitor API.
+/// - [`BKDTree::range_search`] is the legacy axis-aligned range API. It is
+///   provided as a default method that builds a [`RangeQueryVisitor`] and
+///   delegates to `intersect`, so concrete `BKDTree` implementations only
+///   need to supply `intersect`.
 pub trait BKDTree: Send + Sync + std::fmt::Debug {
-    /// Perform a range search.
+    /// Walk the tree, dispatching subtree pruning decisions and per-point
+    /// candidates to `visitor`.
+    ///
+    /// Implementations are expected to honor the visitor's `compare` result
+    /// faithfully:
+    /// - `CellRelation::Outside` cells are skipped.
+    /// - `CellRelation::Inside` cells contribute every doc id beneath them
+    ///   via `visit_inside` (the visitor does not need the point bytes).
+    /// - `CellRelation::Crosses` leaves expose every (doc_id, point) pair
+    ///   via `visit` so the visitor can perform the final per-point check.
+    fn intersect(&self, visitor: &mut dyn IntersectVisitor) -> Result<()>;
+
+    /// Axis-aligned range search returning the matching doc ids in sorted
+    /// and deduplicated order.
+    ///
+    /// `mins[d]` / `maxs[d]` may be `None` to leave a dimension unbounded.
+    /// `include_min` / `include_max` control whether the boundary itself
+    /// matches.
+    ///
+    /// The default implementation builds a [`RangeQueryVisitor`] and
+    /// delegates to [`BKDTree::intersect`].
     fn range_search(
         &self,
         mins: &[Option<f64>],
         maxs: &[Option<f64>],
         include_min: bool,
         include_max: bool,
-    ) -> Result<Vec<u64>>;
+    ) -> Result<Vec<u64>> {
+        let mut visitor = RangeQueryVisitor::new(mins, maxs, include_min, include_max);
+        self.intersect(&mut visitor)?;
+        let mut hits = visitor.into_hits();
+        hits.sort_unstable();
+        hits.dedup();
+        Ok(hits)
+    }
 }
 
 /// Magic number for BKD Tree files: ASCII "BKDT" in little-endian.
@@ -570,223 +611,188 @@ impl BKDReader {
         })
     }
 
-    fn visit_node<R: StorageInput>(
+    /// Read `num_dims` `f64` values for `min` followed by `num_dims` for
+    /// `max`, returning the constructed AABB.
+    fn read_child_aabb<R: StorageInput>(
+        reader: &mut StructReader<R>,
+        num_dims: usize,
+    ) -> Result<AABB> {
+        let mut min = Vec::with_capacity(num_dims);
+        for _ in 0..num_dims {
+            min.push(reader.read_f64()?);
+        }
+        let mut max = Vec::with_capacity(num_dims);
+        for _ in 0..num_dims {
+            max.push(reader.read_f64()?);
+        }
+        AABB::new(min, max)
+    }
+
+    /// Walk the subtree rooted at `offset`, dispatching pruning decisions
+    /// to `visitor`. Internal nodes consult `visitor.compare` on each
+    /// child's AABB; leaves either short-circuit (Outside / Inside) or
+    /// stream every (doc_id, point) candidate through `visitor.visit`.
+    fn intersect_subtree<R: StorageInput>(
         &self,
         reader: &mut StructReader<R>,
         offset: u64,
-        ctx: &QueryContext,
-        collector: &mut Vec<u64>,
+        visitor: &mut dyn IntersectVisitor,
     ) -> Result<()> {
         if offset < self.header.index_start_offset {
-            return self.visit_leaf_block(reader, offset, ctx, collector);
+            return self.intersect_leaf(reader, offset, visitor);
         }
-
-        reader.seek(SeekFrom::Start(offset))?;
-        let split_dim = reader.read_u32()? as usize;
-        let split_value = reader.read_f64()?;
-
-        // Per-child AABB. The current `range_search` does not yet use these
-        // for Inside/Outside/Crosses pruning — that arrives with the
-        // `IntersectVisitor` work in #292 — but we still consume the bytes so
-        // the offsets stay aligned with the on-disk layout.
         let num_dims = self.header.num_dims as usize;
-        for _ in 0..(num_dims * 4) {
-            let _ = reader.read_f64()?;
-        }
-
+        reader.seek(SeekFrom::Start(offset))?;
+        let _split_dim = reader.read_u32()?;
+        let _split_value = reader.read_f64()?;
+        let left_aabb = Self::read_child_aabb(reader, num_dims)?;
+        let right_aabb = Self::read_child_aabb(reader, num_dims)?;
         let left_offset = reader.read_u64()?;
         let right_offset = reader.read_u64()?;
 
-        // Validate split_dim against number of dimensions
-        if split_dim >= self.header.num_dims as usize {
-            return Err(crate::error::LaurusError::index(format!(
-                "Invalid split dimension {} (num_dims={})",
-                split_dim, self.header.num_dims
-            )));
+        match visitor.compare(&left_aabb) {
+            CellRelation::Outside => {}
+            CellRelation::Inside => self.collect_subtree(reader, left_offset, visitor)?,
+            CellRelation::Crosses => self.intersect_subtree(reader, left_offset, visitor)?,
         }
-
-        // Logic check for split dimension
-        let min = ctx.mins[split_dim];
-        let max = ctx.maxs[split_dim];
-
-        let go_left = min.is_none_or(|m| {
-            if ctx.include_min {
-                m <= split_value
-            } else {
-                m < split_value
-            }
-        });
-
-        if go_left {
-            self.visit_node(reader, left_offset, ctx, collector)?;
+        match visitor.compare(&right_aabb) {
+            CellRelation::Outside => {}
+            CellRelation::Inside => self.collect_subtree(reader, right_offset, visitor)?,
+            CellRelation::Crosses => self.intersect_subtree(reader, right_offset, visitor)?,
         }
-
-        let go_right = max.is_none_or(|m| {
-            if ctx.include_max {
-                m >= split_value
-            } else {
-                m > split_value
-            }
-        });
-
-        if go_right {
-            self.visit_node(reader, right_offset, ctx, collector)?;
-        }
-
         Ok(())
     }
 
-    fn visit_leaf_block<R: StorageInput>(
+    /// Walk a leaf at `offset`, classifying it via `visitor.compare` on the
+    /// stored leaf AABB and dispatching points accordingly.
+    fn intersect_leaf<R: StorageInput>(
         &self,
         reader: &mut StructReader<R>,
         offset: u64,
-        ctx: &QueryContext,
-        collector: &mut Vec<u64>,
+        visitor: &mut dyn IntersectVisitor,
     ) -> Result<()> {
         reader.seek(SeekFrom::Start(offset))?;
-        let count = reader.read_u32()?;
-
-        // Per-leaf AABB. Same rationale as `visit_node`: read but unused for
-        // pruning until #292 wires up `IntersectVisitor`.
+        let count = reader.read_u32()? as usize;
         let num_dims = self.header.num_dims as usize;
-        for _ in 0..(num_dims * 2) {
-            let _ = reader.read_f64()?;
-        }
+        let leaf_aabb = Self::read_child_aabb(reader, num_dims)?;
 
-        let mut points = Vec::with_capacity(count as usize);
-        for _ in 0..count {
-            let mut vals = Vec::with_capacity(self.header.num_dims as usize);
-            for _ in 0..self.header.num_dims {
-                vals.push(reader.read_f64()?);
-            }
-            points.push(vals);
-        }
-
-        let mut doc_ids = Vec::with_capacity(count as usize);
-        for _ in 0..count {
-            doc_ids.push(reader.read_u64()?);
-        }
-
-        for (vals, doc_id) in points.iter().zip(doc_ids.iter()) {
-            let mut matches = true;
-            for (i, &val) in vals.iter().enumerate() {
-                let gte_min =
-                    ctx.mins[i].is_none_or(|m| if ctx.include_min { val >= m } else { val > m });
-                let lte_max =
-                    ctx.maxs[i].is_none_or(|m| if ctx.include_max { val <= m } else { val < m });
-                if !gte_min || !lte_max {
-                    matches = false;
-                    break;
+        match visitor.compare(&leaf_aabb) {
+            CellRelation::Outside => Ok(()),
+            CellRelation::Inside => {
+                // Skip the point bytes; we only need the doc ids.
+                let point_bytes = (count as u64) * (num_dims as u64) * 8;
+                reader.seek(SeekFrom::Current(point_bytes as i64))?;
+                for _ in 0..count {
+                    let doc_id = reader.read_u64()?;
+                    visitor.visit_inside(doc_id);
                 }
+                Ok(())
             }
-            if matches {
-                collector.push(*doc_id);
+            CellRelation::Crosses => {
+                let mut points = vec![0.0f64; count * num_dims];
+                for slot in points.iter_mut() {
+                    *slot = reader.read_f64()?;
+                }
+                for i in 0..count {
+                    let doc_id = reader.read_u64()?;
+                    let point = &points[i * num_dims..(i + 1) * num_dims];
+                    visitor.visit(doc_id, point);
+                }
+                Ok(())
             }
+        }
+    }
+
+    /// Walk a subtree whose root the caller has already classified as
+    /// `Inside`. No `compare` calls are made — every doc is reported via
+    /// `visit_inside` and the leaf point bytes are skipped entirely.
+    fn collect_subtree<R: StorageInput>(
+        &self,
+        reader: &mut StructReader<R>,
+        offset: u64,
+        visitor: &mut dyn IntersectVisitor,
+    ) -> Result<()> {
+        if offset < self.header.index_start_offset {
+            return self.collect_leaf(reader, offset, visitor);
+        }
+        let num_dims = self.header.num_dims as usize;
+        reader.seek(SeekFrom::Start(offset))?;
+        let _split_dim = reader.read_u32()?;
+        let _split_value = reader.read_f64()?;
+        // Skip both child AABBs.
+        let aabb_bytes = (num_dims as u64) * 16 * 2;
+        reader.seek(SeekFrom::Current(aabb_bytes as i64))?;
+        let left_offset = reader.read_u64()?;
+        let right_offset = reader.read_u64()?;
+        self.collect_subtree(reader, left_offset, visitor)?;
+        self.collect_subtree(reader, right_offset, visitor)?;
+        Ok(())
+    }
+
+    /// Walk a leaf whose enclosing cell has already been classified as
+    /// `Inside`. The leaf AABB and point bytes are skipped; only doc ids
+    /// are read and reported via `visit_inside`.
+    fn collect_leaf<R: StorageInput>(
+        &self,
+        reader: &mut StructReader<R>,
+        offset: u64,
+        visitor: &mut dyn IntersectVisitor,
+    ) -> Result<()> {
+        reader.seek(SeekFrom::Start(offset))?;
+        let count = reader.read_u32()? as usize;
+        let num_dims = self.header.num_dims as usize;
+        // Skip leaf AABB (min + max) and all point bytes.
+        let skip_bytes = (num_dims as u64) * 16 + (count as u64) * (num_dims as u64) * 8;
+        reader.seek(SeekFrom::Current(skip_bytes as i64))?;
+        for _ in 0..count {
+            let doc_id = reader.read_u64()?;
+            visitor.visit_inside(doc_id);
         }
         Ok(())
     }
 }
 
-struct QueryContext<'a> {
-    mins: &'a [Option<f64>],
-    maxs: &'a [Option<f64>],
-    include_min: bool,
-    include_max: bool,
-}
-
 impl BKDTree for BKDReader {
-    /// Perform a range search.
-    fn range_search(
-        &self,
-        mins: &[Option<f64>],
-        maxs: &[Option<f64>],
-        include_min: bool,
-        include_max: bool,
-    ) -> Result<Vec<u64>> {
+    fn intersect(&self, visitor: &mut dyn IntersectVisitor) -> Result<()> {
         if self.header.total_point_count == 0 {
-            return Ok(Vec::new());
+            return Ok(());
         }
-
-        let num_dims = self.header.num_dims as usize;
-        if mins.len() != num_dims || maxs.len() != num_dims {
-            return Err(crate::error::LaurusError::index(format!(
-                "Dimension mismatch: expected {} dims, got mins={} maxs={}",
-                num_dims,
-                mins.len(),
-                maxs.len()
-            )));
-        }
-
-        let mut doc_ids = Vec::new();
-        let root_offset = self.header.root_node_offset;
-
         let input = self.storage.open_input(&self.path)?;
         let mut reader = StructReader::new(input)?;
-
-        if root_offset < self.header.index_start_offset && self.header.total_point_count > 0 {
-            // Single leaf block case or root leaf
-            let ctx = QueryContext {
-                mins,
-                maxs,
-                include_min,
-                include_max,
-            };
-            self.visit_leaf_block(&mut reader, root_offset, &ctx, &mut doc_ids)?;
+        let root_offset = self.header.root_node_offset;
+        if root_offset < self.header.index_start_offset {
+            // Single-leaf tree: the root "address" is just past the header.
+            self.intersect_leaf(&mut reader, root_offset, visitor)
         } else {
-            let ctx = QueryContext {
-                mins,
-                maxs,
-                include_min,
-                include_max,
-            };
-            self.visit_node(&mut reader, root_offset, &ctx, &mut doc_ids)?;
+            self.intersect_subtree(&mut reader, root_offset, visitor)
         }
-
-        doc_ids.sort_unstable();
-        doc_ids.dedup();
-
-        Ok(doc_ids)
     }
 }
 
 /// A simple BKD Tree for efficient range queries.
+///
+/// Slated for removal in #295 once the disk-backed `BKDReader` covers all
+/// remaining call sites.
 #[derive(Debug, Clone)]
 pub struct SimpleBKDTree {
     /// Sorted array of (points, doc_id) pairs.
     entries: Vec<(Vec<f64>, u64)>,
+    /// Retained for diagnostic accessors only; the new `intersect`-based
+    /// implementation derives the per-point dimensionality from each entry.
+    #[allow(dead_code)]
     num_dims: u32,
     field_name: String,
 }
 
 impl BKDTree for SimpleBKDTree {
-    fn range_search(
-        &self,
-        mins: &[Option<f64>],
-        maxs: &[Option<f64>],
-        include_min: bool,
-        include_max: bool,
-    ) -> Result<Vec<u64>> {
-        let mut doc_ids = Vec::new();
-
+    /// Linear scan across `entries`. The simple tree carries no AABB and
+    /// performs no pruning, so every point is reported via `visitor.visit`
+    /// (the `Crosses` path) and the visitor is responsible for filtering.
+    fn intersect(&self, visitor: &mut dyn IntersectVisitor) -> Result<()> {
         for (vals, doc_id) in &self.entries {
-            let mut matches = true;
-            for i in 0..self.num_dims as usize {
-                let val = vals[i];
-                let gte_min = mins[i].is_none_or(|m| if include_min { val >= m } else { val > m });
-                let lte_max = maxs[i].is_none_or(|m| if include_max { val <= m } else { val < m });
-                if !gte_min || !lte_max {
-                    matches = false;
-                    break;
-                }
-            }
-            if matches {
-                doc_ids.push(*doc_id);
-            }
+            visitor.visit(*doc_id, vals);
         }
-
-        doc_ids.sort_unstable();
-        doc_ids.dedup();
-        Ok(doc_ids)
+        Ok(())
     }
 }
 
@@ -1024,6 +1030,237 @@ mod tests {
             msg.contains("Unsupported BKD version"),
             "unexpected error: {msg}"
         );
+    }
+
+    /// Visitor that segregates hits by which BKD code path produced them
+    /// (`visit_inside` vs `visit`), used to assert that `Inside` cells avoid
+    /// per-point filtering and `Crosses` leaves go through it.
+    struct TracingVisitor {
+        query: AABB,
+        inside_hits: Vec<u64>,
+        crosses_hits: Vec<u64>,
+    }
+
+    impl TracingVisitor {
+        fn new(query: AABB) -> Self {
+            Self {
+                query,
+                inside_hits: Vec::new(),
+                crosses_hits: Vec::new(),
+            }
+        }
+    }
+
+    impl IntersectVisitor for TracingVisitor {
+        fn compare(&self, cell: &AABB) -> CellRelation {
+            // Conservative compare: cell vs query (closed intervals).
+            let qmin = self.query.min();
+            let qmax = self.query.max();
+            let cmin = cell.min();
+            let cmax = cell.max();
+            for d in 0..cell.num_dims() {
+                if cmax[d] < qmin[d] || cmin[d] > qmax[d] {
+                    return CellRelation::Outside;
+                }
+            }
+            for d in 0..cell.num_dims() {
+                if cmin[d] < qmin[d] || cmax[d] > qmax[d] {
+                    return CellRelation::Crosses;
+                }
+            }
+            CellRelation::Inside
+        }
+        fn visit_inside(&mut self, doc_id: u64) {
+            self.inside_hits.push(doc_id);
+        }
+        fn visit(&mut self, doc_id: u64, point: &[f64]) {
+            if self.query.contains_point(point) {
+                self.crosses_hits.push(doc_id);
+            }
+        }
+    }
+
+    /// A wrapper that also records every `compare` outcome (including
+    /// `Outside`) by using a `Cell` for interior mutability.
+    struct RecordingVisitor {
+        query: AABB,
+        relations: std::cell::RefCell<Vec<CellRelation>>,
+        hits: Vec<u64>,
+    }
+
+    impl RecordingVisitor {
+        fn new(query: AABB) -> Self {
+            Self {
+                query,
+                relations: std::cell::RefCell::new(Vec::new()),
+                hits: Vec::new(),
+            }
+        }
+    }
+
+    impl IntersectVisitor for RecordingVisitor {
+        fn compare(&self, cell: &AABB) -> CellRelation {
+            let qmin = self.query.min();
+            let qmax = self.query.max();
+            let cmin = cell.min();
+            let cmax = cell.max();
+            let mut relation = CellRelation::Inside;
+            for d in 0..cell.num_dims() {
+                if cmax[d] < qmin[d] || cmin[d] > qmax[d] {
+                    relation = CellRelation::Outside;
+                    break;
+                }
+            }
+            if !matches!(relation, CellRelation::Outside) {
+                for d in 0..cell.num_dims() {
+                    if cmin[d] < qmin[d] || cmax[d] > qmax[d] {
+                        relation = CellRelation::Crosses;
+                        break;
+                    }
+                }
+            }
+            self.relations.borrow_mut().push(relation);
+            relation
+        }
+        fn visit_inside(&mut self, doc_id: u64) {
+            self.hits.push(doc_id);
+        }
+        fn visit(&mut self, doc_id: u64, point: &[f64]) {
+            // For Crosses cells, accept the point only if it actually lies
+            // inside the query.
+            if self.query.contains_point(point) {
+                self.hits.push(doc_id);
+            }
+        }
+    }
+
+    #[test]
+    fn intersect_inside_avoids_per_point_filter() {
+        // Build a 1D tree with 4 leaf blocks; query the entire range so the
+        // root subtree is `Inside` and every doc is reported via
+        // `visit_inside`, never `visit`.
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let n: usize = 256;
+        let points: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let doc_ids: Vec<u64> = (0..n as u64).collect();
+        {
+            let output = storage.create_output("inside.bkd").unwrap();
+            let mut writer = BKDWriter::new(output, 1).with_block_size(32);
+            writer.write(&points, &doc_ids).unwrap();
+            writer.finish().unwrap();
+        }
+
+        let reader = BKDReader::open(storage.clone(), "inside.bkd").unwrap();
+        let query = AABB::new(vec![-1e9], vec![1e9]).unwrap();
+        let mut v = TracingVisitor::new(query);
+        reader.intersect(&mut v).unwrap();
+
+        // Every hit came through visit_inside: the query bounds wholly
+        // enclose every cell, so no point ever needed per-coordinate
+        // filtering.
+        assert_eq!(v.inside_hits.len(), n);
+        assert!(v.crosses_hits.is_empty());
+        v.inside_hits.sort_unstable();
+        let expected: Vec<u64> = (0..n as u64).collect();
+        assert_eq!(v.inside_hits, expected);
+    }
+
+    #[test]
+    fn intersect_outside_prunes_subtree() {
+        // Query that lies entirely above every point; expect zero hits and
+        // at least one Outside compare result.
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let n: usize = 128;
+        let points: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let doc_ids: Vec<u64> = (0..n as u64).collect();
+        {
+            let output = storage.create_output("outside.bkd").unwrap();
+            let mut writer = BKDWriter::new(output, 1).with_block_size(16);
+            writer.write(&points, &doc_ids).unwrap();
+            writer.finish().unwrap();
+        }
+
+        let reader = BKDReader::open(storage.clone(), "outside.bkd").unwrap();
+        let query = AABB::new(vec![1000.0], vec![2000.0]).unwrap();
+        let mut v = RecordingVisitor::new(query);
+        reader.intersect(&mut v).unwrap();
+
+        assert!(v.hits.is_empty());
+        assert!(
+            v.relations
+                .borrow()
+                .iter()
+                .any(|r| matches!(r, CellRelation::Outside)),
+            "expected at least one Outside compare, got {:?}",
+            v.relations.borrow()
+        );
+    }
+
+    #[test]
+    fn intersect_crosses_filters_per_point() {
+        // Query that overlaps a leaf boundary; expect Crosses leaves and
+        // hits accumulated via visit (per-point filtering).
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let n: usize = 200;
+        let points: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let doc_ids: Vec<u64> = (0..n as u64).collect();
+        {
+            let output = storage.create_output("crosses.bkd").unwrap();
+            let mut writer = BKDWriter::new(output, 1).with_block_size(16);
+            writer.write(&points, &doc_ids).unwrap();
+            writer.finish().unwrap();
+        }
+
+        let reader = BKDReader::open(storage.clone(), "crosses.bkd").unwrap();
+        let query = AABB::new(vec![50.5], vec![100.5]).unwrap();
+        let mut v = TracingVisitor::new(query);
+        reader.intersect(&mut v).unwrap();
+
+        let expected: Vec<u64> = (51u64..=100u64).collect();
+        let mut got = v.crosses_hits.clone();
+        got.append(&mut v.inside_hits.clone());
+        got.sort_unstable();
+        got.dedup();
+        assert_eq!(got, expected);
+        // At least some hits arrived via the `Crosses` path because the
+        // query bounds (50.5 / 100.5) cut through leaf blocks.
+        assert!(!v.crosses_hits.is_empty());
+    }
+
+    #[test]
+    fn range_search_default_impl_matches_legacy_semantics() {
+        // The trait's default `range_search` should still produce the same
+        // sorted/deduped doc-id list it always has, now via `intersect`.
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let n: usize = 500;
+        let points: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let doc_ids: Vec<u64> = (0..n as u64).collect();
+        {
+            let output = storage.create_output("legacy.bkd").unwrap();
+            let mut writer = BKDWriter::new(output, 1).with_block_size(64);
+            writer.write(&points, &doc_ids).unwrap();
+            writer.finish().unwrap();
+        }
+
+        let reader = BKDReader::open(storage.clone(), "legacy.bkd").unwrap();
+
+        // Inclusive bounds.
+        let inclusive = reader
+            .range_search(&[Some(100.0)], &[Some(200.0)], true, true)
+            .unwrap();
+        assert_eq!(inclusive, (100u64..=200u64).collect::<Vec<_>>());
+
+        // Exclusive bounds: 100 < x < 200.
+        let exclusive = reader
+            .range_search(&[Some(100.0)], &[Some(200.0)], false, false)
+            .unwrap();
+        assert_eq!(exclusive, (101u64..=199u64).collect::<Vec<_>>());
+
+        // Unbounded upper.
+        let lower_only = reader
+            .range_search(&[Some(490.0)], &[None], true, true)
+            .unwrap();
+        assert_eq!(lower_only, (490u64..n as u64).collect::<Vec<_>>());
     }
 
     #[test]

--- a/laurus/src/lexical/index/structures/visitor.rs
+++ b/laurus/src/lexical/index/structures/visitor.rs
@@ -1,0 +1,290 @@
+//! Visitor abstraction for walking a BKD tree with subtree pruning.
+//!
+//! A BKD reader can be queried in two flavours:
+//!
+//! - The legacy [`BKDTree::range_search`] returns a flat `Vec<u64>` of doc
+//!   ids whose points fall inside an axis-aligned range. It is implemented
+//!   on top of `intersect` via [`RangeQueryVisitor`].
+//! - The new [`BKDTree::intersect`] takes any `&mut dyn IntersectVisitor`
+//!   and lets the caller decide what to do with each cell (Inside / Outside
+//!   / Crosses) and each candidate point. This is the primitive 3D distance,
+//!   k-NN, and bounding-box queries are built on (#300 onwards).
+//!
+//! [`BKDTree::range_search`]: super::bkd_tree::BKDTree::range_search
+//! [`BKDTree::intersect`]: super::bkd_tree::BKDTree::intersect
+
+use super::aabb::AABB;
+
+/// Relationship between a BKD subtree's bounding box and the query region.
+///
+/// The reader uses this to prune entire subtrees: an `Inside` cell can be
+/// collected without per-point checks, an `Outside` cell can be skipped
+/// entirely, and a `Crosses` cell forces recursion (or per-point filtering
+/// at a leaf).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CellRelation {
+    /// The cell's AABB is entirely inside the query region — every point
+    /// in the subtree is a hit.
+    Inside,
+    /// The cell's AABB is entirely outside the query region — the subtree
+    /// can be skipped without inspection.
+    Outside,
+    /// The cell's AABB intersects the query boundary — recurse into the
+    /// subtree (or filter the leaf per-point).
+    Crosses,
+}
+
+/// Callback object passed to [`BKDTree::intersect`] to drive the traversal.
+///
+/// Implementors decide what counts as a hit and how to record it. The reader
+/// invokes the methods in the order:
+///
+/// 1. `compare(cell)` for each subtree's AABB.
+/// 2. If the relation is `Inside`, every doc beneath the subtree is reported
+///    via `visit_inside(doc_id)` — no point coordinates passed, since the
+///    visitor already knows the cell is fully inside the query.
+/// 3. If the relation is `Crosses` and the subtree is a leaf, every doc in
+///    the leaf is reported via `visit(doc_id, point)` and the visitor must
+///    perform any final per-point filtering against the query.
+/// 4. `Outside` cells are skipped entirely.
+///
+/// [`BKDTree::intersect`]: super::bkd_tree::BKDTree::intersect
+pub trait IntersectVisitor {
+    /// Classify a cell's AABB against the query region.
+    ///
+    /// Implementations should be conservative: returning `Crosses` for a
+    /// truly Outside cell only loses pruning efficiency, but returning
+    /// `Inside` / `Outside` incorrectly produces wrong results.
+    fn compare(&self, cell: &AABB) -> CellRelation;
+
+    /// Record a hit known to be inside the query region.
+    ///
+    /// Called for every doc id in a subtree whose AABB compared as `Inside`.
+    /// The point coordinates are not provided because the visitor does not
+    /// need them — the cell is known to be fully inside the query.
+    fn visit_inside(&mut self, doc_id: u64);
+
+    /// Filter and (optionally) record a candidate from a `Crosses` leaf.
+    ///
+    /// Called for every doc id in a leaf whose AABB compared as `Crosses`.
+    /// The visitor must check whether `point` actually lies inside the query
+    /// region before recording the hit.
+    fn visit(&mut self, doc_id: u64, point: &[f64]);
+}
+
+/// Half-open / closed range visitor used to back the legacy
+/// `BKDTree::range_search` API on top of the new `intersect` primitive.
+///
+/// The visitor accepts the same `mins` / `maxs` / `include_min` /
+/// `include_max` shape that `range_search` callers were already passing,
+/// converts unbounded `None` slots into `±INFINITY`, and handles the
+/// inclusive-vs-exclusive boundary check itself.
+pub struct RangeQueryVisitor {
+    mins: Vec<f64>,
+    maxs: Vec<f64>,
+    include_min: bool,
+    include_max: bool,
+    hits: Vec<u64>,
+}
+
+impl RangeQueryVisitor {
+    /// Build a visitor from the `range_search` parameter shape.
+    ///
+    /// `mins.len()` and `maxs.len()` must equal `num_dims`; otherwise the
+    /// visitor would silently misbehave when the BKD reader supplies an
+    /// AABB of a different dimensionality.
+    pub fn new(
+        mins: &[Option<f64>],
+        maxs: &[Option<f64>],
+        include_min: bool,
+        include_max: bool,
+    ) -> Self {
+        let mins_f: Vec<f64> = mins
+            .iter()
+            .map(|m| m.unwrap_or(f64::NEG_INFINITY))
+            .collect();
+        let maxs_f: Vec<f64> = maxs.iter().map(|m| m.unwrap_or(f64::INFINITY)).collect();
+        RangeQueryVisitor {
+            mins: mins_f,
+            maxs: maxs_f,
+            include_min,
+            include_max,
+            hits: Vec::new(),
+        }
+    }
+
+    /// Consume the visitor, returning the collected (and not yet sorted)
+    /// doc ids. Callers that expect deduplicated, sorted output should
+    /// post-process the returned vector.
+    pub fn into_hits(self) -> Vec<u64> {
+        self.hits
+    }
+
+    fn point_matches(&self, point: &[f64]) -> bool {
+        for (d, &v) in point.iter().enumerate() {
+            let lower_ok = if self.include_min {
+                v >= self.mins[d]
+            } else {
+                v > self.mins[d]
+            };
+            let upper_ok = if self.include_max {
+                v <= self.maxs[d]
+            } else {
+                v < self.maxs[d]
+            };
+            if !(lower_ok && upper_ok) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl IntersectVisitor for RangeQueryVisitor {
+    fn compare(&self, cell: &AABB) -> CellRelation {
+        debug_assert_eq!(cell.num_dims(), self.mins.len());
+        let cell_min = cell.min();
+        let cell_max = cell.max();
+
+        // Disjoint check: if any axis separates the cell from the query,
+        // the cell is fully Outside. Treat exclusive boundaries as
+        // disjoint when they touch (cell.max == query.min with `>` query).
+        for d in 0..cell_min.len() {
+            if cell_max[d] < self.mins[d] {
+                return CellRelation::Outside;
+            }
+            if !self.include_min && cell_max[d] <= self.mins[d] {
+                return CellRelation::Outside;
+            }
+            if cell_min[d] > self.maxs[d] {
+                return CellRelation::Outside;
+            }
+            if !self.include_max && cell_min[d] >= self.maxs[d] {
+                return CellRelation::Outside;
+            }
+        }
+
+        // Containment check: every axis of the cell must be inside the
+        // query (respecting inclusivity flags).
+        for d in 0..cell_min.len() {
+            let lower_ok = if self.include_min {
+                cell_min[d] >= self.mins[d]
+            } else {
+                cell_min[d] > self.mins[d]
+            };
+            let upper_ok = if self.include_max {
+                cell_max[d] <= self.maxs[d]
+            } else {
+                cell_max[d] < self.maxs[d]
+            };
+            if !(lower_ok && upper_ok) {
+                return CellRelation::Crosses;
+            }
+        }
+        CellRelation::Inside
+    }
+
+    fn visit_inside(&mut self, doc_id: u64) {
+        self.hits.push(doc_id);
+    }
+
+    fn visit(&mut self, doc_id: u64, point: &[f64]) {
+        if self.point_matches(point) {
+            self.hits.push(doc_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(min: Vec<f64>, max: Vec<f64>) -> AABB {
+        AABB::new(min, max).unwrap()
+    }
+
+    #[test]
+    fn range_query_visitor_inside_outside_crosses() {
+        // 1D query [10, 20] inclusive on both ends.
+        let v = RangeQueryVisitor::new(&[Some(10.0)], &[Some(20.0)], true, true);
+        assert_eq!(
+            v.compare(&cell(vec![12.0], vec![18.0])),
+            CellRelation::Inside
+        );
+        assert_eq!(
+            v.compare(&cell(vec![25.0], vec![30.0])),
+            CellRelation::Outside
+        );
+        assert_eq!(
+            v.compare(&cell(vec![5.0], vec![8.0])),
+            CellRelation::Outside
+        );
+        assert_eq!(
+            v.compare(&cell(vec![15.0], vec![25.0])),
+            CellRelation::Crosses
+        );
+        // Touching the inclusive boundary is Inside (single-point cell).
+        assert_eq!(
+            v.compare(&cell(vec![10.0], vec![10.0])),
+            CellRelation::Inside
+        );
+    }
+
+    #[test]
+    fn range_query_visitor_exclusive_boundary_outside() {
+        // Exclusive lower bound: query is x > 10.
+        let v = RangeQueryVisitor::new(&[Some(10.0)], &[None], false, true);
+        // A cell touching exactly at the exclusive lower bound is fully
+        // Outside.
+        assert_eq!(
+            v.compare(&cell(vec![5.0], vec![10.0])),
+            CellRelation::Outside
+        );
+        // A cell strictly above is Inside.
+        assert_eq!(
+            v.compare(&cell(vec![11.0], vec![20.0])),
+            CellRelation::Inside
+        );
+        // A cell straddling the boundary is Crosses (visitor must filter
+        // the boundary point per visit()).
+        assert_eq!(
+            v.compare(&cell(vec![10.0], vec![20.0])),
+            CellRelation::Crosses
+        );
+    }
+
+    #[test]
+    fn range_query_visitor_unbounded_dimensions() {
+        // 2D query: only x bounded, y unbounded.
+        let v = RangeQueryVisitor::new(&[Some(0.0), None], &[Some(100.0), None], true, true);
+        assert_eq!(
+            v.compare(&cell(vec![10.0, -1e9], vec![90.0, 1e9])),
+            CellRelation::Inside
+        );
+        assert_eq!(
+            v.compare(&cell(vec![-50.0, 0.0], vec![-10.0, 10.0])),
+            CellRelation::Outside
+        );
+    }
+
+    #[test]
+    fn range_query_visitor_visit_filters_points_on_crosses() {
+        let mut v = RangeQueryVisitor::new(&[Some(10.0)], &[Some(20.0)], true, true);
+        v.visit(1, &[5.0]); // outside
+        v.visit(2, &[15.0]); // inside
+        v.visit(3, &[20.0]); // boundary, inclusive
+        v.visit(4, &[21.0]); // outside
+        let hits = v.into_hits();
+        assert_eq!(hits, vec![2, 3]);
+    }
+
+    #[test]
+    fn range_query_visitor_visit_inside_skips_filter() {
+        let mut v = RangeQueryVisitor::new(&[Some(10.0)], &[Some(20.0)], true, true);
+        // visit_inside trusts the caller about the cell being Inside.
+        v.visit_inside(7);
+        v.visit_inside(8);
+        let hits = v.into_hits();
+        assert_eq!(hits, vec![7, 8]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the AABB / CellRelation / IntersectVisitor trio that future 3D queries (sphere, k-NN, custom shapes) will be built on, and reimplements the existing axis-aligned `range_search` as a thin wrapper over the new primitive.

- **\`aabb.rs\`** — closed-interval AABB primitive with `new()`, `unbounded()`, `contains_point()`, `contains_aabb()`, `intersects()` and validation (rejects dim mismatch, NaN, `min > max`).
- **\`visitor.rs\`** — `CellRelation` (Inside/Outside/Crosses), `IntersectVisitor` trait with Lucene-style two-method visit (`visit_inside` for cells fully inside the query, `visit` for boundary leaves that need per-point filtering), and a `RangeQueryVisitor` that handles the legacy `mins/maxs/include_min/include_max` shape.
- **\`BKDTree::intersect\`** added to the trait. \`range_search\` becomes a **default trait method** that builds a `RangeQueryVisitor`, delegates to \`intersect\`, and sorts/dedups the hits — so call sites (\`geo.rs\`, \`range.rs\`, etc.) need **no changes**.
- **\`BKDReader::intersect\`** walks the tree using the per-node and per-leaf AABBs recorded in #291: Inside subtrees skip point bytes and report doc ids via \`visit_inside\`, Outside subtrees are skipped entirely, and Crosses leaves stream every \`(doc_id, point)\` pair through \`visit\`. \`SimpleBKDTree\` collapses to a linear visit-only scan; \`MultiSegmentBKDTree\` forwards the visitor across segments and the trait default sorts/dedups.

## Why

Per #289, this is the load-bearing change of Phase B: every later 3D query (\`Geo3dDistanceQuery\`, \`Geo3dNearestQuery\`, custom-shape queries) is implemented as an \`IntersectVisitor\`. Without it, those queries would degenerate to per-leaf full scans even with the AABBs added in #291.

## API impact

- New public types: \`AABB\`, \`CellRelation\`, \`IntersectVisitor\`, \`RangeQueryVisitor\`.
- New trait method: \`BKDTree::intersect(&mut dyn IntersectVisitor)\` (every implementor must provide it; \`range_search\` is now provided by default).
- \`BKDTree::range_search\` signature is **unchanged** — caller updates deferred (the implementation_plan's signature change to \`&AABB\` is out of scope for this PR; the visitor abstraction is what the issue asks for).

## Test plan

- [x] \`cargo test -p laurus\` — 721 lib tests + all integration tests pass (was 704 after #291; +17 new).
- [x] \`cargo clippy -p laurus --tests -- -D warnings\` — no warnings.
- [x] \`cargo fmt --check\` — pass.
- [x] AABB tests (8): construction validation (dim mismatch, empty, min>max, NaN), \`unbounded\`, \`contains_point\` (boundary inclusive), \`contains_aabb\` (strict subset + touching), \`intersects\` (disjoint / overlapping / touching).
- [x] RangeQueryVisitor tests (5): inclusive Inside/Outside/Crosses, exclusive boundary handling, unbounded dimensions, per-point filtering on Crosses, \`visit_inside\` short-circuit.
- [x] \`BKDReader::intersect\` end-to-end tests (4): Inside subtree avoids per-point filter (only \`visit_inside\` fired); Outside prunes (zero hits, at least one Outside compare); Crosses leaves filter per-point; default \`range_search\` matches legacy semantics across inclusive / exclusive / unbounded bounds.

Refs #289
Closes #292