### PR TITLE
refactor(php): rename Schema::set_default_fields argument to fields

### DIFF
--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -67,7 +67,7 @@ new \Laurus\Schema()
 | Method | Description |
 | :--- | :--- |
 | `addEmbedder(string $name, array $config): void` | Register a named embedder definition. `$config` is an associative array with a `"type"` key (see below). |
-| `setDefaultFields(array $fieldNames): void` | Set the default fields used when no field is specified in a query. `$fieldNames` is an array of strings. |
+| `setDefaultFields(array $fields): void` | Set the default fields used when no field is specified in a query. `$fields` is an array of strings. |
 | `setDynamicFieldPolicy(string $policy): void` | Set how undeclared fields are handled. `$policy` is `"strict"`, `"dynamic"` (default), or `"ignore"`. See notes below. |
 | `dynamicFieldPolicy(): string` | Return the current policy as a lowercase string. |
 | `fieldNames(): array` | Return the list of field names defined in this schema. |

--- a/laurus-php/src/schema.rs
+++ b/laurus-php/src/schema.rs
@@ -362,9 +362,9 @@ impl PhpSchema {
     ///
     /// # Arguments
     ///
-    /// * `field_names` - Array of field name strings.
-    pub fn set_default_fields(&self, field_names: Vec<String>) {
-        self.inner.borrow_mut().default_fields = field_names;
+    /// * `fields` - Array of field name strings.
+    pub fn set_default_fields(&self, fields: Vec<String>) {
+        self.inner.borrow_mut().default_fields = fields;
     }
 
     /// Set the policy for fields that are not declared in this schema.


### PR DESCRIPTION
## Summary

- Renames the `Schema::set_default_fields` parameter from `field_names` to `fields` in `laurus-php` so the argument name matches the other four bindings (Python / Node.js / Ruby / WASM).
- Updates the corresponding row in `docs/src/laurus-php/api_reference.md` (`$fieldNames` → `$fields`) so the rendered API reference matches the new signature.

## Why

Surfaced by the final cross-binding API parity audit on 2026-04-29. PHP has no keyword arguments, so this rename has zero runtime caller-visible impact, but the parameter name is exposed in PHP `ReflectionAPI` output and in the API reference table — both should match the rest of the bindings for consistency.

The `fieldNames(): array` getter method is unchanged and already consistent across all five bindings.

## Test plan

- [x] `cargo check -p laurus-php`
- [x] `cargo clippy -p laurus-php -- -D warnings`
- [x] `cargo fmt --check -p laurus-php`
- [x] `markdownlint-cli2 "docs/src/laurus-php/api_reference.md"`