### PR TITLE
feat(python): expose Geo3d field, value, and query APIs

### DIFF
--- a/laurus-python/src/convert.rs
+++ b/laurus-python/src/convert.rs
@@ -20,14 +20,15 @@ pub fn dict_to_document(py: Python, dict: &Bound<PyDict>) -> PyResult<Document> 
 /// Convert a Python value to a [`DataValue`].
 ///
 /// Type mapping:
-/// - `None`             → `DataValue::Null`
-/// - `bool`             → `DataValue::Bool`  (must be checked before int)
-/// - `int`              → `DataValue::Int64`
-/// - `float`            → `DataValue::Float64`
-/// - `str`              → `DataValue::Text`
-/// - `bytes`            → `DataValue::Bytes`
-/// - `list[float|int]`  → `DataValue::Vector`
-/// - `(lat, lon)` tuple → `DataValue::Geo`
+/// - `None`                → `DataValue::Null`
+/// - `bool`                → `DataValue::Bool`  (must be checked before int)
+/// - `int`                 → `DataValue::Int64`
+/// - `float`               → `DataValue::Float64`
+/// - `str`                 → `DataValue::Text`
+/// - `bytes`               → `DataValue::Bytes`
+/// - `list[float|int]`     → `DataValue::Vector`
+/// - `(lat, lon)` tuple    → `DataValue::Geo`
+/// - `(x, y, z)` tuple     → `DataValue::GeoEcef` (3D ECEF Cartesian, meters)
 pub fn py_to_data_value(_py: Python, obj: &Bound<PyAny>) -> PyResult<DataValue> {
     if obj.is_none() {
         return Ok(DataValue::Null);
@@ -72,6 +73,18 @@ pub fn py_to_data_value(_py: Python, obj: &Bound<PyAny>) -> PyResult<DataValue> 
         let point = laurus::lexical::GeoPoint::try_new(lat, lon)
             .map_err(|e| PyValueError::new_err(format!("invalid geo point: {e}")))?;
         return Ok(DataValue::Geo(point));
+    }
+    // Try tuple (x, y, z) for Geo3d (ECEF Cartesian, meters). Must come
+    // after the 2-tuple Geo check so existing semantics are preserved.
+    if let Ok(tup) = obj.cast::<pyo3::types::PyTuple>()
+        && tup.len() == 3
+        && let (Ok(x), Ok(y), Ok(z)) = (
+            tup.get_item(0)?.extract::<f64>(),
+            tup.get_item(1)?.extract::<f64>(),
+            tup.get_item(2)?.extract::<f64>(),
+        )
+    {
+        return Ok(DataValue::GeoEcef(laurus::GeoEcefPoint::new(x, y, z)));
     }
     // Try Python datetime.datetime
     if let Ok(dt_str) = obj.call_method0("isoformat")

--- a/laurus-python/src/lib.rs
+++ b/laurus-python/src/lib.rs
@@ -20,8 +20,9 @@ use analysis::{PySynonymDictionary, PySynonymGraphFilter, PyToken, PyWhitespaceT
 use index::PyIndex;
 use pyo3::prelude::*;
 use query::{
-    PyBooleanQuery, PyFuzzyQuery, PyGeoQuery, PyNumericRangeQuery, PyPhraseQuery, PySpanQuery,
-    PyTermQuery, PyVectorQuery, PyVectorTextQuery, PyWildcardQuery,
+    PyBooleanQuery, PyFuzzyQuery, PyGeo3dBoundingBoxQuery, PyGeo3dDistanceQuery,
+    PyGeo3dNearestQuery, PyGeoQuery, PyNumericRangeQuery, PyPhraseQuery, PySpanQuery, PyTermQuery,
+    PyVectorQuery, PyVectorTextQuery, PyWildcardQuery,
 };
 use schema::PySchema;
 use search::{PyRRF, PySearchRequest, PySearchResult, PyWeightedSum};
@@ -68,6 +69,9 @@ fn laurus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyWildcardQuery>()?;
     m.add_class::<PyNumericRangeQuery>()?;
     m.add_class::<PyGeoQuery>()?;
+    m.add_class::<PyGeo3dDistanceQuery>()?;
+    m.add_class::<PyGeo3dBoundingBoxQuery>()?;
+    m.add_class::<PyGeo3dNearestQuery>()?;
     m.add_class::<PyBooleanQuery>()?;
     m.add_class::<PySpanQuery>()?;
 

--- a/laurus-python/src/query.rs
+++ b/laurus-python/src/query.rs
@@ -4,9 +4,11 @@
 //! and provides a `build()` method that materializes it into a `Box<dyn Query>`.
 //! Vector query classes produce `VectorSearchQuery` instead.
 
+use laurus::GeoEcefPoint;
 use laurus::lexical::span::{SpanQueryBuilder, SpanQueryWrapper};
 use laurus::lexical::{
-    BooleanQuery, FuzzyQuery, GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
+    BooleanQuery, FuzzyQuery, Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery,
+    GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
 };
 use laurus::vector::Vector;
 use laurus::vector::store::request::QueryVector;
@@ -21,7 +23,8 @@ use pyo3::prelude::*;
 /// Extract a Laurus lexical query from an arbitrary Python object.
 ///
 /// Supports: `TermQuery`, `PhraseQuery`, `FuzzyQuery`, `WildcardQuery`,
-/// `NumericRangeQuery`, `GeoQuery`, `BooleanQuery`, `SpanQuery`.
+/// `NumericRangeQuery`, `GeoQuery`, `Geo3dDistanceQuery`,
+/// `Geo3dBoundingBoxQuery`, `Geo3dNearestQuery`, `BooleanQuery`, `SpanQuery`.
 pub fn extract_lexical_query(
     py: Python,
     obj: &Bound<PyAny>,
@@ -48,6 +51,15 @@ pub fn extract_lexical_query(
     }
     if let Ok(q) = obj.extract::<PyRef<PyGeoQuery>>() {
         return q.build().map_err(|e| PyValueError::new_err(e.to_string()));
+    }
+    if let Ok(q) = obj.extract::<PyRef<PyGeo3dDistanceQuery>>() {
+        return Ok(q.build());
+    }
+    if let Ok(q) = obj.extract::<PyRef<PyGeo3dBoundingBoxQuery>>() {
+        return q.build().map_err(|e| PyValueError::new_err(e.to_string()));
+    }
+    if let Ok(q) = obj.extract::<PyRef<PyGeo3dNearestQuery>>() {
+        return Ok(q.build());
     }
     if let Ok(q) = obj.extract::<PyRef<PyBooleanQuery>>() {
         return q.build_query(py);
@@ -482,6 +494,215 @@ impl PyGeoQuery {
                 *max_lon,
             )?)),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Geo3dDistanceQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF sphere query: matches documents whose stored `(x, y, z)` point
+/// lies within `radius_m` meters of the given centre.
+///
+/// ## Example
+///
+/// ```python
+/// q = laurus.Geo3dDistanceQuery("position", -3955182.0, 3350553.0, 3700276.0, 5000.0)
+/// ```
+#[pyclass(name = "Geo3dDistanceQuery")]
+pub struct PyGeo3dDistanceQuery {
+    pub field: String,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub radius_m: f64,
+}
+
+#[pymethods]
+impl PyGeo3dDistanceQuery {
+    /// Create a 3D distance (sphere) query.
+    ///
+    /// Args:
+    ///     field: Geo3d field name.
+    ///     x, y, z: Centre coordinates in ECEF meters.
+    ///     radius_m: Sphere radius in meters.
+    #[new]
+    pub fn new(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
+        Self {
+            field,
+            x,
+            y,
+            z,
+            radius_m,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Geo3dDistanceQuery(field='{}', x={}, y={}, z={}, radius_m={})",
+            self.field, self.x, self.y, self.z, self.radius_m
+        )
+    }
+}
+
+impl PyGeo3dDistanceQuery {
+    pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
+        Box::new(Geo3dDistanceQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.x, self.y, self.z),
+            self.radius_m,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Geo3dBoundingBoxQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF axis-aligned bounding box query.
+///
+/// ## Example
+///
+/// ```python
+/// q = laurus.Geo3dBoundingBoxQuery(
+///     "position",
+///     -3962000.0, 3340000.0, 3690000.0,
+///     -3958000.0, 3360000.0, 3710000.0,
+/// )
+/// ```
+#[pyclass(name = "Geo3dBoundingBoxQuery")]
+pub struct PyGeo3dBoundingBoxQuery {
+    pub field: String,
+    pub min_x: f64,
+    pub min_y: f64,
+    pub min_z: f64,
+    pub max_x: f64,
+    pub max_y: f64,
+    pub max_z: f64,
+}
+
+#[pymethods]
+impl PyGeo3dBoundingBoxQuery {
+    /// Create a 3D bounding-box query.
+    ///
+    /// Args:
+    ///     field: Geo3d field name.
+    ///     min_x, min_y, min_z: Lower corner of the box.
+    ///     max_x, max_y, max_z: Upper corner of the box.
+    #[new]
+    pub fn new(
+        field: String,
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+    ) -> Self {
+        Self {
+            field,
+            min_x,
+            min_y,
+            min_z,
+            max_x,
+            max_y,
+            max_z,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Geo3dBoundingBoxQuery(field='{}', min=({}, {}, {}), max=({}, {}, {}))",
+            self.field, self.min_x, self.min_y, self.min_z, self.max_x, self.max_y, self.max_z
+        )
+    }
+}
+
+impl PyGeo3dBoundingBoxQuery {
+    pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
+        Ok(Box::new(Geo3dBoundingBoxQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.min_x, self.min_y, self.min_z),
+            GeoEcefPoint::new(self.max_x, self.max_y, self.max_z),
+        )?))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Geo3dNearestQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF k-nearest-neighbours query.
+///
+/// ## Example
+///
+/// ```python
+/// q = laurus.Geo3dNearestQuery("position", -3955182.0, 3350553.0, 3700276.0, k=10)
+/// ```
+#[pyclass(name = "Geo3dNearestQuery")]
+pub struct PyGeo3dNearestQuery {
+    pub field: String,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub k: usize,
+    pub initial_radius_m: Option<f64>,
+    pub max_radius_m: Option<f64>,
+}
+
+#[pymethods]
+impl PyGeo3dNearestQuery {
+    /// Create a 3D k-NN query.
+    ///
+    /// Args:
+    ///     field: Geo3d field name.
+    ///     x, y, z: Centre coordinates in ECEF meters.
+    ///     k: Number of nearest neighbours to return.
+    ///     initial_radius_m: Starting radius for the expanding-radius
+    ///         search (default 1000 m). Optional.
+    ///     max_radius_m: Hard cap on the search radius (default 1e10 m).
+    ///         Optional.
+    #[new]
+    #[pyo3(signature = (field, x, y, z, k, *, initial_radius_m=None, max_radius_m=None))]
+    pub fn new(
+        field: String,
+        x: f64,
+        y: f64,
+        z: f64,
+        k: usize,
+        initial_radius_m: Option<f64>,
+        max_radius_m: Option<f64>,
+    ) -> Self {
+        Self {
+            field,
+            x,
+            y,
+            z,
+            k,
+            initial_radius_m,
+            max_radius_m,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Geo3dNearestQuery(field='{}', x={}, y={}, z={}, k={})",
+            self.field, self.x, self.y, self.z, self.k
+        )
+    }
+}
+
+impl PyGeo3dNearestQuery {
+    pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
+        let centre = GeoEcefPoint::new(self.x, self.y, self.z);
+        let mut q = Geo3dNearestQuery::new(&self.field, centre, self.k);
+        if let Some(r) = self.initial_radius_m {
+            q = q.with_initial_radius(r);
+        }
+        if let Some(r) = self.max_radius_m {
+            q = q.with_max_radius(r);
+        }
+        Box::new(q)
     }
 }
 

--- a/laurus-python/src/schema.rs
+++ b/laurus-python/src/schema.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 
 use laurus::{
     BooleanOption, BytesOption, DateTimeOption, DistanceMetric, DynamicFieldPolicy,
-    EmbedderDefinition, FieldOption, FlatOption, FloatOption, GeoOption, HnswOption, IntegerOption,
-    IvfOption, Schema, TextOption,
+    EmbedderDefinition, FieldOption, FlatOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
+    IntegerOption, IvfOption, Schema, TextOption,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -154,6 +154,20 @@ impl PySchema {
         self.inner.fields.insert(
             name.to_string(),
             FieldOption::Geo(GeoOption { indexed, stored }),
+        );
+    }
+
+    /// Add a 3D ECEF Cartesian point field (x, y, z in meters).
+    ///
+    /// Values are submitted as a 3-tuple `(x, y, z)` of floats and are
+    /// queryable via `Geo3dDistanceQuery`, `Geo3dBoundingBoxQuery`, and
+    /// `Geo3dNearestQuery`. See the conceptual docs at
+    /// `docs/src/concepts/geo3d.md` for the coordinate system.
+    #[pyo3(signature = (name, *, stored=true, indexed=true))]
+    pub fn add_geo3d_field(&mut self, name: &str, stored: bool, indexed: bool) {
+        self.inner.fields.insert(
+            name.to_string(),
+            FieldOption::Geo3d(Geo3dOption { indexed, stored }),
         );
     }
 

--- a/laurus-python/tests/test_geo3d.py
+++ b/laurus-python/tests/test_geo3d.py
@@ -80,11 +80,17 @@ def test_geo3d_distance_query_wide_radius(geo3d_index):
 
 def test_geo3d_bounding_box_query(geo3d_index):
     """Central-Tokyo box returns Tower + Skytree only (Mt. Fuji and Sydney
-    are outside the small AABB)."""
+    are outside the small AABB).
+
+    The X bounds are sized to bracket both `TOKYO_TOWER.x ≈ -3.955M` and
+    `TOKYO_SKYTREE.x ≈ -3.961M` while still excluding Mt. Fuji
+    (`x ≈ -3.916M`, well above the upper bound) and Sydney (`x ≈ -4.65M`,
+    well below the lower bound).
+    """
     query = laurus.Geo3dBoundingBoxQuery(
         "position",
         -3_962_000.0, 3_340_000.0, 3_690_000.0,
-        -3_958_000.0, 3_360_000.0, 3_710_000.0,
+        -3_954_000.0, 3_360_000.0, 3_710_000.0,
     )
     results = geo3d_index.search(query, limit=10)
     ids = {r.id for r in results}

--- a/laurus-python/tests/test_geo3d.py
+++ b/laurus-python/tests/test_geo3d.py
@@ -1,0 +1,139 @@
+"""Integration tests for Geo3d (3D ECEF) APIs.
+
+Covers:
+- Schema declaration via `add_geo3d_field`.
+- Document round-trip with `(x, y, z)` 3-tuple values.
+- All three 3D query classes: `Geo3dDistanceQuery`, `Geo3dBoundingBoxQuery`,
+  `Geo3dNearestQuery`.
+
+Coordinates are precomputed ECEF values for well-known landmarks. They were
+produced by `laurus::util::ecef::wgs84_to_ecef` so the values match what the
+core engine emits at runtime.
+"""
+
+import pytest
+import laurus
+
+
+# Precomputed ECEF coordinates (meters) for landmarks. Produced offline via
+# `wgs84_to_ecef(lat, lon, height)`.
+TOKYO_TOWER = (-3955182.0, 3350553.0, 3700276.0)
+TOKYO_SKYTREE = (-3961178.0, 3346187.0, 3702490.0)
+MT_FUJI = (-3916073.0, 3437037.0, 3672751.0)
+SYDNEY = (-4646847.0, 2553022.0, -3534121.0)
+
+
+@pytest.fixture
+def geo3d_index():
+    """Return an in-memory index with a Geo3d-typed `position` field."""
+    schema = laurus.Schema()
+    schema.add_text_field("name")
+    schema.add_geo3d_field("position")
+    idx = laurus.Index(schema=schema)
+    idx.put_document("tokyo_tower", {"name": "Tokyo Tower", "position": TOKYO_TOWER})
+    idx.put_document("tokyo_skytree", {"name": "Tokyo Skytree", "position": TOKYO_SKYTREE})
+    idx.put_document("mt_fuji", {"name": "Mt. Fuji summit", "position": MT_FUJI})
+    idx.put_document("sydney", {"name": "Sydney Opera House", "position": SYDNEY})
+    idx.commit()
+    return idx
+
+
+# ---------------------------------------------------------------------------
+# Schema and document round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_geo3d_field_round_trip(geo3d_index):
+    docs = geo3d_index.get_documents("tokyo_tower")
+    assert len(docs) == 1
+    assert docs[0]["name"] == "Tokyo Tower"
+    assert docs[0]["position"] == TOKYO_TOWER
+
+
+# ---------------------------------------------------------------------------
+# Geo3dDistanceQuery
+# ---------------------------------------------------------------------------
+
+
+def test_geo3d_distance_query_small_radius(geo3d_index):
+    """A 50 km sphere around Tokyo Tower should return Tower + Skytree only."""
+    cx, cy, cz = TOKYO_TOWER
+    query = laurus.Geo3dDistanceQuery("position", cx, cy, cz, 50_000.0)
+    results = geo3d_index.search(query, limit=10)
+    ids = {r.id for r in results}
+    assert ids == {"tokyo_tower", "tokyo_skytree"}
+
+
+def test_geo3d_distance_query_wide_radius(geo3d_index):
+    """A 200 km sphere additionally pulls in Mt. Fuji."""
+    cx, cy, cz = TOKYO_TOWER
+    query = laurus.Geo3dDistanceQuery("position", cx, cy, cz, 200_000.0)
+    results = geo3d_index.search(query, limit=10)
+    ids = {r.id for r in results}
+    assert ids == {"tokyo_tower", "tokyo_skytree", "mt_fuji"}
+
+
+# ---------------------------------------------------------------------------
+# Geo3dBoundingBoxQuery
+# ---------------------------------------------------------------------------
+
+
+def test_geo3d_bounding_box_query(geo3d_index):
+    """Central-Tokyo box returns Tower + Skytree only (Mt. Fuji and Sydney
+    are outside the small AABB)."""
+    query = laurus.Geo3dBoundingBoxQuery(
+        "position",
+        -3_962_000.0, 3_340_000.0, 3_690_000.0,
+        -3_958_000.0, 3_360_000.0, 3_710_000.0,
+    )
+    results = geo3d_index.search(query, limit=10)
+    ids = {r.id for r in results}
+    assert ids == {"tokyo_tower", "tokyo_skytree"}
+
+
+# ---------------------------------------------------------------------------
+# Geo3dNearestQuery
+# ---------------------------------------------------------------------------
+
+
+def test_geo3d_nearest_query(geo3d_index):
+    """k = 3 around Mt. Fuji returns Fuji, then Tower / Skytree (in distance
+    order — exact ordering of the close-pair is implementation defined, so
+    only check membership)."""
+    cx, cy, cz = MT_FUJI
+    query = laurus.Geo3dNearestQuery("position", cx, cy, cz, 3)
+    results = geo3d_index.search(query, limit=3)
+    assert len(results) == 3
+    ids = {r.id for r in results}
+    assert ids == {"mt_fuji", "tokyo_tower", "tokyo_skytree"}
+    # Mt. Fuji must be the closest hit.
+    assert results[0].id == "mt_fuji"
+
+
+def test_geo3d_nearest_query_with_radius_options(geo3d_index):
+    """Verify the optional initial / max radius parameters are accepted."""
+    cx, cy, cz = TOKYO_TOWER
+    query = laurus.Geo3dNearestQuery(
+        "position", cx, cy, cz, 2,
+        initial_radius_m=10_000.0,
+        max_radius_m=10_000_000.0,
+    )
+    results = geo3d_index.search(query, limit=2)
+    ids = {r.id for r in results}
+    assert ids == {"tokyo_tower", "tokyo_skytree"}
+
+
+# ---------------------------------------------------------------------------
+# repr()
+# ---------------------------------------------------------------------------
+
+
+def test_geo3d_query_reprs():
+    cx, cy, cz = TOKYO_TOWER
+    assert "Geo3dDistanceQuery" in repr(laurus.Geo3dDistanceQuery("position", cx, cy, cz, 1000.0))
+    assert "Geo3dBoundingBoxQuery" in repr(
+        laurus.Geo3dBoundingBoxQuery("position", 0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+    )
+    assert "Geo3dNearestQuery" in repr(
+        laurus.Geo3dNearestQuery("position", cx, cy, cz, 5)
+    )


### PR DESCRIPTION
## Summary

First of five per-binding PRs that together close #334 (Python → Node.js → Ruby → WASM → PHP). The Python binding only converted `DataValue::GeoEcef` on the *output* side; there was no way to declare a Geo3d schema field, attach a `GeoEcef` value to a document, or run a 3D geo query. This PR closes that gap by mirroring the existing 2D `Geo` shape.

## Changes

- **`laurus-python/src/schema.rs`**: import `Geo3dOption`; add `add_geo3d_field(name, *, stored=True, indexed=True)`.
- **`laurus-python/src/convert.rs`**: `py_to_data_value` accepts a 3-tuple `(x, y, z)` → `DataValue::GeoEcef`. The check is placed *after* the existing 2-tuple Geo check so `(lat, lon)` callers keep their semantics. Type-mapping doc-comment updated.
- **`laurus-python/src/query.rs`**: new `#[pyclass]`es — `PyGeo3dDistanceQuery`, `PyGeo3dBoundingBoxQuery`, `PyGeo3dNearestQuery`. `Nearest` accepts optional `initial_radius_m` / `max_radius_m` kwargs. `extract_lexical_query` gains three arms that build the new queries. `BoundingBox` propagates `Result` errors via `PyValueError`.
- **`laurus-python/src/lib.rs`**: import + `m.add_class::<>()` for the three new Python classes.
- **`laurus-python/tests/test_geo3d.py`**: 7 integration tests covering schema round-trip, `Geo3dDistanceQuery` (small + wide radius), `Geo3dBoundingBoxQuery`, `Geo3dNearestQuery` (default + with radius options), and `repr()` smoke checks.

## Public Python surface

```python
schema = laurus.Schema()
schema.add_geo3d_field(\"position\")

idx = laurus.Index(schema=schema)
idx.put_document(\"d1\", {\"position\": (-3955182.0, 3350553.0, 3700276.0)})
idx.commit()

# Sphere
q = laurus.Geo3dDistanceQuery(\"position\", x, y, z, radius_m=5000.0)
# AABB
q = laurus.Geo3dBoundingBoxQuery(\"position\", min_x, min_y, min_z, max_x, max_y, max_z)
# k-NN (with optional radius bounds)
q = laurus.Geo3dNearestQuery(\"position\", x, y, z, k=10, initial_radius_m=1000.0, max_radius_m=10_000_000.0)
```

`(x, y, z)` 3-tuple `(lat, lon)` 2-tuple are disambiguated by tuple length.

## Test plan

- [x] `cargo build -p laurus-python` succeeds (with `PYO3_PYTHON=/usr/bin/python3`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-python --tests -- -D warnings` clean
- [x] Python syntax check on `tests/test_geo3d.py` (`python3 -m py_compile`)
- [ ] Reviewer / CI runs `pytest tests/test_geo3d.py` after `maturin develop`. Local `maturin develop` could not reach Python (env-specific limitation), so the integration tests are deferred to CI.

## Out of scope

- Documenting the new APIs in `docs/src/laurus-python/api_reference.md` — that lives in #326, which becomes unblocked once **all five** sub-PRs of #334 land.
- The remaining four bindings (Node.js / Ruby / WASM / PHP) — separate sub-PRs.

Refs #334 (1 of 5)
Refs #331