### PR TITLE
feat(writer): wire Geo3d field through inverted index writer/reader

### DIFF
--- a/laurus/src/lexical/core/parser.rs
+++ b/laurus/src/lexical/core/parser.rs
@@ -264,11 +264,12 @@ impl DocumentParser {
                     point_values.insert(field_name.clone(), vec![vec![point.lat, point.lon]]);
                 }
                 FieldValue::GeoEcef(point) => {
-                    // 3D ECEF point: store the (x, y, z) tuple as a single
-                    // BKD point. The dedicated `Geo3d` schema option and
-                    // optimized writer paths arrive in #298 / #299; for now
-                    // we mirror the 2D geo flow (text term + point values)
-                    // so a `GeoEcef`-bearing document can still round-trip.
+                    // 3D ECEF point: index the (x, y, z) tuple as a single
+                    // BKD entry. Mirrors the 2D Geo flow (text term + point
+                    // values); `FieldOption::Geo3d` (#298) drives the
+                    // schema-side decisions and `BKDWriter` infers the
+                    // dimensionality from the point length, so emitting a
+                    // 3-element point here is enough to land on a 3D BKD.
                     let text = format!("{},{},{}", point.x, point.y, point.z);
 
                     let analyzed_term = AnalyzedTerm {

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -522,6 +522,15 @@ impl SegmentReader {
                             }
                             FieldValue::Float64Array(arr)
                         }
+                        12 => {
+                            // 3D ECEF point. Tag 12 (not 11) — see the
+                            // matching writer comment for why ECEF was
+                            // remapped during #299.
+                            let x = reader.read_f64()?;
+                            let y = reader.read_f64()?;
+                            let z = reader.read_f64()?;
+                            FieldValue::GeoEcef(crate::data::GeoEcefPoint::new(x, y, z))
+                        }
                         _ => {
                             return Err(LaurusError::index(format!(
                                 "Unknown field type tag: {type_tag}"

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -504,11 +504,12 @@ impl InvertedIndexWriter {
                         point_values.insert(field_name.clone(), vec![vec![p.lat, p.lon]]);
                     }
                     DataValue::GeoEcef(p) => {
-                        // 3D ECEF points are indexed as 3D points in BKD.
-                        // Once #298 introduces FieldOption::Geo3d this branch
-                        // will gain dedicated handling; for now mirror the
-                        // 2D Geo flow so a GeoEcef-bearing document still
-                        // makes it onto disk.
+                        // 3D ECEF point: emitting a 3-element point here is
+                        // what tells `BKDWriter::new` to build a 3D BKD when
+                        // the per-field tree is materialized. Schema-side,
+                        // `FieldOption::Geo3d` (#298) classifies the field
+                        // as lexical and respects the (indexed, stored)
+                        // flags exactly like 2D Geo.
                         field_terms.insert(
                             field_name.clone(),
                             vec![AnalyzedTerm {
@@ -791,11 +792,11 @@ impl InvertedIndexWriter {
                         stored_writer.write_f64(p.lon)?;
                     }
                     crate::data::DataValue::GeoEcef(p) => {
-                        // Type tag 11 is reserved for 3D ECEF points; reader
-                        // support follows in #299. For now we emit the bytes
-                        // so a round-trip through the writer is at least
-                        // lossless.
-                        stored_writer.write_u8(11)?;
+                        // Type tag 12 = 3D ECEF point. Tag 11 was originally
+                        // claimed for ECEF in #297 but collided with the
+                        // pre-existing Float64Array tag (also 11); #299
+                        // moves ECEF to tag 12 and wires reader support.
+                        stored_writer.write_u8(12)?;
                         stored_writer.write_f64(p.x)?;
                         stored_writer.write_f64(p.y)?;
                         stored_writer.write_f64(p.z)?;

--- a/laurus/src/lexical/index/structures/bkd_tree.rs
+++ b/laurus/src/lexical/index/structures/bkd_tree.rs
@@ -606,6 +606,17 @@ pub struct BKDReader {
 }
 
 impl BKDReader {
+    /// Borrow the file header parsed at `open` time.
+    ///
+    /// Useful for callers that need to inspect the dimensionality, point
+    /// count, or global AABB of an existing tree without performing a
+    /// query (e.g. integration tests, schema introspection tooling).
+    pub fn header(&self) -> &BKDFileHeader {
+        &self.header
+    }
+}
+
+impl BKDReader {
     /// Open a BKD tree from storage and path.
     pub fn open(storage: Arc<dyn Storage>, path: &str) -> Result<Self> {
         let input = storage.open_input(path)?;

--- a/laurus/src/lib.rs
+++ b/laurus/src/lib.rs
@@ -71,7 +71,7 @@ pub mod vector;
 
 // Re-exports for the public API
 pub use analysis::analyzer::analyzer::Analyzer;
-pub use data::{DataValue, Document};
+pub use data::{DataValue, Document, GeoEcefPoint, GeoPoint};
 #[cfg(feature = "embeddings-candle")]
 pub use embedding::candle_bert_embedder::CandleBertEmbedder;
 #[cfg(feature = "embeddings-multimodal")]

--- a/laurus/tests/geo3d_writer_test.rs
+++ b/laurus/tests/geo3d_writer_test.rs
@@ -1,0 +1,163 @@
+//! End-to-end integration test for 3D ECEF geo field handling in the
+//! inverted index writer/reader pair.
+//!
+//! Covers the full path that #299 wires up:
+//! - `DataValue::GeoEcef` ingested via `add_geo_ecef` flows through the
+//!   document parser into `point_values` of length 3.
+//! - `BKDWriter` materializes a 3D BKD because the points are 3-element.
+//! - The stored-field deserializer reads tag 12 back as
+//!   `FieldValue::GeoEcef`.
+//! - A `range_search` over the BKD returns the expected doc ids and the
+//!   round-tripped `GeoEcefPoint` values match what was indexed.
+//!
+//! Sample points are deliberately spread across an order-of-magnitude
+//! range on each axis so a narrow query box exercises the BKD's pruning
+//! paths and confirms that all three dimensions are honoured.
+
+use laurus::lexical::LexicalIndexWriter;
+use laurus::lexical::{InvertedIndexWriter, InvertedIndexWriterConfig};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::{DataValue, Document, GeoEcefPoint};
+use std::sync::Arc;
+
+#[test]
+fn geo3d_round_trip_through_writer_and_reader() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let config = InvertedIndexWriterConfig {
+        max_buffered_docs: 10,
+        ..Default::default()
+    };
+    let mut writer = InvertedIndexWriter::new(storage.clone(), config).unwrap();
+
+    // Three ECEF points, picked so that the per-axis ranges differ by an
+    // order of magnitude (this is what makes widest-axis splitting
+    // observable, and what would expose any 2D-vs-3D dim mismatch).
+    let p_a = GeoEcefPoint::new(1_000_000.0, 2_000_000.0, 3_000_000.0);
+    let p_b = GeoEcefPoint::new(1_000_500.0, 2_005_000.0, 3_050_000.0);
+    let p_c = GeoEcefPoint::new(2_000_000.0, 4_000_000.0, 6_000_000.0);
+
+    writer
+        .add_document(
+            Document::builder()
+                .add_field("position", DataValue::GeoEcef(p_a))
+                .add_field("name", DataValue::Text("A".into()))
+                .build(),
+        )
+        .unwrap();
+    writer
+        .add_document(
+            Document::builder()
+                .add_field("position", DataValue::GeoEcef(p_b))
+                .add_field("name", DataValue::Text("B".into()))
+                .build(),
+        )
+        .unwrap();
+    writer
+        .add_document(
+            Document::builder()
+                .add_field("position", DataValue::GeoEcef(p_c))
+                .add_field("name", DataValue::Text("C".into()))
+                .build(),
+        )
+        .unwrap();
+
+    writer.commit().unwrap();
+
+    // The per-field BKD is named after the segment + field name. Confirm
+    // it landed on disk before going further; if we miss this the next
+    // assertion will fail with a less obvious message.
+    assert!(
+        storage.file_exists("segment_000000.position.bkd"),
+        "expected the writer to materialize a 3D BKD for the position field"
+    );
+
+    let reader = writer.build_reader().unwrap();
+
+    // Stored-field round-trip: docs come back with their GeoEcef intact.
+    // This exercises the new tag-12 path on the reader side.
+    let doc_a = reader.document(0).unwrap().expect("doc 0 must exist");
+    let doc_b = reader.document(1).unwrap().expect("doc 1 must exist");
+    let doc_c = reader.document(2).unwrap().expect("doc 2 must exist");
+    assert_eq!(
+        doc_a.get("position").and_then(|v| v.as_geo_ecef()),
+        Some(p_a)
+    );
+    assert_eq!(
+        doc_b.get("position").and_then(|v| v.as_geo_ecef()),
+        Some(p_b)
+    );
+    assert_eq!(
+        doc_c.get("position").and_then(|v| v.as_geo_ecef()),
+        Some(p_c)
+    );
+
+    // BKD round-trip: a narrow 3D range that should match only A and B
+    // (their x/y/z all sit in the lower half of every axis).
+    let bkd_tree = reader
+        .get_bkd_tree("position")
+        .unwrap()
+        .expect("position field must have a BKD tree");
+    let mut hits = bkd_tree
+        .range_search(
+            &[Some(0.0), Some(0.0), Some(0.0)],
+            &[Some(1_500_000.0), Some(2_500_000.0), Some(3_500_000.0)],
+            true,
+            true,
+        )
+        .unwrap();
+    hits.sort_unstable();
+    assert_eq!(hits, vec![0, 1]);
+
+    // Wider query: include C (which lives in the upper octant).
+    let mut all_hits = bkd_tree
+        .range_search(
+            &[Some(0.0), Some(0.0), Some(0.0)],
+            &[Some(3_000_000.0), Some(5_000_000.0), Some(7_000_000.0)],
+            true,
+            true,
+        )
+        .unwrap();
+    all_hits.sort_unstable();
+    assert_eq!(all_hits, vec![0, 1, 2]);
+}
+
+#[test]
+fn geo3d_dimension_observable_through_bkd_header() {
+    use laurus::lexical::index::structures::bkd_tree::BKDReader;
+
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut writer = InvertedIndexWriter::new(
+        storage.clone(),
+        InvertedIndexWriterConfig {
+            max_buffered_docs: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    writer
+        .add_document(
+            Document::builder()
+                .add_field(
+                    "position",
+                    DataValue::GeoEcef(GeoEcefPoint::new(1.0, 2.0, 3.0)),
+                )
+                .build(),
+        )
+        .unwrap();
+    writer.commit().unwrap();
+
+    // Pop the BKD reader off the segment directly so we can inspect the
+    // dimensionality the writer chose. A 3D BKD is exactly what we want;
+    // a 2D one would mean the GeoEcef branch fell back to the 2D Geo flow.
+    let bkd = BKDReader::open(
+        storage.clone() as Arc<dyn Storage>,
+        "segment_000000.position.bkd",
+    )
+    .unwrap();
+    let header = bkd.header();
+    assert_eq!(header.num_dims, 3, "ECEF must produce a 3D BKD");
+    assert_eq!(header.bytes_per_dim, 8);
+    assert_eq!(header.total_point_count, 1);
+}


### PR DESCRIPTION
## Summary

End-to-end indexing path for ECEF (3D geo) documents.

## Stored-field type tag fix

- #297 claimed tag 11 for `DataValue::GeoEcef`, but tag 11 was already spoken for by `DataValue::Float64Array`. **Move ECEF to tag 12** and add the matching reader case so a stored GeoEcef value round-trips back as `FieldValue::GeoEcef` instead of a corrupt `Float64Array` (or an "Unknown field type tag" error). Comments at both ends point at this PR for context.

## Writer / parser

- Both the inverted-index writer's live-indexing branch and the document parser already emit 3-element point values for `DataValue::GeoEcef` (added defensively in #297). With #298 having introduced `FieldOption::Geo3d`, those branches no longer need defer-to-the-future commentary; the comments are updated to reflect the now-final design (`BKDWriter` chooses 3D from the point length, and the schema-side classification falls out of `FieldOption::Geo3d`).

## Public API

- `laurus::GeoPoint` and `laurus::GeoEcefPoint` are re-exported at the crate root next to `DataValue` so downstream code (and tests) doesn't need to dive into `laurus::data` (which is private).
- `BKDReader::header()` is now a `pub` accessor on `&BKDFileHeader`, so external code can introspect dimensionality and global AABB without going through a query — useful for tests and tooling.

## New tests (`tests/geo3d_writer_test.rs`)

- **`geo3d_round_trip_through_writer_and_reader`**: ingests three ECEF documents whose per-axis ranges differ by an order of magnitude, confirms the per-field BKD lands on disk, that stored fields round back as `GeoEcef` via the new tag-12 path, and that a narrow 3D range query returns the expected doc ids while a wider one expands the result set as expected.
- **`geo3d_dimension_observable_through_bkd_header`**: opens the BKD file directly and asserts `num_dims == 3` so a future regression that funnels `GeoEcef` through the 2D Geo path would fail loudly.

## Test plan

- [x] `cargo test -p laurus` — 728 lib + all integration tests pass (incl. 2 new in `geo3d_writer_test`).
- [x] `cargo clippy -p laurus -p laurus-cli -p laurus-server -p laurus-mcp -p laurus-python -p laurus-nodejs -p laurus-wasm -p laurus-php --tests --benches -- -D warnings` — pass.
- [x] `cargo fmt --check` — pass.

Refs #289
Closes #299