### PR TITLE
refactor(laurus): add 2D Geo*Query factories and 2D DSL forms (step 1 of #344)

### DIFF
--- a/laurus/src/lexical/query/geo.rs
+++ b/laurus/src/lexical/query/geo.rs
@@ -115,6 +115,37 @@ impl GeoDistanceQuery {
         }
     }
 
+    /// Create a geo distance query from raw lat/lon coordinates.
+    ///
+    /// Validates the latitude / longitude bounds via [`GeoPoint::try_new`]
+    /// (`-90 <= lat <= 90`, `-180 <= lon <= 180`) and returns
+    /// `LaurusError::other` for out-of-range values.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The field containing geographical coordinates.
+    /// * `lat` - Center latitude in degrees (`-90` to `90`).
+    /// * `lon` - Center longitude in degrees (`-180` to `180`).
+    /// * `distance_km` - Search radius in kilometres.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use laurus::lexical::query::GeoDistanceQuery;
+    ///
+    /// let query =
+    ///     GeoDistanceQuery::within_radius("location", 40.7128, -74.0060, 10.0).unwrap();
+    /// ```
+    pub fn within_radius<F: Into<String>>(
+        field: F,
+        lat: f64,
+        lon: f64,
+        distance_km: f64,
+    ) -> Result<Self> {
+        let center = GeoPoint::try_new(lat, lon)?;
+        Ok(GeoDistanceQuery::new(field, center, distance_km))
+    }
+
     /// Set the boost factor.
     pub fn with_boost(mut self, boost: f32) -> Self {
         self.boost = boost;
@@ -440,6 +471,42 @@ impl GeoBoundingBoxQuery {
             bounding_box,
             boost: 1.0,
         }
+    }
+
+    /// Create a geo bounding box query from raw lat/lon corner coordinates.
+    ///
+    /// Validates that each corner falls within the latitude / longitude
+    /// bounds (via [`GeoPoint::try_new`]) and that `min_lat <= max_lat`
+    /// / `min_lon <= max_lon` (via [`GeoBoundingBox::new`]).
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The field containing geographical coordinates.
+    /// * `min_lat` - Minimum (south) latitude.
+    /// * `min_lon` - Minimum (west) longitude.
+    /// * `max_lat` - Maximum (north) latitude.
+    /// * `max_lon` - Maximum (east) longitude.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use laurus::lexical::query::GeoBoundingBoxQuery;
+    ///
+    /// let query = GeoBoundingBoxQuery::within_bounding_box(
+    ///     "location", 40.0, -75.0, 41.0, -74.0,
+    /// ).unwrap();
+    /// ```
+    pub fn within_bounding_box<F: Into<String>>(
+        field: F,
+        min_lat: f64,
+        min_lon: f64,
+        max_lat: f64,
+        max_lon: f64,
+    ) -> Result<Self> {
+        let min = GeoPoint::try_new(min_lat, min_lon)?;
+        let max = GeoPoint::try_new(max_lat, max_lon)?;
+        let bbox = GeoBoundingBox::new(min, max)?;
+        Ok(GeoBoundingBoxQuery::new(field, bbox))
     }
 
     /// Set the boost factor.
