### PR TITLE
docs(nodejs): align api_reference and quickstart with current implementation

### DIFF
--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -71,6 +71,7 @@ class Schema {
 | `setDynamicFieldPolicy(policy)` | 未宣言フィールドの扱いを設定。`policy` は `"strict"` / `"dynamic"`（デフォルト）/ `"ignore"`。詳細は下記を参照。 |
 | `dynamicFieldPolicy()` | 現在のポリシーを小文字の文字列で返す。 |
 | `fieldNames()` | 全フィールド名を返す。 |
+| `toString()` | スキーマの文字列表現（`"Schema(fields=[...])"` 形式）を返す。 |
 
 #### Dynamic field policy（動的フィールドポリシー）
 
@@ -135,11 +136,13 @@ new NumericRangeQuery(
   field: string,
   min?: number | null,
   max?: number | null,
-  isFloat?: boolean,
+  numericType?: "integer" | "float",
 )
 ```
 
-`[min, max]` 範囲の数値にマッチ。`null` で開放端。
+`[min, max]` 範囲の数値にマッチします。`null`（または省略）で開放端。
+`numericType` は内部の範囲型を選択します（`"integer"`（デフォルト）または
+`"float"`）。それ以外の値は例外をスローします。
 
 ### GeoDistanceQuery
 
@@ -209,13 +212,37 @@ Geo3dNearestQuery.kNearest(
 ```typescript
 class BooleanQuery {
   constructor();
-  mustTerm(field: string, term: string): void;
-  shouldTerm(field: string, term: string): void;
-  mustNotTerm(field: string, term: string): void;
+  // 各クエリタイプ X について（X は次のいずれか）:
+  //   { Term, Phrase, Fuzzy, Wildcard, NumericRange,
+  //     GeoDistance, GeoBoundingBox,
+  //     Geo3dDistance, Geo3dBoundingBox, Geo3dNearest,
+  //     Boolean, Span }
+  mustX(query: X): void;
+  shouldX(query: X): void;
+  mustNotX(query: X): void;
 }
 ```
 
-MUST / SHOULD / MUST_NOT 句による複合ブーリアンクエリ。
+MUST / SHOULD / MUST_NOT 句による複合ブーリアンクエリ。各句は対応するクエリ
+クラスのインスタンスを引数に取ります。例:
+`mustTerm(new TermQuery("body", "rust"))` や
+`shouldGeo3dNearest(Geo3dNearestQuery.kNearest(...))`。
+
+Node.js バインディングは多態 `must(query)` ではなく 36 個の per-type メソッド
+（12 クエリタイプ × 3 極性）を公開しています。これは `js_name` を上書きした
+クラスに対する `napi-derive` の `Either<&T, ...>` 引数バリデーションの制限を
+回避するためです。
+
+`must` 節はすべて一致する必要があり、`mustNot` 節は一致してはなりません。
+`should` 節はスコアリングに寄与し、`must` 節が無い場合は少なくとも1つが
+一致する必要があります。
+
+```javascript
+const bq = new BooleanQuery();
+bq.mustTerm(new TermQuery("body", "programming"));
+bq.mustNotTerm(new TermQuery("title", "python"));
+bq.shouldFuzzy(new FuzzyQuery("body", "data", 1));
+```
 
 ### SpanQuery
 
@@ -264,23 +291,57 @@ new VectorTextQuery(field: string, text: string)
 高度な制御のための全機能検索リクエスト。
 
 ```typescript
+interface SearchRequestOptions {
+  queryDsl?: string;
+  limit?: number;   // デフォルト 10
+  offset?: number;  // デフォルト 0
+}
+
 class SearchRequest {
-  constructor(limit?: number, offset?: number);
+  constructor(options?: SearchRequestOptions);
 }
 ```
 
-### セッターメソッド
+コンストラクタにはプリミティブな options を渡し、多態クエリ句は下記の
+per-type セッターで設定します。`BooleanQuery` 同様、`napi-derive` の
+`Either<&T, ...>` バリデーション制限を回避するため per-type 化されています。
+
+### DSL とフュージョンセッター
 
 | メソッド | 説明 |
 | :--- | :--- |
-| `setQueryDsl(dsl)` | DSL 文字列クエリを設定。 |
-| `setLexicalTermQuery(field, term)` | Term ベースの Lexical クエリを設定。 |
-| `setLexicalPhraseQuery(field, terms)` | Phrase ベースの Lexical クエリを設定。 |
-| `setVectorQuery(field, vector)` | 事前計算ベクトルクエリを設定。 |
-| `setVectorTextQuery(field, text)` | テキストベースのベクトルクエリを設定。 |
-| `setFilterQuery(field, term)` | スコアリング後のフィルタを設定。 |
-| `setRrfFusion(k?)` | RRF 融合を使用（デフォルト k=60）。 |
-| `setWeightedSumFusion(lexicalWeight?, vectorWeight?)` | 加重和融合を使用。 |
+| `setQueryDsl(dsl: string)` | DSL 文字列クエリを設定。 |
+| `setRrfFusion(rrf: RRF)` | RRF フュージョンを使用。 |
+| `setWeightedSumFusion(ws: WeightedSum)` | 加重和フュージョンを使用。 |
+
+### ベクトルセッター
+
+| メソッド | 説明 |
+| :--- | :--- |
+| `setVectorQuery(query: VectorQuery)` | 事前計算ベクトルクエリを設定。 |
+| `setVectorTextQuery(query: VectorTextQuery)` | テキストベースのベクトルクエリを設定（登録 Embedder で自動埋め込み）。 |
+
+### Lexical セッター（per-type）
+
+`X` を `{ Term, Phrase, Fuzzy, Wildcard, NumericRange, GeoDistance,
+GeoBoundingBox, Geo3dDistance, Geo3dBoundingBox, Geo3dNearest, Boolean,
+Span }` の各クエリタイプとして、以下のメソッドが公開されています:
+
+| メソッド | 説明 |
+| :--- | :--- |
+| `setLexicalX(query: X)` | 明示的なハイブリッドリクエストの Lexical コンポーネントを設定。 |
+| `setFilterX(query: X)` | スコアリング後のフィルタコンポーネントを設定。 |
+
+合計 24 個の per-type セッター（12 lexical + 12 filter）に加え、上記の DSL /
+ベクトル / フュージョンセッターが利用可能です。
+
+```javascript
+const req = new SearchRequest({ limit: 5 });
+req.setLexicalTerm(new TermQuery("title", "rust"));
+req.setVectorQuery(new VectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]));
+req.setRrfFusion(new RRF(60.0));
+const results = await index.searchWithRequest(req);
+```
 
 ---
 
@@ -292,7 +353,7 @@ class SearchRequest {
 interface SearchResult {
   id: string;        // 外部ドキュメント識別子
   score: number;     // 関連度スコア
-  document: object | null; // 取得フィールド、または null
+  document: object | null; // 取得フィールド、stored=false の場合は null
 }
 ```
 
