### PR TITLE
feat(wasm): expose Geo3d field, value, and query APIs

### DIFF
--- a/laurus-wasm/src/convert.rs
+++ b/laurus-wasm/src/convert.rs
@@ -39,6 +39,7 @@ pub fn json_to_document(value: &Value) -> Result<Document, JsValue> {
 /// - `string`                -> `DataValue::Text` (or `DateTime` if ISO8601)
 /// - `array` of numbers      -> `DataValue::Vector`
 /// - `{ "lat", "lon" }`      -> `DataValue::Geo`
+/// - `{ "x", "y", "z" }`     -> `DataValue::GeoEcef` (3D ECEF Cartesian, meters)
 ///
 /// # Arguments
 ///
@@ -89,8 +90,17 @@ pub fn json_to_data_value(value: &Value) -> Result<DataValue, JsValue> {
                     .map_err(|e| JsValue::from_str(&format!("invalid geo point: {e}")))?;
                 return Ok(DataValue::Geo(point));
             }
+            // Check for geo3d { x, y, z } (must come after the {lat, lon}
+            // check so existing 2D Geo semantics are preserved).
+            if let (Some(x), Some(y), Some(z)) = (
+                obj.get("x").and_then(|v| v.as_f64()),
+                obj.get("y").and_then(|v| v.as_f64()),
+                obj.get("z").and_then(|v| v.as_f64()),
+            ) {
+                return Ok(DataValue::GeoEcef(laurus::GeoEcefPoint::new(x, y, z)));
+            }
             Err(JsValue::from_str(
-                "Cannot convert JSON object to DataValue: expected { lat, lon }",
+                "Cannot convert JSON object to DataValue: expected { lat, lon } or { x, y, z }",
             ))
         }
     }

--- a/laurus-wasm/src/index.rs
+++ b/laurus-wasm/src/index.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use crate::convert::{data_value_to_json, json_to_document};
 use crate::errors::laurus_err;
-use crate::query::{JsQuery, JsTermQuery, JsVectorQuery, JsVectorQueryInner, JsVectorTextQuery};
+use crate::query::{
+    JsGeo3dBoundingBoxQuery, JsGeo3dDistanceQuery, JsGeo3dNearestQuery, JsQuery, JsTermQuery,
+    JsVectorQuery, JsVectorQueryInner, JsVectorTextQuery,
+};
 use crate::schema::WasmSchema;
 use crate::search::{build_dsl_request, build_lexical_request, build_vector_request};
 use crate::storage::OpfsPersistence;
