### PR TITLE
docs(php): align api_reference and quickstart with current implementation

### DIFF
--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -51,8 +51,8 @@ new \Laurus\Schema()
 | メソッド | 説明 |
 | :--- | :--- |
 | `addTextField(string $name, bool $stored = true, bool $indexed = true, bool $termVectors = false, ?string $analyzer = null): void` | 全文フィールド（転置インデックス、BM25）。 |
-| `addIntegerField(string $name, bool $stored = true, bool $indexed = true, bool $multi_valued = false): void` | 64 ビット整数フィールド。`$multi_valued = true` で整数配列を受け付け（範囲クエリは "any match"）。 |
-| `addFloatField(string $name, bool $stored = true, bool $indexed = true, bool $multi_valued = false): void` | 64 ビット浮動小数点フィールド。`$multi_valued = true` で浮動小数点配列を受け付け（範囲クエリは "any match"）。 |
+| `addIntegerField(string $name, bool $stored = true, bool $indexed = true, bool $multiValued = false): void` | 64 ビット整数フィールド。`$multiValued = true` で整数配列を受け付け（範囲クエリは "any match"）。 |
+| `addFloatField(string $name, bool $stored = true, bool $indexed = true, bool $multiValued = false): void` | 64 ビット浮動小数点フィールド。`$multiValued = true` で浮動小数点配列を受け付け（範囲クエリは "any match"）。 |
 | `addBooleanField(string $name, bool $stored = true, bool $indexed = true): void` | ブールフィールド。 |
 | `addBytesField(string $name, bool $stored = true): void` | 生バイトフィールド。 |
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | 地理座標フィールド（緯度/経度）。 |
@@ -219,7 +219,7 @@ $bq->should($query);
 $bq->mustNot($query);
 ```
 
-複合ブールクエリ。`must` 節はすべて一致する必要があります。`should` 節は少なくとも1つ一致する必要があります。`mustNot` 節は一致してはなりません。
+複合ブールクエリ。`must` 節はすべて一致する必要があり、`mustNot` 節は一致してはなりません。`should` 節はスコアリングに寄与し、`must` 節が無い場合は少なくとも1つが一致する必要があります。
 
 ### SpanQuery
 
@@ -230,6 +230,9 @@ $bq->mustNot($query);
 // Near: slop 位置以内の語句
 \Laurus\SpanQuery::near(string $field, array $terms, int $slop = 0, bool $ordered = true): SpanQuery
 
+// NearSpans: slop 位置以内のネストされた SpanQuery 句
+\Laurus\SpanQuery::nearSpans(string $field, array $clauses, int $slop = 0, bool $ordered = true): SpanQuery
+
 // Containing: big スパンが little スパンを含む
 \Laurus\SpanQuery::containing(string $field, SpanQuery $big, SpanQuery $little): SpanQuery
 
@@ -237,7 +240,9 @@ $bq->mustNot($query);
 \Laurus\SpanQuery::within(string $field, SpanQuery $include, SpanQuery $exclude, int $distance): SpanQuery
 ```
 
-位置・近接スパンクエリ。`near` は語句文字列の配列を受け取ります。
+位置・近接スパンクエリ。`near` は語句文字列の配列を受け取り、`nearSpans` は
+ネスト式のために `SpanQuery` オブジェクトの配列を受け取ります（各句のフィールド
+は外側の `$field` に再ルートされます）。
 
 ### VectorQuery
 
