### PR TITLE
refactor(wasm): split internal GeoQuery and add initial/max radius args to searchGeo3dNearest (step 5 of #344)

### DIFF
--- a/laurus-wasm/src/index.rs
+++ b/laurus-wasm/src/index.rs
@@ -449,8 +449,18 @@ impl WasmIndex {
         k: u32,
         limit: Option<u32>,
         offset: Option<u32>,
+        initial_radius_m: Option<f64>,
+        max_radius_m: Option<f64>,
     ) -> Result<JsValue, JsValue> {
-        let query = JsQuery::Geo3dNearestQuery(JsGeo3dNearestQuery { field, x, y, z, k });
+        let query = JsQuery::Geo3dNearestQuery(JsGeo3dNearestQuery {
+            field,
+            x,
+            y,
+            z,
+            k,
+            initial_radius_m,
+            max_radius_m,
+        });
         let request = build_lexical_request(
             &query,
             limit.unwrap_or(10) as usize,

--- a/laurus-wasm/src/query.rs
+++ b/laurus-wasm/src/query.rs
@@ -6,7 +6,8 @@ use laurus::GeoEcefPoint;
 use laurus::lexical::span::{SpanQueryBuilder, SpanQueryWrapper};
 use laurus::lexical::{
     BooleanQuery, FuzzyQuery, Geo3dBoundingBoxQuery, Geo3dDistanceQuery, Geo3dNearestQuery,
-    GeoQuery, NumericRangeQuery, PhraseQuery, TermQuery, WildcardQuery,
+    GeoBoundingBoxQuery, GeoDistanceQuery, NumericRangeQuery, PhraseQuery, TermQuery,
+    WildcardQuery,
 };
 use laurus::vector::Vector;
 use laurus::vector::store::request::QueryVector;
@@ -24,7 +25,8 @@ pub enum JsQuery {
     FuzzyQuery(JsFuzzyQuery),
     WildcardQuery(JsWildcardQuery),
     NumericRangeQuery(JsNumericRangeQuery),
-    GeoQuery(JsGeoQuery),
+    GeoDistanceQuery(JsGeoDistanceQuery),
+    GeoBoundingBoxQuery(JsGeoBoundingBoxQuery),
     Geo3dDistanceQuery(JsGeo3dDistanceQuery),
     Geo3dBoundingBoxQuery(JsGeo3dBoundingBoxQuery),
     Geo3dNearestQuery(JsGeo3dNearestQuery),
@@ -55,7 +57,8 @@ pub fn extract_lexical_query(query: &JsQuery) -> Result<Box<dyn laurus::lexical:
                 .map_err(|e| JsValue::from_str(&e.to_string()))?,
         )),
         JsQuery::NumericRangeQuery(q) => Ok(q.build()),
-        JsQuery::GeoQuery(q) => q.build().map_err(|e| JsValue::from_str(&e.to_string())),
+        JsQuery::GeoDistanceQuery(q) => q.build().map_err(|e| JsValue::from_str(&e.to_string())),
+        JsQuery::GeoBoundingBoxQuery(q) => q.build().map_err(|e| JsValue::from_str(&e.to_string())),
         JsQuery::Geo3dDistanceQuery(q) => Ok(q.build()),
         JsQuery::Geo3dBoundingBoxQuery(q) => {
             q.build().map_err(|e| JsValue::from_str(&e.to_string()))
@@ -168,52 +171,51 @@ impl JsNumericRangeQuery {
     }
 }
 
-pub struct JsGeoQuery {
+/// 2D Geo distance (radius) query (internal).
+///
+/// Construction is internal — JS callers reach 2D Geo through the DSL
+/// (`field:geo_distance(...)`) since `JsGeoDistanceQuery` is not exposed
+/// as a JS class.
+pub struct JsGeoDistanceQuery {
     pub field: String,
-    pub kind: GeoKind,
+    pub lat: f64,
+    pub lon: f64,
+    pub distance_km: f64,
 }
 
-#[derive(Clone)]
-pub enum GeoKind {
-    Radius {
-        lat: f64,
-        lon: f64,
-        distance_km: f64,
-    },
-    BoundingBox {
-        min_lat: f64,
-        min_lon: f64,
-        max_lat: f64,
-        max_lon: f64,
-    },
-}
-
-impl JsGeoQuery {
+impl JsGeoDistanceQuery {
     pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
-        match &self.kind {
-            GeoKind::Radius {
-                lat,
-                lon,
-                distance_km,
-            } => Ok(Box::new(GeoQuery::within_radius(
-                &self.field,
-                *lat,
-                *lon,
-                *distance_km,
-            )?)),
-            GeoKind::BoundingBox {
-                min_lat,
-                min_lon,
-                max_lat,
-                max_lon,
-            } => Ok(Box::new(GeoQuery::within_bounding_box(
-                &self.field,
-                *min_lat,
-                *min_lon,
-                *max_lat,
-                *max_lon,
-            )?)),
-        }
+        Ok(Box::new(GeoDistanceQuery::within_radius(
+            &self.field,
+            self.lat,
+            self.lon,
+            self.distance_km,
+        )?))
+    }
+}
+
+/// 2D Geo bounding-box query (internal).
+///
+/// Construction is internal — JS callers reach 2D Geo through the DSL
+/// (`field:geo_bbox(...)`) since `JsGeoBoundingBoxQuery` is not exposed
+/// as a JS class.
+pub struct JsGeoBoundingBoxQuery {
+    pub field: String,
+    pub min_lat: f64,
+    pub min_lon: f64,
+    pub max_lat: f64,
+    pub max_lon: f64,
+}
+
+impl JsGeoBoundingBoxQuery {
+    pub fn build(&self) -> laurus::Result<Box<dyn laurus::lexical::Query>> {
+        Ok(Box::new(GeoBoundingBoxQuery::within_bounding_box(
+            &self.field,
+            self.min_lat,
+            self.min_lon,
+            self.max_lat,
+            self.max_lon,
+        )?))
     }
 }
 
@@ -221,7 +223,7 @@ impl JsGeoQuery {
 ///
 /// Constructed by `Index::searchGeo3dDistance`. JS callers cannot
 /// instantiate this directly; the method-on-Index pattern matches the
-/// existing 2D `JsGeoQuery` and `JsTermQuery` flows.
+/// existing 2D `JsGeoDistanceQuery` and `JsTermQuery` flows.
 pub struct JsGeo3dDistanceQuery {
     pub field: String,
     pub x: f64,
@@ -268,15 +270,24 @@ pub struct JsGeo3dNearestQuery {
     pub y: f64,
     pub z: f64,
     pub k: u32,
+    pub initial_radius_m: Option<f64>,
+    pub max_radius_m: Option<f64>,
 }
 
 impl JsGeo3dNearestQuery {
     pub fn build(&self) -> Box<dyn laurus::lexical::Query> {
-        Box::new(Geo3dNearestQuery::new(
+        let mut q = Geo3dNearestQuery::new(
             &self.field,
             GeoEcefPoint::new(self.x, self.y, self.z),
             self.k as usize,
-        ))
+        );
+        if let Some(r) = self.initial_radius_m {
+            q = q.with_initial_radius(r);
+        }
+        if let Some(r) = self.max_radius_m {
+            q = q.with_max_radius(r);
+        }
+        Box::new(q)
     }
 }
 


### PR DESCRIPTION
## Summary

Step 5 of #344. Two changes for the WASM binding:

1. **Split the internal `JsGeoQuery` + `GeoKind` enum** into two separate internal structs `JsGeoDistanceQuery` and `JsGeoBoundingBoxQuery`, matching the new core split. These structs are pure-Rust internals and **not exposed to JS callers** (JS reaches 2D Geo through the DSL forms `field:geo_distance(...)` / `field:geo_bbox(...)` introduced in PR 1), so this is a pure-internal cleanup with **no JS API impact**.

2. **Add `initialRadiusM` and `maxRadiusM` optional trailing arguments** to `Index.searchGeo3dNearest`, fixing the cross-binding parity gap noted in #344. WASM users can now tune the expanding-radius search the same way Python, Node.js, and Ruby users can.

## Migration

```javascript
// Before — only the basic 5-arg form
const results = await index.searchGeo3dNearest(
  "position", x, y, z, k, /* limit */ 10, /* offset */ 0,
);

// After — same 7-arg form still works AND the two new tuning kwargs are accepted
const results = await index.searchGeo3dNearest(
  "position", x, y, z, k,
  /* limit */ 10, /* offset */ 0,
  /* initialRadiusM */ 10_000.0,
  /* maxRadiusM */ 10_000_000.0,
);
```

Existing call sites need no changes (the new arguments are optional).

## Files

- `laurus-wasm/src/query.rs` — replace `JsGeoQuery` + `GeoKind` enum with `JsGeoDistanceQuery` and `JsGeoBoundingBoxQuery` structs that delegate to the new core factories. Update the `JsQuery` discriminator enum and `extract_lexical_query` match. Update `JsGeo3dNearestQuery` to carry `initial_radius_m: Option<f64>` and `max_radius_m: Option<f64>`, with `build()` calling `with_initial_radius` / `with_max_radius` on the core query. Refresh the doc-comment that referenced the removed `JsGeoQuery`.
- `laurus-wasm/src/index.rs` — `searchGeo3dNearest` accepts two new optional trailing arguments and threads them through into the internal `JsGeo3dNearestQuery`.

## Test plan

- [x] `cargo build -p laurus-wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo fmt --check -p laurus-wasm` — clean
- [x] `cargo clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings` — clean
- [ ] CI runs the WASM build/clippy matrix

## Sequencing

Done so far: PR 1 (#355) core · PR 2 (#356) Python · PR 3 (#357) Node.js · PR 4 (#358) Ruby.

Remaining:

- PR 6 — `laurus-php`: drop `GeoQuery`; add `initial_radius_m` / `max_radius_m`
- PR 7 — remove `GeoQuery` enum from core + update all `api_reference.md` (en/ja) + CHANGELOG

Refs #344