### PR TITLE
feat(query): introduce Geo3dNearestQuery (k-NN, expanding-radius)

### DIFF
--- a/laurus/src/lexical/query.rs
+++ b/laurus/src/lexical/query.rs
@@ -23,7 +23,10 @@ pub use advanced_query::AdvancedQuery;
 pub use boolean::{BooleanQuery, BooleanQueryBuilder};
 pub use fuzzy::FuzzyQuery;
 pub use geo::{GeoBoundingBox, GeoBoundingBoxQuery, GeoDistanceQuery, GeoPoint, GeoQuery};
-pub use geo3d::{Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dMatch, Geo3dMatcher, Geo3dScorer};
+pub use geo3d::{
+    Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dMatch, Geo3dMatcher, Geo3dNearestQuery,
+    Geo3dScorer,
+};
 pub use multi_term::MultiTermQuery;
 pub use parser::LexicalQueryParser;
 pub use phrase::PhraseQuery;

--- a/laurus/src/lexical/query/geo3d.rs
+++ b/laurus/src/lexical/query/geo3d.rs
@@ -14,8 +14,10 @@
 //!   ECEF point lies within `radius_m` meters of the query center.
 //! - [`Geo3dBoundingBoxQuery`] — 3D axis-aligned box search: every doc
 //!   whose stored ECEF point falls inside the closed `[min, max]` box.
-//!
-//! The k-NN flavour arrives in #302.
+//! - [`Geo3dNearestQuery`] — k-nearest-neighbour search: the `k` docs
+//!   whose stored ECEF points lie closest to the query center, returned
+//!   in distance-ascending order. Built on an expanding-radius loop on
+//!   top of the same BKD `intersect` primitive.
 //!
 //! # How sphere queries reach the BKD
 //!
@@ -552,6 +554,327 @@ impl Query for Geo3dBoundingBoxQuery {
     }
 }
 
