### PR TITLE
docs: refresh README Features section for Geo3d, dynamic schema, multi-valued numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ Comprehensive documentation is available online:
 - **Pure Rust Implementation**: Memory-safe and fast performance with zero-cost abstractions.
 - **Hybrid Search**: Seamlessly combine BM25 lexical search with HNSW vector search using configurable fusion strategies.
 - **Multimodal Capabilities**: Native support for text-to-image and image-to-image search via CLIP embeddings.
-- **Rich Query DSL**: Term, phrase, boolean, fuzzy, wildcard, range, geographic, and span queries.
+- **Rich Query DSL**: Term, phrase, boolean, fuzzy, wildcard, range, 2D / 3D geographic (sphere, bounding box, k-NN), and span queries.
 - **Flexible Analysis**: Configurable pipelines for tokenization, normalization, and stemming (including CJK support via [Lindera](https://github.com/lindera/lindera)).
 - **Pluggable Storage**: Interfaces for in-memory, file-system, and memory-mapped storage backends.
+- **Dynamic Schema**: Optional schema-on-write — undeclared fields are inferred from the value, with `Strict` / `Dynamic` / `Ignore` policies for fine-grained control.
+- **Multi-valued Numeric Fields**: Integer and Float fields can hold multiple values per document; range queries match if any value satisfies the predicate (Lucene-style "any match" semantics).
 - **Scoring & Ranking**: BM25 scoring with customizable fusion strategies for hybrid results.
 - **Faceting & Highlighting**: Built-in support for faceted navigation and search result highlighting.
 - **Spelling Correction**: Suggest corrections for misspelled query terms.


### PR DESCRIPTION
## Summary

- Extend the **Rich Query DSL** bullet from `geographic` to `2D / 3D geographic (sphere, bounding box, k-NN)` so the 3D ECEF support added in PR #289 is visible.
- Add a **Dynamic Schema** bullet covering schema-on-write and the `Strict` / `Dynamic` / `Ignore` policies.
- Add a **Multi-valued Numeric Fields** bullet describing the Lucene-style "any match" semantics for range queries.

The new bullets are inserted between *Pluggable Storage* and *Scoring & Ranking* so data-model features are grouped together.

## Test plan

- [x] `git diff README.md` shows only the intended 3-line change (1 modified + 2 added)
- [x] `markdownlint-cli2 "docs/src/**/*.md"` reports zero errors (76 files; README is outside the lint scope but unaffected)
- [ ] Reviewer reads the full Features section and confirms tone / granularity match the surrounding bullets

Closes #329
Refs #331