### PR TITLE
docs(ruby): correct BooleanQuery semantics and add GeoEcef field value type

### DIFF
--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -209,7 +209,7 @@ bq.should(query)
 bq.must_not(query)
 ```
 
-複合ブールクエリ。`must` 節はすべて一致する必要があります。`should` 節は少なくとも1つ一致する必要があります。`must_not` 節は一致してはなりません。
+複合ブールクエリ。`must` 節はすべて一致する必要があり、`must_not` 節は一致してはなりません。`should` 節はスコアリングに寄与し、`must` 節が無い場合は少なくとも1つが一致する必要があります。
 
 ### SpanQuery
 
@@ -367,4 +367,5 @@ Ruby の値は自動的に Laurus の `DataValue` 型に変換されます：
 | `String` | `Text` | |
 | `Array`（数値） | `Vector` | 要素は `f32` に変換 |
 | `Hash`（`"lat"`, `"lon"`） | `Geo` | 2 つの `Float` 値 |
-| `Time`（`iso8601` に応答） | `DateTime` | `iso8601` 経由で変換 |
+| `Hash`（`"x"`, `"y"`, `"z"`） | `GeoEcef` | 3 つの `Float` 値（メートル単位、3D ECEF 直交座標） |
+| `Time` / `String`（`iso8601` に応答） | `DateTime` | `iso8601` 経由で変換 |

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -215,7 +215,7 @@ bq.should(query)
 bq.must_not(query)
 ```
 
-Compound boolean query. `must` clauses all have to match; at least one `should` clause must match; `must_not` clauses must not match.
+Compound boolean query. `must` clauses all have to match; `must_not` clauses must not match. `should` clauses contribute to scoring; at least one of them must match if there are no `must` clauses.
 
 ### SpanQuery
 
@@ -373,4 +373,5 @@ Ruby values are automatically converted to Laurus `DataValue` types:
 | `String` | `Text` | |
 | `Array` of numerics | `Vector` | Elements coerced to `f32` |
 | `Hash` with `"lat"`, `"lon"` | `Geo` | Two `Float` values |
-| `Time` (responds to `iso8601`) | `DateTime` | Converted via `iso8601` |
+| `Hash` with `"x"`, `"y"`, `"z"` | `GeoEcef` | Three `Float` values, meters (3D ECEF Cartesian) |
+| `Time` / `String` responding to `iso8601` | `DateTime` | Converted via `iso8601` |


### PR DESCRIPTION
## Summary

- Fix `BooleanQuery` semantic description: `should` clauses only need to match when no `must` clauses are present (Lucene-style), not unconditionally.
- Add the missing `Hash` with `"x"`, `"y"`, `"z"` → `GeoEcef` row to the "Field value types" table — the binding has supported this since the Geo3d work landed but the table only listed the 2D `"lat"`, `"lon"` → `Geo` form.
- Note that the `iso8601` row also accepts `String` (in addition to `Time`), matching the actual `convert.rs:135` behavior.

Both English ([docs/src/laurus-ruby/api_reference.md](docs/src/laurus-ruby/api_reference.md)) and Japanese ([docs/ja/src/laurus-ruby/api_reference.md](docs/ja/src/laurus-ruby/api_reference.md)) versions are updated.

Surfaced by the comprehensive cross-binding doc-vs-implementation audit on 2026-04-29.

## Test plan

- [x] `markdownlint-cli2 "docs/src/laurus-ruby/api_reference.md" "docs/ja/src/laurus-ruby/api_reference.md"`