### PR TITLE
feat(ruby): expose Geo3d field, value, and query APIs

### DIFF
--- a/laurus-ruby/src/convert.rs
+++ b/laurus-ruby/src/convert.rs
@@ -55,6 +55,7 @@ pub fn hash_to_document(ruby: &Ruby, hash: RHash) -> Result<Document, Error> {
 /// | `String`                      | `Text`               |
 /// | `Array` of numerics           | `Vector`             |
 /// | `Hash` with `"lat"`, `"lon"`  | `Geo`                |
+/// | `Hash` with `"x"`, `"y"`, `"z"` | `GeoEcef` (3D ECEF Cartesian, meters) |
 /// | `Time` / ISO 8601 string      | `DateTime`           |
 ///
 /// # Arguments
@@ -97,7 +98,7 @@ pub fn rb_to_data_value(ruby: &Ruby, value: Value) -> Result<DataValue, Error> {
         let vec: Vec<f32> = arr.to_vec()?;
         return Ok(DataValue::Vector(vec));
     }
-    // Hash with "lat"/"lon" → Geo
+    // Hash with "lat"/"lon" → Geo, or with "x"/"y"/"z" → Geo3d
     if value.is_kind_of(ruby.class_hash()) {
         let hash = RHash::from_value(value)
             .ok_or_else(|| Error::new(ruby.exception_type_error(), "expected Hash"))?;
@@ -114,9 +115,20 @@ pub fn rb_to_data_value(ruby: &Ruby, value: Value) -> Result<DataValue, Error> {
             })?;
             return Ok(DataValue::Geo(point));
         }
+        // Geo3d (3D ECEF Cartesian point) — must come after the {lat, lon}
+        // check so existing 2D Geo semantics are preserved.
+        let x_val: Option<Value> = hash.get(ruby.str_new("x"));
+        let y_val: Option<Value> = hash.get(ruby.str_new("y"));
+        let z_val: Option<Value> = hash.get(ruby.str_new("z"));
+        if let (Some(xv), Some(yv), Some(zv)) = (x_val, y_val, z_val) {
+            let x: f64 = magnus::TryConvert::try_convert(xv)?;
+            let y: f64 = magnus::TryConvert::try_convert(yv)?;
+            let z: f64 = magnus::TryConvert::try_convert(zv)?;
+            return Ok(DataValue::GeoEcef(laurus::GeoEcefPoint::new(x, y, z)));
+        }
         return Err(Error::new(
             ruby.exception_arg_error(),
-            "Hash must have 'lat' and 'lon' keys for Geo conversion",
+            "Hash must have 'lat' and 'lon' keys for Geo conversion, or 'x', 'y', 'z' keys for Geo3d",
         ));
     }
     // Try Time → DateTime (call .iso8601 or .to_s)

--- a/laurus-ruby/src/query.rs
+++ b/laurus-ruby/src/query.rs
@@ -5,9 +5,11 @@
 
 use std::cell::RefCell;
 
+use laurus::GeoEcefPoint;
 use laurus::lexical::span::{SpanQueryBuilder, SpanQueryWrapper};
 use laurus::lexical::{
-    BooleanQuery, FuzzyQuery, GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
+    BooleanQuery, FuzzyQuery, Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery,
+    GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
 };
 use laurus::vector::Vector;
 use laurus::vector::store::request::QueryVector;
@@ -23,7 +25,8 @@ use magnus::{Error, RArray, RHash, RModule, Ruby, Value};
 /// Extract a Laurus lexical query from an arbitrary Ruby value.
 ///
 /// Supports: `TermQuery`, `PhraseQuery`, `FuzzyQuery`, `WildcardQuery`,
-/// `NumericRangeQuery`, `GeoQuery`, `BooleanQuery`, `SpanQuery`.
+/// `NumericRangeQuery`, `GeoQuery`, `Geo3dDistanceQuery`,
+/// `Geo3dBoundingBoxQuery`, `Geo3dNearestQuery`, `BooleanQuery`, `SpanQuery`.
 ///
 /// # Arguments
 ///