+/// k-nearest-neighbour query against an ECEF-typed field.
+///
+/// Returns the `k` documents whose stored [`GeoEcefPoint`] lies closest
+/// to `center`, sorted distance-ascending. Implemented as a sphere
+/// query whose radius doubles until at least `k` candidates have been
+/// collected (or the index is exhausted, or `max_radius_m` is reached).
+///
+/// Unlike [`Geo3dDistanceQuery`], the visitor here never lets the BKD
+/// short-circuit a subtree as Inside: k-NN ordering needs the *exact*
+/// per-point distance, and the Inside path skips reading the
+/// coordinates. The trade-off is slightly less aggressive pruning in
+/// exchange for stable ordering.
+///
+/// # Configuration
+///
+/// - `initial_radius_m`: first radius the loop probes. Default `1000.0`
+///   (1 km). Picking this close to the expected nearest-neighbour
+///   distance avoids wasted work.
+/// - `max_radius_m`: ceiling for the doubling loop. Default `1e10`
+///   meters (well beyond Earth radius), large enough that the loop
+///   terminates because either `k` candidates are found or the index
+///   has been visited in full.
+///
+/// # Termination
+///
+/// The loop exits as soon as one of these holds:
+/// 1. The number of distinct candidates collected reaches `k`.
+/// 2. Doubling the radius produced no additional hits — the index is
+///    exhausted.
+/// 3. The next radius would exceed `max_radius_m`.
+///
+/// In every case the result is truncated to the top-`k` by distance,
+/// so a smaller-than-`k` result simply means the index does not contain
+/// `k` indexed points within `max_radius_m`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Geo3dNearestQuery {
+    field: String,
+    center: GeoEcefPoint,
+    k: usize,
+    initial_radius_m: f64,
+    max_radius_m: f64,
+    boost: f32,
+}
+
+impl Geo3dNearestQuery {
+    /// Initial sphere radius used for the first probe (meters).
+    pub const DEFAULT_INITIAL_RADIUS_M: f64 = 1_000.0;
+    /// Upper bound for the expanding radius loop (meters). 10⁷ km is
+    /// well beyond any real ECEF distance.
+    pub const DEFAULT_MAX_RADIUS_M: f64 = 1.0e10;
+
+    /// Construct a new k-NN query with the default radius schedule.
+    pub fn new<F: Into<String>>(field: F, center: GeoEcefPoint, k: usize) -> Self {
+        Self {
+            field: field.into(),
+            center,
+            k,
+            initial_radius_m: Self::DEFAULT_INITIAL_RADIUS_M,
+            max_radius_m: Self::DEFAULT_MAX_RADIUS_M,
+            boost: 1.0,
+        }
+    }
+
+    /// Override the initial probe radius.
+    pub fn with_initial_radius(mut self, radius_m: f64) -> Self {
+        self.initial_radius_m = radius_m.max(0.0);
+        self
+    }
+
+    /// Override the doubling-loop ceiling.
+    pub fn with_max_radius(mut self, radius_m: f64) -> Self {
+        self.max_radius_m = radius_m.max(0.0);
+        self
+    }
+
+    /// Set the boost factor applied to every match's score.
+    pub fn with_boost(mut self, boost: f32) -> Self {
+        self.boost = boost;
+        self
+    }
+
+    /// Field name this query targets.
+    pub fn field(&self) -> &str {
+        &self.field
+    }
+
+    /// Search center.
+    pub fn center(&self) -> GeoEcefPoint {
+        self.center
+    }
+
+    /// Number of neighbours requested.
+    pub fn k(&self) -> usize {
+        self.k
+    }
+
+    /// Initial probe radius (meters).
+    pub fn initial_radius_m(&self) -> f64 {
+        self.initial_radius_m
+    }
+
+    /// Doubling-loop ceiling (meters).
+    pub fn max_radius_m(&self) -> f64 {
+        self.max_radius_m
+    }
+
+    /// Run the query and return the top-`k` matches in distance-ascending
+    /// order. Score is normalized so that the closest hit gets `1.0` and
+    /// the farthest hit in the returned set gets `0.0`.
+    pub fn find_matches(&self, reader: &dyn LexicalIndexReader) -> Result<Vec<Geo3dMatch>> {
+        if self.k == 0 {
+            return Ok(Vec::new());
+        }
+        let Some(bkd) = reader.get_bkd_tree(&self.field)? else {
+            return Ok(Vec::new());
+        };
+
+        // Expanding-radius loop. Start at `initial_radius_m`, double the
+        // radius until we collect at least k distinct hits or the radius
+        // ceiling is reached. We deliberately do NOT short-circuit on
+        // "no growth this iteration": a doubling can fail to add any
+        // hits and still reveal new ones a few doublings later (e.g.
+        // points clustered far away beyond an empty annulus). Bounding
+        // the loop only by `max_radius_m` is safe because doubling from
+        // `initial_radius_m` (default 1 km) to `max_radius_m` (default
+        // 10⁷ km) takes about 23 iterations — and once we hit k we
+        // exit immediately, which is the usual case in practice.
+        let mut radius = self.initial_radius_m.max(0.0);
+        let visitor: NearestVisitor;
+
+        loop {
+            let mut current = NearestVisitor::new(self.center, radius);
+            bkd.intersect(&mut current)?;
+
+            // Deduplicate by doc_id (multi-segment readers can produce
+            // duplicates) to get an accurate "unique candidates" count.
+            let mut deduped = current.hits.clone();
+            deduped.sort_by(|a, b| {
+                a.doc_id.cmp(&b.doc_id).then_with(|| {
+                    a.distance_sq
+                        .partial_cmp(&b.distance_sq)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+            });
+            deduped.dedup_by_key(|h| h.doc_id);
+            let unique_count = deduped.len();
+
+            // Termination #1: collected enough.
+            if unique_count >= self.k {
+                current.hits = deduped;
+                visitor = current;
+                break;
+            }
+
+            // Termination #2: hit the radius ceiling — return whatever
+            // we found (fewer than k means the index does not contain
+            // k points within `max_radius_m`).
+            if radius >= self.max_radius_m {
+                current.hits = deduped;
+                visitor = current;
+                break;
+            }
+
+            // Double the radius (capped at the ceiling). A starting
+            // radius of zero gets bumped to a small positive value so
+            // doubling can make progress.
+            let next = if radius == 0.0 {
+                self.max_radius_m.min(1.0)
+            } else {
+                (radius * 2.0).min(self.max_radius_m)
+            };
+            if next == radius {
+                current.hits = deduped;
+                visitor = current;
+                break;
+            }
+            radius = next;
+        }
+
+        // Final sort by distance ascending and truncation to top-k.
+        let mut hits = visitor.hits;
+        hits.sort_by(|a, b| {
+            a.distance_sq
+                .partial_cmp(&b.distance_sq)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        hits.truncate(self.k);
+
+        // Normalize scores against the farthest distance in the returned
+        // set: closest gets 1.0, farthest gets 0.0. Single-hit results
+        // and all-coincident results normalize to 1.0.
+        let max_distance = hits.last().map(|h| h.distance_sq.sqrt()).unwrap_or(0.0);
+
+        Ok(hits
+            .into_iter()
+            .map(|h| {
+                let distance = h.distance_sq.sqrt();
+                let score = if max_distance == 0.0 {
+                    1.0
+                } else {
+                    (1.0 - distance / max_distance).clamp(0.0, 1.0) as f32
+                };
+                Geo3dMatch {
+                    doc_id: h.doc_id,
+                    distance_m: distance,
+                    score,
+                }
+            })
+            .collect())
+    }
+}
+
+/// `IntersectVisitor` for k-NN. Always returns `Outside` or `Crosses`
+/// from `compare` — never `Inside` — so every candidate goes through
+/// `visit` with its exact coordinates and the visitor can record an
+/// exact distance for k-NN ordering.
+struct NearestVisitor {
+    center: [f64; 3],
+    radius_sq: f64,
+    hits: Vec<NearestHit>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NearestHit {
+    doc_id: u64,
+    distance_sq: f64,
+}
+
+impl NearestVisitor {
+    fn new(center: GeoEcefPoint, radius_m: f64) -> Self {
+        let r = radius_m.max(0.0);
+        Self {
+            center: [center.x, center.y, center.z],
+            radius_sq: r * r,
+            hits: Vec::new(),
+        }
+    }
+}
+
+impl IntersectVisitor for NearestVisitor {
+    fn compare(&self, cell: &AABB) -> CellRelation {
+        debug_assert_eq!(cell.num_dims(), 3, "NearestVisitor expects a 3D BKD");
+        let min_d_sq = cell.min_distance_sq_to_point(&self.center);
+        if min_d_sq > self.radius_sq {
+            CellRelation::Outside
+        } else {
+            // Always Crosses: k-NN needs the exact per-point distance,
+            // which the Inside path withholds.
+            CellRelation::Crosses
+        }
+    }
+
+    fn visit_inside(&mut self, _doc_id: u64) {
+        // Unreachable in practice — `compare` never returns Inside —
+        // but if a future BKD impl chooses to call this we ignore the
+        // hit (we have no exact distance to record for k-NN ordering).
+    }
+
+    fn visit(&mut self, doc_id: u64, point: &[f64]) {
+        debug_assert_eq!(point.len(), 3, "NearestVisitor expects a 3D BKD");
+        let dx = point[0] - self.center[0];
+        let dy = point[1] - self.center[1];
+        let dz = point[2] - self.center[2];
+        let d_sq = dx * dx + dy * dy + dz * dz;
+        if d_sq <= self.radius_sq {
+            self.hits.push(NearestHit {
+                doc_id,
+                distance_sq: d_sq,
+            });
+        }
+    }
+}
+
+impl Query for Geo3dNearestQuery {
+    fn matcher(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Matcher>> {
+        Ok(Box::new(Geo3dMatcher::new(self.find_matches(reader)?)))
+    }
+
+    fn scorer(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Scorer>> {
+        Ok(Box::new(Geo3dScorer::new(
+            self.find_matches(reader)?,
+            self.boost,
+        )))
+    }
+
+    fn boost(&self) -> f32 {
+        self.boost
+    }
+
+    fn set_boost(&mut self, boost: f32) {
+        self.boost = boost;
+    }
+
+    fn clone_box(&self) -> Box<dyn Query> {
+        Box::new(self.clone())
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "Geo3dNearestQuery(field: {}, center: {:?}, k: {}, initial_radius: {}m, max_radius: {}m)",
+            self.field, self.center, self.k, self.initial_radius_m, self.max_radius_m
+        )
+    }
+
+    fn is_empty(&self, _reader: &dyn LexicalIndexReader) -> Result<bool> {
+        Ok(self.k == 0)
+    }
+
+    fn cost(&self, reader: &dyn LexicalIndexReader) -> Result<u64> {
+        // The expanding-radius loop visits the index roughly once per
+        // doubling iteration in the worst case; bound at doc_count * 4
+        // to give the planner a moderate-cost signal.
+        let doc_count = reader.doc_count();
+        Ok(doc_count.saturating_mul(4))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -677,6 +1000,52 @@ mod tests {
             q.is_ok(),
             "box with zero extent on one axis must be accepted"
         );
+    }
+
+    #[test]
+    fn geo3d_nearest_query_basics() {
+        let q = Geo3dNearestQuery::new("position", GeoEcefPoint::new(1.0, 2.0, 3.0), 5)
+            .with_initial_radius(100.0)
+            .with_max_radius(1_000_000.0)
+            .with_boost(2.5);
+        assert_eq!(q.field(), "position");
+        assert_eq!(q.center(), GeoEcefPoint::new(1.0, 2.0, 3.0));
+        assert_eq!(q.k(), 5);
+        assert_eq!(q.initial_radius_m(), 100.0);
+        assert_eq!(q.max_radius_m(), 1_000_000.0);
+        assert_eq!(q.boost(), 2.5);
+        let cloned = q.clone_box();
+        assert!(cloned.description().contains("Geo3dNearestQuery"));
+    }
+
+    #[test]
+    fn nearest_visitor_compare_outside_when_cell_too_far() {
+        let v = NearestVisitor::new(GeoEcefPoint::new(0.0, 0.0, 0.0), 5.0);
+        let c = cell([100.0, 100.0, 100.0], [110.0, 110.0, 110.0]);
+        assert_eq!(v.compare(&c), CellRelation::Outside);
+    }
+
+    #[test]
+    fn nearest_visitor_never_returns_inside() {
+        // Tight cell wholly inside a huge sphere — `SphereVisitor`
+        // would say Inside; `NearestVisitor` must say Crosses so the
+        // BKD streams the points and we can compute exact distances.
+        let v = NearestVisitor::new(GeoEcefPoint::new(0.0, 0.0, 0.0), 10_000.0);
+        let c = cell([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]);
+        assert_eq!(v.compare(&c), CellRelation::Crosses);
+    }
+
+    #[test]
+    fn nearest_visitor_visit_records_exact_distance() {
+        let mut v = NearestVisitor::new(GeoEcefPoint::new(0.0, 0.0, 0.0), 100.0);
+        v.visit(1, &[3.0, 4.0, 0.0]); // dist 5
+        v.visit(2, &[0.0, 0.0, 6.0]); // dist 6
+        v.visit(3, &[200.0, 0.0, 0.0]); // outside
+        assert_eq!(v.hits.len(), 2);
+        assert_eq!(v.hits[0].doc_id, 1);
+        assert_eq!(v.hits[0].distance_sq, 25.0);
+        assert_eq!(v.hits[1].doc_id, 2);
+        assert_eq!(v.hits[1].distance_sq, 36.0);
     }
 
     #[test]

--- a/laurus/tests/geo3d_writer_test.rs
+++ b/laurus/tests/geo3d_writer_test.rs
@@ -16,7 +16,7 @@
 
 use laurus::lexical::LexicalIndexWriter;
 use laurus::lexical::query::Query;
-use laurus::lexical::query::{Geo3dBoundingBoxQuery, Geo3dDistanceQuery};
+use laurus::lexical::query::{Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery};
 use laurus::lexical::{InvertedIndexWriter, InvertedIndexWriterConfig};
 use laurus::storage::Storage;
 use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
@@ -374,4 +374,97 @@ fn geo3d_bbox_query_finds_docs_inside_box() {
         assert_eq!(m.score, 1.0);
         assert_eq!(m.distance_m, 0.0);
     }
+}
+
+#[test]
+fn geo3d_nearest_query_finds_top_k_in_distance_order() {
+    // Index five points along the x-axis at increasing distances from
+    // the origin, then exercise the k-NN query at various k values and
+    // initial-radius settings.
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut writer = InvertedIndexWriter::new(
+        storage.clone(),
+        InvertedIndexWriterConfig {
+            max_buffered_docs: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let center = GeoEcefPoint::new(0.0, 0.0, 0.0);
+    // Doc i sits at (10^i, 0, 0): 1, 10, 100, 1000, 10000.
+    let positions = [1.0_f64, 10.0, 100.0, 1_000.0, 10_000.0];
+    for &x in &positions {
+        writer
+            .add_document(
+                Document::builder()
+                    .add_field(
+                        "position",
+                        DataValue::GeoEcef(GeoEcefPoint::new(x, 0.0, 0.0)),
+                    )
+                    .build(),
+            )
+            .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let reader = writer.build_reader().unwrap();
+
+    // k=1: closest doc is doc 0 (distance 1).
+    let q1 = Geo3dNearestQuery::new("position", center, 1);
+    let m1 = q1.find_matches(&*reader).unwrap();
+    assert_eq!(m1.len(), 1);
+    assert_eq!(m1[0].doc_id, 0);
+    assert_eq!(m1[0].distance_m, 1.0);
+
+    // k=3: docs 0, 1, 2 in distance order.
+    let q3 = Geo3dNearestQuery::new("position", center, 3);
+    let m3 = q3.find_matches(&*reader).unwrap();
+    let ids3: Vec<u64> = m3.iter().map(|m| m.doc_id).collect();
+    assert_eq!(ids3, vec![0, 1, 2]);
+    // Distance-ascending: each subsequent hit is farther than the last.
+    for w in m3.windows(2) {
+        assert!(w[0].distance_m <= w[1].distance_m);
+    }
+    // Score: monotonically decreasing as distance grows, with the
+    // farthest hit normalized to 0.0 by `1 - distance/max_distance`.
+    assert!(m3[0].score > m3[1].score);
+    assert!(m3[1].score > m3[2].score);
+    assert_eq!(m3[2].score, 0.0);
+    // m3[0] is the closest of the returned top-k; with positions
+    // {1, 10, 100} it scores `1 - 1/100 = 0.99`, very close to 1.0.
+    assert!((m3[0].score - 0.99).abs() < 1e-4);
+
+    // k > #docs: returns all docs (5).
+    let q_all = Geo3dNearestQuery::new("position", center, 100);
+    let m_all = q_all.find_matches(&*reader).unwrap();
+    assert_eq!(m_all.len(), 5);
+    let ids_all: Vec<u64> = m_all.iter().map(|m| m.doc_id).collect();
+    assert_eq!(ids_all, vec![0, 1, 2, 3, 4]);
+
+    // k=0: empty result.
+    let q0 = Geo3dNearestQuery::new("position", center, 0);
+    assert!(q0.find_matches(&*reader).unwrap().is_empty());
+    assert!(q0.is_empty(&*reader).unwrap());
+
+    // Convergence with a tiny initial radius: even though the loop
+    // starts at 1m (smaller than the closest doc), it must double up
+    // until 5 hits are collected.
+    let q_small_init = Geo3dNearestQuery::new("position", center, 5).with_initial_radius(0.5);
+    let m_si = q_small_init.find_matches(&*reader).unwrap();
+    assert_eq!(m_si.len(), 5);
+    let ids_si: Vec<u64> = m_si.iter().map(|m| m.doc_id).collect();
+    assert_eq!(ids_si, vec![0, 1, 2, 3, 4]);
+
+    // Sparse: query center far from every point. With default initial
+    // radius (1km), the first probe finds nothing — the loop must keep
+    // doubling until the index is exhausted within max_radius.
+    let far_center = GeoEcefPoint::new(1_000_000.0, 0.0, 0.0);
+    let q_far = Geo3dNearestQuery::new("position", far_center, 2);
+    let m_far = q_far.find_matches(&*reader).unwrap();
+    assert_eq!(m_far.len(), 2);
+    // Closest to (1e6, 0, 0) is doc 4 at (10000, 0, 0), then doc 3 at
+    // (1000, 0, 0).
+    assert_eq!(m_far[0].doc_id, 4);
+    assert_eq!(m_far[1].doc_id, 3);
 }


### PR DESCRIPTION
## Summary

Add the k-nearest-neighbour query that closes Phase E of #289.

## Design

- `Geo3dNearestQuery { field, center, k, initial_radius_m, max_radius_m, boost }` lives next to `Geo3dDistanceQuery` / `Geo3dBoundingBoxQuery` in `lexical/query/geo3d.rs`.
- The query starts a `NearestVisitor` with `initial_radius_m` (default 1 km), runs `bkd.intersect`, and either returns the top-`k` by exact distance or doubles the radius and tries again. Doubling is bounded by `max_radius_m` (default 10 million km — well beyond Earth radius, so the loop terminates on `k` hits or on the ceiling).
- Builder methods `with_initial_radius` / `with_max_radius` / `with_boost` let callers tune the loop or stack a query boost.

## Visitor

- New `NearestVisitor` always returns `Outside` or `Crosses` from `compare`; it **never returns `Inside`**. The Inside short-circuit would suppress per-point coordinates, but k-NN ordering needs the exact distance for every candidate, so the trade-off is to give up some pruning to keep the ordering stable.
- `visit_inside` is a no-op (unreachable with the current `compare`, but defensive in case a future BKD impl decides to invoke it).

## Termination

The loop exits as soon as either:

1. At least `k` distinct hits have been collected, or
2. The radius has reached `max_radius_m`.

A previous draft also tried a "no growth" heuristic, but a single doubling can fail to add hits and still reveal new ones a few doublings later (e.g. points clustered far away beyond an empty annulus), so growth-based termination is unsafe — bounding by `max_radius_m` alone is.

Score normalization: closest = `1.0`, k-th = `0.0` (`1 - distance / max_distance_in_topk`). Single-hit and all-coincident sets normalize to `1.0`.

## Test plan (5 new tests)

- [x] **Unit (4)**:
  - `geo3d_nearest_query_basics` — getters / builder / description.
  - `nearest_visitor_compare_outside_when_cell_too_far`.
  - `nearest_visitor_never_returns_inside` — asserts the always-Crosses invariant.
  - `nearest_visitor_visit_records_exact_distance`.
- [x] **Integration (1)**: `geo3d_nearest_query_finds_top_k_in_distance_order` indexes five ECEF docs at distances `{1, 10, 100, 1000, 10000}m` from the origin and exercises `k=1` / `k=3` / `k > #docs` / `k=0` / convergence with a tiny (0.5m) initial radius / sparse query at `(1e6, 0, 0)`. Confirms distance-ascending ordering, score monotonicity, and that the convergence loop survives multiple doublings before finding the first hit.
- [x] `cargo test -p laurus` — 748 lib + all integration tests pass (was 744; +4 new lib tests).
- [x] `cargo clippy -p laurus -p laurus-cli -p laurus-server -p laurus-mcp -p laurus-python -p laurus-nodejs -p laurus-wasm -p laurus-php --tests --benches -- -D warnings` — pass.
- [x] `cargo fmt --check` — pass.

Refs #289
Closes #302