@@ -382,8 +443,7 @@ JavaScript の値は自動的に Laurus の `DataValue` 型に変換されます
 | `boolean` | `Bool` | |
 | `number`（整数） | `Int64` | |
 | `number`（浮動小数点） | `Float64` | |
-| `string` | `Text` | ISO8601 文字列は `DateTime` になる |
+| `string` | `Text` | ISO 8601 文字列は `DateTime` になる |
 | `number[]` | `Vector` | `f32` に変換 |
-| `{ lat, lon }` | `Geo` | 2つの `number` 値 |
-| `Date` | `DateTime` | タイムスタンプ経由 |
-| `Buffer` | `Bytes` | |
+| `{ lat, lon }` | `Geo` | 2 つの `number` 値 |
+| `{ x, y, z }` | `GeoEcef` | 3 つの `number` 値（メートル単位、3D ECEF 直交座標） |

--- a/docs/ja/src/laurus-nodejs/quickstart.md
+++ b/docs/ja/src/laurus-nodejs/quickstart.md
@@ -77,12 +77,18 @@ const results = await index.searchVector(
 ## 5. ハイブリッド検索
 
 ```javascript
-import { SearchRequest } from "laurus-nodejs";
+import {
+  Index,
+  RRF,
+  SearchRequest,
+  TermQuery,
+  VectorQuery,
+} from "laurus-nodejs";
 
-const req = new SearchRequest(5);
-req.setLexicalTermQuery("name", "express");
-req.setVectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]);
-req.setRrfFusion(60.0);
+const req = new SearchRequest({ limit: 5 });
+req.setLexicalTerm(new TermQuery("name", "express"));
+req.setVectorQuery(new VectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]));
+req.setRrfFusion(new RRF(60.0));
 
 const results = await index.searchWithRequest(req);
 ```

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -71,6 +71,7 @@ class Schema {
 | `setDynamicFieldPolicy(policy)` | Set how undeclared fields are handled. `policy` is `"strict"`, `"dynamic"` (default), or `"ignore"`. See notes below. |
 | `dynamicFieldPolicy()` | Return the current policy as a lowercase string. |
 | `fieldNames()` | Return all field names. |
+| `toString()` | Return a string representation of the schema (`"Schema(fields=[...])"`). |
 
 #### Dynamic field policy
 
@@ -142,12 +143,13 @@ new NumericRangeQuery(
   field: string,
   min?: number | null,
   max?: number | null,
-  isFloat?: boolean,
+  numericType?: "integer" | "float",
 )
 ```
 
-Matches numeric values in `[min, max]`. Pass `null` for an
-open bound.
+Matches numeric values in `[min, max]`. Pass `null` (or omit) for an
+open bound. `numericType` selects the underlying range type
+(`"integer"` (default) or `"float"`); other values throw.
 
 ### GeoDistanceQuery
 
@@ -218,13 +220,37 @@ search cone.
 ```typescript
 class BooleanQuery {
   constructor();
-  mustTerm(field: string, term: string): void;
-  shouldTerm(field: string, term: string): void;
-  mustNotTerm(field: string, term: string): void;
+  // For each query type X in
+  //   { Term, Phrase, Fuzzy, Wildcard, NumericRange,
+  //     GeoDistance, GeoBoundingBox,
+  //     Geo3dDistance, Geo3dBoundingBox, Geo3dNearest,
+  //     Boolean, Span }:
+  mustX(query: X): void;
+  shouldX(query: X): void;
+  mustNotX(query: X): void;
 }
 ```
 
-Compound boolean query with MUST / SHOULD / MUST_NOT clauses.
+Compound boolean query with MUST / SHOULD / MUST_NOT clauses. Each clause
+takes an instance of a specific query class — for example,
+`mustTerm(new TermQuery("body", "rust"))` or
+`shouldGeo3dNearest(Geo3dNearestQuery.kNearest(...))`.
+
+The Node.js binding exposes 36 per-type methods (12 query types × 3
+polarities) instead of a single polymorphic `must(query)` because of a
+limitation in `napi-derive`'s validation of `Either<&T, ...>` arguments
+for classes with `js_name` overrides.
+
+`must` clauses all have to match; `mustNot` clauses must not match.
+`should` clauses contribute to scoring; at least one of them must match if
+there are no `must` clauses.
+
+```javascript
+const bq = new BooleanQuery();
+bq.mustTerm(new TermQuery("body", "programming"));
+bq.mustNotTerm(new TermQuery("title", "python"));
+bq.shouldFuzzy(new FuzzyQuery("body", "data", 1));
+```
 
 ### SpanQuery
 
@@ -273,23 +299,58 @@ embedder configured on the index.
 Full-featured search request for advanced control.
 
 ```typescript
+interface SearchRequestOptions {
+  queryDsl?: string;
+  limit?: number;   // default 10
+  offset?: number;  // default 0
+}
+
 class SearchRequest {
-  constructor(limit?: number, offset?: number);
+  constructor(options?: SearchRequestOptions);
 }
 ```
 
-### Setter methods
+Construct with primitive options first; attach polymorphic clauses with
+the per-type setters below. As with `BooleanQuery`, the binding exposes
+per-type setters because of `napi-derive`'s limitation on `Either<&T, ...>`
+arguments.
+
+### DSL and fusion setters
 
 | Method | Description |
 | :--- | :--- |
-| `setQueryDsl(dsl)` | Set a DSL string query. |
-| `setLexicalTermQuery(field, term)` | Set a term-based lexical query. |
-| `setLexicalPhraseQuery(field, terms)` | Set a phrase-based lexical query. |
-| `setVectorQuery(field, vector)` | Set a pre-computed vector query. |
-| `setVectorTextQuery(field, text)` | Set a text-based vector query. |
-| `setFilterQuery(field, term)` | Set a post-scoring filter. |
-| `setRrfFusion(k?)` | Use RRF fusion (default k=60). |
-| `setWeightedSumFusion(lexicalWeight?, vectorWeight?)` | Use weighted sum fusion. |
+| `setQueryDsl(dsl: string)` | Set a DSL string query. |
+| `setRrfFusion(rrf: RRF)` | Use RRF fusion. |
+| `setWeightedSumFusion(ws: WeightedSum)` | Use weighted-sum fusion. |
+
+### Vector setters
+
+| Method | Description |
+| :--- | :--- |
+| `setVectorQuery(query: VectorQuery)` | Set a pre-computed vector query. |
+| `setVectorTextQuery(query: VectorTextQuery)` | Set a text-based vector query (auto-embedded by the configured embedder). |
+
+### Lexical setters (per type)
+
+For each query type `X` in `{ Term, Phrase, Fuzzy, Wildcard, NumericRange,
+GeoDistance, GeoBoundingBox, Geo3dDistance, Geo3dBoundingBox, Geo3dNearest,
+Boolean, Span }`, the request exposes:
+
+| Method | Description |
+| :--- | :--- |
+| `setLexicalX(query: X)` | Set the lexical component for an explicit hybrid request. |
+| `setFilterX(query: X)` | Set the post-scoring filter component. |
+
+That is, 24 per-type setters in total (12 lexical + 12 filter), in addition
+to the DSL, vector, and fusion setters above.
+
+```javascript
+const req = new SearchRequest({ limit: 5 });
+req.setLexicalTerm(new TermQuery("title", "rust"));
+req.setVectorQuery(new VectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]));
+req.setRrfFusion(new RRF(60.0));
+const results = await index.searchWithRequest(req);
+```
 
 ---
 
@@ -301,7 +362,7 @@ Returned by search methods as an array.
 interface SearchResult {
   id: string;        // External document identifier
   score: number;     // Relevance score
-  document: object | null; // Retrieved fields, or null
+  document: object | null; // Retrieved fields, or null if not stored
 }
 ```
 
