### PR TITLE
test(bkd): add criterion benchmark suite

### DIFF
--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -153,6 +153,10 @@ harness = false
 name = "vector_search_bench"
 harness = false
 
+[[bench]]
+name = "bkd_bench"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 tokio-test = "0.4.5"

--- a/laurus/benches/bkd_bench.rs
+++ b/laurus/benches/bkd_bench.rs
@@ -1,0 +1,228 @@
+//! Criterion benchmarks for the BKD tree.
+//!
+//! Covers `BKDReader::range_search` (the legacy axis-aligned API) and
+//! `BKDReader::intersect` (the visitor-driven primitive that 3D distance,
+//! k-NN, and other custom-shape queries will be built on) across 1D, 2D,
+//! and 3D datasets at 10k / 100k / 1M points.
+//!
+//! # Running
+//!
+//! Run every bench in this file:
+//!
+//! ```sh
+//! cargo bench --bench bkd_bench
+//! ```
+//!
+//! Filter by group / case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench bkd_bench -- range_search/3d/100000
+//! cargo bench --bench bkd_bench -- intersect_counting
+//! ```
+//!
+//! Compile-only smoke check (skips the runtime, used by CI):
+//!
+//! ```sh
+//! cargo bench --bench bkd_bench --no-run
+//! ```
+//!
+//! All trees are built once per `(num_dims, n)` combination and reused
+//! across iterations. Synthetic data is generated with an inline LCG so
+//! the benches stay deterministic without pulling in `rand`.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use laurus::lexical::index::structures::aabb::AABB;
+use laurus::lexical::index::structures::bkd_tree::{BKDReader, BKDTree, BKDWriter};
+use laurus::lexical::index::structures::visitor::{CellRelation, IntersectVisitor};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use std::hint::black_box;
+use std::sync::Arc;
+
+/// Inline LCG (numerical recipes constants) so the bench stays deterministic
+/// without pulling in `rand` as a dev dep.
+fn lcg_next(state: &mut u64) -> f64 {
+    *state = state
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    // Take the high 32 bits and rescale to [0, 1000).
+    let bits = (*state >> 32) as u32;
+    (bits as f64) * (1000.0 / (u32::MAX as f64))
+}
+
+/// Build an in-memory BKD tree of `n` random points in `num_dims` dimensions
+/// with coordinates uniformly distributed in `[0, 1000)`. Returns the open
+/// `BKDReader` ready for query benchmarking.
+fn build_tree(num_dims: usize, n: usize) -> BKDReader {
+    let storage: Arc<MemoryStorage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut points: Vec<f64> = Vec::with_capacity(n * num_dims);
+    let mut doc_ids: Vec<u64> = Vec::with_capacity(n);
+    let mut rng_state: u64 = 0xDEAD_BEEF_CAFE_F00D;
+    for i in 0..n {
+        for _ in 0..num_dims {
+            points.push(lcg_next(&mut rng_state));
+        }
+        doc_ids.push(i as u64);
+    }
+    let path = format!("bench_{num_dims}d_{n}.bkd");
+    let output = storage.create_output(&path).unwrap();
+    let mut writer = BKDWriter::new(output, num_dims as u32);
+    writer.write(&points, &doc_ids).unwrap();
+    writer.finish().unwrap();
+    BKDReader::open(storage, &path).unwrap()
+}
+
+/// Visitor that just counts hits, used to benchmark the raw `intersect`
+/// path without paying the `RangeQueryVisitor` boundary-handling cost.
+struct CountingVisitor {
+    query: AABB,
+    count: u64,
+}
+
+impl IntersectVisitor for CountingVisitor {
+    fn compare(&self, cell: &AABB) -> CellRelation {
+        let qmin = self.query.min();
+        let qmax = self.query.max();
+        let cmin = cell.min();
+        let cmax = cell.max();
+        for d in 0..cell.num_dims() {
+            if cmax[d] < qmin[d] || cmin[d] > qmax[d] {
+                return CellRelation::Outside;
+            }
+        }
+        for d in 0..cell.num_dims() {
+            if cmin[d] < qmin[d] || cmax[d] > qmax[d] {
+                return CellRelation::Crosses;
+            }
+        }
+        CellRelation::Inside
+    }
+    fn visit_inside(&mut self, _doc_id: u64) {
+        self.count += 1;
+    }
+    fn visit(&mut self, _doc_id: u64, point: &[f64]) {
+        if self.query.contains_point(point) {
+            self.count += 1;
+        }
+    }
+}
+
+/// Sizes to sweep across the dimensionality axis.
+const SIZES: &[usize] = &[10_000, 100_000, 1_000_000];
+
+/// Dimensionalities to sweep.
+const DIMS: &[usize] = &[1, 2, 3];
+
+/// Narrow (selective) query: 1% of the per-dimension data range.
+/// Hit counts: ~1% × n in 1D, ~0.01% × n in 2D, ~0.0001% × n in 3D.
+const QUERY_NARROW_LO: f64 = 100.0;
+const QUERY_NARROW_HI: f64 = 110.0;
+
+/// Wide query: 50% of the per-dimension data range.
+/// Hit counts: ~50% × n in 1D, ~25% × n in 2D, ~12.5% × n in 3D.
+const QUERY_WIDE_LO: f64 = 100.0;
+const QUERY_WIDE_HI: f64 = 600.0;
+
+fn bench_range_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bkd_range_search");
+    for &num_dims in DIMS {
+        for &n in SIZES {
+            let reader = build_tree(num_dims, n);
+            for (label, lo, hi) in [
+                ("narrow", QUERY_NARROW_LO, QUERY_NARROW_HI),
+                ("wide", QUERY_WIDE_LO, QUERY_WIDE_HI),
+            ] {
+                let mins: Vec<Option<f64>> = (0..num_dims).map(|_| Some(lo)).collect();
+                let maxs: Vec<Option<f64>> = (0..num_dims).map(|_| Some(hi)).collect();
+                let id = format!("{num_dims}d/{label}/{n}");
+                group.throughput(Throughput::Elements(n as u64));
+                group.bench_with_input(BenchmarkId::from_parameter(id), &(mins, maxs), |b, qs| {
+                    let (mins, maxs) = qs;
+                    b.iter(|| {
+                        let hits = reader
+                            .range_search(black_box(mins), black_box(maxs), true, true)
+                            .unwrap();
+                        black_box(hits);
+                    });
+                });
+            }
+        }
+    }
+    group.finish();
+}
+
+fn bench_intersect_counting(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bkd_intersect_counting");
+    for &num_dims in DIMS {
+        for &n in SIZES {
+            let reader = build_tree(num_dims, n);
+            for (label, lo, hi) in [
+                ("narrow", QUERY_NARROW_LO, QUERY_NARROW_HI),
+                ("wide", QUERY_WIDE_LO, QUERY_WIDE_HI),
+            ] {
+                let qmin: Vec<f64> = (0..num_dims).map(|_| lo).collect();
+                let qmax: Vec<f64> = (0..num_dims).map(|_| hi).collect();
+                let id = format!("{num_dims}d/{label}/{n}");
+                group.throughput(Throughput::Elements(n as u64));
+                group.bench_with_input(BenchmarkId::from_parameter(id), &(qmin, qmax), |b, qs| {
+                    let (qmin, qmax) = qs;
+                    b.iter(|| {
+                        let mut v = CountingVisitor {
+                            query: AABB::new(qmin.clone(), qmax.clone()).unwrap(),
+                            count: 0,
+                        };
+                        reader.intersect(&mut v).unwrap();
+                        black_box(v.count);
+                    });
+                });
+            }
+        }
+    }
+    group.finish();
+}
+
+fn bench_build(c: &mut Criterion) {
+    // Tree construction itself, useful as a baseline and to gauge the
+    // amortized cost of widest-axis splitting + AABB computation
+    // introduced in #291–#293.
+    let mut group = c.benchmark_group("bkd_build");
+    // Smaller sweep: building 1M points × 3 dims repeatedly is slow.
+    for &num_dims in DIMS {
+        for &n in &[10_000usize, 100_000] {
+            let id = format!("{num_dims}d/{n}");
+            group.throughput(Throughput::Elements(n as u64));
+            group.bench_function(BenchmarkId::from_parameter(id), |b| {
+                // Pre-generate input outside the iter loop so we measure
+                // build, not data generation.
+                let mut points: Vec<f64> = Vec::with_capacity(n * num_dims);
+                let mut doc_ids: Vec<u64> = Vec::with_capacity(n);
+                let mut rng_state: u64 = 0xDEAD_BEEF_CAFE_F00D;
+                for i in 0..n {
+                    for _ in 0..num_dims {
+                        points.push(lcg_next(&mut rng_state));
+                    }
+                    doc_ids.push(i as u64);
+                }
+                b.iter(|| {
+                    let storage: Arc<MemoryStorage> =
+                        Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+                    let path = "build.bkd";
+                    let output = storage.create_output(path).unwrap();
+                    let mut writer = BKDWriter::new(output, num_dims as u32);
+                    writer.write(&points, &doc_ids).unwrap();
+                    writer.finish().unwrap();
+                    black_box(storage);
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_range_search,
+    bench_intersect_counting,
+    bench_build
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Add `benches/bkd_bench.rs` so future BKD changes can be evaluated quantitatively. The suite covers:

- **`bkd_range_search`** — `BKDReader::range_search` across 1D / 2D / 3D × 10k / 100k / 1M points × narrow (`[100, 110]`) + wide (`[100, 600]`) queries.
- **`bkd_intersect_counting`** — `BKDReader::intersect` with a custom `CountingVisitor` (no per-point boundary-check overhead from `RangeQueryVisitor`) over the same dim/size/query matrix.
- **`bkd_build`** — `BKDWriter::write` end-to-end build cost over 10k / 100k for each dim, useful as a baseline for the widest-axis splitting and per-subtree AABB work introduced in #291–#293.

Trees are built once per `(num_dims, n)` and reused across iterations. Synthetic data uses an inline LCG so the bench stays deterministic without pulling `rand` into dev-dependencies. `criterion` 0.8.2 is already in `[dev-dependencies]`; the only Cargo.toml change is a new `[[bench]]` entry with `harness = false`.

The module-level rustdoc explains how to run the suite, filter by group/case, and use `--no-run` for a compile-only smoke check.

## Sanity run (1d / narrow)

| Size | Time | Throughput |
|---|---|---|
| 10k | ~11 µs | ~910 Melem/s |
| 100k | ~89 µs | ~1.12 Gelem/s |
| 1M | ~1.0 ms | ~990 Melem/s |

Linear scaling confirms `cargo bench --bench bkd_bench` runs to completion.

## How to run

```sh
# Full suite
cargo bench --bench bkd_bench

# Filter
cargo bench --bench bkd_bench -- range_search/3d/100000

# Compile-only smoke check (CI-friendly)
cargo bench --bench bkd_bench --no-run
```

## Test plan

- [x] `cargo bench --bench bkd_bench --no-run` — compiles cleanly.
- [x] Sanity run on `1d/narrow/10000`, `1d/narrow/100000`, `1d/narrow/1000000` — runtime scales linearly (see table above).
- [x] `cargo test -p laurus` — 724 lib tests + all integration tests pass.
- [x] `cargo clippy -p laurus --tests --benches -- -D warnings` — no warnings.
- [x] `cargo fmt --check` — pass.

Refs #289
Closes #296