### PR TITLE
docs(wasm): align api_reference and overview with current implementation

### DIFF
--- a/docs/ja/src/laurus-wasm.md
+++ b/docs/ja/src/laurus-wasm.md
@@ -37,16 +37,13 @@ graph LR
     WASM -.->|永続化| OPFS
 ```
 
-## 制限事項: エンジン内自動 Embedding の非対応
+## Embedding 戦略
 
-ネイティブ環境での Laurus の特徴の一つに**自動 Embedding** があります。
-ドキュメントをインデックスする際、エンジンが登録された Embedder（Candle BERT、
-Candle CLIP、OpenAI API）を使ってテキストフィールドを自動的にベクトル埋め込みに
-変換します。これにより `searchVectorText("field", "query text")` がシームレスに
-動作し、呼び出し側で埋め込みを計算する必要がありません。
-
-**laurus-wasm ではこの機能を利用できません。** `precomputed`（事前計算済み）
-Embedder のみがサポートされます。理由は以下の通りです:
+ネイティブ環境では Laurus に複数の組み込み Embedder（Candle BERT、Candle CLIP、
+OpenAI API）が用意されており、ドキュメントのインデックス時や
+`searchVectorText("field", "query text")` 実行時にエンジンが自動で呼び出します。
+これらネイティブ Embedder は `wasm32-unknown-unknown` 上で動作しないため、
+WASM ビルドでは無効化されています:
 
 | Embedder | Dependency | Why it cannot run in WASM |
 | --- | --- | --- |
@@ -54,11 +51,21 @@ Embedder のみがサポートされます。理由は以下の通りです:
 | `candle_clip` | candle | Same as above |
 | `openai` | reqwest (HTTP) | Requires a full async HTTP client (tokio + TLS) |
 
-これらの依存は Feature Flags（`embeddings-candle`、`embeddings-openai`）で
-管理されており、`wasm32-unknown-unknown` ビルドで無効化される `native` feature
-に依存しているため除外されます。
+（これらは `embeddings-candle` / `embeddings-openai` Feature Flags で管理されており、
+`wasm32-unknown-unknown` で無効化される `native` feature に依存するため
+WASM ビルドから除外されます。）
 
-### 推奨される代替手段
+`laurus-wasm` ではその代わりに以下 2 種類の `addEmbedder` タイプを公開しています:
+
+- **`"precomputed"`** — 呼び出し側が `putDocument()` / `searchVector()` 経由で
+  ベクトルを直接渡します。エンジンは埋め込みを行いません。
+- **`"callback"`** — JavaScript コールバック
+  `embed: (text) => Promise<number[]>` を登録し、エンジンがインジェスト時および
+  `searchVectorText()` から呼び出します。Transformers.js 等のブラウザ内埋め込み
+  ライブラリと組み合わせることでエンジン内自動埋め込みが実現でき、ネイティブ環境と
+  同じく `searchVectorText("field", "query text")` を呼び出すだけで利用できます。
+
+### Option A — 事前計算済みベクトル
 
 **JavaScript 側で埋め込みを計算**し、事前計算済みベクトルを `putDocument()` と
 `searchVector()` に渡します:
@@ -88,6 +95,38 @@ const results = await index.searchVector("embedding", queryVec);
 セマンティック検索がブラウザ内で実現できます。埋め込み計算は candle ではなく
 Transformers.js（ONNX Runtime Web）が担当します。
 
+### Option B — Callback Embedder
+
+Transformers.js の同じパイプラインを `"callback"` Embedder として登録すれば、
+エンジンが自動で呼び出してくれます。登録後は呼び出し側がベクトルを管理することなく、
+インジェストおよび `searchVectorText()` が透過的に動作します:
+
+```javascript
+import { pipeline } from '@huggingface/transformers';
+
+const extractor = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
+
+schema.addEmbedder("transformers", {
+  type: "callback",
+  embed: async (text) => {
+    const output = await extractor(text, { pooling: 'mean', normalize: true });
+    return Array.from(output.data);
+  },
+});
+schema.addHnswField("embedding", 384, "cosine", undefined, undefined, "transformers");
+const index = await Index.create(schema);
+
+await index.putDocument("doc1", { title: "Rust 入門" });
+await index.commit();
+
+const results = await index.searchVectorText("embedding", "安全なシステムプログラミング");
+```
+
+Option A と比べると、Callback アプローチではエンジンがインジェスト時に埋め込みを
+キャッシュでき、書き込み側と読み出し側で埋め込みコードを重複させずに済みます。
+ただし `commit()` のたびに JS コールバックの解決を待つため、大量バルク投入時には
+事前計算ベクトルのほうが有利な場合があります。
+
 ## laurus-wasm と laurus-nodejs の使い分け
 
 | 基準           | `laurus-wasm`              | `laurus-nodejs`                    |
@@ -95,6 +134,6 @@ Transformers.js（ONNX Runtime Web）が担当します。
 | 実行環境       | ブラウザ、エッジランタイム | Node.js サーバー                   |
 | パフォーマンス | 良好（シングルスレッド）   | 最高（ネイティブ、マルチスレッド） |
 | ストレージ     | インメモリ + OPFS          | インメモリ + ファイルシステム      |
-| 埋め込み       | 事前計算のみ               | Candle、OpenAI、事前計算           |
+| 埋め込み       | 事前計算 + JS コールバック | Candle、OpenAI、事前計算           |
 | パッケージ     | `npm install laurus-wasm`  | `npm install laurus-nodejs`        |
 | バイナリサイズ | 約 5-10 MB（WASM）         | プラットフォームネイティブ         |

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -203,6 +203,8 @@ WASM バインディングは `Geo3dDistanceQuery` / `Geo3dBoundingBoxQuery` /
 HNSW ベクトルインデックスフィールドを追加します。
 
 - `distance`: `"cosine"`（デフォルト）、`"euclidean"`、`"dot_product"`、`"manhattan"`、`"angular"`
+- `m`: 分岐係数（デフォルト 16）
+- `efConstruction`: 構築時の探索幅（デフォルト 200）
 
 #### `addFlatField(name, dimension, distance?, embedder?)`
 
@@ -212,9 +214,33 @@ HNSW ベクトルインデックスフィールドを追加します。
 
 IVF ベクトルインデックスフィールドを追加します。
 
+- `nClusters`: パーティショニングクラスタ数（デフォルト 100）
+- `nProbe`: 検索時にプローブするクラスタ数（デフォルト 1）
+
 #### `addEmbedder(name, config)`
 
-名前付き埋め込み器を登録します。WASM では `"precomputed"` のみ対応しています。
+名前付き埋め込み器を登録します。WASM では以下の 2 種類の `type` をサポートします:
+
+- `"precomputed"` — 埋め込みは行いません。ベクトルは `putDocument()` /
+  `searchVector()` 経由で直接渡します。
+- `"callback"` — JavaScript コールバック `embed: (text) => Promise<number[]>` を
+  登録します。エンジンがインジェスト時および `searchVectorText()` で呼び出します。
+  Transformers.js などのブラウザ内埋め込みライブラリと組み合わせることで、
+  エンジン内自動埋め込みが可能になります。
+
+```javascript
+// Precomputed embedder
+schema.addEmbedder("precomputed-embedder", { type: "precomputed" });
+
+// Callback embedder（例: Transformers.js）
+schema.addEmbedder("callback-embedder", {
+  type: "callback",
+  embed: async (text) => {
+    const output = await pipeline(text, { pooling: "mean", normalize: true });
+    return Array.from(output.data);
+  },
+});
+```
 
 #### `setDefaultFields(fields)`
 
@@ -238,6 +264,10 @@ IVF ベクトルインデックスフィールドを追加します。
 
 定義済みフィールド名の配列を返します。
 
+#### `toString()`
+
+スキーマの文字列表現（`"Schema(fields=[...])"` 形式）を返します。
+
 ## SearchResult
 
 ```typescript