@@ -339,6 +342,115 @@ impl WasmIndex {
         offset: Option<u32>,
     ) -> Result<JsValue, JsValue> {
         let query = JsQuery::TermQuery(JsTermQuery { field, term });
+        let request = build_lexical_request(
+            &query,
+            limit.unwrap_or(10) as usize,
+            offset.unwrap_or(0) as usize,
+        )?;
+        let results = self.engine.search(request).await.map_err(laurus_err)?;
+        search_results_to_js(results)
+    }
+
+    /// Search using a 3D ECEF distance (sphere) query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The Geo3d field name.
+    /// * `x`, `y`, `z` - Sphere centre in ECEF meters.
+    /// * `radius_m` - Sphere radius in meters.
+    /// * `limit` - Maximum number of results (default 10).
+    /// * `offset` - Pagination offset (default 0).
+    #[wasm_bindgen(js_name = "searchGeo3dDistance")]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn search_geo3d_distance(
+        &self,
+        field: String,
+        x: f64,
+        y: f64,
+        z: f64,
+        radius_m: f64,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<JsValue, JsValue> {
+        let query = JsQuery::Geo3dDistanceQuery(JsGeo3dDistanceQuery {
+            field,
+            x,
+            y,
+            z,
+            radius_m,
+        });
+        let request = build_lexical_request(
+            &query,
+            limit.unwrap_or(10) as usize,
+            offset.unwrap_or(0) as usize,
+        )?;
+        let results = self.engine.search(request).await.map_err(laurus_err)?;
+        search_results_to_js(results)
+    }
+
+    /// Search using a 3D ECEF axis-aligned bounding-box query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The Geo3d field name.
+    /// * `min_x`, `min_y`, `min_z` - Lower corner of the box.
+    /// * `max_x`, `max_y`, `max_z` - Upper corner of the box.
+    /// * `limit` - Maximum number of results (default 10).
+    /// * `offset` - Pagination offset (default 0).
+    #[wasm_bindgen(js_name = "searchGeo3dBoundingBox")]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn search_geo3d_bounding_box(
+        &self,
+        field: String,
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<JsValue, JsValue> {
+        let query = JsQuery::Geo3dBoundingBoxQuery(JsGeo3dBoundingBoxQuery {
+            field,
+            min_x,
+            min_y,
+            min_z,
+            max_x,
+            max_y,
+            max_z,
+        });
+        let request = build_lexical_request(
+            &query,
+            limit.unwrap_or(10) as usize,
+            offset.unwrap_or(0) as usize,
+        )?;
+        let results = self.engine.search(request).await.map_err(laurus_err)?;
+        search_results_to_js(results)
+    }
+
+    /// Search using a 3D ECEF k-nearest-neighbours query.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The Geo3d field name.
+    /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
+    /// * `k` - Number of nearest neighbours to return.
+    /// * `limit` - Maximum number of results (default 10).
+    /// * `offset` - Pagination offset (default 0).
+    #[wasm_bindgen(js_name = "searchGeo3dNearest")]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn search_geo3d_nearest(
+        &self,
+        field: String,
+        x: f64,
+        y: f64,
+        z: f64,
+        k: u32,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<JsValue, JsValue> {
+        let query = JsQuery::Geo3dNearestQuery(JsGeo3dNearestQuery { field, x, y, z, k });
         let request = build_lexical_request(
             &query,
             limit.unwrap_or(10) as usize,

--- a/laurus-wasm/src/query.rs
+++ b/laurus-wasm/src/query.rs
@@ -2,9 +2,11 @@
 //!
 //! Each query struct stores the data needed to construct the Rust query.
 
+use laurus::GeoEcefPoint;
 use laurus::lexical::span::{SpanQueryBuilder, SpanQueryWrapper};
 use laurus::lexical::{
-    BooleanQuery, FuzzyQuery, GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
+    BooleanQuery, FuzzyQuery, Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery,
+    GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
 };
 use laurus::vector::Vector;
 use laurus::vector::store::request::QueryVector;
@@ -23,6 +25,9 @@ pub enum JsQuery {
     WildcardQuery(JsWildcardQuery),
     NumericRangeQuery(JsNumericRangeQuery),
     GeoQuery(JsGeoQuery),
+    Geo3dDistanceQuery(JsGeo3dDistanceQuery),
+    Geo3dBoundingBoxQuery(JsGeo3dBoundingBoxQuery),
+    Geo3dNearestQuery(JsGeo3dNearestQuery),
     BooleanQuery(JsBooleanQuery),
     SpanQuery(JsSpanQuery),
 }
@@ -51,6 +56,11 @@ pub fn extract_lexical_query(query: &JsQuery) -> Result<Box<dyn laurus::lexical:
         )),
         JsQuery::NumericRangeQuery(q) => Ok(q.build()),
         JsQuery::GeoQuery(q) => q.build().map_err(|e| JsValue::from_str(&e.to_string())),
+        JsQuery::Geo3dDistanceQuery(q) => Ok(q.build()),
+        JsQuery::Geo3dBoundingBoxQuery(q) => {
+            q.build().map_err(|e| JsValue::from_str(&e.to_string()))
+        }
+        JsQuery::Geo3dNearestQuery(q) => Ok(q.build()),
         JsQuery::BooleanQuery(q) => q.build_query(),
         JsQuery::SpanQuery(q) => Ok(Box::new(SpanQueryWrapper::new(q.kind.build(&q.field)))),
     }
@@ -204,6 +214,69 @@ impl JsGeoQuery {
                 *max_lon,
             )?)),
         }
+    }
+}
+
+/// 3D ECEF sphere query (internal).
+///
+/// Constructed by `Index::searchGeo3dDistance`. JS callers cannot
+/// instantiate this directly; the method-on-Index pattern matches the
+/// existing 2D `JsGeoQuery` and `JsTermQuery` flows.
+pub struct JsGeo3dDistanceQuery {
+    pub field: String,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub radius_m: f64,
+}
+
+impl JsGeo3dDistanceQuery {
+    pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
+        Box::new(Geo3dDistanceQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.x, self.y, self.z),
+            self.radius_m,
+        ))
+    }
+}
+
+/// 3D ECEF axis-aligned bounding-box query (internal).
+pub struct JsGeo3dBoundingBoxQuery {
+    pub field: String,
+    pub min_x: f64,
+    pub min_y: f64,
+    pub min_z: f64,
+    pub max_x: f64,
+    pub max_y: f64,
+    pub max_z: f64,
+}
+
+impl JsGeo3dBoundingBoxQuery {
+    pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
+        Ok(Box::new(Geo3dBoundingBoxQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.min_x, self.min_y, self.min_z),
+            GeoEcefPoint::new(self.max_x, self.max_y, self.max_z),
+        )?))
+    }
+}
+
+/// 3D ECEF k-nearest-neighbours query (internal).
+pub struct JsGeo3dNearestQuery {
+    pub field: String,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub k: u32,
+}
+
+impl JsGeo3dNearestQuery {
+    pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
+        Box::new(Geo3dNearestQuery::new(
+            &self.field,
+            GeoEcefPoint::new(self.x, self.y, self.z),
+            self.k as usize,
+        ))
     }
 }
 