@@ -1100,6 +1167,45 @@ mod tests {
         assert_eq!(query.field(), "location");
         assert_eq!(query.bounding_box().min, min);
         assert_eq!(query.bounding_box().max, max);
+    }
+
+    #[test]
+    fn test_geo_distance_query_within_radius_factory() {
+        let query = GeoDistanceQuery::within_radius("location", 40.7128, -74.0060, 10.0).unwrap();
+
+        assert_eq!(query.field(), "location");
+        assert_eq!(query.center().lat, 40.7128);
+        assert_eq!(query.center().lon, -74.0060);
+        assert_eq!(query.distance_km(), 10.0);
+    }
+
+    #[test]
+    fn test_geo_distance_query_within_radius_invalid_lat() {
+        // Latitude outside [-90, 90] is rejected by GeoPoint::try_new.
+        let err = GeoDistanceQuery::within_radius("location", 95.0, 0.0, 10.0).unwrap_err();
+        assert!(format!("{err}").to_lowercase().contains("lat"));
+    }
+
+    #[test]
+    fn test_geo_bounding_box_query_within_bounding_box_factory() {
+        let query =
+            GeoBoundingBoxQuery::within_bounding_box("location", 40.0, -75.0, 41.0, -74.0).unwrap();
+
+        assert_eq!(query.field(), "location");
+        assert_eq!(query.bounding_box().min.lat, 40.0);
+        assert_eq!(query.bounding_box().min.lon, -75.0);
+        assert_eq!(query.bounding_box().max.lat, 41.0);
+        assert_eq!(query.bounding_box().max.lon, -74.0);
+    }
+
+    #[test]
+    fn test_geo_bounding_box_query_within_bounding_box_inverted() {
+        // min > max is rejected by GeoBoundingBox::new.
+        let err = GeoBoundingBoxQuery::within_bounding_box("location", 50.0, 0.0, 40.0, 10.0)
+            .unwrap_err();
+        // Error mentions either bounding-box or min/max.
+        let msg = format!("{err}").to_lowercase();
+        assert!(msg.contains("bounding") || msg.contains("min") || msg.contains("max"));
     }
 
     #[test]

--- a/laurus/src/lexical/query/parser.pest
+++ b/laurus/src/lexical/query/parser.pest
@@ -23,7 +23,7 @@ boolean_op = { ^"AND" | ^"OR" }
 // Field-specific queries
 field_query = { field ~ ":" ~ field_value }
 
-field_value = { geo3d_query | range_query | phrase_query | fuzzy_term | wildcard_term | simple_term }
+field_value = { geo3d_query | geo_query | range_query | phrase_query | fuzzy_term | wildcard_term | simple_term }
 
 // 3D geo queries (ECEF Cartesian coordinates, meters):
 //   field:geo3d_distance(x, y, z, radius_m)
