### PR TITLE
feat(nodejs): expose Geo3d field, value, and query APIs

### DIFF
--- a/laurus-nodejs/__tests__/geo3d.spec.mjs
+++ b/laurus-nodejs/__tests__/geo3d.spec.mjs
@@ -1,0 +1,176 @@
+/**
+ * Integration tests for Geo3d (3D ECEF) APIs in the Node.js binding.
+ *
+ * Covers:
+ * - Schema declaration via `addGeo3dField`.
+ * - Document round-trip with `{ x, y, z }` JSON values.
+ * - All three 3D query setters on `SearchRequest`:
+ *   `setLexicalGeo3dDistanceQuery`, `setLexicalGeo3dBoundingBoxQuery`,
+ *   `setLexicalGeo3dNearestQuery`.
+ *
+ * Coordinates are precomputed ECEF values for well-known landmarks. They were
+ * produced by `laurus::util::ecef::wgs84_to_ecef` so the values match what
+ * the core engine emits at runtime.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  Index,
+  Schema,
+  SearchRequest,
+  Geo3dDistanceQuery,
+  Geo3dBoundingBoxQuery,
+  Geo3dNearestQuery,
+} from "../index.js";
+
+// Precomputed ECEF coordinates (meters) for landmarks.
+const TOKYO_TOWER = { x: -3955182.0, y: 3350553.0, z: 3700276.0 };
+const TOKYO_SKYTREE = { x: -3961178.0, y: 3346187.0, z: 3702490.0 };
+const MT_FUJI = { x: -3916073.0, y: 3437037.0, z: 3672751.0 };
+const SYDNEY = { x: -4646847.0, y: 2553022.0, z: -3534121.0 };
+
+async function createGeo3dIndex() {
+  const schema = new Schema();
+  schema.addTextField("name");
+  schema.addGeo3dField("position");
+  const index = await Index.create(null, schema);
+  await index.putDocument("tokyo_tower", { name: "Tokyo Tower", position: TOKYO_TOWER });
+  await index.putDocument("tokyo_skytree", { name: "Tokyo Skytree", position: TOKYO_SKYTREE });
+  await index.putDocument("mt_fuji", { name: "Mt. Fuji summit", position: MT_FUJI });
+  await index.putDocument("sydney", { name: "Sydney Opera House", position: SYDNEY });
+  await index.commit();
+  return index;
+}
+
+describe("Geo3d field round-trip", () => {
+  it("returns the stored {x, y, z} object on get", async () => {
+    const index = await createGeo3dIndex();
+    const docs = await index.getDocuments("tokyo_tower");
+    expect(docs).toHaveLength(1);
+    expect(docs[0].name).toBe("Tokyo Tower");
+    expect(docs[0].position).toEqual(TOKYO_TOWER);
+  });
+});
+
+describe("Geo3dDistanceQuery", () => {
+  it("50 km sphere around Tokyo Tower returns Tower + Skytree", async () => {
+    const index = await createGeo3dIndex();
+    const req = new SearchRequest();
+    req.setLexicalGeo3dDistanceQuery(
+      "position",
+      TOKYO_TOWER.x,
+      TOKYO_TOWER.y,
+      TOKYO_TOWER.z,
+      50_000.0,
+    );
+    const results = await index.searchWithRequest(req);
+    const ids = new Set(results.map((r) => r.id));
+    expect(ids).toEqual(new Set(["tokyo_tower", "tokyo_skytree"]));
+  });
+
+  it("200 km sphere additionally pulls in Mt. Fuji", async () => {
+    const index = await createGeo3dIndex();
+    const req = new SearchRequest();
+    req.setLexicalGeo3dDistanceQuery(
+      "position",
+      TOKYO_TOWER.x,
+      TOKYO_TOWER.y,
+      TOKYO_TOWER.z,
+      200_000.0,
+    );
+    const results = await index.searchWithRequest(req);
+    const ids = new Set(results.map((r) => r.id));
+    expect(ids).toEqual(new Set(["tokyo_tower", "tokyo_skytree", "mt_fuji"]));
+  });
+});
+
+describe("Geo3dBoundingBoxQuery", () => {
+  it("central-Tokyo box returns Tower + Skytree only", async () => {
+    // The X bounds bracket both TOKYO_TOWER.x ≈ -3.955M and
+    // TOKYO_SKYTREE.x ≈ -3.961M while still excluding Mt. Fuji
+    // (x ≈ -3.916M, well above the upper bound) and Sydney
+    // (x ≈ -4.65M, well below the lower bound).
+    const index = await createGeo3dIndex();
+    const req = new SearchRequest();
+    req.setLexicalGeo3dBoundingBoxQuery(
+      "position",
+      -3_962_000.0,
+      3_340_000.0,
+      3_690_000.0,
+      -3_954_000.0,
+      3_360_000.0,
+      3_710_000.0,
+    );
+    const results = await index.searchWithRequest(req);
+    const ids = new Set(results.map((r) => r.id));
+    expect(ids).toEqual(new Set(["tokyo_tower", "tokyo_skytree"]));
+  });
+});
+
+describe("Geo3dNearestQuery", () => {
+  it("k = 3 around Mt. Fuji returns Fuji + Tower + Skytree", async () => {
+    const index = await createGeo3dIndex();
+    const req = new SearchRequest();
+    req.setLexicalGeo3dNearestQuery("position", MT_FUJI.x, MT_FUJI.y, MT_FUJI.z, 3);
+    const results = await index.searchWithRequest(req);
+    expect(results).toHaveLength(3);
+    const ids = new Set(results.map((r) => r.id));
+    expect(ids).toEqual(new Set(["mt_fuji", "tokyo_tower", "tokyo_skytree"]));
+    // Mt. Fuji must be the closest hit.
+    expect(results[0].id).toBe("mt_fuji");
+  });
+
+  it("accepts optional initial / max radius bounds", async () => {
+    const index = await createGeo3dIndex();
+    const req = new SearchRequest();
+    req.setLexicalGeo3dNearestQuery(
+      "position",
+      TOKYO_TOWER.x,
+      TOKYO_TOWER.y,
+      TOKYO_TOWER.z,
+      2,
+      10_000.0,
+      10_000_000.0,
+    );
+    const results = await index.searchWithRequest(req);
+    const ids = new Set(results.map((r) => r.id));
+    expect(ids).toEqual(new Set(["tokyo_tower", "tokyo_skytree"]));
+  });
+});
+
+describe("Geo3d query factory classes", () => {
+  it("Geo3dDistanceQuery.withinSphere creates an instance", () => {
+    const q = Geo3dDistanceQuery.withinSphere(
+      "position",
+      TOKYO_TOWER.x,
+      TOKYO_TOWER.y,
+      TOKYO_TOWER.z,
+      1000.0,
+    );
+    expect(q).toBeDefined();
+  });
+
+  it("Geo3dBoundingBoxQuery.withinBox creates an instance", () => {
+    const q = Geo3dBoundingBoxQuery.withinBox(
+      "position",
+      0.0,
+      0.0,
+      0.0,
+      1.0,
+      1.0,
+      1.0,
+    );
+    expect(q).toBeDefined();
+  });
+
+  it("Geo3dNearestQuery.kNearest creates an instance", () => {
+    const q = Geo3dNearestQuery.kNearest(
+      "position",
+      TOKYO_TOWER.x,
+      TOKYO_TOWER.y,
+      TOKYO_TOWER.z,
+      5,
+    );
+    expect(q).toBeDefined();
+  });
+});

--- a/laurus-nodejs/src/convert.rs
+++ b/laurus-nodejs/src/convert.rs
@@ -41,6 +41,7 @@ pub fn json_to_document(value: &Value) -> napi::Result<Document> {
 /// - `string`                -> `DataValue::Text` (or `DateTime` if ISO8601)
 /// - `array` of numbers      -> `DataValue::Vector`
 /// - `{ "lat", "lon" }`      -> `DataValue::Geo`
+/// - `{ "x", "y", "z" }`     -> `DataValue::GeoEcef` (3D ECEF Cartesian, meters)
 ///
 /// # Arguments
 ///
@@ -91,8 +92,17 @@ pub fn json_to_data_value(value: &Value) -> napi::Result<DataValue> {
                     .map_err(|e| napi::Error::from_reason(format!("invalid geo point: {e}")))?;
                 return Ok(DataValue::Geo(point));
             }
+            // Check for geo3d { x, y, z } (must come after the 2D Geo check
+            // so existing { lat, lon } semantics are preserved).
+            if let (Some(x), Some(y), Some(z)) = (
+                obj.get("x").and_then(|v| v.as_f64()),
+                obj.get("y").and_then(|v| v.as_f64()),
+                obj.get("z").and_then(|v| v.as_f64()),
+            ) {
+                return Ok(DataValue::GeoEcef(laurus::GeoEcefPoint::new(x, y, z)));
+            }
             Err(napi::Error::from_reason(
-                "Cannot convert JSON object to DataValue: expected { lat, lon }",
+                "Cannot convert JSON object to DataValue: expected { lat, lon } or { x, y, z }",
             ))
         }
     }

--- a/laurus-nodejs/src/query.rs
+++ b/laurus-nodejs/src/query.rs
@@ -3,9 +3,11 @@
 //! Each query class stores the data needed to construct the Rust query.
 //! Vector query classes produce `VectorSearchQuery` instead of lexical queries.
 
+use laurus::GeoEcefPoint;
 use laurus::lexical::span::{SpanQueryBuilder, SpanQueryWrapper};
 use laurus::lexical::{
-    BooleanQuery, FuzzyQuery, GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
+    BooleanQuery, FuzzyQuery, Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery,
+    GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
 };
 use laurus::vector::Vector;
 use laurus::vector::store::request::QueryVector;
@@ -41,6 +43,11 @@ pub fn extract_lexical_query(query: &JsQuery) -> Result<Box<dyn laurus::lexical:
         JsQuery::GeoQuery(q) => q
             .build()
             .map_err(|e| napi::Error::from_reason(e.to_string())),
+        JsQuery::Geo3dDistanceQuery(q) => Ok(q.build()),
+        JsQuery::Geo3dBoundingBoxQuery(q) => q
+            .build()
+            .map_err(|e| napi::Error::from_reason(e.to_string())),
+        JsQuery::Geo3dNearestQuery(q) => Ok(q.build()),
         JsQuery::BooleanQuery(q) => q.build_query(),
         JsQuery::SpanQuery(q) => Ok(Box::new(SpanQueryWrapper::new(q.kind.build(&q.field)))),
     }
@@ -96,6 +103,9 @@ pub enum JsQuery {
     WildcardQuery(JsWildcardQuery),
     NumericRangeQuery(JsNumericRangeQuery),
     GeoQuery(JsGeoQuery),
+    Geo3dDistanceQuery(JsGeo3dDistanceQuery),
+    Geo3dBoundingBoxQuery(JsGeo3dBoundingBoxQuery),
+    Geo3dNearestQuery(JsGeo3dNearestQuery),
     BooleanQuery(JsBooleanQuery),
     SpanQuery(JsSpanQuery),
 }
@@ -451,6 +461,203 @@ impl JsGeoQuery {
                 *max_lon,
             )?)),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Geo3dDistanceQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF sphere query: matches documents whose stored `(x, y, z)` point
+/// lies within `radius_m` meters of the given centre.
+///
+/// ## Example
+///
+/// ```javascript
+/// const { Geo3dDistanceQuery } = require("laurus-nodejs");
+/// const q = Geo3dDistanceQuery.withinSphere(
+///     "position", -3955182.0, 3350553.0, 3700276.0, 5000.0,
+/// );
+/// ```
+#[napi(js_name = "Geo3dDistanceQuery")]
+pub struct JsGeo3dDistanceQuery {
+    pub(crate) field: String,
+    pub(crate) x: f64,
+    pub(crate) y: f64,
+    pub(crate) z: f64,
+    pub(crate) radius_m: f64,
+}
+
+#[napi]
+impl JsGeo3dDistanceQuery {
+    /// Create a 3D distance (sphere) query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Geo3d field name.
+    /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
+    /// * `radius_m` - Sphere radius in meters.
+    #[napi(factory)]
+    pub fn within_sphere(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
+        Self {
+            field,
+            x,
+            y,
+            z,
+            radius_m,
+        }
+    }
+}
+
+impl JsGeo3dDistanceQuery {
+    pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
+        Box::new(Geo3dDistanceQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.x, self.y, self.z),
+            self.radius_m,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Geo3dBoundingBoxQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF axis-aligned bounding box query.
+///
+/// ## Example
+///
+/// ```javascript
+/// const { Geo3dBoundingBoxQuery } = require("laurus-nodejs");
+/// const q = Geo3dBoundingBoxQuery.withinBox(
+///     "position",
+///     -3962000.0, 3340000.0, 3690000.0,
+///     -3954000.0, 3360000.0, 3710000.0,
+/// );
+/// ```
+#[napi(js_name = "Geo3dBoundingBoxQuery")]
+pub struct JsGeo3dBoundingBoxQuery {
+    pub(crate) field: String,
+    pub(crate) min_x: f64,
+    pub(crate) min_y: f64,
+    pub(crate) min_z: f64,
+    pub(crate) max_x: f64,
+    pub(crate) max_y: f64,
+    pub(crate) max_z: f64,
+}
+
+#[napi]
+impl JsGeo3dBoundingBoxQuery {
+    /// Create a 3D bounding-box query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Geo3d field name.
+    /// * `min_x`, `min_y`, `min_z` - Lower corner of the box.
+    /// * `max_x`, `max_y`, `max_z` - Upper corner of the box.
+    #[napi(factory)]
+    pub fn within_box(
+        field: String,
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+    ) -> Self {
+        Self {
+            field,
+            min_x,
+            min_y,
+            min_z,
+            max_x,
+            max_y,
+            max_z,
+        }
+    }
+}
+
+impl JsGeo3dBoundingBoxQuery {
+    pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
+        Ok(Box::new(Geo3dBoundingBoxQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.min_x, self.min_y, self.min_z),
+            GeoEcefPoint::new(self.max_x, self.max_y, self.max_z),
+        )?))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Geo3dNearestQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF k-nearest-neighbours query.
+///
+/// ## Example
+///
+/// ```javascript
+/// const { Geo3dNearestQuery } = require("laurus-nodejs");
+/// const q = Geo3dNearestQuery.kNearest(
+///     "position", -3955182.0, 3350553.0, 3700276.0, 10,
+/// );
+/// ```
+#[napi(js_name = "Geo3dNearestQuery")]
+pub struct JsGeo3dNearestQuery {
+    pub(crate) field: String,
+    pub(crate) x: f64,
+    pub(crate) y: f64,
+    pub(crate) z: f64,
+    pub(crate) k: u32,
+    pub(crate) initial_radius_m: Option<f64>,
+    pub(crate) max_radius_m: Option<f64>,
+}
+
+#[napi]
+impl JsGeo3dNearestQuery {
+    /// Create a 3D k-NN query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Geo3d field name.
+    /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
+    /// * `k` - Number of nearest neighbours to return.
+    /// * `initial_radius_m` - Starting radius for the expanding-radius
+    ///   search (default 1000 m). Optional.
+    /// * `max_radius_m` - Hard cap on the search radius (default 1e10 m).
+    ///   Optional.
+    #[napi(factory)]
+    pub fn k_nearest(
+        field: String,
+        x: f64,
+        y: f64,
+        z: f64,
+        k: u32,
+        initial_radius_m: Option<f64>,
+        max_radius_m: Option<f64>,
+    ) -> Self {
+        Self {
+            field,
+            x,
+            y,
+            z,
+            k,
+            initial_radius_m,
+            max_radius_m,
+        }
+    }
+}
+
+impl JsGeo3dNearestQuery {
+    pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
+        let centre = GeoEcefPoint::new(self.x, self.y, self.z);
+        let mut q = Geo3dNearestQuery::new(&self.field, centre, self.k as usize);
+        if let Some(r) = self.initial_radius_m {
+            q = q.with_initial_radius(r);
+        }
+        if let Some(r) = self.max_radius_m {
+            q = q.with_max_radius(r);
+        }
+        Box::new(q)
     }
 }
 

--- a/laurus-nodejs/src/schema.rs
+++ b/laurus-nodejs/src/schema.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 
 use laurus::{
     BooleanOption, BytesOption, DateTimeOption, DistanceMetric, DynamicFieldPolicy,
-    EmbedderDefinition, FieldOption, FlatOption, FloatOption, GeoOption, HnswOption, IntegerOption,
-    IvfOption, Schema, TextOption,
+    EmbedderDefinition, FieldOption, FlatOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
+    IntegerOption, IvfOption, Schema, TextOption,
 };
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -198,6 +198,29 @@ impl JsSchema {
         self.inner.fields.insert(
             name,
             FieldOption::Geo(GeoOption {
+                indexed: indexed.unwrap_or(true),
+                stored: stored.unwrap_or(true),
+            }),
+        );
+    }
+
+    /// Add a 3D ECEF Cartesian point field (x, y, z in meters).
+    ///
+    /// Values are submitted as a `{ x, y, z }` JSON object and are queryable
+    /// via `Geo3dDistanceQuery`, `Geo3dBoundingBoxQuery`, and
+    /// `Geo3dNearestQuery` (passed through `SearchRequest.setLexicalGeo3d*`
+    /// setters). See the conceptual docs at `docs/src/concepts/geo3d.md`.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Field name.
+    /// * `stored` - Whether the value is retrievable (default `true`).
+    /// * `indexed` - Whether the field is searchable (default `true`).
+    #[napi(js_name = "addGeo3dField")]
+    pub fn add_geo3d_field(&mut self, name: String, stored: Option<bool>, indexed: Option<bool>) {
+        self.inner.fields.insert(
+            name,
+            FieldOption::Geo3d(Geo3dOption {
                 indexed: indexed.unwrap_or(true),
                 stored: stored.unwrap_or(true),
             }),

--- a/laurus-nodejs/src/search.rs
+++ b/laurus-nodejs/src/search.rs
@@ -2,8 +2,9 @@
 
 use crate::convert::data_value_to_json;
 use crate::query::{
-    JsPhraseQuery, JsQuery, JsTermQuery, JsVectorQuery, JsVectorQueryInner, JsVectorTextQuery,
-    extract_lexical_query, query_to_lexical_search_query, vector_query_to_search_query,
+    JsGeo3dBoundingBoxQuery, JsGeo3dDistanceQuery, JsGeo3dNearestQuery, JsPhraseQuery, JsQuery,
+    JsTermQuery, JsVectorQuery, JsVectorQueryInner, JsVectorTextQuery, extract_lexical_query,
+    query_to_lexical_search_query, vector_query_to_search_query,
 };
 use laurus::{FusionAlgorithm, LexicalSearchQuery, SearchRequestBuilder, SearchResult};
 use napi::bindgen_prelude::*;
@@ -208,6 +209,94 @@ impl JsSearchRequest {
     #[napi]
     pub fn set_lexical_phrase_query(&mut self, field: String, terms: Vec<String>) {
         self.lexical_query = Some(JsQuery::PhraseQuery(JsPhraseQuery { field, terms }));
+    }
+
+    /// Set a 3D ECEF distance (sphere) query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The Geo3d field name.
+    /// * `x`, `y`, `z` - Sphere centre in ECEF meters.
+    /// * `radius_m` - Sphere radius in meters.
+    #[napi(js_name = "setLexicalGeo3dDistanceQuery")]
+    pub fn set_lexical_geo3d_distance_query(
+        &mut self,
+        field: String,
+        x: f64,
+        y: f64,
+        z: f64,
+        radius_m: f64,
+    ) {
+        self.lexical_query = Some(JsQuery::Geo3dDistanceQuery(JsGeo3dDistanceQuery {
+            field,
+            x,
+            y,
+            z,
+            radius_m,
+        }));
+    }
+
+    /// Set a 3D ECEF axis-aligned bounding-box query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The Geo3d field name.
+    /// * `min_x`, `min_y`, `min_z` - Lower corner of the box.
+    /// * `max_x`, `max_y`, `max_z` - Upper corner of the box.
+    #[napi(js_name = "setLexicalGeo3dBoundingBoxQuery")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_lexical_geo3d_bounding_box_query(
+        &mut self,
+        field: String,
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+    ) {
+        self.lexical_query = Some(JsQuery::Geo3dBoundingBoxQuery(JsGeo3dBoundingBoxQuery {
+            field,
+            min_x,
+            min_y,
+            min_z,
+            max_x,
+            max_y,
+            max_z,
+        }));
+    }
+
+    /// Set a 3D ECEF k-nearest-neighbours query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The Geo3d field name.
+    /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
+    /// * `k` - Number of nearest neighbours to return.
+    /// * `initial_radius_m` - Optional starting radius for the
+    ///   expanding-radius search.
+    /// * `max_radius_m` - Optional hard cap on the search radius.
+    #[napi(js_name = "setLexicalGeo3dNearestQuery")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_lexical_geo3d_nearest_query(
+        &mut self,
+        field: String,
+        x: f64,
+        y: f64,
+        z: f64,
+        k: u32,
+        initial_radius_m: Option<f64>,
+        max_radius_m: Option<f64>,
+    ) {
+        self.lexical_query = Some(JsQuery::Geo3dNearestQuery(JsGeo3dNearestQuery {
+            field,
+            x,
+            y,
+            z,
+            k,
+            initial_radius_m,
+            max_radius_m,
+        }));
     }
 
     /// Set a vector query with a pre-computed embedding.


### PR DESCRIPTION
## Summary

Second of five per-binding sub-PRs for #334. Mirror the Python shape (landed in #342) using NAPI-RS idioms — camelCase methods, factory constructors, `JsQuery` enum + `setLexical*Query` setters.

## Changes

- **`laurus-nodejs/src/schema.rs`**: import `Geo3dOption`; add `addGeo3dField(name, stored?, indexed?)`. Uses `#[napi(js_name = "addGeo3dField")]` so the lower-case `d` is preserved (NAPI's default snake_case→camelCase emits `Geo3D`).
- **`laurus-nodejs/src/convert.rs`**: `json_to_data_value` accepts `{x, y, z}` JSON → `DataValue::GeoEcef`. Placed after the `{lat, lon}` check so existing 2D Geo semantics are preserved.
- **`laurus-nodejs/src/query.rs`**: new `#[napi]`-annotated classes — `Geo3dDistanceQuery` (`withinSphere` factory), `Geo3dBoundingBoxQuery` (`withinBox` factory), `Geo3dNearestQuery` (`kNearest` factory with optional `initialRadiusM` / `maxRadiusM`). Extend `JsQuery` enum with three variants; add the matching arms to `extract_lexical_query`.
- **`laurus-nodejs/src/search.rs`**: three new `SearchRequest` setters — `setLexicalGeo3dDistanceQuery`, `setLexicalGeo3dBoundingBoxQuery`, `setLexicalGeo3dNearestQuery`. Each carries `#[napi(js_name = ...)]` for the lower-case `d`. The bbox and nearest setters add `#[allow(clippy::too_many_arguments)]` (7 / 7 args by design).
- **`laurus-nodejs/__tests__/geo3d.spec.mjs`** (new): 8 Vitest integration tests — schema round-trip, distance (50 km / 200 km), bounding box, k-NN (default + radius bounds), factory smoke checks.

## Public Node.js surface

```javascript
const schema = new Schema();
schema.addGeo3dField("position");
const idx = await Index.create(null, schema);
await idx.putDocument("d1", { position: { x: -3955182.0, y: 3350553.0, z: 3700276.0 } });
await idx.commit();

// Run any 3D query via SearchRequest setters
const req = new SearchRequest();
req.setLexicalGeo3dDistanceQuery("position", x, y, z, 5000.0);
const results = await idx.searchWithRequest(req);

// Or instantiate the factory classes (for future hybrid-search composition)
const sphere = Geo3dDistanceQuery.withinSphere("position", x, y, z, 5000.0);
const box = Geo3dBoundingBoxQuery.withinBox("position", minX, minY, minZ, maxX, maxY, maxZ);
const knn = Geo3dNearestQuery.kNearest("position", x, y, z, 10);
```

`{x, y, z}` and `{lat, lon}` are disambiguated by which keys are present.

## Test plan

- [x] `cargo build -p laurus-nodejs` succeeds
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-nodejs --tests -- -D warnings` clean
- [x] `npm run build:debug` regenerates `index.js` / `index.d.ts` with `addGeo3dField` and `setLexicalGeo3d*Query` (lower-case `d`)
- [x] `npm test` passes — 38 / 38 (existing 30 + new Geo3d 8)

## Notes

- `index.js` and `index.d.ts` are gitignored. NAPI regenerates them at build time, so this PR only ships sources + tests.
- The remaining three bindings (Ruby / WASM / PHP) — separate sub-PRs.
- After all five sub-PRs land, #326 (binding documentation) is unblocked.

Refs #334 (2 of 5)
Refs #331