--- a/laurus-wasm/src/schema.rs
+++ b/laurus-wasm/src/schema.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 
 use laurus::{
     BooleanOption, BytesOption, DateTimeOption, DistanceMetric, DynamicFieldPolicy,
-    EmbedderDefinition, FieldOption, FlatOption, FloatOption, GeoOption, HnswOption, IntegerOption,
-    IvfOption, Schema, TextOption,
+    EmbedderDefinition, FieldOption, FlatOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
+    IntegerOption, IvfOption, Schema, TextOption,
 };
 use wasm_bindgen::prelude::*;
 
@@ -165,6 +165,23 @@ impl WasmSchema {
         self.inner.fields.insert(
             name,
             FieldOption::Geo(GeoOption {
+                indexed: indexed.unwrap_or(true),
+                stored: stored.unwrap_or(true),
+            }),
+        );
+    }
+
+    /// Add a 3D ECEF Cartesian point field (x, y, z in meters).
+    ///
+    /// Values are submitted as a `{ x, y, z }` JSON object and are
+    /// queryable via `searchGeo3dDistance`, `searchGeo3dBoundingBox`,
+    /// and `searchGeo3dNearest` on `Index`. See the conceptual docs at
+    /// `docs/src/concepts/geo3d.md`.
+    #[wasm_bindgen(js_name = "addGeo3dField")]
+    pub fn add_geo3d_field(&mut self, name: String, stored: Option<bool>, indexed: Option<bool>) {
+        self.inner.fields.insert(
+            name,
+            FieldOption::Geo3d(Geo3dOption {
                 indexed: indexed.unwrap_or(true),
                 stored: stored.unwrap_or(true),
             }),


### PR DESCRIPTION
## Summary

Fourth of five per-binding sub-PRs for #334. WASM differs from the Python / Node.js / Ruby pattern: query builders are not exposed to JS (neither `GeoQuery` nor `SearchRequest` carry `#[wasm_bindgen]`), so 3D geo support arrives as three new async methods directly on `Index`, mirroring the existing `searchTerm` / `searchVector` / `searchVectorText` pattern.

## Changes

- **`laurus-wasm/src/schema.rs`**: import `Geo3dOption`; add `addGeo3dField(name, stored?, indexed?)`. Uses `#[wasm_bindgen(js_name = \"addGeo3dField\")]` so the lower-case `d` is preserved (default snake_case→camelCase emits `Geo3D`).
- **`laurus-wasm/src/convert.rs`**: `json_to_data_value` accepts a JSON object with `x` / `y` / `z` keys → `DataValue::GeoEcef`. Placed after the `{lat, lon}` check to preserve existing 2D Geo semantics. Type-mapping doc-comment + error message updated.
- **`laurus-wasm/src/query.rs`**: internal-only structs `JsGeo3dDistanceQuery`, `JsGeo3dBoundingBoxQuery`, `JsGeo3dNearestQuery` (no `#[wasm_bindgen]` — same as `JsGeoQuery`). Extend `JsQuery` enum with three new variants and add the matching arms to `extract_lexical_query`.
- **`laurus-wasm/src/index.rs`**: three new `#[wasm_bindgen]`-annotated async methods on `Index` — `searchGeo3dDistance`, `searchGeo3dBoundingBox`, `searchGeo3dNearest`. All three carry `#[allow(clippy::too_many_arguments)]` (7-9 args by design — field + 3-6 coords + radius/k + limit + offset).

## Public WASM / JS surface

```javascript
const schema = new Schema();
schema.addGeo3dField(\"position\");
const idx = await Index.create(schema);
await idx.putDocument(\"d1\", { position: { x: -3955182.0, y: 3350553.0, z: 3700276.0 } });
await idx.commit();

const r1 = await idx.searchGeo3dDistance(\"position\", x, y, z, 5000.0, 10);
const r2 = await idx.searchGeo3dBoundingBox(\"position\", minX, minY, minZ, maxX, maxY, maxZ, 10);
const r3 = await idx.searchGeo3dNearest(\"position\", x, y, z, 10);
```

`{x, y, z}` and `{lat, lon}` are disambiguated by which keys are present.

## Test plan

- [x] `cargo build -p laurus-wasm --target wasm32-unknown-unknown` succeeds
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings` clean
- [N/A] CI for laurus-wasm runs only `cargo build` and `cargo clippy`; no JS-side integration tests are exercised (matches the existing CI shape for this binding).

## Notes

- Implementation correctness for the same core API surface is covered by the Python (#342), Node.js (#343), and Ruby (#345) integration tests.
- One more binding to go (PHP). After all five sub-PRs land, #326 (binding documentation) is unblocked.

Refs #334 (4 of 5)
Refs #331