### PR TITLE
feat(nodejs): SearchRequest accepts an options object instead of setter chains

### DIFF
--- a/laurus-nodejs/__tests__/geo3d.spec.mjs
+++ b/laurus-nodejs/__tests__/geo3d.spec.mjs
@@ -5,8 +5,8 @@
  * - Schema declaration via `addGeo3dField`.
  * - Document round-trip with `{ x, y, z }` JSON values.
  * - All three 3D query setters on `SearchRequest`:
- *   `setLexicalGeo3dDistanceQuery`, `setLexicalGeo3dBoundingBoxQuery`,
- *   `setLexicalGeo3dNearestQuery`.
+ *   `setLexicalGeo3dDistance`, `setLexicalGeo3dBoundingBox`,
+ *   `setLexicalGeo3dNearest`.
  *
  * Coordinates are precomputed ECEF values for well-known landmarks. They were
  * produced by `laurus::util::ecef::wgs84_to_ecef` so the values match what
@@ -56,12 +56,14 @@ describe("Geo3dDistanceQuery", () => {
   it("50 km sphere around Tokyo Tower returns Tower + Skytree", async () => {
     const index = await createGeo3dIndex();
     const req = new SearchRequest();
-    req.setLexicalGeo3dDistanceQuery(
-      "position",
-      TOKYO_TOWER.x,
-      TOKYO_TOWER.y,
-      TOKYO_TOWER.z,
-      50_000.0,
+    req.setLexicalGeo3dDistance(
+      Geo3dDistanceQuery.withinSphere(
+        "position",
+        TOKYO_TOWER.x,
+        TOKYO_TOWER.y,
+        TOKYO_TOWER.z,
+        50_000.0,
+      ),
     );
     const results = await index.searchWithRequest(req);
     const ids = new Set(results.map((r) => r.id));
@@ -71,12 +73,14 @@ describe("Geo3dDistanceQuery", () => {
   it("200 km sphere additionally pulls in Mt. Fuji", async () => {
     const index = await createGeo3dIndex();
     const req = new SearchRequest();
-    req.setLexicalGeo3dDistanceQuery(
-      "position",
-      TOKYO_TOWER.x,
-      TOKYO_TOWER.y,
-      TOKYO_TOWER.z,
-      200_000.0,
+    req.setLexicalGeo3dDistance(
+      Geo3dDistanceQuery.withinSphere(
+        "position",
+        TOKYO_TOWER.x,
+        TOKYO_TOWER.y,
+        TOKYO_TOWER.z,
+        200_000.0,
+      ),
     );
     const results = await index.searchWithRequest(req);
     const ids = new Set(results.map((r) => r.id));
@@ -92,14 +96,16 @@ describe("Geo3dBoundingBoxQuery", () => {
     // (x ≈ -4.65M, well below the lower bound).
     const index = await createGeo3dIndex();
     const req = new SearchRequest();
-    req.setLexicalGeo3dBoundingBoxQuery(
-      "position",
-      -3_962_000.0,
-      3_340_000.0,
-      3_690_000.0,
-      -3_954_000.0,
-      3_360_000.0,
-      3_710_000.0,
+    req.setLexicalGeo3dBoundingBox(
+      Geo3dBoundingBoxQuery.withinBox(
+        "position",
+        -3_962_000.0,
+        3_340_000.0,
+        3_690_000.0,
+        -3_954_000.0,
+        3_360_000.0,
+        3_710_000.0,
+      ),
     );
     const results = await index.searchWithRequest(req);
     const ids = new Set(results.map((r) => r.id));
@@ -111,7 +117,9 @@ describe("Geo3dNearestQuery", () => {
   it("k = 3 around Mt. Fuji returns Fuji + Tower + Skytree", async () => {
     const index = await createGeo3dIndex();
     const req = new SearchRequest();
-    req.setLexicalGeo3dNearestQuery("position", MT_FUJI.x, MT_FUJI.y, MT_FUJI.z, 3);
+    req.setLexicalGeo3dNearest(
+      Geo3dNearestQuery.kNearest("position", MT_FUJI.x, MT_FUJI.y, MT_FUJI.z, 3),
+    );
     const results = await index.searchWithRequest(req);
     expect(results).toHaveLength(3);
     const ids = new Set(results.map((r) => r.id));
@@ -123,14 +131,16 @@ describe("Geo3dNearestQuery", () => {
   it("accepts optional initial / max radius bounds", async () => {
     const index = await createGeo3dIndex();
     const req = new SearchRequest();
-    req.setLexicalGeo3dNearestQuery(
-      "position",
-      TOKYO_TOWER.x,
-      TOKYO_TOWER.y,
-      TOKYO_TOWER.z,
-      2,
-      10_000.0,
-      10_000_000.0,
+    req.setLexicalGeo3dNearest(
+      Geo3dNearestQuery.kNearest(
+        "position",
+        TOKYO_TOWER.x,
+        TOKYO_TOWER.y,
+        TOKYO_TOWER.z,
+        2,
+        10_000.0,
+        10_000_000.0,
+      ),
     );
     const results = await index.searchWithRequest(req);
     const ids = new Set(results.map((r) => r.id));

--- a/laurus-nodejs/__tests__/index.spec.mjs
+++ b/laurus-nodejs/__tests__/index.spec.mjs
@@ -227,18 +227,31 @@ describe("Vector search", () => {
 describe("Hybrid search", () => {
   it("searches with SearchRequest (lexical only)", async () => {
     const index = await createTextIndex();
-    const req = new SearchRequest(5);
-    req.setLexicalTermQuery("title", "rust");
+    const req = new SearchRequest({ limit: 5 });
+    req.setLexicalTerm(new TermQuery("title", "rust"));
     const results = await index.searchWithRequest(req);
     expect(results.length).toBeGreaterThanOrEqual(1);
   });
 
   it("searches with SearchRequest (hybrid)", async () => {
     const index = await createVectorIndex();
-    const req = new SearchRequest(5);
-    req.setLexicalTermQuery("title", "rust");
-    req.setVectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]);
-    req.setRrfFusion(60.0);
+    const req = new SearchRequest({ limit: 5 });
+    req.setLexicalTerm(new TermQuery("title", "rust"));
+    req.setVectorQuery(new VectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]));
+    req.setRrfFusion(new RRF(60.0));
+    const results = await index.searchWithRequest(req);
+    expect(results.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("searches with SearchRequest constructed via options object only", async () => {
+    // The constructor accepts an options object with primitive fields.
+    // Polymorphic clauses are still attached via per-type setters.
+    const index = await createTextIndex();
+    const req = new SearchRequest({
+      queryDsl: "title:rust",
+      limit: 5,
+      offset: 0,
+    });
     const results = await index.searchWithRequest(req);
     expect(results.length).toBeGreaterThanOrEqual(1);
   });
@@ -251,8 +264,8 @@ describe("Hybrid search", () => {
 describe("Query types", () => {
   it("phrase query", async () => {
     const index = await createTextIndex();
-    const req = new SearchRequest(5);
-    req.setLexicalPhraseQuery("title", ["introduction", "rust"]);
+    const req = new SearchRequest({ limit: 5 });
+    req.setLexicalPhrase(new PhraseQuery("title", ["introduction", "rust"]));
     const results = await index.searchWithRequest(req);
     expect(results.some((r) => r.id === "doc1")).toBe(true);
   });
@@ -266,7 +279,7 @@ describe("Query types", () => {
     await index.commit();
 
     const q = new NumericRangeQuery("year", 2022, 2024);
-    const req = new SearchRequest(5);
+    const req = new SearchRequest({ limit: 5 });
     // Use DSL or searchTerm - NumericRangeQuery needs to be used via SearchRequest
     // For now, test that the class can be constructed
     expect(q).toBeDefined();

--- a/laurus-nodejs/examples/hybrid-search.mjs
+++ b/laurus-nodejs/examples/hybrid-search.mjs
@@ -5,7 +5,15 @@
  * with RRF and WeightedSum fusion.
  */
 
-import { Index, Schema, SearchRequest } from "../index.js";
+import {
+  Index,
+  RRF,
+  Schema,
+  SearchRequest,
+  TermQuery,
+  VectorQuery,
+  WeightedSum,
+} from "../index.js";
 
 // Create schema with text + vector fields
 const schema = new Schema();
@@ -35,10 +43,10 @@ await index.commit();
 
 // Hybrid search with RRF fusion
 console.log("=== Hybrid search (RRF) ===");
-const rrfReq = new SearchRequest(5);
-rrfReq.setLexicalTermQuery("description", "fast");
-rrfReq.setVectorQuery("embedding", [0.85, 0.15, 0.2, 0.3]);
-rrfReq.setRrfFusion(60.0);
+const rrfReq = new SearchRequest({ limit: 5 });
+rrfReq.setLexicalTerm(new TermQuery("description", "fast"));
+rrfReq.setVectorQuery(new VectorQuery("embedding", [0.85, 0.15, 0.2, 0.3]));
+rrfReq.setRrfFusion(new RRF(60.0));
 for (const r of await index.searchWithRequest(rrfReq)) {
   console.log(`  ${r.id}  score=${r.score.toFixed(4)}  name="${r.document.name}"`);
 }
@@ -47,10 +55,10 @@ for (const r of await index.searchWithRequest(rrfReq)) {
 console.log(
   "\n=== Hybrid search (WeightedSum: 0.3 lexical, 0.7 vector) ===",
 );
-const wsReq = new SearchRequest(5);
-wsReq.setLexicalTermQuery("description", "fast");
-wsReq.setVectorQuery("embedding", [0.85, 0.15, 0.2, 0.3]);
-wsReq.setWeightedSumFusion(0.3, 0.7);
+const wsReq = new SearchRequest({ limit: 5 });
+wsReq.setLexicalTerm(new TermQuery("description", "fast"));
+wsReq.setVectorQuery(new VectorQuery("embedding", [0.85, 0.15, 0.2, 0.3]));
+wsReq.setWeightedSumFusion(new WeightedSum(0.3, 0.7));
 for (const r of await index.searchWithRequest(wsReq)) {
   console.log(`  ${r.id}  score=${r.score.toFixed(4)}  name="${r.document.name}"`);
 }

--- a/laurus-nodejs/src/query.rs
+++ b/laurus-nodejs/src/query.rs
@@ -1105,6 +1105,7 @@ impl JsSpanQuery {
 /// const { VectorQuery } = require("laurus-nodejs");
 /// const results = await index.search(new VectorQuery("text_vec", [0.1, 0.2, ...]));
 /// ```
+#[derive(Clone)]
 #[napi(js_name = "VectorQuery")]
 pub struct JsVectorQueryInner {
     pub(crate) field: String,
@@ -1140,6 +1141,7 @@ impl JsVectorQueryInner {
 /// const { VectorTextQuery } = require("laurus-nodejs");
 /// const results = await index.search(new VectorTextQuery("text_vec", "memory safety"));
 /// ```
+#[derive(Clone)]
 #[napi(js_name = "VectorTextQuery")]
 pub struct JsVectorTextQuery {
     pub(crate) field: String,

--- a/laurus-nodejs/src/search.rs
+++ b/laurus-nodejs/src/search.rs
@@ -2,9 +2,11 @@
 
 use crate::convert::data_value_to_json;
 use crate::query::{
-    JsGeo3dBoundingBoxQuery, JsGeo3dDistanceQuery, JsGeo3dNearestQuery, JsPhraseQuery, JsQuery,
-    JsTermQuery, JsVectorQuery, JsVectorQueryInner, JsVectorTextQuery, extract_lexical_query,
-    query_to_lexical_search_query, vector_query_to_search_query,
+    JsBooleanQuery, JsFuzzyQuery, JsGeo3dBoundingBoxQuery, JsGeo3dDistanceQuery,
+    JsGeo3dNearestQuery, JsGeoBoundingBoxQuery, JsGeoDistanceQuery, JsNumericRangeQuery,
+    JsPhraseQuery, JsQuery, JsSpanQuery, JsTermQuery, JsVectorQuery, JsVectorQueryInner,
+    JsVectorTextQuery, JsWildcardQuery, extract_lexical_query, query_to_lexical_search_query,
+    vector_query_to_search_query,
 };
 use laurus::{FusionAlgorithm, LexicalSearchQuery, SearchRequestBuilder, SearchResult};
 use napi::bindgen_prelude::*;
@@ -158,211 +160,253 @@ pub enum FusionChoice {
     WeightedSum(f32, f32),
 }
 
+/// Options object accepted by [`JsSearchRequest::new`].
+///
+/// Only the primitive fields (`queryDsl`, `limit`, `offset`) live here.
+/// Polymorphic fields (lexical / filter / vector / fusion) are populated
+/// after construction via the per-type `setLexicalX` / `setFilterX` /
+/// `setVector*` / `setRrfFusion` / `setWeightedSumFusion` methods —
+/// napi-rs cannot accept a class-instance union as an `#[napi(object)]`
+/// field because the auto-generated `ValidateNapiValue` for `&T` looks
+/// up the JS class constructor by the *Rust* struct name instead of the
+/// JS name set via `js_name = "..."`, so any polymorphic field on a
+/// napi options struct rejects every instance at runtime.
+#[napi(object)]
+pub struct JsSearchRequestOptions {
+    /// Optional query DSL string (e.g. `"title:hello"`).
+    pub query_dsl: Option<String>,
+    /// Maximum number of results (default 10).
+    pub limit: Option<u32>,
+    /// Pagination offset (default 0).
+    pub offset: Option<u32>,
+}
+
 #[napi]
 impl JsSearchRequest {
     /// Create a new search request.
     ///
-    /// # Arguments
+    /// Accepts an options object containing the primitive fields. Use
+    /// the `setLexicalX` / `setFilterX` / `setVector*` /
+    /// `setRrfFusion` / `setWeightedSumFusion` setters to attach
+    /// query objects after construction.
     ///
-    /// * `limit` - Maximum number of results (default 10).
-    /// * `offset` - Pagination offset (default 0).
+    /// ## Example
+    ///
+    /// ```javascript
+    /// const req = new SearchRequest({ queryDsl: "title:rust", limit: 5 });
+    ///
+    /// // Or build one piece at a time:
+    /// const req2 = new SearchRequest({ limit: 5 });
+    /// req2.setLexicalTerm(new TermQuery("title", "rust"));
+    /// req2.setVectorQuery(new VectorQuery("embedding", [0.1, 0.2]));
+    /// req2.setRrfFusion(new RRF(60.0));
+    /// ```
     #[napi(constructor)]
-    pub fn new(limit: Option<u32>, offset: Option<u32>) -> Self {
-        Self {
+    pub fn new(options: Option<JsSearchRequestOptions>) -> Self {
+        let options = options.unwrap_or(JsSearchRequestOptions {
             query_dsl: None,
+            limit: None,
+            offset: None,
+        });
+        Self {
+            query_dsl: options.query_dsl,
             lexical_query: None,
             vector_query: None,
             filter_query: None,
             fusion: None,
-            limit: limit.unwrap_or(10) as usize,
-            offset: offset.unwrap_or(0) as usize,
+            limit: options.limit.unwrap_or(10) as usize,
+            offset: options.offset.unwrap_or(0) as usize,
         }
     }
 
     /// Set a DSL string query.
-    ///
-    /// # Arguments
-    ///
-    /// * `dsl` - The query DSL string (e.g. `"title:hello"`).
     #[napi]
     pub fn set_query_dsl(&mut self, dsl: String) {
         self.query_dsl = Some(dsl);
     }
 
-    /// Set a lexical term query.
-    ///
-    /// # Arguments
-    ///
-    /// * `field` - The field name.
-    /// * `term` - The term to match.
+    // ── Lexical query setters (one per query type) ──────────────────────
+    //
+    // Each takes a `&JsXxxQuery` class instance — the same pattern used
+    // by `JsBooleanQuery` for the same napi-derive limitation around
+    // class-ref unions described above on `JsSearchRequestOptions`.
+
+    /// Set a [`JsTermQuery`] as the lexical clause.
     #[napi]
-    pub fn set_lexical_term_query(&mut self, field: String, term: String) {
-        self.lexical_query = Some(JsQuery::TermQuery(JsTermQuery { field, term }));
+    pub fn set_lexical_term(&mut self, query: &JsTermQuery) {
+        self.lexical_query = Some(JsQuery::TermQuery(query.clone()));
     }
 
-    /// Set a lexical phrase query.
-    ///
-    /// # Arguments
-    ///
-    /// * `field` - The field name.
-    /// * `terms` - The ordered list of terms.
+    /// Set a [`JsPhraseQuery`] as the lexical clause.
     #[napi]
-    pub fn set_lexical_phrase_query(&mut self, field: String, terms: Vec<String>) {
-        self.lexical_query = Some(JsQuery::PhraseQuery(JsPhraseQuery { field, terms }));
+    pub fn set_lexical_phrase(&mut self, query: &JsPhraseQuery) {
+        self.lexical_query = Some(JsQuery::PhraseQuery(query.clone()));
     }
 
-    /// Set a 3D ECEF distance (sphere) query.
-    ///
-    /// # Arguments
-    ///
-    /// * `field` - The Geo3d field name.
-    /// * `x`, `y`, `z` - Sphere centre in ECEF meters.
-    /// * `radius_m` - Sphere radius in meters.
-    #[napi(js_name = "setLexicalGeo3dDistanceQuery")]
-    pub fn set_lexical_geo3d_distance_query(
-        &mut self,
-        field: String,
-        x: f64,
-        y: f64,
-        z: f64,
-        radius_m: f64,
-    ) {
-        self.lexical_query = Some(JsQuery::Geo3dDistanceQuery(JsGeo3dDistanceQuery {
-            field,
-            x,
-            y,
-            z,
-            radius_m,
-        }));
-    }
-
-    /// Set a 3D ECEF axis-aligned bounding-box query.
-    ///
-    /// # Arguments
-    ///
-    /// * `field` - The Geo3d field name.
-    /// * `min_x`, `min_y`, `min_z` - Lower corner of the box.
-    /// * `max_x`, `max_y`, `max_z` - Upper corner of the box.
-    #[napi(js_name = "setLexicalGeo3dBoundingBoxQuery")]
-    #[allow(clippy::too_many_arguments)]
-    pub fn set_lexical_geo3d_bounding_box_query(
-        &mut self,
-        field: String,
-        min_x: f64,
-        min_y: f64,
-        min_z: f64,
-        max_x: f64,
-        max_y: f64,
-        max_z: f64,
-    ) {
-        self.lexical_query = Some(JsQuery::Geo3dBoundingBoxQuery(JsGeo3dBoundingBoxQuery {
-            field,
-            min_x,
-            min_y,
-            min_z,
-            max_x,
-            max_y,
-            max_z,
-        }));
-    }
-
-    /// Set a 3D ECEF k-nearest-neighbours query.
-    ///
-    /// # Arguments
-    ///
-    /// * `field` - The Geo3d field name.
-    /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
-    /// * `k` - Number of nearest neighbours to return.
-    /// * `initial_radius_m` - Optional starting radius for the
-    ///   expanding-radius search.
-    /// * `max_radius_m` - Optional hard cap on the search radius.
-    #[napi(js_name = "setLexicalGeo3dNearestQuery")]
-    #[allow(clippy::too_many_arguments)]
-    pub fn set_lexical_geo3d_nearest_query(
-        &mut self,
-        field: String,
-        x: f64,
-        y: f64,
-        z: f64,
-        k: u32,
-        initial_radius_m: Option<f64>,
-        max_radius_m: Option<f64>,
-    ) {
-        self.lexical_query = Some(JsQuery::Geo3dNearestQuery(JsGeo3dNearestQuery {
-            field,
-            x,
-            y,
-            z,
-            k,
-            initial_radius_m,
-            max_radius_m,
-        }));
-    }
-
-    /// Set a vector query with a pre-computed embedding.
-    ///
-    /// # Arguments
-    ///
-    /// * `field` - The vector field name.
-    /// * `vector` - The embedding vector as an array of numbers.
+    /// Set a [`JsFuzzyQuery`] as the lexical clause.
     #[napi]
-    pub fn set_vector_query(&mut self, field: String, vector: Vec<f64>) {
-        self.vector_query = Some(JsVectorQuery::VectorQuery(JsVectorQueryInner {
-            field,
-            vector: vector.into_iter().map(|v| v as f32).collect(),
-        }));
+    pub fn set_lexical_fuzzy(&mut self, query: &JsFuzzyQuery) {
+        self.lexical_query = Some(JsQuery::FuzzyQuery(query.clone()));
     }
 
-    /// Set a vector text query (text will be embedded by the registered embedder).
-    ///
-    /// # Arguments
-    ///
-    /// * `field` - The vector field name.
-    /// * `text` - The text to embed.
+    /// Set a [`JsWildcardQuery`] as the lexical clause.
     #[napi]
-    pub fn set_vector_text_query(&mut self, field: String, text: String) {
-        self.vector_query = Some(JsVectorQuery::VectorTextQuery(JsVectorTextQuery {
-            field,
-            text,
-        }));
+    pub fn set_lexical_wildcard(&mut self, query: &JsWildcardQuery) {
+        self.lexical_query = Some(JsQuery::WildcardQuery(query.clone()));
     }
 
-    /// Set a filter query (applied after scoring).
-    ///
-    /// # Arguments
-    ///
-    /// * `field` - The field name.
-    /// * `term` - The term to filter on.
+    /// Set a [`JsNumericRangeQuery`] as the lexical clause.
     #[napi]
-    pub fn set_filter_query(&mut self, field: String, term: String) {
-        self.filter_query = Some(JsQuery::TermQuery(JsTermQuery { field, term }));
+    pub fn set_lexical_numeric_range(&mut self, query: &JsNumericRangeQuery) {
+        self.lexical_query = Some(JsQuery::NumericRangeQuery(query.clone()));
     }
 
-    /// Set RRF fusion algorithm.
-    ///
-    /// # Arguments
-    ///
-    /// * `k` - The RRF parameter (default 60.0).
+    /// Set a [`JsGeoDistanceQuery`] as the lexical clause.
     #[napi]
-    pub fn set_rrf_fusion(&mut self, k: Option<f64>) {
-        self.fusion = Some(FusionChoice::RRF(k.unwrap_or(60.0)));
+    pub fn set_lexical_geo_distance(&mut self, query: &JsGeoDistanceQuery) {
+        self.lexical_query = Some(JsQuery::GeoDistanceQuery(query.clone()));
     }
 
-    /// Set weighted sum fusion algorithm.
-    ///
-    /// # Arguments
-    ///
-    /// * `lexical_weight` - Weight for lexical scores (default 0.5).
-    /// * `vector_weight` - Weight for vector scores (default 0.5).
+    /// Set a [`JsGeoBoundingBoxQuery`] as the lexical clause.
     #[napi]
-    pub fn set_weighted_sum_fusion(
-        &mut self,
-        lexical_weight: Option<f64>,
-        vector_weight: Option<f64>,
-    ) {
+    pub fn set_lexical_geo_bounding_box(&mut self, query: &JsGeoBoundingBoxQuery) {
+        self.lexical_query = Some(JsQuery::GeoBoundingBoxQuery(query.clone()));
+    }
+
+    /// Set a [`JsGeo3dDistanceQuery`] as the lexical clause.
+    #[napi(js_name = "setLexicalGeo3dDistance")]
+    pub fn set_lexical_geo3d_distance(&mut self, query: &JsGeo3dDistanceQuery) {
+        self.lexical_query = Some(JsQuery::Geo3dDistanceQuery(query.clone()));
+    }
+
+    /// Set a [`JsGeo3dBoundingBoxQuery`] as the lexical clause.
+    #[napi(js_name = "setLexicalGeo3dBoundingBox")]
+    pub fn set_lexical_geo3d_bounding_box(&mut self, query: &JsGeo3dBoundingBoxQuery) {
+        self.lexical_query = Some(JsQuery::Geo3dBoundingBoxQuery(query.clone()));
+    }
+
+    /// Set a [`JsGeo3dNearestQuery`] as the lexical clause.
+    #[napi(js_name = "setLexicalGeo3dNearest")]
+    pub fn set_lexical_geo3d_nearest(&mut self, query: &JsGeo3dNearestQuery) {
+        self.lexical_query = Some(JsQuery::Geo3dNearestQuery(query.clone()));
+    }
+
+    /// Set a [`JsBooleanQuery`] as the lexical clause.
+    #[napi]
+    pub fn set_lexical_boolean(&mut self, query: &JsBooleanQuery) {
+        self.lexical_query = Some(JsQuery::BooleanQuery(query.clone()));
+    }
+
+    /// Set a [`JsSpanQuery`] as the lexical clause.
+    #[napi]
+    pub fn set_lexical_span(&mut self, query: &JsSpanQuery) {
+        self.lexical_query = Some(JsQuery::SpanQuery(query.clone()));
+    }
+
+    // ── Filter query setters (one per query type) ───────────────────────
+
+    /// Set a [`JsTermQuery`] as the filter clause (applied after scoring).
+    #[napi]
+    pub fn set_filter_term(&mut self, query: &JsTermQuery) {
+        self.filter_query = Some(JsQuery::TermQuery(query.clone()));
+    }
+
+    /// Set a [`JsPhraseQuery`] as the filter clause.
+    #[napi]
+    pub fn set_filter_phrase(&mut self, query: &JsPhraseQuery) {
+        self.filter_query = Some(JsQuery::PhraseQuery(query.clone()));
+    }
+
+    /// Set a [`JsFuzzyQuery`] as the filter clause.
+    #[napi]
+    pub fn set_filter_fuzzy(&mut self, query: &JsFuzzyQuery) {
+        self.filter_query = Some(JsQuery::FuzzyQuery(query.clone()));
+    }
+
+    /// Set a [`JsWildcardQuery`] as the filter clause.
+    #[napi]
+    pub fn set_filter_wildcard(&mut self, query: &JsWildcardQuery) {
+        self.filter_query = Some(JsQuery::WildcardQuery(query.clone()));
+    }
+
+    /// Set a [`JsNumericRangeQuery`] as the filter clause.
+    #[napi]
+    pub fn set_filter_numeric_range(&mut self, query: &JsNumericRangeQuery) {
+        self.filter_query = Some(JsQuery::NumericRangeQuery(query.clone()));
+    }
+
+    /// Set a [`JsGeoDistanceQuery`] as the filter clause.
+    #[napi]
+    pub fn set_filter_geo_distance(&mut self, query: &JsGeoDistanceQuery) {
+        self.filter_query = Some(JsQuery::GeoDistanceQuery(query.clone()));
+    }
+
+    /// Set a [`JsGeoBoundingBoxQuery`] as the filter clause.
+    #[napi]
+    pub fn set_filter_geo_bounding_box(&mut self, query: &JsGeoBoundingBoxQuery) {
+        self.filter_query = Some(JsQuery::GeoBoundingBoxQuery(query.clone()));
+    }
+
+    /// Set a [`JsGeo3dDistanceQuery`] as the filter clause.
+    #[napi(js_name = "setFilterGeo3dDistance")]
+    pub fn set_filter_geo3d_distance(&mut self, query: &JsGeo3dDistanceQuery) {
+        self.filter_query = Some(JsQuery::Geo3dDistanceQuery(query.clone()));
+    }
+
+    /// Set a [`JsGeo3dBoundingBoxQuery`] as the filter clause.
+    #[napi(js_name = "setFilterGeo3dBoundingBox")]
+    pub fn set_filter_geo3d_bounding_box(&mut self, query: &JsGeo3dBoundingBoxQuery) {
+        self.filter_query = Some(JsQuery::Geo3dBoundingBoxQuery(query.clone()));
+    }
+
+    /// Set a [`JsGeo3dNearestQuery`] as the filter clause.
+    #[napi(js_name = "setFilterGeo3dNearest")]
+    pub fn set_filter_geo3d_nearest(&mut self, query: &JsGeo3dNearestQuery) {
+        self.filter_query = Some(JsQuery::Geo3dNearestQuery(query.clone()));
+    }
+
+    /// Set a [`JsBooleanQuery`] as the filter clause.
+    #[napi]
+    pub fn set_filter_boolean(&mut self, query: &JsBooleanQuery) {
+        self.filter_query = Some(JsQuery::BooleanQuery(query.clone()));
+    }
+
+    /// Set a [`JsSpanQuery`] as the filter clause.
+    #[napi]
+    pub fn set_filter_span(&mut self, query: &JsSpanQuery) {
+        self.filter_query = Some(JsQuery::SpanQuery(query.clone()));
+    }
+
+    // ── Vector query setters ────────────────────────────────────────────
+
+    /// Set a [`JsVectorQueryInner`] (pre-computed embedding) as the
+    /// vector clause.
+    #[napi]
+    pub fn set_vector_query(&mut self, query: &JsVectorQueryInner) {
+        self.vector_query = Some(JsVectorQuery::VectorQuery(query.clone()));
+    }
+
+    /// Set a [`JsVectorTextQuery`] (text-to-be-embedded) as the vector
+    /// clause.
+    #[napi]
+    pub fn set_vector_text_query(&mut self, query: &JsVectorTextQuery) {
+        self.vector_query = Some(JsVectorQuery::VectorTextQuery(query.clone()));
+    }
+
+    // ── Fusion algorithm setters ────────────────────────────────────────
+
+    /// Set RRF fusion using a [`JsRRF`] instance.
+    #[napi]
+    pub fn set_rrf_fusion(&mut self, rrf: &JsRRF) {
+        self.fusion = Some(FusionChoice::RRF(rrf.k));
+    }
+
+    /// Set weighted-sum fusion using a [`JsWeightedSum`] instance.
+    #[napi]
+    pub fn set_weighted_sum_fusion(&mut self, ws: &JsWeightedSum) {
         self.fusion = Some(FusionChoice::WeightedSum(
-            lexical_weight.unwrap_or(0.5) as f32,
-            vector_weight.unwrap_or(0.5) as f32,
+            ws.lexical_weight as f32,
+            ws.vector_weight as f32,
         ));
     }
 }


### PR DESCRIPTION
## Summary

The existing imperative `SearchRequest` API was the most-cited cross-binding outlier in the post-#334 audit:

```js
const req = new SearchRequest(10, 0);          // positional limit/offset
req.setLexicalTermQuery("body", "world");
req.setVectorQuery("embedding", [/* … */]);
req.setRrfFusion(60);
```

Every other binding (Python, Ruby, PHP) builds the same request through a single declarative constructor call. This PR moves the Node.js binding closer to the same shape.

## Changes

- Add `JsSearchRequestOptions` (`#[napi(object)]`) carrying the primitive fields (`queryDsl`, `limit`, `offset`).
- Replace the `(limit, offset)` constructor with one that accepts `Option<JsSearchRequestOptions>`. Both `new SearchRequest()` and `new SearchRequest({ limit, offset, queryDsl })` work.
- Replace each setter that previously took raw arguments with a per-type setter that takes the corresponding wrapper class instance, mirroring the same workaround used by `JsBooleanQuery` for the napi-derive class-ref-union limitation:
  - 12 `setLexicalX` methods (term, phrase, fuzzy, wildcard, numericRange, geoDistance, geoBoundingBox, geo3dDistance, geo3dBoundingBox, geo3dNearest, boolean, span)
  - 12 corresponding `setFilterX` methods
  - `setVectorQuery(query: VectorQuery)`, `setVectorTextQuery(query: VectorTextQuery)`
  - `setRrfFusion(rrf: RRF)`, `setWeightedSumFusion(ws: WeightedSum)`
- Derive `Clone` on `JsVectorQueryInner` and `JsVectorTextQuery` (the two wrapper structs that did not yet derive it). All other lexical wrappers gained `Clone` in #366.

## Migration (pre-1.0 breaking)

```diff
- const req = new SearchRequest(5, 0);
- req.setLexicalTermQuery("title", "rust");
- req.setVectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]);
- req.setRrfFusion(60.0);
+ const req = new SearchRequest({ limit: 5, offset: 0 });
+ req.setLexicalTerm(new TermQuery("title", "rust"));
+ req.setVectorQuery(new VectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]));
+ req.setRrfFusion(new RRF(60.0));
```

DSL-only requests now fit in a single expression:

```js
const req = new SearchRequest({ queryDsl: "title:rust", limit: 5 });
```

## Why polymorphic fields stay out of the options object

napi-rs's auto-generated `ValidateNapiValue` for `&T` looks the JS class constructor up by the *Rust* struct name instead of the JS name set via `js_name = "..."`. Any `Either<&T, ...>`-typed field on a `#[napi(object)]` therefore rejects every instance at runtime — exactly the issue we fought through in #366. Per-type setters bypass this because napi-derive special-cases bare `&T` arguments at the function-signature level via `FromNapiRef`.

## Files

- `laurus-nodejs/src/search.rs` — the rewrite described above.
- `laurus-nodejs/src/query.rs` — derive `Clone` on `JsVectorQueryInner` and `JsVectorTextQuery`.
- `laurus-nodejs/__tests__/index.spec.mjs` — migrate `searchWithRequest` tests + add a new "options-only" test.
- `laurus-nodejs/__tests__/geo3d.spec.mjs` — migrate the three Geo3d SearchRequest tests; the new factory-style query constructors thread cleanly into the new setters.
- `laurus-nodejs/examples/hybrid-search.mjs` — show the new shape with TermQuery + VectorQuery + RRF / WeightedSum class instances.

## Test plan

- [x] `cargo build -p laurus-nodejs` — clean
- [x] `cargo fmt --check -p laurus-nodejs` — clean
- [x] `cargo clippy -p laurus-nodejs -- -D warnings` — clean
- [ ] CI runs the Vitest suite (existing `searchWithRequest` tests + new options-object test + the Geo3d trio)

Closes #353