@@ -292,7 +297,7 @@ new \Laurus\SearchRequest(
 ```php
 $result->getId()        // string   -- 外部ドキュメント識別子
 $result->getScore()     // float    -- 関連性スコア
-$result->getDocument()  // array|null -- 取得されたフィールド値。削除済みの場合は null
+$result->getDocument()  // array|null -- 取得されたフィールド値。stored=false の場合は null
 ```
 
 ---
@@ -340,6 +345,16 @@ $tokens = $tokenizer->tokenize("hello world");
 ### SynonymGraphFilter
 
 ```php
+new \Laurus\SynonymGraphFilter(SynonymDictionary $dictionary, bool $keepOriginal = true, float $boost = 1.0)
+```
+
+| パラメータ | 説明 |
+| :--- | :--- |
+| `$dictionary` | 同義語グループのソース。 |
+| `$keepOriginal` | `true`（デフォルト）の場合は元のトークンも同義語と並べて保持します。 |
+| `$boost` | 挿入される同義語トークンに適用されるスコアブースト（デフォルト `1.0`）。 |
+
+```php
 $filter = new \Laurus\SynonymGraphFilter($dictionary, true, 1.0);
 $expanded = $filter->apply($tokens);
 ```
@@ -374,4 +389,5 @@ PHP の値は自動的に Laurus の `DataValue` 型に変換されます：
 | `string` | `Text` | |
 | `array`（数値） | `Vector` | 要素は `f32` に変換 |
 | `array`（`"lat"`, `"lon"`） | `Geo` | 2 つの `float` 値 |
+| `array`（`"x"`, `"y"`, `"z"`） | `GeoEcef` | 3 つの `float` 値（メートル単位、3D ECEF 直交座標） |
 | `string`（ISO 8601） | `DateTime` | ISO 8601 形式からパース |

--- a/docs/ja/src/laurus-php/quickstart.md
+++ b/docs/ja/src/laurus-php/quickstart.md
@@ -123,7 +123,7 @@ $schema->addGeoField("location");
 $schema->addDatetimeField("created_at");
 $schema->addHnswField("embedding", 384);
 $schema->addFlatField("small_vec", 64);
-$schema->addIvfField("ivf_vec", 128, null, 100, 1);
+$schema->addIvfField("ivf_vec", 128, "cosine", 100, 1);
 ```
 
 ## 8. インデックス統計

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -51,8 +51,8 @@ new \Laurus\Schema()
 | Method | Description |
 | :--- | :--- |
 | `addTextField(string $name, bool $stored = true, bool $indexed = true, bool $termVectors = false, ?string $analyzer = null): void` | Full-text field (inverted index, BM25). |
-| `addIntegerField(string $name, bool $stored = true, bool $indexed = true, bool $multi_valued = false): void` | 64-bit integer field. Pass `$multi_valued = true` to accept arrays of integers (range queries match if any value satisfies the predicate). |
-| `addFloatField(string $name, bool $stored = true, bool $indexed = true, bool $multi_valued = false): void` | 64-bit float field. Pass `$multi_valued = true` to accept arrays of floats (range queries match if any value satisfies the predicate). |
+| `addIntegerField(string $name, bool $stored = true, bool $indexed = true, bool $multiValued = false): void` | 64-bit integer field. Pass `$multiValued = true` to accept arrays of integers (range queries match if any value satisfies the predicate). |
+| `addFloatField(string $name, bool $stored = true, bool $indexed = true, bool $multiValued = false): void` | 64-bit float field. Pass `$multiValued = true` to accept arrays of floats (range queries match if any value satisfies the predicate). |
 | `addBooleanField(string $name, bool $stored = true, bool $indexed = true): void` | Boolean field. |
 | `addBytesField(string $name, bool $stored = true): void` | Raw bytes field. |
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | Geographic coordinate field (lat/lon). |
@@ -225,7 +225,7 @@ $bq->should($query);
 $bq->mustNot($query);
 ```
 
-Compound boolean query. `must` clauses all have to match; at least one `should` clause must match; `mustNot` clauses must not match.
+Compound boolean query. `must` clauses all have to match; `mustNot` clauses must not match. `should` clauses contribute to scoring; at least one of them must match if there are no `must` clauses.
 
 ### SpanQuery
 
@@ -236,6 +236,9 @@ Compound boolean query. `must` clauses all have to match; at least one `should` 
 // Near: terms within slop positions
 \Laurus\SpanQuery::near(string $field, array $terms, int $slop = 0, bool $ordered = true): SpanQuery
 
+// NearSpans: nested SpanQuery clauses within slop positions
+\Laurus\SpanQuery::nearSpans(string $field, array $clauses, int $slop = 0, bool $ordered = true): SpanQuery
+
 // Containing: big span contains little span
 \Laurus\SpanQuery::containing(string $field, SpanQuery $big, SpanQuery $little): SpanQuery
 
@@ -243,7 +246,9 @@ Compound boolean query. `must` clauses all have to match; at least one `should` 
 \Laurus\SpanQuery::within(string $field, SpanQuery $include, SpanQuery $exclude, int $distance): SpanQuery
 ```
 
-Positional / proximity span queries. `near` takes an array of term strings.
+Positional / proximity span queries. `near` takes an array of term strings,
+while `nearSpans` takes an array of `SpanQuery` objects for nested expressions
+(each clause's field is re-rooted to the outer `$field`).
 
 ### VectorQuery
 
@@ -298,7 +303,7 @@ Returned by `Index->search()`.
 ```php
 $result->getId()        // string   -- External document identifier
 $result->getScore()     // float    -- Relevance score
-$result->getDocument()  // array|null -- Retrieved field values, or null if deleted
+$result->getDocument()  // array|null -- Retrieved field values, or null if not stored
 ```
 
 ---
@@ -346,6 +351,16 @@ Splits text on whitespace boundaries and returns an array of `Token` objects.
 ### SynonymGraphFilter
 
 ```php
+new \Laurus\SynonymGraphFilter(SynonymDictionary $dictionary, bool $keepOriginal = true, float $boost = 1.0)
+```
+
+| Parameter | Description |
+| :--- | :--- |
+| `$dictionary` | Source synonym groups. |
+| `$keepOriginal` | When `true` (default), keep the original token alongside the synonyms. |
+| `$boost` | Score boost applied to the inserted synonym tokens (default `1.0`). |
+
+```php
 $filter = new \Laurus\SynonymGraphFilter($dictionary, true, 1.0);
 $expanded = $filter->apply($tokens);
 ```
@@ -380,4 +395,5 @@ PHP values are automatically converted to Laurus `DataValue` types:
 | `string` | `Text` | |
 | `array` of numerics | `Vector` | Elements coerced to `f32` |
 | `array` with `"lat"`, `"lon"` | `Geo` | Two `float` values |
+| `array` with `"x"`, `"y"`, `"z"` | `GeoEcef` | Three `float` values, meters (3D ECEF Cartesian) |
 | `string` (ISO 8601) | `DateTime` | Parsed from ISO 8601 format |

--- a/docs/src/laurus-php/quickstart.md
+++ b/docs/src/laurus-php/quickstart.md
@@ -123,7 +123,7 @@ $schema->addGeoField("location");
 $schema->addDatetimeField("created_at");
 $schema->addHnswField("embedding", 384);
 $schema->addFlatField("small_vec", 64);
-$schema->addIvfField("ivf_vec", 128, null, 100, 1);
+$schema->addIvfField("ivf_vec", 128, "cosine", 100, 1);
 ```
 
 ## 8. Index statistics


### PR DESCRIPTION
## Summary

Surfaced by the comprehensive cross-binding doc-vs-implementation audit on 2026-04-29. PHP was already in good shape but had several small drifts where the docs hadn't kept up with recent implementation changes.

- Add the missing `SpanQuery::nearSpans` factory (#349) to the `SpanQuery` section in both [api_reference.md](docs/src/laurus-php/api_reference.md) and [api_reference.md (ja)](docs/ja/src/laurus-php/api_reference.md). It takes nested `SpanQuery` clauses rather than term strings.
- Add the missing `array` with `"x"`, `"y"`, `"z"` → `GeoEcef` row to the "Field value types" table — the binding has supported this since the Geo3d work landed.
- Document the `SynonymGraphFilter` constructor's `$keepOriginal` and `$boost` parameters with their defaults.
- Rename `$multi_valued` → `$multiValued` in `addIntegerField` / `addFloatField` signatures for consistency with the other camelCase parameter names (`$termVectors`, `$efConstruction`, `$nClusters`, `$nProbe`).
- Correct `BooleanQuery` semantic description: `should` clauses contribute to scoring; at least one must match only when no `must` clauses are present (Lucene-style), not unconditionally.
- Replace `getDocument()` "or null if deleted" with the more accurate "or null if not stored" — that's what the binding actually returns.
- Replace the misleading `null` distance argument in the `addIvfField` quickstart example with the explicit `"cosine"` default.

## Test plan

- [x] `markdownlint-cli2 "docs/src/laurus-php/{api_reference,quickstart}.md" "docs/ja/src/laurus-php/{api_reference,quickstart}.md"`