### PR TITLE
feat(grpc/mcp): expose 3D geo (Geo3d) on the gRPC + MCP API surface

### DIFF
--- a/laurus-mcp/src/convert.rs
+++ b/laurus-mcp/src/convert.rs
@@ -77,6 +77,7 @@ fn proto_value_to_json(val: &v1::Value) -> Value {
             }
         }
         Some(Kind::GeoValue(g)) => json!({ "lat": g.latitude, "lon": g.longitude }),
+        Some(Kind::Geo3dValue(p)) => json!({ "x": p.x, "y": p.y, "z": p.z }),
         Some(Kind::Int64ArrayValue(arr)) => json!(arr.values),
         Some(Kind::Float64ArrayValue(arr)) => json!(arr.values),
     }
@@ -102,7 +103,34 @@ fn json_to_proto_value(val: &Value) -> v1::Value {
                 arr.iter().map(|v| v.as_f64().map(|f| f as f32)).collect();
             floats.map(|values| Kind::VectorValue(v1::VectorValue { values }))
         }
-        Value::Object(_) => Some(Kind::NullValue(true)),
+        Value::Object(obj) => {
+            // 3D ECEF point: { x, y, z } — must be checked before 2D geo
+            // since both are objects.
+            if let (Some(x), Some(y), Some(z)) = (
+                obj.get("x").and_then(|v| v.as_f64()),
+                obj.get("y").and_then(|v| v.as_f64()),
+                obj.get("z").and_then(|v| v.as_f64()),
+            ) {
+                Some(Kind::Geo3dValue(v1::Geo3dPoint { x, y, z }))
+            } else if let (Some(lat), Some(lon)) = (
+                // 2D geo point: { lat, lon } (also accepts the full names
+                // "latitude" / "longitude" for symmetry with the gateway
+                // converter that infers `DataValue::Geo` from JSON).
+                obj.get("lat")
+                    .or_else(|| obj.get("latitude"))
+                    .and_then(|v| v.as_f64()),
+                obj.get("lon")
+                    .or_else(|| obj.get("longitude"))
+                    .and_then(|v| v.as_f64()),
+            ) {
+                Some(Kind::GeoValue(v1::GeoPoint {
+                    latitude: lat,
+                    longitude: lon,
+                }))
+            } else {
+                Some(Kind::NullValue(true))
+            }
+        }
     };
     v1::Value { kind }
 }
@@ -311,5 +339,61 @@ mod tests {
             doc.fields["vec_field"].kind,
             Some(v1::value::Kind::VectorValue(_))
         ));
+    }
+
+    #[test]
+    fn json_to_proto_geo_3d_object() {
+        // `{ x, y, z }` JSON input must be encoded as a Geo3dValue proto
+        // kind so MCP `put_document` can pass ECEF coordinates through
+        // to laurus-server.
+        let json_val =
+            json!({ "position": { "x": 1_000_000.0, "y": 2_000_000.0, "z": 3_000_000.0 } });
+        let doc = json_to_document(json_val).unwrap();
+        match &doc.fields["position"].kind {
+            Some(v1::value::Kind::Geo3dValue(p)) => {
+                assert_eq!(p.x, 1_000_000.0);
+                assert_eq!(p.y, 2_000_000.0);
+                assert_eq!(p.z, 3_000_000.0);
+            }
+            other => panic!("expected Geo3dValue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_proto_geo_2d_object() {
+        // `{ lat, lon }` (and the long-form `latitude` / `longitude`)
+        // produces a 2D GeoValue. Confirms #305 wiring did not break
+        // the historical 2D shape.
+        let json_val = json!({
+            "spot_a": { "lat": 35.6, "lon": 139.7 },
+            "spot_b": { "latitude": -33.86, "longitude": 151.21 },
+        });
+        let doc = json_to_document(json_val).unwrap();
+        for field in ["spot_a", "spot_b"] {
+            assert!(
+                matches!(doc.fields[field].kind, Some(v1::value::Kind::GeoValue(_))),
+                "{field} must be GeoValue"
+            );
+        }
+    }
+
+    #[test]
+    fn proto_to_json_geo_3d_round_trip() {
+        // Reverse direction: a Geo3dValue from the server is surfaced
+        // to MCP clients as `{ x, y, z }`.
+        let mut fields = HashMap::new();
+        fields.insert(
+            "position".to_string(),
+            v1::Value {
+                kind: Some(v1::value::Kind::Geo3dValue(v1::Geo3dPoint {
+                    x: 4.0,
+                    y: 5.0,
+                    z: 6.0,
+                })),
+            },
+        );
+        let doc = v1::Document { fields };
+        let json = document_to_json(&doc);
+        assert_eq!(json["position"], json!({"x": 4.0, "y": 5.0, "z": 6.0}));
     }
 }

--- a/laurus-server/proto/laurus/v1/common.proto
+++ b/laurus-server/proto/laurus/v1/common.proto
@@ -15,6 +15,7 @@ message Value {
     GeoPoint geo_value = 9;
     Int64ArrayValue int64_array_value = 10;
     Float64ArrayValue float64_array_value = 11;
+    Geo3dPoint geo3d_value = 12;
   }
 }
 
