### PR TITLE
refactor(nodejs): align NumericRangeQuery int/float discriminator with PHP

### DIFF
--- a/laurus-nodejs/__tests__/index.spec.mjs
+++ b/laurus-nodejs/__tests__/index.spec.mjs
@@ -283,6 +283,12 @@ describe("Query types", () => {
     // Use DSL or searchTerm - NumericRangeQuery needs to be used via SearchRequest
     // For now, test that the class can be constructed
     expect(q).toBeDefined();
+    // Explicit "integer" discriminator should also work.
+    expect(new NumericRangeQuery("year", 2022, 2024, "integer")).toBeDefined();
+    // "float" discriminator should also work.
+    expect(new NumericRangeQuery("price", 1.5, 9.5, "float")).toBeDefined();
+    // Anything else throws.
+    expect(() => new NumericRangeQuery("year", 0, 1, "double")).toThrow();
   });
 
   it("boolean query accepts any clause type via mustX/shouldX/mustNotX", async () => {

--- a/laurus-nodejs/src/query.rs
+++ b/laurus-nodejs/src/query.rs
@@ -299,11 +299,22 @@ impl JsWildcardQuery {
 
 /// Numeric range filter query (integer or float).
 ///
+/// Use the `numericType` parameter to choose between an integer range
+/// (default `"integer"`) and a float range (`"float"`). The same string
+/// discriminator is used by the PHP binding's `NumericRangeQuery`, so the
+/// two bindings now agree on the call shape.
+///
 /// ## Example
 ///
 /// ```javascript
 /// const { NumericRangeQuery } = require("laurus-nodejs");
-/// const q = new NumericRangeQuery("year", 2020, 2023);
+///
+/// // Integer range (default).
+/// const q1 = new NumericRangeQuery("year", 2020, 2023);
+/// const q2 = new NumericRangeQuery("year", 2020, 2023, "integer");
+///
+/// // Float range.
+/// const q3 = new NumericRangeQuery("price", 9.99, 19.99, "float");
 /// ```
 #[derive(Clone)]
 #[napi(js_name = "NumericRangeQuery")]
@@ -318,22 +329,35 @@ pub struct JsNumericRangeQuery {
 impl JsNumericRangeQuery {
     /// Create a new numeric range query.
     ///
-    /// Pass integer values for integer range, or use `isFloat: true` for float range.
-    ///
     /// # Arguments
     ///
     /// * `field` - The field name to filter on.
     /// * `min` - Minimum value (inclusive), or `null` for unbounded.
     /// * `max` - Maximum value (inclusive), or `null` for unbounded.
-    /// * `is_float` - Whether to treat values as float (default `false`, integer).
+    /// * `numeric_type` - Either `"integer"` or `"float"`. Defaults to
+    ///   `"integer"` when omitted. Anything else throws an `Error`.
     #[napi(constructor)]
-    pub fn new(field: String, min: Option<f64>, max: Option<f64>, is_float: Option<bool>) -> Self {
-        Self {
+    pub fn new(
+        field: String,
+        min: Option<f64>,
+        max: Option<f64>,
+        numeric_type: Option<String>,
+    ) -> Result<Self> {
+        let is_float = match numeric_type.as_deref() {
+            Some("integer") | None => false,
+            Some("float") => true,
+            Some(other) => {
+                return Err(napi::Error::from_reason(format!(
+                    "numericType must be \"integer\" or \"float\", got {other:?}"
+                )));
+            }
+        };
+        Ok(Self {
             field,
             min,
             max,
-            is_float: is_float.unwrap_or(false),
-        }
+            is_float,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Before this PR, `NumericRangeQuery` was the only query in laurus where the bindings disagreed on **how to express the integer-vs-float distinction**:

| Binding | Construction | Int / float decision |
|:--|:--|:--|
| Python | `laurus.NumericRangeQuery(field, min, max)` | Auto-inferred from the Python type of `min`/`max`. |
| Ruby | `Laurus::NumericRangeQuery.new(field, min:, max:)` | Auto-inferred from the Ruby type of `min`/`max`. |
| **Node.js (before)** | `new NumericRangeQuery(field, min?, max?, isFloat?)` | Explicit fourth arg — **`isFloat: boolean`**. |
| PHP | `new Laurus\\NumericRangeQuery(\$field, \$min, \$max, \$numericType)` | Explicit fourth arg — **`numericType: \"integer\" | \"float\"`** string. |
| WASM | (no class exposed; reachable only via the DSL) | — |

The same audit that produced #348-#353 flagged this as the last remaining cross-binding inconsistency. Issue #368 picked the string discriminator as the canonical shape, with Node.js the binding to flip.

## Migration (Node.js only, pre-1.0 breaking)

```diff
- new NumericRangeQuery(\"year\",  2020, 2030);            // default integer
- new NumericRangeQuery(\"year\",  2020, 2030, false);     // integer (explicit)
- new NumericRangeQuery(\"price\", 9.99, 19.99, true);     // float
+ new NumericRangeQuery(\"year\",  2020, 2030);            // default \"integer\"
+ new NumericRangeQuery(\"year\",  2020, 2030, \"integer\"); // integer (explicit)
+ new NumericRangeQuery(\"price\", 9.99, 19.99, \"float\");  // float
```

Anything other than `\"integer\"` / `\"float\"` (or omitted) throws:

```
Error: numericType must be \"integer\" or \"float\", got \"...\"
```

## Files

- `laurus-nodejs/src/query.rs` — change the constructor's fourth parameter from `Option<bool>` to `Option<String>`, validate it against the two allowed values, and surface a descriptive error for unknown discriminators. The internal `is_float: bool` field is unchanged so `build()` is untouched.
- `laurus-nodejs/__tests__/index.spec.mjs` — extend the existing numeric-range-query test to cover the explicit `\"integer\"`, explicit `\"float\"`, and unknown-discriminator-rejection cases.

## Out of scope

- PHP — already uses `numericType: string` and matches the new Node.js shape unchanged.
- Python / Ruby — keep auto-inference (idiomatic for those languages).
- WASM — `NumericRangeQuery` is reachable only via the DSL; no class to update.

## Test plan

- [x] `cargo build -p laurus-nodejs` — clean
- [x] `cargo fmt --check -p laurus-nodejs` — clean
- [x] `cargo clippy -p laurus-nodejs -- -D warnings` — clean
- [ ] CI runs the Vitest suite

Closes #368