@@ -392,8 +453,7 @@ JavaScript values are automatically converted to Laurus
 | `boolean` | `Bool` | |
 | `number` (integer) | `Int64` | |
 | `number` (float) | `Float64` | |
-| `string` | `Text` | ISO8601 strings become `DateTime` |
+| `string` | `Text` | ISO 8601 strings become `DateTime` |
 | `number[]` | `Vector` | Coerced to `f32` |
 | `{ lat, lon }` | `Geo` | Two `number` values |
-| `Date` | `DateTime` | Via timestamp |
-| `Buffer` | `Bytes` | |
+| `{ x, y, z }` | `GeoEcef` | Three `number` values, meters (3D ECEF Cartesian) |

--- a/docs/src/laurus-nodejs/quickstart.md
+++ b/docs/src/laurus-nodejs/quickstart.md
@@ -77,12 +77,18 @@ const results = await index.searchVector(
 ## 5. Hybrid search
 
 ```javascript
-import { SearchRequest } from "laurus-nodejs";
+import {
+  Index,
+  RRF,
+  SearchRequest,
+  TermQuery,
+  VectorQuery,
+} from "laurus-nodejs";
 
-const req = new SearchRequest(5);
-req.setLexicalTermQuery("name", "express");
-req.setVectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]);
-req.setRrfFusion(60.0);
+const req = new SearchRequest({ limit: 5 });
+req.setLexicalTerm(new TermQuery("name", "express"));
+req.setVectorQuery(new VectorQuery("embedding", [0.1, 0.2, 0.3, 0.4]));
+req.setRrfFusion(new RRF(60.0));
 
 const results = await index.searchWithRequest(req);
 ```


### PR DESCRIPTION
## Summary

Surfaced by the comprehensive cross-binding doc-vs-implementation audit on 2026-04-29. Node.js had the most extensive drift — large parts of the `SearchRequest` and `BooleanQuery` documentation reflected the pre-refactor API and code samples in those sections would not run as written.

### Critical fixes (sample code now actually runs)

- `SearchRequest` constructor: `(limit?, offset?)` → `({ queryDsl?, limit?, offset? })` options object ([search.rs:204-220](laurus-nodejs/src/search.rs#L204-L220)).
- Replace the 8 primitive-arg setter rows (`setLexicalTermQuery(field, term)` etc.) with the actual 31-method surface ([search.rs:222-411](laurus-nodejs/src/search.rs#L222-L411)): 12 `setLexicalX(query: X)`, 12 `setFilterX(query: X)`, `setQueryDsl`, `setVectorQuery`, `setVectorTextQuery`, `setRrfFusion(rrf: RRF)`, `setWeightedSumFusion(ws: WeightedSum)`.
- Replace the 3 primitive-arg `BooleanQuery` methods (`mustTerm(field, term)` etc.) with the actual 36 per-type methods (`mustX(query: X)` for 12 query types × 3 polarities) ([query.rs:728-977](laurus-nodejs/src/query.rs#L728-L977)). Note the `napi-derive` `Either<&T, ...>` workaround.
- `NumericRangeQuery` 4th arg: `isFloat?: boolean` → `numericType?: "integer" | "float"` (PR #369).
- Update the hybrid-search quickstart example to use the new constructor and per-type setters.

### Other corrections

- Add the missing `Schema.toString()` method (#365).
- Replace the false `Buffer → Bytes` and `Date → DateTime` conversion rows with the real `{ x, y, z } → GeoEcef` row; [convert.rs](laurus-nodejs/src/convert.rs) does not handle `Buffer` or `Date`.
- `SearchResult.document`: "or null" → "or null if not stored".

Both English and Japanese versions are updated.

## Test plan

- [x] `markdownlint-cli2 "docs/src/laurus-nodejs/{api_reference,quickstart}.md" "docs/ja/src/laurus-nodejs/{api_reference,quickstart}.md"`