### PR TITLE
feat(nodejs,wasm): add Schema.toString() for parity with Python/Ruby/PHP

### DIFF
--- a/laurus-nodejs/src/schema.rs
+++ b/laurus-nodejs/src/schema.rs
@@ -454,4 +454,14 @@ impl JsSchema {
     pub fn field_names(&self) -> Vec<String> {
         self.inner.fields.keys().cloned().collect()
     }
+
+    /// Return a string representation of this schema, listing the declared
+    /// field names. Convenient for `console.log` / `String(schema)`.
+    #[napi(js_name = "toString")]
+    pub fn to_string_repr(&self) -> String {
+        format!(
+            "Schema(fields={:?})",
+            self.inner.fields.keys().collect::<Vec<_>>()
+        )
+    }
 }

--- a/laurus-wasm/src/schema.rs
+++ b/laurus-wasm/src/schema.rs
@@ -384,4 +384,14 @@ impl WasmSchema {
     pub fn field_names(&self) -> Vec<String> {
         self.inner.fields.keys().cloned().collect()
     }
+
+    /// Return a string representation of this schema, listing the declared
+    /// field names. Convenient for `console.log` / `String(schema)`.
+    #[wasm_bindgen(js_name = "toString")]
+    pub fn to_string_repr(&self) -> String {
+        format!(
+            "Schema(fields={:?})",
+            self.inner.fields.keys().collect::<Vec<_>>()
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Three of the five bindings already exposed a string representation of `Schema`:

- Python — `__repr__`
- Ruby — `inspect` / `to_s`
- PHP — `__to_string`

Node.js and WASM did not, so `console.log(schema)` / `String(schema)` in those two bindings produced default object printouts. This PR fills the gap by adding a `toString()` method to both `Schema` classes that returns the same shape as the existing bindings:

```text
Schema(fields=["title", "body"])
```

## Naming note

The Rust method is named `to_string_repr` rather than `to_string` because clippy's `inherent_to_string` lint reserves `to_string` for `std::fmt::Display` impls — which neither `#[napi]` nor `#[wasm_bindgen]` can wrap. The JS-facing name is fixed to `toString` via `js_name = "toString"` so the user-visible API on both bindings is the conventional `schema.toString()`.

## Files

- `laurus-nodejs/src/schema.rs` — `#[napi(js_name = "toString")] fn to_string_repr` returning the formatted string.
- `laurus-wasm/src/schema.rs` — `#[wasm_bindgen(js_name = "toString")] fn to_string_repr` doing the same.

## Test plan

- [x] `cargo build -p laurus-nodejs` — clean
- [x] `cargo build -p laurus-wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo fmt --check -p laurus-nodejs -p laurus-wasm` — clean
- [x] `cargo clippy -p laurus-nodejs -- -D warnings` — clean
- [x] `cargo clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings` — clean
- [ ] CI runs the Vitest and WASM build matrix

Closes #351