@@ -37,6 +38,17 @@ message Float64ArrayValue {
 message GeoPoint {
   double latitude = 1;
   double longitude = 2;
+}
+
+// A 3D Earth-Centered Earth-Fixed (ECEF) Cartesian point in meters.
+// Origin is the Earth's center of mass; units are meters on every axis.
+// Suitable for true 3D geospatial queries (drone proximity, satellite
+// tracking, indoor 3D positioning) where altitude is a first-class
+// dimension that 2D `GeoPoint` cannot represent.
+message Geo3dPoint {
+  double x = 1;
+  double y = 2;
+  double z = 3;
 }
 
 // A document consisting of named fields.

--- a/laurus-server/proto/laurus/v1/index.proto
+++ b/laurus-server/proto/laurus/v1/index.proto
@@ -74,6 +74,7 @@ message FieldOption {
     HnswOption hnsw = 8;
     FlatOption flat = 9;
     IvfOption ivf = 10;
+    Geo3dOption geo3d = 11;
   }
 }
 
@@ -115,6 +116,14 @@ message DateTimeOption {
 }
 
 message GeoOption {
+  bool indexed = 1;
+  bool stored = 2;
+}
+
+// Options for 3D ECEF (Earth-Centered Earth-Fixed) geographic point fields.
+// Indexed values are stored in a 3D BKD tree and queryable via the
+// `geo3d_distance` / `geo3d_bbox` / `geo3d_nearest` DSL forms.
+message Geo3dOption {
   bool indexed = 1;
   bool stored = 2;
 }

--- a/laurus-server/src/convert/document.rs
+++ b/laurus-server/src/convert/document.rs
@@ -58,14 +58,10 @@ pub fn data_value_to_proto(val: &DataValue) -> v1::Value {
             latitude: p.lat,
             longitude: p.lon,
         })),
