### PR TITLE
refactor(nodejs): split GeoQuery into GeoDistanceQuery + GeoBoundingBoxQuery (step 3 of #344)

### DIFF
--- a/laurus-nodejs/src/query.rs
+++ b/laurus-nodejs/src/query.rs
@@ -7,7 +7,8 @@ use laurus::GeoEcefPoint;
 use laurus::lexical::span::{SpanQueryBuilder, SpanQueryWrapper};
 use laurus::lexical::{
     BooleanQuery, FuzzyQuery, Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery,
-    GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
+    GeoBoundingBoxQuery, GeoDistanceQuery, NumericRangeQuery, PhraseQuery, TermQuery,
+    WildcardQuery,
 };
 use laurus::vector::Vector;
 use laurus::vector::store::request::QueryVector;
@@ -40,7 +41,10 @@ pub fn extract_lexical_query(query: &JsQuery) -> Result<Box<dyn laurus::lexical:
                 .map_err(|e| napi::Error::from_reason(e.to_string()))?,
         )),
         JsQuery::NumericRangeQuery(q) => Ok(q.build()),
-        JsQuery::GeoQuery(q) => q
+        JsQuery::GeoDistanceQuery(q) => q
+            .build()
+            .map_err(|e| napi::Error::from_reason(e.to_string())),
+        JsQuery::GeoBoundingBoxQuery(q) => q
             .build()
             .map_err(|e| napi::Error::from_reason(e.to_string())),
         JsQuery::Geo3dDistanceQuery(q) => Ok(q.build()),