@@ -247,3 +277,43 @@ interface SearchResult {
   document: object | null;
 }
 ```
+
+## Analysis
+
+### WhitespaceTokenizer
+
+```javascript
+const tokenizer = new WhitespaceTokenizer();
+const tokens = tokenizer.tokenize("hello world");
+// [{ text, position, startOffset, endOffset, boost, stopped, positionIncrement, positionLength }]
+```
+
+空白を境界としてテキストを分割し、`Token` オブジェクトの配列を返します。
+
+### SynonymDictionary
+
+```javascript
+const dict = new SynonymDictionary();
+dict.addSynonymGroup(["ml", "machine learning"]);
+```
+
+同義語グループの辞書。グループ内のすべての語句が互いに同義語として扱われます。
+
+### SynonymGraphFilter
+
+```javascript
+new SynonymGraphFilter(dictionary, keepOriginal = true, boost = 1.0)
+```
+
+- `dictionary` (`SynonymDictionary`) — 同義語グループのソース。
+- `keepOriginal` (boolean, デフォルト `true`) — 元のトークンを挿入された同義語と
+  並べて保持します。
+- `boost` (number, デフォルト `1.0`) — 挿入される同義語トークンに適用される
+  スコアブースト。
+
+```javascript
+const filter = new SynonymGraphFilter(dict, true, 0.8);
+const expanded = filter.apply(tokens);
+```
+
+`SynonymDictionary` の同義語でトークンを展開するトークンフィルターです。

--- a/docs/src/laurus-wasm.md
+++ b/docs/src/laurus-wasm.md
@@ -43,16 +43,13 @@ graph LR
     WASM -.->|persist| OPFS
 ```
 
