### PR TITLE
refactor(python): split GeoQuery and switch Geo3d* to factory style (step 2 of #344)

### DIFF
--- a/laurus-python/README.md
+++ b/laurus-python/README.md
@@ -78,7 +78,11 @@ index = laurus.Index(path="./myindex", schema=schema)
 | `FuzzyQuery(field, term, max_edits)` | Approximate term match |
 | `WildcardQuery(field, pattern)` | Wildcard pattern match (`*`, `?`) |
 | `NumericRangeQuery(field, min, max)` | Numeric range (int or float) |
-| `GeoQuery(field, lat, lon, radius_km)` | Geo-distance radius search |
+| `GeoDistanceQuery.within_radius(field, lat, lon, distance_km)` | Geo-distance radius search |
+| `GeoBoundingBoxQuery.within_bounding_box(field, min_lat, min_lon, max_lat, max_lon)` | Geo bounding-box search |
+| `Geo3dDistanceQuery.within_sphere(field, x, y, z, radius_m)` | 3D ECEF sphere search |
+| `Geo3dBoundingBoxQuery.within_box(field, min_x, min_y, min_z, max_x, max_y, max_z)` | 3D ECEF AABB search |
+| `Geo3dNearestQuery.k_nearest(field, x, y, z, k)` | 3D ECEF k-nearest neighbours |
 | `BooleanQuery(must, should, must_not)` | Compound boolean logic |
 | `SpanNearQuery(field, [terms], slop)` | Proximity / ordered span match |
 | `VectorQuery(field, vector)` | Pre-computed vector similarity |

--- a/laurus-python/README_ja.md
+++ b/laurus-python/README_ja.md
@@ -78,7 +78,11 @@ index = laurus.Index(path="./myindex", schema=schema)
 | `FuzzyQuery(field, term, max_edits)` | 近似一致検索 |
 | `WildcardQuery(field, pattern)` | ワイルドカード検索（`*`、`?`） |
 | `NumericRangeQuery(field, min, max)` | 数値範囲検索（int または float） |
-| `GeoQuery(field, lat, lon, radius_km)` | 地理的距離検索（半径指定） |
+| `GeoDistanceQuery.within_radius(field, lat, lon, distance_km)` | 地理的距離検索（半径指定） |
+| `GeoBoundingBoxQuery.within_bounding_box(field, min_lat, min_lon, max_lat, max_lon)` | 地理的範囲検索（バウンディングボックス） |
+| `Geo3dDistanceQuery.within_sphere(field, x, y, z, radius_m)` | 3D ECEF 球距離検索 |
+| `Geo3dBoundingBoxQuery.within_box(field, min_x, min_y, min_z, max_x, max_y, max_z)` | 3D ECEF AABB 検索 |
+| `Geo3dNearestQuery.k_nearest(field, x, y, z, k)` | 3D ECEF k 最近傍検索 |
 | `BooleanQuery(must, should, must_not)` | 複合ブール検索 |
 | `SpanNearQuery(field, [terms], slop)` | 近接検索（スパン） |
 | `VectorQuery(field, vector)` | 事前計算済みベクトルによる類似度検索 |

--- a/laurus-python/examples/lexical_search.py
+++ b/laurus-python/examples/lexical_search.py
@@ -7,7 +7,7 @@ Demonstrates every lexical query type Laurus supports:
 3. FuzzyQuery        — approximate matching (typo tolerance)
 4. WildcardQuery     — pattern matching with * and ?
 5. NumericRangeQuery — numeric range filtering (int and float)
-6. GeoQuery          — geographic radius / bounding box
+6. GeoDistanceQuery / GeoBoundingBoxQuery — geographic radius / bounding box
 7. BooleanQuery      — AND / OR / NOT combinations
 8. SpanQuery         — positional / proximity search
 
@@ -225,16 +225,18 @@ def main() -> None:
     _print_results(index.search("price:[4.5 TO 4.9]", limit=5))
 
     # =====================================================================
-    # PART 6: GeoQuery — geographic search
+    # PART 6: GeoDistanceQuery / GeoBoundingBoxQuery — geographic search
     # =====================================================================
     print("\n" + "=" * 60)
-    print("PART 6: GeoQuery (no DSL equivalent)")
+    print("PART 6: GeoDistanceQuery / GeoBoundingBoxQuery")
     print("=" * 60)
 
     print("\n[6a] Within 100 km of San Francisco (37.77, -122.42):")
     _print_results(
         index.search(
-            laurus.GeoQuery.within_radius("location", 37.7749, -122.4194, 100.0),
+            laurus.GeoDistanceQuery.within_radius(
+                "location", 37.7749, -122.4194, 100.0
+            ),
             limit=5,
         )
     )
@@ -242,7 +244,7 @@ def main() -> None:
     print("\n[6b] Bounding box — US West Coast (33, -123) to (48, -117):")
     _print_results(
         index.search(
-            laurus.GeoQuery.within_bounding_box(
+            laurus.GeoBoundingBoxQuery.within_bounding_box(
                 "location", 33.0, -123.0, 48.0, -117.0
             ),
             limit=5,

--- a/laurus-python/src/index.rs
+++ b/laurus-python/src/index.rs
@@ -166,7 +166,7 @@ impl PyIndex {
     ///
     /// `query` may be:
     ///   - A **DSL string** (e.g. `"title:hello"`, `"~\"memory safety\""`)
-    ///   - A **lexical query** object (`TermQuery`, `BooleanQuery`, `GeoQuery`, …)
+    ///   - A **lexical query** object (`TermQuery`, `BooleanQuery`, `GeoDistanceQuery`, …)
     ///   - A **vector query** object (`VectorQuery`, `VectorTextQuery`)
     ///   - A **[`SearchRequest`]** for full control (hybrid, filter, fusion)
     ///

--- a/laurus-python/src/lib.rs
+++ b/laurus-python/src/lib.rs
@@ -21,8 +21,8 @@ use index::PyIndex;
 use pyo3::prelude::*;
 use query::{
     PyBooleanQuery, PyFuzzyQuery, PyGeo3dBoundingBoxQuery, PyGeo3dDistanceQuery,
-    PyGeo3dNearestQuery, PyGeoQuery, PyNumericRangeQuery, PyPhraseQuery, PySpanQuery, PyTermQuery,
-    PyVectorQuery, PyVectorTextQuery, PyWildcardQuery,
+    PyGeo3dNearestQuery, PyGeoBoundingBoxQuery, PyGeoDistanceQuery, PyNumericRangeQuery,
+    PyPhraseQuery, PySpanQuery, PyTermQuery, PyVectorQuery, PyVectorTextQuery, PyWildcardQuery,
 };
 use schema::PySchema;
 use search::{PyRRF, PySearchRequest, PySearchResult, PyWeightedSum};
@@ -68,7 +68,8 @@ fn laurus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFuzzyQuery>()?;
     m.add_class::<PyWildcardQuery>()?;
     m.add_class::<PyNumericRangeQuery>()?;
-    m.add_class::<PyGeoQuery>()?;
+    m.add_class::<PyGeoDistanceQuery>()?;
+    m.add_class::<PyGeoBoundingBoxQuery>()?;
     m.add_class::<PyGeo3dDistanceQuery>()?;
     m.add_class::<PyGeo3dBoundingBoxQuery>()?;
     m.add_class::<PyGeo3dNearestQuery>()?;

--- a/laurus-python/src/query.rs
+++ b/laurus-python/src/query.rs
@@ -8,7 +8,8 @@ use laurus::GeoEcefPoint;
 use laurus::lexical::span::{SpanQueryBuilder, SpanQueryWrapper};
 use laurus::lexical::{
     BooleanQuery, FuzzyQuery, Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery,
-    GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
+    GeoBoundingBoxQuery, GeoDistanceQuery, NumericRangeQuery, PhraseQuery, TermQuery,
+    WildcardQuery,
 };
 use laurus::vector::Vector;
 use laurus::vector::store::request::QueryVector;
@@ -23,8 +24,9 @@ use pyo3::prelude::*;
 /// Extract a Laurus lexical query from an arbitrary Python object.
 ///
 /// Supports: `TermQuery`, `PhraseQuery`, `FuzzyQuery`, `WildcardQuery`,
-/// `NumericRangeQuery`, `GeoQuery`, `Geo3dDistanceQuery`,
-/// `Geo3dBoundingBoxQuery`, `Geo3dNearestQuery`, `BooleanQuery`, `SpanQuery`.
+/// `NumericRangeQuery`, `GeoDistanceQuery`, `GeoBoundingBoxQuery`,
+/// `Geo3dDistanceQuery`, `Geo3dBoundingBoxQuery`, `Geo3dNearestQuery`,
+/// `BooleanQuery`, `SpanQuery`.
 pub fn extract_lexical_query(
     py: Python,
     obj: &Bound<PyAny>,
@@ -49,7 +51,10 @@ pub fn extract_lexical_query(
     if let Ok(q) = obj.extract::<PyRef<PyNumericRangeQuery>>() {
         return Ok(q.build());
     }
-    if let Ok(q) = obj.extract::<PyRef<PyGeoQuery>>() {
+    if let Ok(q) = obj.extract::<PyRef<PyGeoDistanceQuery>>() {
+        return q.build().map_err(|e| PyValueError::new_err(e.to_string()));
+    }
+    if let Ok(q) = obj.extract::<PyRef<PyGeoBoundingBoxQuery>>() {
         return q.build().map_err(|e| PyValueError::new_err(e.to_string()));
     }
     if let Ok(q) = obj.extract::<PyRef<PyGeo3dDistanceQuery>>() {
@@ -362,44 +367,28 @@ impl PyNumericRangeQuery {
 }
 
 // ---------------------------------------------------------------------------
-// GeoQuery
+// GeoDistanceQuery
 // ---------------------------------------------------------------------------
 
-/// Geographic search query (radius or bounding box).
+/// Geographic distance (radius) search query.
 ///
 /// ## Example
 ///
 /// ```python
-/// # Radius search: within 100 km of San Francisco
-/// q = laurus.GeoQuery.within_radius("location", 37.77, -122.42, 100.0)
-///
-/// # Bounding box search
-/// q = laurus.GeoQuery.within_bounding_box("location", 33.0, -123.0, 48.0, -117.0)
+/// # Within 100 km of San Francisco
+/// q = laurus.GeoDistanceQuery.within_radius("location", 37.77, -122.42, 100.0)
 /// ```
-#[pyclass(name = "GeoQuery")]
-pub struct PyGeoQuery {
+#[pyclass(name = "GeoDistanceQuery")]
+pub struct PyGeoDistanceQuery {
     pub field: String,
-    pub kind: GeoKind,
-}
-
-#[derive(Clone)]
-pub enum GeoKind {
-    Radius {
-        lat: f64,
-        lon: f64,
-        distance_km: f64,
-    },
-    BoundingBox {
-        min_lat: f64,
-        min_lon: f64,
-        max_lat: f64,
-        max_lon: f64,
-    },
+    pub lat: f64,
+    pub lon: f64,
+    pub distance_km: f64,
 }
 
 #[pymethods]
-impl PyGeoQuery {
-    /// Create a radius-based geo query.
+impl PyGeoDistanceQuery {
+    /// Create a radius-based geo distance query.
     ///
     /// Args:
     ///     field: Geo field name.
@@ -410,14 +399,55 @@ impl PyGeoQuery {
     pub fn within_radius(field: String, lat: f64, lon: f64, distance_km: f64) -> Self {
         Self {
             field,
-            kind: GeoKind::Radius {
-                lat,
-                lon,
-                distance_km,
-            },
+            lat,
+            lon,
+            distance_km,
         }
     }
 
+    fn __repr__(&self) -> String {
+        format!(
+            "GeoDistanceQuery.within_radius(field='{}', lat={}, lon={}, distance_km={})",
+            self.field, self.lat, self.lon, self.distance_km
+        )
+    }
+}
+
+impl PyGeoDistanceQuery {
+    pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
+        Ok(Box::new(GeoDistanceQuery::within_radius(
+            &self.field,
+            self.lat,
+            self.lon,
+            self.distance_km,
+        )?))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GeoBoundingBoxQuery
+// ---------------------------------------------------------------------------
+
+/// Geographic bounding-box search query.
+///
+/// ## Example
+///
+/// ```python
+/// q = laurus.GeoBoundingBoxQuery.within_bounding_box(
+///     "location", 33.0, -123.0, 48.0, -117.0,
+/// )
+/// ```
+#[pyclass(name = "GeoBoundingBoxQuery")]
+pub struct PyGeoBoundingBoxQuery {
+    pub field: String,
+    pub min_lat: f64,
+    pub min_lon: f64,
+    pub max_lat: f64,
+    pub max_lon: f64,
+}
+
+#[pymethods]
+impl PyGeoBoundingBoxQuery {
     /// Create a bounding-box geo query.
     ///
     /// Args:
@@ -436,64 +466,30 @@ impl PyGeoQuery {
     ) -> Self {
         Self {
             field,
-            kind: GeoKind::BoundingBox {
-                min_lat,
-                min_lon,
-                max_lat,
-                max_lon,
-            },
+            min_lat,
+            min_lon,
+            max_lat,
+            max_lon,
         }
     }
 
     fn __repr__(&self) -> String {
-        match &self.kind {
-            GeoKind::Radius {
-                lat,
-                lon,
-                distance_km,
-            } => format!(
-                "GeoQuery.within_radius(field='{}', lat={}, lon={}, distance_km={})",
-                self.field, lat, lon, distance_km
-            ),
-            GeoKind::BoundingBox {
-                min_lat,
-                min_lon,
-                max_lat,
-                max_lon,
-            } => format!(
-                "GeoQuery.within_bounding_box(field='{}', min_lat={}, min_lon={}, max_lat={}, max_lon={})",
-                self.field, min_lat, min_lon, max_lat, max_lon
-            ),
-        }
+        format!(
+            "GeoBoundingBoxQuery.within_bounding_box(field='{}', min_lat={}, min_lon={}, max_lat={}, max_lon={})",
+            self.field, self.min_lat, self.min_lon, self.max_lat, self.max_lon
+        )
     }
 }
 
-impl PyGeoQuery {
+impl PyGeoBoundingBoxQuery {
     pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
-        match &self.kind {
-            GeoKind::Radius {
-                lat,
-                lon,
-                distance_km,
-            } => Ok(Box::new(GeoQuery::within_radius(
-                &self.field,
-                *lat,
-                *lon,
-                *distance_km,
-            )?)),
-            GeoKind::BoundingBox {
-                min_lat,
-                min_lon,
-                max_lat,
-                max_lon,
-            } => Ok(Box::new(GeoQuery::within_bounding_box(
-                &self.field,
-                *min_lat,
-                *min_lon,
-                *max_lat,
-                *max_lon,
-            )?)),
-        }
+        Ok(Box::new(GeoBoundingBoxQuery::within_bounding_box(
+            &self.field,
+            self.min_lat,
+            self.min_lon,
+            self.max_lat,
+            self.max_lon,
+        )?))
     }
 }
 
@@ -507,7 +503,9 @@ impl PyGeoQuery {
 /// ## Example
 ///
 /// ```python
-/// q = laurus.Geo3dDistanceQuery("position", -3955182.0, 3350553.0, 3700276.0, 5000.0)
+/// q = laurus.Geo3dDistanceQuery.within_sphere(
+///     "position", -3955182.0, 3350553.0, 3700276.0, 5000.0,
+/// )
 /// ```
 #[pyclass(name = "Geo3dDistanceQuery")]
 pub struct PyGeo3dDistanceQuery {
@@ -526,8 +524,8 @@ impl PyGeo3dDistanceQuery {
     ///     field: Geo3d field name.
     ///     x, y, z: Centre coordinates in ECEF meters.
     ///     radius_m: Sphere radius in meters.
-    #[new]
-    pub fn new(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
+    #[staticmethod]
+    pub fn within_sphere(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
         Self {
             field,
             x,
@@ -539,7 +537,7 @@ impl PyGeo3dDistanceQuery {
 
     fn __repr__(&self) -> String {
         format!(
-            "Geo3dDistanceQuery(field='{}', x={}, y={}, z={}, radius_m={})",
+            "Geo3dDistanceQuery.within_sphere(field='{}', x={}, y={}, z={}, radius_m={})",
             self.field, self.x, self.y, self.z, self.radius_m
         )
     }
@@ -564,7 +562,7 @@ impl PyGeo3dDistanceQuery {
 /// ## Example
 ///
 /// ```python
-/// q = laurus.Geo3dBoundingBoxQuery(
+/// q = laurus.Geo3dBoundingBoxQuery.within_box(
 ///     "position",
 ///     -3962000.0, 3340000.0, 3690000.0,
 ///     -3958000.0, 3360000.0, 3710000.0,
@@ -589,8 +587,9 @@ impl PyGeo3dBoundingBoxQuery {
     ///     field: Geo3d field name.
     ///     min_x, min_y, min_z: Lower corner of the box.
     ///     max_x, max_y, max_z: Upper corner of the box.
-    #[new]
-    pub fn new(
+    #[staticmethod]
+    #[allow(clippy::too_many_arguments)]
+    pub fn within_box(
         field: String,
         min_x: f64,
         min_y: f64,
@@ -612,7 +611,7 @@ impl PyGeo3dBoundingBoxQuery {
 
     fn __repr__(&self) -> String {
         format!(
-            "Geo3dBoundingBoxQuery(field='{}', min=({}, {}, {}), max=({}, {}, {}))",
+            "Geo3dBoundingBoxQuery.within_box(field='{}', min=({}, {}, {}), max=({}, {}, {}))",
             self.field, self.min_x, self.min_y, self.min_z, self.max_x, self.max_y, self.max_z
         )
     }
@@ -637,7 +636,9 @@ impl PyGeo3dBoundingBoxQuery {
 /// ## Example
 ///
 /// ```python
-/// q = laurus.Geo3dNearestQuery("position", -3955182.0, 3350553.0, 3700276.0, k=10)
+/// q = laurus.Geo3dNearestQuery.k_nearest(
+///     "position", -3955182.0, 3350553.0, 3700276.0, 10,
+/// )
 /// ```
 #[pyclass(name = "Geo3dNearestQuery")]
 pub struct PyGeo3dNearestQuery {
@@ -662,9 +663,9 @@ impl PyGeo3dNearestQuery {
     ///         search (default 1000 m). Optional.
     ///     max_radius_m: Hard cap on the search radius (default 1e10 m).
     ///         Optional.
-    #[new]
+    #[staticmethod]
     #[pyo3(signature = (field, x, y, z, k, *, initial_radius_m=None, max_radius_m=None))]
-    pub fn new(
+    pub fn k_nearest(
         field: String,
         x: f64,
         y: f64,
@@ -686,7 +687,7 @@ impl PyGeo3dNearestQuery {
 
     fn __repr__(&self) -> String {
         format!(
-            "Geo3dNearestQuery(field='{}', x={}, y={}, z={}, k={})",
+            "Geo3dNearestQuery.k_nearest(field='{}', x={}, y={}, z={}, k={})",
             self.field, self.x, self.y, self.z, self.k
         )
     }

--- a/laurus-python/tests/test_geo3d.py
+++ b/laurus-python/tests/test_geo3d.py
@@ -58,7 +58,7 @@ def test_geo3d_field_round_trip(geo3d_index):
 def test_geo3d_distance_query_small_radius(geo3d_index):
     """A 50 km sphere around Tokyo Tower should return Tower + Skytree only."""
     cx, cy, cz = TOKYO_TOWER
-    query = laurus.Geo3dDistanceQuery("position", cx, cy, cz, 50_000.0)
+    query = laurus.Geo3dDistanceQuery.within_sphere("position", cx, cy, cz, 50_000.0)
     results = geo3d_index.search(query, limit=10)
     ids = {r.id for r in results}
     assert ids == {"tokyo_tower", "tokyo_skytree"}
@@ -67,7 +67,7 @@ def test_geo3d_distance_query_small_radius(geo3d_index):
 def test_geo3d_distance_query_wide_radius(geo3d_index):
     """A 200 km sphere additionally pulls in Mt. Fuji."""
     cx, cy, cz = TOKYO_TOWER
-    query = laurus.Geo3dDistanceQuery("position", cx, cy, cz, 200_000.0)
+    query = laurus.Geo3dDistanceQuery.within_sphere("position", cx, cy, cz, 200_000.0)
     results = geo3d_index.search(query, limit=10)
     ids = {r.id for r in results}
     assert ids == {"tokyo_tower", "tokyo_skytree", "mt_fuji"}
@@ -87,7 +87,7 @@ def test_geo3d_bounding_box_query(geo3d_index):
     (`x ≈ -3.916M`, well above the upper bound) and Sydney (`x ≈ -4.65M`,
     well below the lower bound).
     """
-    query = laurus.Geo3dBoundingBoxQuery(
+    query = laurus.Geo3dBoundingBoxQuery.within_box(
         "position",
         -3_962_000.0, 3_340_000.0, 3_690_000.0,
         -3_954_000.0, 3_360_000.0, 3_710_000.0,
@@ -107,7 +107,7 @@ def test_geo3d_nearest_query(geo3d_index):
     order — exact ordering of the close-pair is implementation defined, so
     only check membership)."""
     cx, cy, cz = MT_FUJI
-    query = laurus.Geo3dNearestQuery("position", cx, cy, cz, 3)
+    query = laurus.Geo3dNearestQuery.k_nearest("position", cx, cy, cz, 3)
     results = geo3d_index.search(query, limit=3)
     assert len(results) == 3
     ids = {r.id for r in results}
@@ -119,7 +119,7 @@ def test_geo3d_nearest_query(geo3d_index):
 def test_geo3d_nearest_query_with_radius_options(geo3d_index):
     """Verify the optional initial / max radius parameters are accepted."""
     cx, cy, cz = TOKYO_TOWER
-    query = laurus.Geo3dNearestQuery(
+    query = laurus.Geo3dNearestQuery.k_nearest(
         "position", cx, cy, cz, 2,
         initial_radius_m=10_000.0,
         max_radius_m=10_000_000.0,
@@ -136,10 +136,14 @@ def test_geo3d_nearest_query_with_radius_options(geo3d_index):
 
 def test_geo3d_query_reprs():
     cx, cy, cz = TOKYO_TOWER
-    assert "Geo3dDistanceQuery" in repr(laurus.Geo3dDistanceQuery("position", cx, cy, cz, 1000.0))
+    assert "Geo3dDistanceQuery" in repr(
+        laurus.Geo3dDistanceQuery.within_sphere("position", cx, cy, cz, 1000.0)
+    )
     assert "Geo3dBoundingBoxQuery" in repr(
-        laurus.Geo3dBoundingBoxQuery("position", 0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+        laurus.Geo3dBoundingBoxQuery.within_box(
+            "position", 0.0, 0.0, 0.0, 1.0, 1.0, 1.0
+        )
     )
     assert "Geo3dNearestQuery" in repr(
-        laurus.Geo3dNearestQuery("position", cx, cy, cz, 5)
+        laurus.Geo3dNearestQuery.k_nearest("position", cx, cy, cz, 5)
     )


### PR DESCRIPTION
## Summary

Step 2 of #344. Aligns the Python binding's Geo API with the structure that the other four bindings (Node.js / Ruby / WASM / PHP) already use: **one class per query type, constructed via static factory methods only**.

This is the first user-visible binding-level change in the #344 series. Pre-1.0, breaking change.

## Changes

### Removed (Python)

- `laurus.GeoQuery` (the unified 2D enum wrapper) — split into two classes
- `laurus.Geo3dDistanceQuery(...)` direct constructor
- `laurus.Geo3dBoundingBoxQuery(...)` direct constructor
- `laurus.Geo3dNearestQuery(...)` direct constructor

### Added (Python)

- `laurus.GeoDistanceQuery.within_radius(field, lat, lon, distance_km)` — same shape as the old `GeoQuery.within_radius`
- `laurus.GeoBoundingBoxQuery.within_bounding_box(field, min_lat, min_lon, max_lat, max_lon)` — same shape as the old `GeoQuery.within_bounding_box`
- `laurus.Geo3dDistanceQuery.within_sphere(field, x, y, z, radius_m)`
- `laurus.Geo3dBoundingBoxQuery.within_box(field, min_x, min_y, min_z, max_x, max_y, max_z)`
- `laurus.Geo3dNearestQuery.k_nearest(field, x, y, z, k, initial_radius_m=..., max_radius_m=...)`

### Cross-binding parity

The factory names match the **same logical names** used by Ruby / Node.js / PHP. Each language uses its own case convention (snake_case in Python / Ruby, camelCase in Node.js / PHP) per language idiom, but the logical method name is identical:

| Logical name | Python / Ruby | Node.js / PHP |
|---|---|---|
| Geo distance | `within_radius` | `withinRadius` |
| Geo bbox | `within_bounding_box` | `withinBoundingBox` |
| Geo3d sphere | `within_sphere` | `withinSphere` |
| Geo3d bbox | `within_box` | `withinBox` |
| Geo3d k-NN | `k_nearest` | `kNearest` |

## Files

- `laurus-python/src/query.rs` — replace `PyGeoQuery` enum with `PyGeoDistanceQuery` + `PyGeoBoundingBoxQuery`; switch `PyGeo3d*` from `#[new]` to `#[staticmethod]` factories
- `laurus-python/src/lib.rs` — register the two new classes, drop `PyGeoQuery`
- `laurus-python/src/index.rs` — doc-comment example reference
- `laurus-python/tests/test_geo3d.py` — switch all Geo3d* construction to factory style
- `laurus-python/examples/lexical_search.py` — switch GeoQuery to GeoDistanceQuery / GeoBoundingBoxQuery
- `laurus-python/README.md` / `README_ja.md` — update query-types table

## Test plan

- [x] `cargo build -p laurus-python` (with `PYO3_PYTHON=/usr/bin/python3`) — clean
- [x] `cargo fmt --check -p laurus-python` — clean
- [x] `cargo clippy -p laurus-python -- -D warnings` — clean
- [ ] CI runs the pytest suite (test_geo3d.py + test_index.py)

## Sequencing

Done: PR 1 (#355) — core split + 2D DSL forms.

This PR (PR 2) is followed by:

- PR 3 — `laurus-nodejs`: drop `GeoQuery`, expose new classes
- PR 4 — `laurus-ruby`: drop `GeoQuery` + add `initial_radius_m` / `max_radius_m`
- PR 5 — `laurus-wasm`: same
- PR 6 — `laurus-php`: same
- PR 7 — remove `GeoQuery` enum from core + update all `api_reference.md` (en/ja) + CHANGELOG

Refs #344