@@ -39,6 +39,18 @@ geo3d_bbox = {
 geo3d_nearest = {
     ^"geo3d_nearest" ~ "(" ~ signed_float ~ "," ~ signed_float ~ "," ~ signed_float ~ "," ~ unsigned_int ~ ")"
 }
+
+// 2D geo queries (latitude / longitude in degrees, distance in km):
+//   field:geo_distance(lat, lon, distance_km)
+//   field:geo_bbox(min_lat, min_lon, max_lat, max_lon)
+geo_query = { geo_distance | geo_bbox }
+geo_distance = {
+    ^"geo_distance" ~ "(" ~ signed_float ~ "," ~ signed_float ~ "," ~ signed_float ~ ")"
+}
+geo_bbox = {
+    ^"geo_bbox" ~ "(" ~ signed_float ~ "," ~ signed_float ~ "," ~ signed_float ~ "," ~ signed_float ~ ")"
+}
+
 signed_float = @{ "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)? }
 unsigned_int = @{ ASCII_DIGIT+ }
 

--- a/laurus/src/lexical/query/parser.rs
+++ b/laurus/src/lexical/query/parser.rs
@@ -26,6 +26,7 @@ use crate::lexical::core::field::NumericType;
 use crate::lexical::query::Query;
 use crate::lexical::query::boolean::{BooleanClause, BooleanQuery, Occur};
 use crate::lexical::query::fuzzy::FuzzyQuery;
+use crate::lexical::query::geo::{GeoBoundingBoxQuery, GeoDistanceQuery};
 use crate::lexical::query::geo3d::{Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery};
 use crate::lexical::query::phrase::PhraseQuery;
 use crate::lexical::query::range::NumericRangeQuery;
@@ -360,6 +361,7 @@ impl LexicalQueryParser {
         for inner_pair in pair.into_inner() {
             match inner_pair.as_rule() {
                 Rule::geo3d_query => return self.parse_geo3d_query(inner_pair, field),
+                Rule::geo_query => return self.parse_geo_query(inner_pair, field),
                 Rule::range_query => return self.parse_range_query(inner_pair, field),
                 Rule::phrase_query => return self.parse_phrase_query(inner_pair, field),
                 Rule::fuzzy_term => return self.parse_fuzzy_term(inner_pair, field),
@@ -481,6 +483,72 @@ impl LexicalQueryParser {
         })?;
         let center = GeoEcefPoint::new(floats[0], floats[1], floats[2]);
         Ok(Box::new(Geo3dNearestQuery::new(field, center, k)))
+    }
+
+    /// Parse a 2D geo query (`geo_distance` or `geo_bbox`). Both require a
+    /// target field; the DSL rejects bare invocations like
+    /// `geo_distance(...)` without a `field:` prefix.
+    fn parse_geo_query(
+        &self,
+        pair: pest::iterators::Pair<Rule>,
+        field: Option<&str>,
+    ) -> Result<Box<dyn Query>> {
+        let field = field.ok_or_else(|| {
+            LaurusError::parse(
+                "2D geo queries require an explicit field prefix \
+                 (e.g. `location:geo_distance(...)`)"
+                    .to_string(),
+            )
+        })?;
+
+        for inner in pair.into_inner() {
+            match inner.as_rule() {
+                Rule::geo_distance => return self.parse_geo_distance(inner, field),
+                Rule::geo_bbox => return self.parse_geo_bbox(inner, field),
+                _ => {}
+            }
+        }
+        Err(LaurusError::parse(
+            "Invalid 2D geo query (expected geo_distance / geo_bbox)".to_string(),
+        ))
+    }
+
+    fn parse_geo_distance(
+        &self,
+        pair: pest::iterators::Pair<Rule>,
+        field: &str,
+    ) -> Result<Box<dyn Query>> {
+        // Grammar: lat, lon, distance_km.
+        let args = collect_signed_floats(pair)?;
+        if args.len() != 3 {
+            return Err(LaurusError::parse(format!(
+                "geo_distance expects 3 numeric arguments (lat, lon, distance_km), got {}",
+                args.len()
+            )));
+        }
+        Ok(Box::new(
+            GeoDistanceQuery::within_radius(field, args[0], args[1], args[2])
+                .map_err(|e| LaurusError::parse(format!("invalid geo_distance arguments: {e}")))?,
+        ))
+    }
+
+    fn parse_geo_bbox(
+        &self,
+        pair: pest::iterators::Pair<Rule>,
+        field: &str,
+    ) -> Result<Box<dyn Query>> {
+        // Grammar: min_lat, min_lon, max_lat, max_lon.
+        let args = collect_signed_floats(pair)?;
+        if args.len() != 4 {
+            return Err(LaurusError::parse(format!(
+                "geo_bbox expects 4 numeric arguments (min_lat, min_lon, max_lat, max_lon), got {}",
+                args.len()
+            )));
+        }
+        Ok(Box::new(
+            GeoBoundingBoxQuery::within_bounding_box(field, args[0], args[1], args[2], args[3])
+                .map_err(|e| LaurusError::parse(format!("invalid geo_bbox arguments: {e}")))?,
+        ))
     }
 
     fn parse_range_query(
@@ -980,6 +1048,76 @@ mod tests {
         let msg = format!("{err:?}");
         assert!(
             msg.contains("3D geo queries require an explicit field prefix"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_geo_distance_basic() {
+        let parser = create_test_parser().with_default_field("content");
+        let q = parser
+            .parse("location:geo_distance(40.7128, -74.0060, 10)")
+            .unwrap();
+        let dbg = format!("{q:?}");
+        assert!(dbg.contains("GeoDistanceQuery"), "got: {dbg}");
+        assert!(dbg.contains("location"), "got: {dbg}");
+    }
+
+    #[test]
+    fn test_geo_distance_invalid_lat_rejected() {
+        // Latitude > 90 should be rejected by GeoPoint::try_new and
+        // surface as a parse error.
+        let parser = create_test_parser().with_default_field("content");
+        let err = parser
+            .parse("location:geo_distance(95.0, 0.0, 10)")
+            .unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("invalid geo_distance arguments"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_geo_bbox_basic() {
+        let parser = create_test_parser().with_default_field("content");
+        let q = parser
+            .parse("location:geo_bbox(40.0, -75.0, 41.0, -74.0)")
+            .unwrap();
+        let dbg = format!("{q:?}");
+        assert!(dbg.contains("GeoBoundingBoxQuery"), "got: {dbg}");
+        assert!(dbg.contains("location"), "got: {dbg}");
+    }
+
+    #[test]
+    fn test_geo_bbox_inverted_rejected() {
+        // The pest grammar accepts the syntactic form but the
+        // GeoBoundingBox constructor rejects min > max.
+        let parser = create_test_parser().with_default_field("content");
+        let err = parser
+            .parse("location:geo_bbox(50.0, 0.0, 40.0, 10.0)")
+            .unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("invalid geo_bbox arguments"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_geo_query_combined_with_boolean() {
+        // 2D geo queries can mix with the rest of the DSL.
+        let parser = create_test_parser().with_default_field("content");
+        let q = parser
+            .parse("city:Tokyo AND location:geo_distance(35.68, 139.76, 5)")
+            .unwrap();
+        let dbg = format!("{q:?}");
+        assert!(dbg.contains("BooleanQuery"), "got: {dbg}");
+        assert!(dbg.contains("GeoDistanceQuery"), "got: {dbg}");
+    }
+
+    #[test]
+    fn test_geo_without_field_rejected() {
+        // Bare `geo_distance(...)` (without a field prefix) is rejected.
+        let parser = create_test_parser().with_default_field("content");
+        let err = parser.parse("geo_distance(0, 0, 1)").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("2D geo queries require an explicit field prefix"),
             "got: {msg}"
         );
     }


### PR DESCRIPTION
## Summary

Step 1 of the #344 Geo refactor. Adds direct factory methods on `GeoDistanceQuery` and `GeoBoundingBoxQuery`, and adds matching 2D DSL forms (`geo_distance`, `geo_bbox`). The existing `GeoQuery` enum is preserved to keep the 5 language bindings compiling — they will migrate in PRs 2-6, and PR 7 will remove the now-unused `GeoQuery` wrapper plus update docs.

## Changes

### Core API (additive)

- `GeoDistanceQuery::within_radius(field, lat, lon, distance_km)` — validates lat/lon via `GeoPoint::try_new`, returns `Result<Self>`. Same shape and arguments as `GeoQuery::within_radius` so bindings can drop the wrapper without changing call sites.
- `GeoBoundingBoxQuery::within_bounding_box(field, min_lat, min_lon, max_lat, max_lon)` — validates corners and box order via `GeoBoundingBox::new`, returns `Result<Self>`.

### DSL (additive)

In `parser.pest` and `parser.rs`:

- `field:geo_distance(lat, lon, distance_km)` — 2D radius form.
- `field:geo_bbox(min_lat, min_lon, max_lat, max_lon)` — 2D bounding-box form.

These parallel the existing `geo3d_distance` / `geo3d_bbox` / `geo3d_nearest` forms so the textual and typed surfaces are now symmetric in both 2D and 3D. `geo_query` is placed after `geo3d_query` in the `field_value` rule so the longer 3D prefix wins.

### Tests

- 4 new factory unit tests in `geo.rs` (factory happy path, invalid lat, inverted bbox rejection).
- 6 new parser tests for the 2D DSL forms (basic, invalid args, inverted bbox, boolean composition, missing field prefix).

## Test plan

- [x] `cargo build -p laurus` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p laurus -- -D warnings` — clean
- [x] `cargo test -p laurus --lib` — 784 passed, 0 failed (11 new geo-related tests)
- [ ] CI runs full workspace tests

## Sequencing

This is the first of seven PRs that fulfil #344:

- **PR 1 (this PR)** — core: add factories + 2D DSL forms ✨
- PR 2 — `laurus-python`: drop `GeoQuery`, expose `GeoDistanceQuery` / `GeoBoundingBoxQuery`; switch Geo3d* to factory style; preserve `kNearest` factory name
- PR 3 — `laurus-nodejs`: drop `GeoQuery`, expose new classes
- PR 4 — `laurus-ruby`: drop `GeoQuery`; add `initial_radius_m` / `max_radius_m` to `Geo3dNearestQuery`
- PR 5 — `laurus-wasm`: drop `GeoQuery` Index methods (or keep as shortcut); add the 3D nearest tuning options
- PR 6 — `laurus-php`: drop `GeoQuery`; add the 3D nearest tuning options
- PR 7 — docs + remove the now-unused `GeoQuery` wrapper from core; update all `api_reference.md` and CHANGELOG

After PRs 1-6 land, the wrapper is dead code; PR 7 cleans it up.

Refs #344