@@ -102,7 +106,8 @@ pub enum JsQuery {
     FuzzyQuery(JsFuzzyQuery),
     WildcardQuery(JsWildcardQuery),
     NumericRangeQuery(JsNumericRangeQuery),
-    GeoQuery(JsGeoQuery),
+    GeoDistanceQuery(JsGeoDistanceQuery),
+    GeoBoundingBoxQuery(JsGeoBoundingBoxQuery),
     Geo3dDistanceQuery(JsGeo3dDistanceQuery),
     Geo3dBoundingBoxQuery(JsGeo3dBoundingBoxQuery),
     Geo3dNearestQuery(JsGeo3dNearestQuery),
@@ -345,48 +350,30 @@ impl JsNumericRangeQuery {
 }
 
 // ---------------------------------------------------------------------------
-// GeoQuery
+// GeoDistanceQuery
 // ---------------------------------------------------------------------------
 
-/// Geographic search query (radius or bounding box).
-///
-/// Use the static factory methods to create queries:
+/// Geographic distance (radius) search query.
 ///
 /// ## Example
 ///
 /// ```javascript
-/// const { GeoQuery } = require("laurus-nodejs");
+/// const { GeoDistanceQuery } = require("laurus-nodejs");
 ///
 /// // Radius search: within 100 km of San Francisco
-/// const q = GeoQuery.withinRadius("location", 37.77, -122.42, 100.0);
-///
-/// // Bounding box search
-/// const q2 = GeoQuery.withinBoundingBox("location", 33.0, -123.0, 48.0, -117.0);
+/// const q = GeoDistanceQuery.withinRadius("location", 37.77, -122.42, 100.0);
 /// ```
-#[napi(js_name = "GeoQuery")]
-pub struct JsGeoQuery {
+#[napi(js_name = "GeoDistanceQuery")]
+pub struct JsGeoDistanceQuery {
     pub(crate) field: String,
-    pub(crate) kind: GeoKind,
-}
-
-#[derive(Clone)]
-pub enum GeoKind {
-    Radius {
-        lat: f64,
-        lon: f64,
-        distance_km: f64,
-    },
-    BoundingBox {
-        min_lat: f64,
-        min_lon: f64,
-        max_lat: f64,
-        max_lon: f64,
-    },
+    pub(crate) lat: f64,
+    pub(crate) lon: f64,
+    pub(crate) distance_km: f64,
 }
 
 #[napi]
-impl JsGeoQuery {
-    /// Create a radius-based geo query.
+impl JsGeoDistanceQuery {
+    /// Create a radius-based geo distance query.
     ///
     /// # Arguments
     ///
@@ -398,14 +385,50 @@ impl JsGeoQuery {
     pub fn within_radius(field: String, lat: f64, lon: f64, distance_km: f64) -> Self {
         Self {
             field,
-            kind: GeoKind::Radius {
-                lat,
-                lon,
-                distance_km,
-            },
+            lat,
+            lon,
+            distance_km,
         }
     }
+}
 
+impl JsGeoDistanceQuery {
+    pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
+        Ok(Box::new(GeoDistanceQuery::within_radius(
+            &self.field,
+            self.lat,
+            self.lon,
+            self.distance_km,
+        )?))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GeoBoundingBoxQuery
+// ---------------------------------------------------------------------------
+
+/// Geographic bounding-box search query.
+///
+/// ## Example
+///
+/// ```javascript
+/// const { GeoBoundingBoxQuery } = require("laurus-nodejs");
+///
+/// const q = GeoBoundingBoxQuery.withinBoundingBox(
+///   "location", 33.0, -123.0, 48.0, -117.0,
+/// );
+/// ```
+#[napi(js_name = "GeoBoundingBoxQuery")]
+pub struct JsGeoBoundingBoxQuery {
+    pub(crate) field: String,
+    pub(crate) min_lat: f64,
+    pub(crate) min_lon: f64,
+    pub(crate) max_lat: f64,
+    pub(crate) max_lon: f64,
+}
+
+#[napi]
+impl JsGeoBoundingBoxQuery {
     /// Create a bounding-box geo query.
     ///
     /// # Arguments
@@ -425,42 +448,23 @@ impl JsGeoQuery {
     ) -> Self {
         Self {
             field,
-            kind: GeoKind::BoundingBox {
-                min_lat,
-                min_lon,
-                max_lat,
-                max_lon,
-            },
+            min_lat,
+            min_lon,
+            max_lat,
+            max_lon,
         }
     }
 }
 
-impl JsGeoQuery {
+impl JsGeoBoundingBoxQuery {
     pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
-        match &self.kind {
-            GeoKind::Radius {
-                lat,
-                lon,
-                distance_km,
-            } => Ok(Box::new(GeoQuery::within_radius(
-                &self.field,
-                *lat,
-                *lon,
-                *distance_km,
-            )?)),
-            GeoKind::BoundingBox {
-                min_lat,
-                min_lon,
-                max_lat,
-                max_lon,
-            } => Ok(Box::new(GeoQuery::within_bounding_box(
-                &self.field,
-                *min_lat,
-                *min_lon,
-                *max_lat,
-                *max_lon,
-            )?)),
-        }
+        Ok(Box::new(GeoBoundingBoxQuery::within_bounding_box(
+            &self.field,
+            self.min_lat,
+            self.min_lon,
+            self.max_lat,
+            self.max_lon,
+        )?))
     }
 }
 


### PR DESCRIPTION
## Summary

Step 3 of #344. Aligns the Node.js binding's 2D Geo API with the new core split: `GeoQuery` (the unified enum class) is replaced with two top-level classes — `GeoDistanceQuery` and `GeoBoundingBoxQuery` — each handling one query type, mirroring the layout already used for the `Geo3d*` classes.

Pre-1.0, breaking change.

## Changes (Node.js)

### Removed

- `GeoQuery` class

### Added

- `GeoDistanceQuery.withinRadius(field, lat, lon, distanceKm)` — same factory shape as the old `GeoQuery.withinRadius`
- `GeoBoundingBoxQuery.withinBoundingBox(field, minLat, minLon, maxLat, maxLon)` — same factory shape as the old `GeoQuery.withinBoundingBox`

### Migration

```javascript
// Before
const q = GeoQuery.withinRadius("location", 37.77, -122.42, 100.0);

// After
const q = GeoDistanceQuery.withinRadius("location", 37.77, -122.42, 100.0);
```

Same arguments, different class. No other call site changes needed.

## Files

- `laurus-nodejs/src/query.rs` — replace `JsGeoQuery` + internal `GeoKind` enum with `JsGeoDistanceQuery` and `JsGeoBoundingBoxQuery`, each holding its own typed fields and exposing a single `#[napi(factory)]` method. Update the `JsQuery` discriminator enum and `extract_lexical_query` match.

## Out of scope

- The Node.js Geo3d API is already factory-only with `kNearest` matching the cross-binding canonical name decided in #344, so no Geo3d changes are needed in this PR.
- Tests, README, and `index.d.ts` need no updates: existing tests only use `setLexicalGeo3d*` setters and the typed-d.ts file is regenerated by the napi build.

## Test plan

- [x] `cargo build -p laurus-nodejs` — clean
- [x] `cargo fmt --check -p laurus-nodejs` — clean
- [x] `cargo clippy -p laurus-nodejs -- -D warnings` — clean
- [ ] CI runs the Vitest suite

## Sequencing

Done so far: PR 1 (#355) core split + 2D DSL forms · PR 2 (#356) Python.

Remaining:

- PR 4 — `laurus-ruby`: drop `GeoQuery` + add `initial_radius_m` / `max_radius_m`
- PR 5 — `laurus-wasm`: same
- PR 6 — `laurus-php`: same
- PR 7 — remove `GeoQuery` enum from core + update all `api_reference.md` (en/ja) + CHANGELOG

Refs #344