### PR TITLE
feat(php): add SpanQuery::nearSpans for nested span clauses

### DIFF
--- a/laurus-php/src/query.rs
+++ b/laurus-php/src/query.rs
@@ -903,6 +903,34 @@ impl PhpSpanQuery {
         }
     }
 
+    /// SpanNear with nested `SpanQuery` clauses instead of plain terms.
+    ///
+    /// Use this when you need a `SpanNear` that contains other span queries
+    /// (e.g. another `SpanNear`, a `SpanContaining`, or a `SpanWithin`)
+    /// rather than just term clauses.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Field to search.
+    /// * `clauses` - Array of `Laurus\\SpanQuery` instances. Each clause's
+    ///   `field` is replaced by `field` at build time, so nested clauses are
+    ///   re-rooted onto the outer field.
+    /// * `slop` - Maximum token distance between clauses (default: 0).
+    /// * `ordered` - Whether clauses must appear in order (default: true).
+    #[php(defaults(slop = 0, ordered = true))]
+    pub fn near_spans(
+        field: String,
+        clauses: Vec<&PhpSpanQuery>,
+        slop: i64,
+        ordered: bool,
+    ) -> Self {
+        let kinds: Vec<SpanKind> = clauses.iter().map(|c| c.kind.clone()).collect();
+        Self {
+            field,
+            kind: SpanKind::Near(kinds, slop as u32, ordered),
+        }
+    }
+
     /// SpanContaining: a span that contains another span.
     ///
     /// # Arguments

--- a/laurus-php/tests/LaurusTest.php
+++ b/laurus-php/tests/LaurusTest.php
@@ -250,6 +250,46 @@ class LaurusTest extends TestCase
         $this->assertEquals("d2", $results[0]->getId());
     }
 
+    // ── SpanQuery ───────────────────────────────────────────────────────
+
+    public function testSpanQueryNear(): void
+    {
+        // Plain term-only `near` already works via `SpanQuery::near`.
+        $schema = new Laurus\Schema();
+        $schema->addTextField("body", true, true, true);
+        $idx = new Laurus\Index(null, $schema);
+        $idx->putDocument("d1", ["body" => "the quick brown fox"]);
+        $idx->putDocument("d2", ["body" => "the slow red fox"]);
+        $idx->commit();
+        $q = Laurus\SpanQuery::near("body", ["quick", "fox"], 2, true);
+        $results = $idx->search($q);
+        $this->assertCount(1, $results);
+        $this->assertEquals("d1", $results[0]->getId());
+    }
+
+    public function testSpanQueryNearSpansWithNestedClauses(): void
+    {
+        // `nearSpans` accepts pre-built SpanQuery instances, so callers can
+        // nest other span constructions (e.g. another `near`, `containing`,
+        // `within`) inside a `SpanNear`. The simplest exercise wraps two
+        // bare `term` clauses and verifies the result is identical to the
+        // plain `near` form.
+        $schema = new Laurus\Schema();
+        $schema->addTextField("body", true, true, true);
+        $idx = new Laurus\Index(null, $schema);
+        $idx->putDocument("d1", ["body" => "the quick brown fox"]);
+        $idx->putDocument("d2", ["body" => "the slow red fox"]);
+        $idx->commit();
+        $clauses = [
+            Laurus\SpanQuery::term("body", "quick"),
+            Laurus\SpanQuery::term("body", "fox"),
+        ];
+        $q = Laurus\SpanQuery::nearSpans("body", $clauses, 2, true);
+        $results = $idx->search($q);
+        $this->assertCount(1, $results);
+        $this->assertEquals("d1", $results[0]->getId());
+    }
+
     // ── Geo3d (3D ECEF) ─────────────────────────────────────────────────
 
     public function testGeo3dFieldRoundTrip(): void


### PR DESCRIPTION
## Summary

The PHP `SpanQuery` exposed `term`, `near`, `containing`, and `within`, but lacked the `near_spans` factory that the other four bindings already ship (Python `near_spans`, Node.js `nearSpans`, Ruby `near_spans`, and the underlying core API). PHP users could therefore not build a `SpanNear` whose clauses are themselves non-term span queries (e.g. another `SpanNear`, a `SpanContaining`, or a `SpanWithin`).

This PR adds `Laurus\SpanQuery::nearSpans(\$field, array \$clauses, int \$slop = 0, bool \$ordered = true)` which accepts an array of `Laurus\SpanQuery` instances and reuses the existing internal `SpanKind::Near` recipe, mirroring the Python implementation.

## Migration / usage

```php
\$clauses = [
    Laurus\SpanQuery::term(\"body\", \"quick\"),
    Laurus\SpanQuery::term(\"body\", \"fox\"),
    // …or arbitrary nested SpanQuery instances
];
\$q = Laurus\SpanQuery::nearSpans(\"body\", \$clauses, 2, true);
\$results = \$index->search(\$q);
```

## Files

- `laurus-php/src/query.rs` — add `near_spans` factory accepting `Vec<&PhpSpanQuery>` (same pattern that `PhpSynonymGraphFilter::apply` already uses for `Vec<&PhpToken>`, so no new ext-php-rs glue is needed).
- `laurus-php/tests/LaurusTest.php` — add `testSpanQueryNear` (sanity check for the existing term-only `near` factory; the file had no SpanQuery test before this PR) and `testSpanQueryNearSpansWithNestedClauses` (exercises the new factory by wrapping two `SpanQuery::term` clauses and confirming the result matches the equivalent `near` invocation).

## Test plan

- [x] `cargo build -p laurus-php` — clean
- [x] `cargo fmt --check -p laurus-php` — clean
- [x] `cargo clippy -p laurus-php -- -D warnings` — clean
- [ ] CI runs the PHPUnit suite

Closes #349