-## Limitation: No In-Engine Auto-Embedding
+## Embedding Strategies
 
-One of Laurus's key features on native platforms is **automatic embedding** --
-when a document is indexed, the engine can automatically convert text fields
-into vector embeddings using a registered embedder (Candle BERT, Candle CLIP,
-or OpenAI API). This allows `searchVectorText("field", "query text")` to
-work seamlessly without the caller computing embeddings.
-
-**In laurus-wasm, this feature is not available.** Only the `precomputed`
-embedder type is supported. The reasons are:
+On native platforms Laurus supports several built-in embedders (Candle BERT,
+Candle CLIP, OpenAI API) that the engine can invoke automatically when a
+document is indexed or when `searchVectorText("field", "query text")` is
+called. These native embedders cannot run inside `wasm32-unknown-unknown` and
+are therefore disabled in the WASM build:
 
 | Embedder      | Dependency        | Why it cannot run in WASM                                   |
 | ------------- | ----------------- | ----------------------------------------------------------- |
@@ -60,11 +57,22 @@ embedder type is supported. The reasons are:
 | `candle_clip` | candle            | Same as above                                               |
 | `openai`      | reqwest (HTTP)    | Requires a full async HTTP client (tokio + TLS)             |
 
-These dependencies are excluded from the WASM build via feature flags
-(`embeddings-candle`, `embeddings-openai`), which depend on the `native`
-feature that is disabled for `wasm32-unknown-unknown`.
+(They are excluded from the WASM build via the `embeddings-candle` /
+`embeddings-openai` feature flags, which depend on the `native` feature that
+is disabled for `wasm32-unknown-unknown`.)
 
-### Recommended Alternative
+`laurus-wasm` exposes two `addEmbedder` types instead:
+
+- **`"precomputed"`** — The caller supplies vectors directly via `putDocument()`
+  and `searchVector()`. The engine performs no embedding.
+- **`"callback"`** — Register a JavaScript callback
+  `embed: (text) => Promise<number[]>` and the engine will invoke it during
+  ingestion and from `searchVectorText()`. This enables in-engine
+  auto-embedding using Transformers.js (or any other in-browser embedding
+  library) so callers can use the same `searchVectorText("field", "query text")`
+  pattern as on native platforms.
+
+### Option A — Precomputed vectors
 
 Compute embeddings on the **JavaScript side** and pass precomputed vectors
 to `putDocument()` and `searchVector()`:
@@ -94,6 +102,38 @@ This approach gives you real semantic search in the browser using the same
 sentence-transformer models available on native platforms, with the embedding
 computation handled by Transformers.js (ONNX Runtime Web) instead of candle.
 
+### Option B — Callback embedder
+
+Register the same Transformers.js pipeline as a `"callback"` embedder so that
+the engine can call it automatically. After registration, ingestion and
+`searchVectorText()` work transparently without the caller managing vectors:
+
+```javascript
+import { pipeline } from '@huggingface/transformers';
+
+const extractor = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
+
+schema.addEmbedder("transformers", {
+  type: "callback",
+  embed: async (text) => {
+    const output = await extractor(text, { pooling: 'mean', normalize: true });
+    return Array.from(output.data);
+  },
+});
+schema.addHnswField("embedding", 384, "cosine", undefined, undefined, "transformers");
+const index = await Index.create(schema);
+
+await index.putDocument("doc1", { title: "Introduction to Rust" });
+await index.commit();
+
+const results = await index.searchVectorText("embedding", "safe systems programming");
+```
+
+Compared to Option A, the callback approach lets the engine cache embeddings
+during ingestion and avoids duplicating embedding code between writers and
+readers. The trade-off is that every `commit()` waits for the JS callback to
+resolve, so heavy bulk ingestion may benefit from precomputing vectors.
+
 ## When to Use laurus-wasm vs laurus-nodejs
 
 | Criterion   | `laurus-wasm`              | `laurus-nodejs`               |