-        DataValue::GeoEcef(p) => Some(Kind::GeoValue(v1::GeoPoint {
-            // Reuse the existing GeoPoint proto kind for now: the dedicated
-            // GeoEcef proto message lands with #305 (gRPC/MCP API surface
-            // for 3D geo). Fall back to lat=x, lon=y so the value at least
-            // round-trips to bytes; once #305 lands this branch is replaced
-            // with `Kind::Geo3dValue`.
-            latitude: p.x,
-            longitude: p.y,
+        DataValue::GeoEcef(p) => Some(Kind::Geo3dValue(v1::Geo3dPoint {
+            x: p.x,
+            y: p.y,
+            z: p.z,
         })),
         DataValue::Int64Array(arr) => Some(Kind::Int64ArrayValue(v1::Int64ArrayValue {
             values: arr.clone(),
@@ -102,8 +98,47 @@ pub fn data_value_from_proto(val: &v1::Value) -> DataValue {
             laurus::lexical::GeoPoint::try_new(g.latitude, g.longitude)
                 .unwrap_or_else(|_| laurus::lexical::GeoPoint::new(0.0, 0.0)),
         ),
+        Some(Kind::Geo3dValue(p)) => DataValue::GeoEcef(laurus::GeoEcefPoint::new(p.x, p.y, p.z)),
         Some(Kind::Int64ArrayValue(arr)) => DataValue::Int64Array(arr.values.clone()),
         Some(Kind::Float64ArrayValue(arr)) => DataValue::Float64Array(arr.values.clone()),
         None => DataValue::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use laurus::GeoEcefPoint;
+
+    /// `DataValue::GeoEcef` round-trips through the new `Geo3dValue`
+    /// proto kind added in #305 (it used to be encoded as a `GeoValue`
+    /// fallback that quietly lost the `z` component).
+    #[test]
+    fn data_value_geo_ecef_round_trip() {
+        let original =
+            DataValue::GeoEcef(GeoEcefPoint::new(1_234_567.0, -2_345_678.0, 3_456_789.5));
+        let proto = data_value_to_proto(&original);
+        match &proto.kind {
+            Some(v1::value::Kind::Geo3dValue(p)) => {
+                assert_eq!(p.x, 1_234_567.0);
+                assert_eq!(p.y, -2_345_678.0);
+                assert_eq!(p.z, 3_456_789.5);
+            }
+            other => panic!("expected Geo3dValue, got {other:?}"),
+        }
+        let back = data_value_from_proto(&proto);
+        assert_eq!(back, original);
+    }
+
+    /// `DataValue::Geo` continues to use the 2D `GeoValue` proto kind,
+    /// so adding the `Geo3dValue` variant in #305 cannot disturb the
+    /// existing 2D wire format.
+    #[test]
+    fn data_value_geo_still_uses_2d_kind() {
+        let original = DataValue::Geo(laurus::lexical::GeoPoint::new(35.1, 139.0));
+        let proto = data_value_to_proto(&original);
+        assert!(matches!(proto.kind, Some(v1::value::Kind::GeoValue(_))));
+        let back = data_value_from_proto(&proto);
+        assert_eq!(back, original);
     }
 }

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 use laurus::{
     AnalyzerDefinition, BooleanOption, BytesOption, CharFilterConfig, DateTimeOption,
     DistanceMetric, DynamicFieldPolicy, EmbedderDefinition, FieldOption, FlatOption, FloatOption,
-    GeoOption, HnswOption, IntegerOption, IvfOption, QuantizationMethod, Schema, TextOption,
-    TokenFilterConfig, TokenizerConfig,
+    Geo3dOption, GeoOption, HnswOption, IntegerOption, IvfOption, QuantizationMethod, Schema,
+    TextOption, TokenFilterConfig, TokenizerConfig,
 };
 
 use crate::proto::laurus::v1;
@@ -132,11 +132,10 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
             indexed: o.indexed,
             stored: o.stored,
         })),
-        // Geo3d (3D ECEF) does not yet have a proto representation; the
-        // dedicated `Geo3dOption` proto message lands with #305 (gRPC/MCP
-        // API for 3D geo). Until then, skip the variant — receivers can
-        // distinguish Geo3d fields via the schema kind once #305 lands.
-        FieldOption::Geo3d(_) => None,
+        FieldOption::Geo3d(o) => Some(Opt::Geo3d(v1::Geo3dOption {
+            indexed: o.indexed,
+            stored: o.stored,
+        })),
         FieldOption::Bytes(o) => Some(Opt::Bytes(v1::BytesOption { stored: o.stored })),
         FieldOption::Hnsw(o) => Some(Opt::Hnsw(v1::HnswOption {
             dimension: o.dimension as u32,
@@ -206,6 +205,10 @@ pub fn field_option_from_proto(fo: &v1::FieldOption) -> Option<FieldOption> {
             stored: o.stored,
         })),
         Some(Opt::Geo(o)) => Some(FieldOption::Geo(GeoOption {
+            indexed: o.indexed,
+            stored: o.stored,
+        })),
+        Some(Opt::Geo3d(o)) => Some(FieldOption::Geo3d(Geo3dOption {
             indexed: o.indexed,
             stored: o.stored,
         })),
@@ -718,5 +721,32 @@ mod tests {
         let proto = to_proto(&schema);
         let back = from_proto(&proto).unwrap();
         assert_eq!(back.dynamic_field_policy, DynamicFieldPolicy::Dynamic);
+    }
+
+    /// `FieldOption::Geo3d` round-trips through the proto `Geo3dOption`
+    /// variant added in #305 (it used to be silently dropped to `None`
+    /// before the proto representation existed).
+    #[test]
+    fn schema_field_option_geo3d_round_trip() {
+        let schema = Schema::builder()
+            .add_geo3d_field(
+                "position",
+                Geo3dOption {
+                    indexed: true,
+                    stored: false,
+                },
+            )
+            .build();
+
+        let proto = to_proto(&schema);
+        let back = from_proto(&proto).expect("from_proto must succeed");
+
+        match back.fields.get("position") {
+            Some(FieldOption::Geo3d(o)) => {
+                assert!(o.indexed);
+                assert!(!o.stored);
+            }
+            other => panic!("expected FieldOption::Geo3d, got {other:?}"),
+        }
     }
 }

--- a/laurus-server/src/gateway/convert.rs
+++ b/laurus-server/src/gateway/convert.rs
@@ -83,6 +83,9 @@ pub fn proto_value_to_json(val: &v1::Value) -> Value {
         Some(Kind::GeoValue(g)) => {
             json!({"latitude": g.latitude, "longitude": g.longitude})
         }
+        Some(Kind::Geo3dValue(p)) => {
+            json!({"x": p.x, "y": p.y, "z": p.z})
+        }
         Some(Kind::Int64ArrayValue(arr)) => {
             Value::Array(arr.values.iter().map(|v| json!(*v)).collect())
         }
@@ -395,6 +398,11 @@ pub fn json_to_proto_field_option(json: &Value) -> Result<v1::FieldOption, Strin
             indexed: v.get("indexed").and_then(|v| v.as_bool()).unwrap_or(false),
             stored: v.get("stored").and_then(|v| v.as_bool()).unwrap_or(false),
         })
+    } else if let Some(v) = obj.get("geo3d") {
+        Opt::Geo3d(v1::Geo3dOption {
+            indexed: v.get("indexed").and_then(|v| v.as_bool()).unwrap_or(false),
+            stored: v.get("stored").and_then(|v| v.as_bool()).unwrap_or(false),
+        })
     } else if let Some(v) = obj.get("bytes") {
         Opt::Bytes(v1::BytesOption {
             stored: v.get("stored").and_then(|v| v.as_bool()).unwrap_or(false),
@@ -442,6 +450,9 @@ fn proto_field_option_to_json(opt: &v1::FieldOption) -> Value {
         }),
         Some(Opt::Geo(v)) => json!({
             "geo": { "indexed": v.indexed, "stored": v.stored }
+        }),
+        Some(Opt::Geo3d(v)) => json!({
+            "geo3d": { "indexed": v.indexed, "stored": v.stored }
         }),
         Some(Opt::Bytes(v)) => json!({
             "bytes": { "stored": v.stored }

--- a/laurus/src/lib.rs
+++ b/laurus/src/lib.rs
@@ -97,7 +97,8 @@ pub use engine::search::{
 pub use engine::type_inference::{InferredValue, infer_from_json, infer_option_from_data_value};
 pub use error::{LaurusError, Result};
 pub use lexical::core::field::{
-    BooleanOption, BytesOption, DateTimeOption, FloatOption, GeoOption, IntegerOption, TextOption,
+    BooleanOption, BytesOption, DateTimeOption, FloatOption, Geo3dOption, GeoOption, IntegerOption,
+    TextOption,
 };
 pub use lexical::search::searcher::{
     LexicalSearchParams, LexicalSearchQuery, LexicalSearchRequest, SortField, SortOrder,


### PR DESCRIPTION
## Summary

Promote the Geo3d wire format from a temporary stub to a first-class proto message so gRPC and MCP clients can store and query 3D ECEF points end-to-end.

## Proto (`laurus-server/proto/laurus/v1`)

- `common.proto`: add `Geo3dPoint { x, y, z }` and a new `geo3d_value` variant on the `Value` oneof (field 12).
- `index.proto`: add `Geo3dOption { indexed, stored }` and the matching `geo3d` variant on `FieldOption.option` (field 11).

## Server converters (`laurus-server/src/convert`)

- `document.rs`: `DataValue::GeoEcef` now encodes as `Kind::Geo3dValue` (replacing the `Kind::GeoValue` fallback added in #297 that quietly lost the `z` axis). The reverse path decodes `Geo3dValue` back into `DataValue::GeoEcef`.
- `schema.rs`: `FieldOption::Geo3d` encodes as `Opt::Geo3d` (replacing the `None` placeholder added in #298 that silently dropped the variant). The reverse path mirrors it.

## Gateway (`laurus-server/src/gateway/convert.rs`)

JSON object `{ x, y, z }` becomes `Opt::Geo3d` on schema input; the reverse direction surfaces a `Geo3dValue` back as the same `{ x, y, z }` shape, so REST clients see ECEF round-trips.

## MCP (`laurus-mcp/src/convert.rs`)

- `json_to_proto_value` now recognises both `{ x, y, z }` (Geo3d) and `{ lat, lon }` / `{ latitude, longitude }` (2D Geo) JSON objects — the existing implementation silently dropped every JSON object to `NullValue`, so this also fixes 2D Geo on the MCP surface as a by-product.
- `proto_value_to_json` renders `Geo3dValue` as `{ x, y, z }`.

## Public API

`laurus::Geo3dOption` is re-exported at the crate root next to `GeoOption` so downstream code (and laurus-server's converter) doesn't need to dive into `laurus::lexical::core::field`.

## Bindings

The Python / Node.js / Wasm / PHP / Ruby bindings call laurus directly (no gRPC); they were already wired in #297 / #299, so this PR does not need to touch them.

## Test plan (6 new tests)

- [x] **server document.rs**: `data_value_geo_ecef_round_trip` (forward + reverse with non-trivial ECEF coordinates) and `data_value_geo_still_uses_2d_kind` (regression guard for the existing 2D wire format).
- [x] **server schema.rs**: `schema_field_option_geo3d_round_trip` walks `SchemaBuilder::add_geo3d_field` through `to_proto` / `from_proto`.
- [x] **mcp convert.rs**: `json_to_proto_geo_3d_object`, `json_to_proto_geo_2d_object`, `proto_to_json_geo_3d_round_trip`.
- [x] `cargo test -p laurus -p laurus-server -p laurus-mcp` — all green (laurus 767 + server 12 schema tests + 26 MCP tests + 0 failures).
- [x] `cargo clippy -p laurus -p laurus-cli -p laurus-server -p laurus-mcp -p laurus-python -p laurus-nodejs -p laurus-wasm -p laurus-php --tests --benches -- -D warnings` — pass.
- [x] `cargo fmt --check` — pass.

Refs #289
Closes #305