@@ -57,6 +60,17 @@ pub fn extract_lexical_query(value: Value) -> Result<Box<dyn laurus::lexical::Qu
         return q
             .build()
             .map_err(|e| Error::new(ruby.exception_arg_error(), e.to_string()));
+    }
+    if let Ok(q) = <&RbGeo3dDistanceQuery>::try_convert(value) {
+        return Ok(q.build());
+    }
+    if let Ok(q) = <&RbGeo3dBoundingBoxQuery>::try_convert(value) {
+        return q
+            .build()
+            .map_err(|e| Error::new(ruby.exception_arg_error(), e.to_string()));
+    }
+    if let Ok(q) = <&RbGeo3dNearestQuery>::try_convert(value) {
+        return Ok(q.build());
     }
     if let Ok(q) = <&RbBooleanQuery>::try_convert(value) {
         return q.build_query();
@@ -548,6 +562,169 @@ impl RbGeoQuery {
 }
 
 // ---------------------------------------------------------------------------
+// Geo3dDistanceQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF sphere query (`Laurus::Geo3dDistanceQuery`).
+///
+/// Matches every document whose stored `(x, y, z)` point lies within
+/// `radius_m` meters of the given centre.
+#[magnus::wrap(class = "Laurus::Geo3dDistanceQuery")]
+pub struct RbGeo3dDistanceQuery {
+    pub field: String,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub radius_m: f64,
+}
+
+impl RbGeo3dDistanceQuery {
+    /// Create a 3D distance (sphere) query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Geo3d field name.
+    /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
+    /// * `radius_m` - Sphere radius in meters.
+    fn within_sphere(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
+        Self {
+            field,
+            x,
+            y,
+            z,
+            radius_m,
+        }
+    }
+
+    fn inspect(&self) -> String {
+        format!(
+            "Geo3dDistanceQuery.within_sphere(field='{}', x={}, y={}, z={}, radius_m={})",
+            self.field, self.x, self.y, self.z, self.radius_m
+        )
+    }
+}
+
+impl RbGeo3dDistanceQuery {
+    /// Build the underlying Rust `Geo3dDistanceQuery`.
+    pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
+        Box::new(Geo3dDistanceQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.x, self.y, self.z),
+            self.radius_m,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Geo3dBoundingBoxQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF axis-aligned bounding box query (`Laurus::Geo3dBoundingBoxQuery`).
+#[magnus::wrap(class = "Laurus::Geo3dBoundingBoxQuery")]
+pub struct RbGeo3dBoundingBoxQuery {
+    pub field: String,
+    pub min_x: f64,
+    pub min_y: f64,
+    pub min_z: f64,
+    pub max_x: f64,
+    pub max_y: f64,
+    pub max_z: f64,
+}
+
+impl RbGeo3dBoundingBoxQuery {
+    /// Create a 3D bounding-box query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Geo3d field name.
+    /// * `min_x`, `min_y`, `min_z` - Lower corner of the box.
+    /// * `max_x`, `max_y`, `max_z` - Upper corner of the box.
+    #[allow(clippy::too_many_arguments)]
+    fn within_box(
+        field: String,
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+    ) -> Self {
+        Self {
+            field,
+            min_x,
+            min_y,
+            min_z,
+            max_x,
+            max_y,
+            max_z,
+        }
+    }
+
+    fn inspect(&self) -> String {
+        format!(
+            "Geo3dBoundingBoxQuery.within_box(field='{}', min=({}, {}, {}), max=({}, {}, {}))",
+            self.field, self.min_x, self.min_y, self.min_z, self.max_x, self.max_y, self.max_z
+        )
+    }
+}
+
+impl RbGeo3dBoundingBoxQuery {
+    /// Build the underlying Rust `Geo3dBoundingBoxQuery`.
+    pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
+        Ok(Box::new(Geo3dBoundingBoxQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.min_x, self.min_y, self.min_z),
+            GeoEcefPoint::new(self.max_x, self.max_y, self.max_z),
+        )?))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Geo3dNearestQuery
+// ---------------------------------------------------------------------------
+
+/// 3D ECEF k-nearest-neighbours query (`Laurus::Geo3dNearestQuery`).
+#[magnus::wrap(class = "Laurus::Geo3dNearestQuery")]
+pub struct RbGeo3dNearestQuery {
+    pub field: String,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub k: u32,
+}
+
+impl RbGeo3dNearestQuery {
+    /// Create a 3D k-NN query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Geo3d field name.
+    /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
+    /// * `k` - Number of nearest neighbours to return.
+    fn k_nearest(field: String, x: f64, y: f64, z: f64, k: u32) -> Self {
+        Self { field, x, y, z, k }
+    }
+
+    fn inspect(&self) -> String {
+        format!(
+            "Geo3dNearestQuery.k_nearest(field='{}', x={}, y={}, z={}, k={})",
+            self.field, self.x, self.y, self.z, self.k
+        )
+    }
+}
+
+impl RbGeo3dNearestQuery {
+    /// Build the underlying Rust `Geo3dNearestQuery`.
+    pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
+        Box::new(Geo3dNearestQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.x, self.y, self.z),
+            self.k as usize,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // BooleanQuery - stores extracted Rust queries, not Ruby Values
 // ---------------------------------------------------------------------------
 
@@ -872,6 +1049,36 @@ pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     )?;
     geo_q.define_method("inspect", magnus::method!(RbGeoQuery::inspect, 0))?;
     geo_q.define_method("to_s", magnus::method!(RbGeoQuery::inspect, 0))?;
+
+    // Geo3dDistanceQuery
+    let g3d_dist = module.define_class("Geo3dDistanceQuery", ruby.class_object())?;
+    g3d_dist.define_singleton_method(
+        "within_sphere",
+        magnus::function!(RbGeo3dDistanceQuery::within_sphere, 5),
+    )?;
+    g3d_dist.define_method("inspect", magnus::method!(RbGeo3dDistanceQuery::inspect, 0))?;
+    g3d_dist.define_method("to_s", magnus::method!(RbGeo3dDistanceQuery::inspect, 0))?;
+
+    // Geo3dBoundingBoxQuery
+    let g3d_bbox = module.define_class("Geo3dBoundingBoxQuery", ruby.class_object())?;
+    g3d_bbox.define_singleton_method(
+        "within_box",
+        magnus::function!(RbGeo3dBoundingBoxQuery::within_box, 7),
+    )?;
+    g3d_bbox.define_method(
+        "inspect",
+        magnus::method!(RbGeo3dBoundingBoxQuery::inspect, 0),
+    )?;
+    g3d_bbox.define_method("to_s", magnus::method!(RbGeo3dBoundingBoxQuery::inspect, 0))?;
+
+    // Geo3dNearestQuery
+    let g3d_near = module.define_class("Geo3dNearestQuery", ruby.class_object())?;
+    g3d_near.define_singleton_method(
+        "k_nearest",
+        magnus::function!(RbGeo3dNearestQuery::k_nearest, 5),
+    )?;
+    g3d_near.define_method("inspect", magnus::method!(RbGeo3dNearestQuery::inspect, 0))?;
+    g3d_near.define_method("to_s", magnus::method!(RbGeo3dNearestQuery::inspect, 0))?;
 
     // BooleanQuery
     let bool_q = module.define_class("BooleanQuery", ruby.class_object())?;

--- a/laurus-ruby/src/schema.rs
+++ b/laurus-ruby/src/schema.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 
 use laurus::{
     BooleanOption, BytesOption, DateTimeOption, DistanceMetric, DynamicFieldPolicy,
-    EmbedderDefinition, FieldOption, FloatOption, GeoOption, HnswOption, IntegerOption, IvfOption,
-    Schema, TextOption,
+    EmbedderDefinition, FieldOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
+    IntegerOption, IvfOption, Schema, TextOption,
 };
 use magnus::prelude::*;
 use magnus::scan_args::{get_kwargs, scan_args};
@@ -228,6 +228,38 @@ impl RbSchema {
         self.inner.borrow_mut().fields.insert(
             name,
             FieldOption::Geo(GeoOption {
+                indexed: indexed.unwrap_or(true),
+                stored: stored.unwrap_or(true),
+            }),
+        );
+        Ok(())
+    }
+
+    /// Add a 3D ECEF Cartesian point field (x, y, z in meters).
+    ///
+    /// Values are submitted as a Hash `{ "x" => ..., "y" => ..., "z" => ... }`
+    /// and are queryable via `Geo3dDistanceQuery`, `Geo3dBoundingBoxQuery`,
+    /// and `Geo3dNearestQuery`. See the conceptual docs at
+    /// `docs/src/concepts/geo3d.md`.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - Positional and keyword arguments:
+    ///   - `name` (String): Field name.
+    ///   - `stored:` (bool, default true): Whether the value is retrievable.
+    ///   - `indexed:` (bool, default true): Whether the field is searchable.
+    fn add_geo3d_field(&self, args: &[Value]) -> Result<(), Error> {
+        let args = scan_args::<(String,), (), (), (), RHash, ()>(args)?;
+        let (name,) = args.required;
+        let kwargs = get_kwargs::<_, (), (Option<bool>, Option<bool>), ()>(
+            args.keywords,
+            &[],
+            &["stored", "indexed"],
+        )?;
+        let (stored, indexed) = kwargs.optional;
+        self.inner.borrow_mut().fields.insert(
+            name,
+            FieldOption::Geo3d(Geo3dOption {
                 indexed: indexed.unwrap_or(true),
                 stored: stored.unwrap_or(true),
             }),
@@ -553,6 +585,10 @@ pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     class.define_method(
         "add_geo_field",
         magnus::method!(RbSchema::add_geo_field, -1),
+    )?;
+    class.define_method(
+        "add_geo3d_field",
+        magnus::method!(RbSchema::add_geo3d_field, -1),
     )?;
     class.define_method(
         "add_bytes_field",

--- a/laurus-ruby/test/test_geo3d.rb
+++ b/laurus-ruby/test/test_geo3d.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "set"
+require_relative "test_helper"
+
+# Integration tests for Geo3d (3D ECEF) APIs.
+#
+# Covers:
+# - Schema declaration via `add_geo3d_field`.
+# - Document round-trip with `{ "x", "y", "z" }` Hash values.
+# - All three 3D query classes: `Geo3dDistanceQuery`, `Geo3dBoundingBoxQuery`,
+#   `Geo3dNearestQuery`.
+class TestGeo3d < Minitest::Test
+  # Precomputed ECEF coordinates (meters) for landmarks.
+  TOKYO_TOWER   = { "x" => -3_955_182.0, "y" =>  3_350_553.0, "z" =>  3_700_276.0 }.freeze
+  TOKYO_SKYTREE = { "x" => -3_961_178.0, "y" =>  3_346_187.0, "z" =>  3_702_490.0 }.freeze
+  MT_FUJI       = { "x" => -3_916_073.0, "y" =>  3_437_037.0, "z" =>  3_672_751.0 }.freeze
+  SYDNEY        = { "x" => -4_646_847.0, "y" =>  2_553_022.0, "z" => -3_534_121.0 }.freeze
+
+  def make_index
+    schema = Laurus::Schema.new
+    schema.add_text_field("name")
+    schema.add_geo3d_field("position")
+    idx = Laurus::Index.new(schema: schema)
+    idx.put_document("tokyo_tower",   { "name" => "Tokyo Tower",        "position" => TOKYO_TOWER })
+    idx.put_document("tokyo_skytree", { "name" => "Tokyo Skytree",      "position" => TOKYO_SKYTREE })
+    idx.put_document("mt_fuji",       { "name" => "Mt. Fuji summit",    "position" => MT_FUJI })
+    idx.put_document("sydney",        { "name" => "Sydney Opera House", "position" => SYDNEY })
+    idx.commit
+    idx
+  end
+
+  # ---------------------------------------------------------------------------
+  # Schema and document round-trip
+  # ---------------------------------------------------------------------------
+
+  def test_geo3d_field_round_trip
+    idx = make_index
+    docs = idx.get_documents("tokyo_tower")
+    assert_equal 1, docs.length
+    assert_equal "Tokyo Tower", docs.first["name"]
+    assert_equal TOKYO_TOWER, docs.first["position"]
+  end
+
+  # ---------------------------------------------------------------------------
+  # Geo3dDistanceQuery
+  # ---------------------------------------------------------------------------
+
+  def test_geo3d_distance_query_small_radius
+    idx = make_index
+    q = Laurus::Geo3dDistanceQuery.within_sphere(
+      "position", TOKYO_TOWER["x"], TOKYO_TOWER["y"], TOKYO_TOWER["z"], 50_000.0,
+    )
+    results = idx.search(q, limit: 10)
+    ids = results.map(&:id).to_set
+    assert_equal Set["tokyo_tower", "tokyo_skytree"], ids
+  end
+
+  def test_geo3d_distance_query_wide_radius
+    idx = make_index
+    q = Laurus::Geo3dDistanceQuery.within_sphere(
+      "position", TOKYO_TOWER["x"], TOKYO_TOWER["y"], TOKYO_TOWER["z"], 200_000.0,
+    )
+    results = idx.search(q, limit: 10)
+    ids = results.map(&:id).to_set
+    assert_equal Set["tokyo_tower", "tokyo_skytree", "mt_fuji"], ids
+  end
+
+  # ---------------------------------------------------------------------------
+  # Geo3dBoundingBoxQuery
+  # ---------------------------------------------------------------------------
+
+  def test_geo3d_bounding_box_query
+    # Central-Tokyo box: must include Tokyo Tower (x ≈ -3.955M) and Tokyo
+    # Skytree (x ≈ -3.961M) but exclude Mt. Fuji (x ≈ -3.916M, above the
+    # upper bound) and Sydney (x ≈ -4.65M, well below).
+    idx = make_index
+    q = Laurus::Geo3dBoundingBoxQuery.within_box(
+      "position",
+      -3_962_000.0,  3_340_000.0,  3_690_000.0,
+      -3_954_000.0,  3_360_000.0,  3_710_000.0,
+    )
+    results = idx.search(q, limit: 10)
+    ids = results.map(&:id).to_set
+    assert_equal Set["tokyo_tower", "tokyo_skytree"], ids
+  end
+
+  # ---------------------------------------------------------------------------
+  # Geo3dNearestQuery
+  # ---------------------------------------------------------------------------
+
+  def test_geo3d_nearest_query
+    idx = make_index
+    q = Laurus::Geo3dNearestQuery.k_nearest(
+      "position", MT_FUJI["x"], MT_FUJI["y"], MT_FUJI["z"], 3,
+    )
+    results = idx.search(q, limit: 3)
+    assert_equal 3, results.length
+    ids = results.map(&:id).to_set
+    assert_equal Set["mt_fuji", "tokyo_tower", "tokyo_skytree"], ids
+    # Mt. Fuji must be the closest hit.
+    assert_equal "mt_fuji", results.first.id
+  end
+
+  # ---------------------------------------------------------------------------
+  # Factory smoke checks
+  # ---------------------------------------------------------------------------
+
+  def test_geo3d_query_factories_create_instances
+    refute_nil Laurus::Geo3dDistanceQuery.within_sphere(
+      "position", TOKYO_TOWER["x"], TOKYO_TOWER["y"], TOKYO_TOWER["z"], 1000.0,
+    )
+    refute_nil Laurus::Geo3dBoundingBoxQuery.within_box(
+      "position", 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+    )
+    refute_nil Laurus::Geo3dNearestQuery.k_nearest(
+      "position", TOKYO_TOWER["x"], TOKYO_TOWER["y"], TOKYO_TOWER["z"], 5,
+    )
+  end
+
+  def test_geo3d_query_inspect_includes_class_name
+    q1 = Laurus::Geo3dDistanceQuery.within_sphere("position", 1.0, 2.0, 3.0, 1000.0)
+    assert_includes q1.inspect, "Geo3dDistanceQuery"
+
+    q2 = Laurus::Geo3dBoundingBoxQuery.within_box("position", 0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+    assert_includes q2.inspect, "Geo3dBoundingBoxQuery"
+
+    q3 = Laurus::Geo3dNearestQuery.k_nearest("position", 1.0, 2.0, 3.0, 5)
+    assert_includes q3.inspect, "Geo3dNearestQuery"
+  end
+end


### PR DESCRIPTION
## Summary

Third of five per-binding sub-PRs for #334. Mirror the Python (#342) and Node.js (#343) shapes using magnus idioms — snake_case methods, factory class methods (`within_sphere`, `within_box`, `k_nearest`), and Hash-based document values.

## Changes

- **`laurus-ruby/src/schema.rs`**: import `Geo3dOption`; add `add_geo3d_field(name, stored: true, indexed: true)` (kwarg style, mirrors `add_geo_field`); register the new method in `init_module`.
- **`laurus-ruby/src/convert.rs`**: `rb_to_data_value` accepts a Hash with `\"x\"` / `\"y\"` / `\"z\"` keys → `DataValue::GeoEcef`. Placed after the `{lat, lon}` check so existing 2D Geo semantics are preserved. Type-mapping doc-comment + error message updated.
- **`laurus-ruby/src/query.rs`**: three new `#[magnus::wrap]`-annotated classes — `Geo3dDistanceQuery` (`within_sphere` factory), `Geo3dBoundingBoxQuery` (`within_box` factory, with `#[allow(clippy::too_many_arguments)]`), `Geo3dNearestQuery` (`k_nearest` factory, 5 args; radius bounds left to a follow-up). Each gets `inspect` / `to_s`. `extract_lexical_query` gains three arms; `init_module` registers all three classes.
- **`laurus-ruby/test/test_geo3d.rb`** (new): 7 Minitest integration tests for schema round-trip, distance (50 km / 200 km), bounding box, k-NN (with closest-hit assertion), factory + `inspect` smoke checks.

## Public Ruby surface

```ruby
schema = Laurus::Schema.new
schema.add_geo3d_field(\"position\")
idx = Laurus::Index.new(schema: schema)
idx.put_document(\"d1\", { \"position\" => { \"x\" => -3955182.0, \"y\" => 3350553.0, \"z\" => 3700276.0 } })
idx.commit

q = Laurus::Geo3dDistanceQuery.within_sphere(\"position\", x, y, z, 5000.0)
q = Laurus::Geo3dBoundingBoxQuery.within_box(\"position\", min_x, min_y, min_z, max_x, max_y, max_z)
q = Laurus::Geo3dNearestQuery.k_nearest(\"position\", x, y, z, 10)
results = idx.search(q, limit: 10)
```

`{x, y, z}` and `{lat, lon}` Hashes are disambiguated by which keys are present.

## Test plan

- [x] `cargo build -p laurus-ruby` succeeds
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-ruby --tests -- -D warnings` clean
- [x] `bundle exec rake compile && bundle exec rake test` — 37 / 37 pass (existing 30 + new 7)

## Notes

- Radius-bound builders (`with_initial_radius` / `with_max_radius`) for `Geo3dNearestQuery` are out of scope here; the 5-arg factory matches the existing 2D `RbGeoQuery` style. They can land in a follow-up if needed.
- Two more bindings to go (WASM, PHP). After all five sub-PRs land, #326 (binding documentation) is unblocked.

Refs #334 (3 of 5)
Refs #331