@@ -101,6 +141,6 @@ computation handled by Transformers.js (ONNX Runtime Web) instead of candle.
 | Environment | Browser, Edge Runtime      | Node.js server                |
 | Performance | Good (single-threaded)     | Best (native, multi-threaded) |
 | Storage     | In-memory + OPFS           | In-memory + File system       |
-| Embedding   | Precomputed only           | Candle, OpenAI, Precomputed   |
+| Embedding   | Precomputed + JS callback  | Candle, OpenAI, Precomputed   |
 | Package     | `npm install laurus-wasm`  | `npm install laurus-nodejs`   |
 | Binary size | ~5-10 MB (WASM)            | Platform-native               |

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -219,12 +219,32 @@ Add a brute-force vector index field.
 
 Add an IVF vector index field.
 
+- `nClusters`: Number of partitioning clusters (default 100)
+- `nProbe`: Number of clusters to probe at query time (default 1)
+
 #### `addEmbedder(name, config)`
 
-Register a named embedder. In WASM, only `"precomputed"` type is supported.
+Register a named embedder. WASM supports two `type` values:
+
+- `"precomputed"` — No embedding is performed; vectors are passed directly via
+  `putDocument()` / `searchVector()`.
+- `"callback"` — Provide a JavaScript callback `embed: (text) => Promise<number[]>`
+  that the engine will invoke during ingestion and `searchVectorText()`. This
+  enables in-engine auto-embedding using Transformers.js or any other in-browser
+  embedding library.
 
 ```javascript
-schema.addEmbedder("my-embedder", { type: "precomputed" });
+// Precomputed embedder
+schema.addEmbedder("precomputed-embedder", { type: "precomputed" });
+
+// Callback embedder (e.g. backed by Transformers.js)
+schema.addEmbedder("callback-embedder", {
+  type: "callback",
+  embed: async (text) => {
+    const output = await pipeline(text, { pooling: "mean", normalize: true });
+    return Array.from(output.data);
+  },
+});
 ```
 
 #### `setDefaultFields(fields)`
@@ -254,6 +274,10 @@ Returns the current policy as a lowercase string.
 
 Returns an array of defined field names.
 
+#### `toString()`
+
+Returns a string representation of the schema (`"Schema(fields=[...])"`).
+
 ## SearchResult
 
 ```typescript
@@ -282,6 +306,16 @@ dict.addSynonymGroup(["ml", "machine learning"]);
 ```
 
 ### SynonymGraphFilter
+
+```javascript
+new SynonymGraphFilter(dictionary, keepOriginal = true, boost = 1.0)
+```
+
+- `dictionary` (`SynonymDictionary`) — Source synonym groups.
+- `keepOriginal` (boolean, default `true`) — Keep the original token alongside
+  the inserted synonyms.
+- `boost` (number, default `1.0`) — Score boost applied to inserted synonym
+  tokens.
 
 ```javascript
 const filter = new SynonymGraphFilter(dict, true, 0.8);


### PR DESCRIPTION
## Summary

Surfaced by the comprehensive cross-binding doc-vs-implementation audit on 2026-04-29. The WASM docs had drifted in several places — most importantly the embedding story, where `addEmbedder` already supports a `"callback"` type that enables in-engine auto-embedding, but the docs still claimed only `"precomputed"` was supported.

- Document the `"callback"` `addEmbedder` type alongside `"precomputed"`. Callback embedders accept a JavaScript `embed: (text) => Promise<number[]>` and let `searchVectorText("field", "query text")` work transparently using Transformers.js or any other in-browser embedding library, contradicting the previous "no in-engine auto-embedding" claim.
- Add the missing `Schema.toString()` method (#365) to the API reference (en/ja).
- Add the missing Analysis section (`WhitespaceTokenizer`, `SynonymDictionary`, `SynonymGraphFilter`) to [the Japanese API reference](docs/ja/src/laurus-wasm/api_reference.md), which previously omitted the entire chapter.
- Document HNSW `m` / `efConstruction` and IVF `nClusters` / `nProbe` defaults consistently across both English and Japanese.
- Document `SynonymGraphFilter` constructor parameters (`keepOriginal`, `boost`) with their defaults.
- Refresh [laurus-wasm.md](docs/src/laurus-wasm.md) (en/ja): rename "Limitation: No In-Engine Auto-Embedding" to "Embedding Strategies", describe both Option A (precomputed) and Option B (callback), and update the comparison table to "Precomputed + JS callback".

## Test plan

- [x] `markdownlint-cli2 "docs/src/laurus-wasm.md" "docs/src/laurus-wasm/api_reference.md" "docs/ja/src/laurus-wasm.md" "docs/ja/src/laurus-wasm/api_reference.md"`