### PR TITLE
feat(schema): add FieldOption::Geo3d and Geo3dOption

### DIFF
--- a/laurus-cli/src/commands/create.rs
+++ b/laurus-cli/src/commands/create.rs
@@ -408,6 +408,7 @@ fn is_lexical_field(option: &FieldOption) -> bool {
             | FieldOption::Boolean(_)
             | FieldOption::DateTime(_)
             | FieldOption::Geo(_)
+            | FieldOption::Geo3d(_)
             | FieldOption::Bytes(_)
     )
 }
@@ -421,6 +422,7 @@ fn field_type_label(option: &FieldOption) -> &'static str {
         FieldOption::Boolean(_) => "Boolean",
         FieldOption::DateTime(_) => "DateTime",
         FieldOption::Geo(_) => "Geo",
+        FieldOption::Geo3d(_) => "Geo3d",
         FieldOption::Bytes(_) => "Bytes",
         FieldOption::Hnsw(_) => "Hnsw",
         FieldOption::Flat(_) => "Flat",

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -132,6 +132,11 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
             indexed: o.indexed,
             stored: o.stored,
         })),
+        // Geo3d (3D ECEF) does not yet have a proto representation; the
+        // dedicated `Geo3dOption` proto message lands with #305 (gRPC/MCP
+        // API for 3D geo). Until then, skip the variant — receivers can
+        // distinguish Geo3d fields via the schema kind once #305 lands.
+        FieldOption::Geo3d(_) => None,
         FieldOption::Bytes(o) => Some(Opt::Bytes(v1::BytesOption { stored: o.stored })),
         FieldOption::Hnsw(o) => Some(Opt::Hnsw(v1::HnswOption {
             dimension: o.dimension as u32,

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -923,6 +923,7 @@ impl Engine {
                 FieldOption::Boolean(o) => o.stored,
                 FieldOption::DateTime(o) => o.stored,
                 FieldOption::Geo(o) => o.stored,
+                FieldOption::Geo3d(o) => o.stored,
                 FieldOption::Bytes(o) => o.stored,
                 // Vector fields are always stored
                 FieldOption::Hnsw(_) | FieldOption::Flat(_) | FieldOption::Ivf(_) => true,

--- a/laurus/src/engine/schema.rs
+++ b/laurus/src/engine/schema.rs
@@ -8,7 +8,8 @@ use self::analyzer::AnalyzerDefinition;
 use self::embedder::EmbedderDefinition;
 
 use crate::lexical::core::field::{
-    BooleanOption, BytesOption, DateTimeOption, FloatOption, GeoOption, IntegerOption, TextOption,
+    BooleanOption, BytesOption, DateTimeOption, FloatOption, Geo3dOption, GeoOption, IntegerOption,
+    TextOption,
 };
 use crate::vector::core::field::{FlatOption, HnswOption, IvfOption};
 
@@ -183,8 +184,10 @@ pub enum FieldOption {
     Boolean(BooleanOption),
     /// DateTime field options.
     DateTime(DateTimeOption),
-    /// Geo field options.
+    /// 2D geo field options.
     Geo(GeoOption),
+    /// 3D ECEF geo field options.
+    Geo3d(Geo3dOption),
     /// Bytes field options.
     Bytes(BytesOption),
     /// HNSW vector index options.
@@ -211,6 +214,7 @@ impl FieldOption {
                 | Self::Boolean(_)
                 | Self::DateTime(_)
                 | Self::Geo(_)
+                | Self::Geo3d(_)
                 | Self::Bytes(_)
         )
     }
@@ -246,6 +250,7 @@ impl FieldOption {
                 o.clone(),
             )),
             Self::Geo(o) => Some(crate::lexical::core::field::FieldOption::Geo(o.clone())),
+            Self::Geo3d(o) => Some(crate::lexical::core::field::FieldOption::Geo3d(o.clone())),
             Self::Bytes(o) => Some(crate::lexical::core::field::FieldOption::Bytes(o.clone())),
             _ => None,
         }
@@ -302,6 +307,12 @@ impl SchemaBuilder {
 
     pub fn add_geo_field(self, name: impl Into<String>, option: impl Into<GeoOption>) -> Self {
         self.add_field(name, FieldOption::Geo(option.into()))
+    }
+
+    /// Add a 3D ECEF geo field, indexed in a 3D BKD tree for sphere /
+    /// k-NN queries (queries themselves arrive with #300–#302).
+    pub fn add_geo3d_field(self, name: impl Into<String>, option: impl Into<Geo3dOption>) -> Self {
+        self.add_field(name, FieldOption::Geo3d(option.into()))
     }
 
     pub fn add_bytes_field(self, name: impl Into<String>, option: impl Into<BytesOption>) -> Self {
@@ -453,6 +464,30 @@ mod tests {
             .add_field("title", FieldOption::Text(TextOption::default()))
             .try_build();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn schema_builder_add_geo3d_field_round_trips() {
+        let schema = Schema::builder()
+            .add_geo3d_field("position", Geo3dOption::default())
+            .build();
+        let opt = schema.fields.get("position").expect("field declared");
+        match opt {
+            FieldOption::Geo3d(g3d) => {
+                assert!(g3d.indexed);
+                assert!(g3d.stored);
+            }
+            other => panic!("expected FieldOption::Geo3d, got {other:?}"),
+        }
+
+        // The engine schema -> lexical schema bridge must preserve Geo3d.
+        let lexical = opt.to_lexical().expect("Geo3d is a lexical field");
+        assert!(matches!(
+            lexical,
+            crate::lexical::core::field::FieldOption::Geo3d(_)
+        ));
+        assert!(opt.is_lexical());
+        assert!(!opt.is_vector());
     }
 
     #[test]

--- a/laurus/src/engine/type_coercion.rs
+++ b/laurus/src/engine/type_coercion.rs
@@ -52,6 +52,7 @@ pub fn coerce_value(field_name: &str, option: &FieldOption, value: DataValue) ->
         FieldOption::Boolean(_) => coerce_to_boolean(field_name, value),
         FieldOption::DateTime(_) => coerce_to_datetime(field_name, value),
         FieldOption::Geo(_) => coerce_to_geo(field_name, value),
+        FieldOption::Geo3d(_) => coerce_to_geo3d(field_name, value),
         FieldOption::Bytes(_) => coerce_to_bytes(field_name, value),
         FieldOption::Hnsw(_) | FieldOption::Flat(_) | FieldOption::Ivf(_) => {
             coerce_to_vector(field_name, value)
@@ -242,6 +243,16 @@ fn coerce_to_geo(field_name: &str, value: DataValue) -> Result<DataValue> {
     }
 }
 
+fn coerce_to_geo3d(field_name: &str, value: DataValue) -> Result<DataValue> {
+    match value {
+        DataValue::GeoEcef(p) => Ok(DataValue::GeoEcef(p)),
+        other => Err(LaurusError::invalid_argument(format!(
+            "field '{field_name}': cannot coerce {} to a 3D ECEF geo point",
+            describe(&other)
+        ))),
+    }
+}
+
 fn coerce_to_bytes(field_name: &str, value: DataValue) -> Result<DataValue> {
     match value {
         DataValue::Bytes(data, mime) => Ok(DataValue::Bytes(data, mime)),
@@ -302,7 +313,7 @@ fn describe(value: &DataValue) -> &'static str {
 mod tests {
     use super::*;
     use crate::lexical::core::field::{
-        BooleanOption, FloatOption, GeoOption, IntegerOption, TextOption,
+        BooleanOption, FloatOption, Geo3dOption, GeoOption, IntegerOption, TextOption,
     };
 
     fn integer() -> FieldOption {
@@ -323,6 +334,10 @@ mod tests {
 
     fn geo() -> FieldOption {
         FieldOption::Geo(GeoOption::default())
+    }
+
+    fn geo3d() -> FieldOption {
+        FieldOption::Geo3d(Geo3dOption::default())
     }
 
     #[test]
@@ -449,5 +464,20 @@ mod tests {
             DataValue::Geo(crate::data::GeoPoint::new(35.1, 139.0))
         );
         assert!(coerce_value("g", &geo(), DataValue::Int64(35)).is_err());
+    }
+
+    #[test]
+    fn geo3d_passthrough_only() {
+        let p = crate::data::GeoEcefPoint::new(1_234_567.0, 2_345_678.0, 3_456_789.0);
+        assert_eq!(
+            coerce_value("g3", &geo3d(), DataValue::GeoEcef(p)).unwrap(),
+            DataValue::GeoEcef(p)
+        );
+        // 2D geo cannot coerce to 3D ECEF: the schema declared the field
+        // as Geo3d, so the writer must reject a 2D value rather than
+        // silently lose the altitude dimension.
+        let p2d = crate::data::GeoPoint::new(35.1, 139.0);
+        assert!(coerce_value("g3", &geo3d(), DataValue::Geo(p2d)).is_err());
+        assert!(coerce_value("g3", &geo3d(), DataValue::Int64(35)).is_err());
     }
 }

--- a/laurus/src/engine/type_inference.rs
+++ b/laurus/src/engine/type_inference.rs
@@ -92,10 +92,9 @@ pub fn infer_option_from_data_value(value: &DataValue) -> Result<Option<FieldOpt
             crate::lexical::core::field::DateTimeOption::default(),
         ))),
         DataValue::Geo(_) => Ok(Some(FieldOption::Geo(GeoOption::default()))),
-        DataValue::GeoEcef(_) => Err(LaurusError::invalid_argument(
-            "ECEF (3D geo) values require an explicit Geo3d field declaration \
-             in the schema",
-        )),
+        DataValue::GeoEcef(_) => Ok(Some(FieldOption::Geo3d(
+            crate::lexical::core::field::Geo3dOption::default(),
+        ))),
         DataValue::Int64Array(_) => Ok(Some(FieldOption::Integer(IntegerOption {
             multi_valued: true,
             ..Default::default()
@@ -422,6 +421,34 @@ mod tests {
     fn infer_geo_out_of_range_lon() {
         let err = infer_from_json(&json!({"lat": 35.1, "lon": 200.0})).unwrap_err();
         assert!(err.to_string().contains("longitude"));
+    }
+
+    #[test]
+    fn infer_option_from_data_value_geo_ecef_to_geo3d() {
+        // The dynamic-schema path: a `GeoEcef` value with no declared
+        // option must auto-infer `FieldOption::Geo3d`. Without this, a
+        // ECEF document with a missing schema entry would either fail or
+        // (worse) be silently classified as 2D Geo.
+        let p = crate::data::GeoEcefPoint::new(1.0, 2.0, 3.0);
+        let inferred = infer_option_from_data_value(&DataValue::GeoEcef(p))
+            .unwrap()
+            .expect("GeoEcef must infer some FieldOption");
+        assert!(
+            matches!(inferred, FieldOption::Geo3d(_)),
+            "expected FieldOption::Geo3d, got {inferred:?}"
+        );
+    }
+
+    #[test]
+    fn infer_option_from_data_value_geo_to_geo() {
+        let p = crate::data::GeoPoint::new(35.1, 139.0);
+        let inferred = infer_option_from_data_value(&DataValue::Geo(p))
+            .unwrap()
+            .expect("Geo must infer some FieldOption");
+        assert!(
+            matches!(inferred, FieldOption::Geo(_)),
+            "expected FieldOption::Geo, got {inferred:?}"
+        );
     }
 
     #[test]

--- a/laurus/src/lexical/core/field.rs
+++ b/laurus/src/lexical/core/field.rs
@@ -506,6 +506,49 @@ impl GeoOption {
     }
 }
 
+/// Options for 3D Earth-Centered Earth-Fixed (ECEF) geographic point fields.
+///
+/// ECEF stores points as `(x, y, z)` Cartesian meters (origin at Earth's
+/// center of mass), enabling true 3D queries — sphere distance, k-NN, and
+/// 3D bounding boxes — that 2D `GeoOption` cannot express. Schema fields
+/// declared with `Geo3dOption` accept `DataValue::GeoEcef` values and are
+/// indexed in a 3D BKD tree.
+#[derive(
+    Debug, Clone, PartialEq, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize,
+)]
+pub struct Geo3dOption {
+    /// Whether to index this field for 3D geo queries.
+    #[serde(default = "default_true")]
+    pub indexed: bool,
+
+    /// Whether to store the original value.
+    #[serde(default = "default_true")]
+    pub stored: bool,
+}
+
+impl Geo3dOption {
+    /// Set whether the field is indexed.
+    pub fn indexed(mut self, indexed: bool) -> Self {
+        self.indexed = indexed;
+        self
+    }
+
+    /// Set whether the field is stored.
+    pub fn stored(mut self, stored: bool) -> Self {
+        self.stored = stored;
+        self
+    }
+}
+
+impl Default for Geo3dOption {
+    fn default() -> Self {
+        Self {
+            indexed: true,
+            stored: true,
+        }
+    }
+}
+
 /// Unified field option type that wraps all field-specific options.
 ///
 /// This enum provides a type-safe way to store configuration options
@@ -549,8 +592,12 @@ pub enum FieldOption {
     /// Options for datetime fields.
     DateTime(DateTimeOption),
 
-    /// Options for geographic point fields.
+    /// Options for 2D geographic point fields (WGS84 lat/lon).
     Geo(GeoOption),
+
+    /// Options for 3D Earth-Centered Earth-Fixed (ECEF) geographic point
+    /// fields. See [`Geo3dOption`] for details.
+    Geo3d(Geo3dOption),
 }
 
 impl Default for FieldOption {
@@ -575,13 +622,7 @@ impl FieldOption {
             }
             FieldValue::DateTime(_) => FieldOption::DateTime(DateTimeOption::default()),
             FieldValue::Geo(_) => FieldOption::Geo(GeoOption::default()),
-            // ECEF (3D geo) does not yet have a dedicated FieldOption — a
-            // schema with a `GeoEcef` value still needs an explicit Geo3d
-            // declaration, which is the work of #298. Until then, fall back
-            // to the closest existing option (2D geo) so the schema-less
-            // path keeps compiling. Once #298 lands, swap this for
-            // `FieldOption::Geo3d(Geo3dOption::default())`.
-            FieldValue::GeoEcef(_) => FieldOption::Geo(GeoOption::default()),
+            FieldValue::GeoEcef(_) => FieldOption::Geo3d(Geo3dOption::default()),
             FieldValue::Null => FieldOption::Text(TextOption::default()),
             FieldValue::Int64Array(_) => FieldOption::Integer(IntegerOption {
                 multi_valued: true,

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -410,6 +410,7 @@ impl InvertedIndexWriter {
                 Some(FieldOption::Boolean(opt)) => (opt.indexed, opt.stored),
                 Some(FieldOption::DateTime(opt)) => (opt.indexed, opt.stored),
                 Some(FieldOption::Geo(opt)) => (opt.indexed, opt.stored),
+                Some(FieldOption::Geo3d(opt)) => (opt.indexed, opt.stored),
                 Some(FieldOption::Bytes(opt)) => (false, opt.stored), // Bytes are not lexically indexed
                 None => (true, true), // Internal or schema-less default
             };


### PR DESCRIPTION
## Summary

Wire the schema-level option that 3D ECEF geo fields need so `DataValue::GeoEcef` can finally have a typed home in the schema.

## Schema layer

- New `Geo3dOption { indexed, stored }` in `lexical/core/field.rs`, defaulting both flags to `true` and offering builder methods that match the existing `GeoOption` shape.
- `FieldOption::Geo3d(Geo3dOption)` added to both the lexical-core enum and the engine-facing `engine::schema::FieldOption`. The engine variant is wired into `is_lexical()` and `to_lexical()` so a Geo3d field bridges across to the lexical writer.
- `SchemaBuilder::add_geo3d_field(name, option)` lets user code declare the field as ergonomically as `add_geo_field`.
- `FieldOption::from_field_value` now maps `FieldValue::GeoEcef` to `FieldOption::Geo3d` (replacing the Geo-fallback placeholder added in #297).

## Engine layer

- `infer_option_from_data_value` returns `Geo3d` for `GeoEcef` (was an error in #297 because the variant didn't exist yet). The dynamic schema path can now auto-onboard ECEF documents.
- `coerce_value` gains a `coerce_to_geo3d` arm. A Geo3d field passes ECEF values through and rejects everything else — in particular it **refuses to silently coerce a 2D `GeoPoint` into 3D** so the altitude dimension cannot be quietly lost.
- The lexical writer's per-field `(indexed, stored)` decision now understands `FieldOption::Geo3d`, and `engine::is_field_stored` honours the new variant.

## Bindings

- `laurus-cli` shows "Geo3d" in field-type labels and treats it as a lexical field for the create-index flow.
- `laurus-server` skips Geo3d in the proto field-option converter with a comment pointing at #305, where the dedicated `Geo3dOption` proto message will land.

## Test plan

- [x] `cargo test -p laurus` — 728 lib tests + all integration tests pass (was 724; +4 new).
- [x] `cargo clippy -p laurus -p laurus-cli -p laurus-server -p laurus-mcp -p laurus-python -p laurus-nodejs -p laurus-wasm -p laurus-php --tests --benches -- -D warnings` — pass.
- [x] `cargo fmt --check` — pass.
- [x] **type_coercion**: `geo3d_passthrough_only` — ECEF-in / ECEF-out passthrough + rejection of 2D Geo and Int64.
- [x] **type_inference**: `infer_option_from_data_value_geo_ecef_to_geo3d` pins the `GeoEcef → Geo3d` dynamic-schema mapping; sibling test guards `GeoPoint → Geo`.
- [x] **engine schema**: `schema_builder_add_geo3d_field_round_trips` covers `SchemaBuilder` ergonomics, the engine ↔ lexical bridge, and the lexical/vector classification flags.

Refs #289
Closes #298