### PR TITLE
refactor(geo): unify 2D/3D distance units to meters

### DIFF
--- a/docs/ja/src/concepts/geo3d.md
+++ b/docs/ja/src/concepts/geo3d.md
@@ -120,7 +120,7 @@ let (lat, lon, height) = ecef_to_wgs84(&p);
 
 ### 球（半径） — `Geo3dDistanceQuery`
 
-中心点から `radius_m` メートル以内に格納済みポイントが入っているドキュメントを
+中心点から `distance_m` メートル以内に格納済みポイントが入っているドキュメントを
 すべて返す。スコアは `1 - distance / radius` を `[0, 1]` にクランプした
 値。
 
@@ -200,7 +200,7 @@ position:geo3d_nearest(-3955182, 3350553, 3700276, 10)
 
 | 形式 | 引数 |
 | :--- | :--- |
-| `geo3d_distance(x, y, z, radius_m)` | 中心 `(x, y, z)` と検索半径（m） |
+| `geo3d_distance(x, y, z, distance_m)` | 中心 `(x, y, z)` と最大距離（m） |
 | `geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)` | AABB の対角の 2 隅 |
 | `geo3d_nearest(x, y, z, k)` | 中心 `(x, y, z)` と整数 `k` |
 

--- a/docs/ja/src/concepts/query_dsl.md
+++ b/docs/ja/src/concepts/query_dsl.md
@@ -89,23 +89,23 @@ price:[* TO 100]
 ### 2D 地理クエリ（`geo_*`)
 
 2 種類の関数形式を `Geo`（2D 緯度 / 経度）フィールドに対して使えます。
-緯度・経度は度単位、半径はキロメートル単位の符号付き浮動小数点数：
+緯度・経度は度単位、距離はメートル単位の符号付き浮動小数点数：
 
 ```text
-location:geo_distance(lat, lon, distance_km)
+location:geo_distance(lat, lon, distance_m)
 location:geo_bbox(min_lat, min_lon, max_lat, max_lon)
 ```
 
 | 形式 | 動作 |
 | :--- | :--- |
-| `geo_distance(lat, lon, distance_km)` | 中心 `(lat, lon)` から `distance_km` キロメートル以内の格納済み座標を返す |
+| `geo_distance(lat, lon, distance_m)` | 中心 `(lat, lon)` から `distance_m` メートル以内の格納済み座標を返す |
 | `geo_bbox(min_lat, min_lon, max_lat, max_lon)` | 軸並行緯度・経度範囲に含まれる格納済み座標を返す |
 
 例：
 
 ```text
-# 東京から 10 km 以内（35.6895, 139.6917）
-location:geo_distance(35.6895, 139.6917, 10)
+# 東京から 10 km（= 10 000 m）以内（35.6895, 139.6917）
+location:geo_distance(35.6895, 139.6917, 10000)
 
 # 軸並行緯度・経度範囲
 location:geo_bbox(35.0, 139.0, 36.0, 140.0)
@@ -120,14 +120,14 @@ location:geo_bbox(35.0, 139.0, 36.0, 140.0)
 `k` 以外の引数はすべてメートル単位の符号付き浮動小数点数、`k` のみ符号なし整数：
 
 ```text
-position:geo3d_distance(x, y, z, radius_m)
+position:geo3d_distance(x, y, z, distance_m)
 position:geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)
 position:geo3d_nearest(x, y, z, k)
 ```
 
 | 形式 | 動作 |
 | :--- | :--- |
-| `geo3d_distance(x, y, z, radius_m)` | `(x, y, z)` から `radius_m` メートル以内の格納済みポイントを返す |
+| `geo3d_distance(x, y, z, distance_m)` | `(x, y, z)` から `distance_m` メートル以内の格納済みポイントを返す |
 | `geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)` | 軸並行 3D ボックスに含まれる格納済みポイントを返す |
 | `geo3d_nearest(x, y, z, k)` | `(x, y, z)` に最も近い `k` 件をユークリッド距離順で返す |
 

--- a/docs/ja/src/concepts/search/lexical_search.md
+++ b/docs/ja/src/concepts/search/lexical_search.md
@@ -162,8 +162,8 @@ let query = NumericRangeQuery::new(
 ```rust
 use laurus::lexical::query::geo::GeoQuery;
 
-// Find documents within 10km of Tokyo Station (35.6812, 139.7671)
-let query = GeoQuery::within_radius("location", 35.6812, 139.7671, 10.0)?; // radius in kilometers
+// Find documents within 10 km (= 10 000 m) of Tokyo Station (35.6812, 139.7671)
+let query = GeoQuery::within_radius("location", 35.6812, 139.7671, 10_000.0)?; // distance in metres
 
 // Find documents within a bounding box (min_lat, min_lon, max_lat, max_lon)
 let query = GeoQuery::within_bounding_box(

--- a/docs/ja/src/laurus-mcp/tools.md
+++ b/docs/ja/src/laurus-mcp/tools.md
@@ -300,7 +300,7 @@ laurus 統一クエリ DSL を使用してドキュメントを検索します�
 
 | クエリ | 説明 |
 | :--- | :--- |
-| `position:geo3d_distance(x, y, z, radius_m)` | `(x, y, z)` を中心とした半径（メートル単位）の球 |
+| `position:geo3d_distance(x, y, z, distance_m)` | `(x, y, z)` を中心とした最大距離（メートル単位）の球 |
 | `position:geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)` | 3D 軸並行バウンディングボックス |
 | `position:geo3d_nearest(x, y, z, k)` | `(x, y, z)` に最も近い k 個の近傍点 |
 

--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -148,7 +148,7 @@ new NumericRangeQuery(
 
 ```typescript
 GeoDistanceQuery.withinRadius(
-  field: string, lat: number, lon: number, distanceKm: number,
+  field: string, lat: number, lon: number, distanceM: number,
 ): GeoDistanceQuery
 ```
 
@@ -172,11 +172,11 @@ GeoBoundingBoxQuery.withinBoundingBox(
 Geo3dDistanceQuery.withinSphere(
   field: string,
   x: number, y: number, z: number,
-  radiusM: number,
+  distanceM: number,
 ): Geo3dDistanceQuery
 ```
 
-3D ECEF 座標フィールドへの球距離検索。中心から `radiusM` メートル以内の `(x, y, z)`
+3D ECEF 座標フィールドへの球距離検索。中心から `distanceM` メートル以内の `(x, y, z)`
 座標を持つドキュメントを返します。ECEF の理論については
 [Geo3d の概念](../concepts/geo3d.md) を参照。
 

--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -149,11 +149,11 @@ new \Laurus\NumericRangeQuery(string $field, mixed $min, mixed $max, ?string $nu
 
 ```php
 \Laurus\GeoDistanceQuery::withinRadius(
-    string $field, float $lat, float $lon, float $distanceKm,
+    string $field, float $lat, float $lon, float $distanceM,
 ): GeoDistanceQuery
 ```
 
-地理的距離検索（半径指定）。指定した地点から `$distanceKm` キロメートル以内の
+地理的距離検索（半径指定）。指定した地点から `$distanceM` メートル以内の
 `(lat, lon)` 座標を持つドキュメントを返します。
 
 ### GeoBoundingBoxQuery
@@ -175,11 +175,11 @@ new \Laurus\NumericRangeQuery(string $field, mixed $min, mixed $max, ?string $nu
 \Laurus\Geo3dDistanceQuery::withinSphere(
     string $field,
     float $x, float $y, float $z,
-    float $radiusM,
+    float $distanceM,
 ): Geo3dDistanceQuery
 ```
 
-3D ECEF 座標フィールドへの球距離検索。中心 `(x, y, z)` から `$radiusM` メートル以内
+3D ECEF 座標フィールドへの球距離検索。中心 `(x, y, z)` から `$distanceM` メートル以内
 の座標を持つドキュメントを返します。ECEF の理論については
 [Geo3d の概念](../concepts/geo3d.md) を参照。
 

--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -153,11 +153,11 @@ NumericRangeQuery(field: str, *, min: int | float | None = None, max: int | floa
 
 ```python
 GeoDistanceQuery.within_radius(
-    field: str, lat: float, lon: float, distance_km: float,
+    field: str, lat: float, lon: float, distance_m: float,
 )
 ```
 
-地理的距離検索（半径指定）。指定した地点から `distance_km` キロメートル以内の
+地理的距離検索（半径指定）。指定した地点から `distance_m` メートル以内の
 `(lat, lon)` 座標を持つドキュメントを返します。
 
 ### GeoBoundingBoxQuery
@@ -177,11 +177,11 @@ GeoBoundingBoxQuery.within_bounding_box(
 
 ```python
 Geo3dDistanceQuery.within_sphere(
-    field: str, x: float, y: float, z: float, radius_m: float,
+    field: str, x: float, y: float, z: float, distance_m: float,
 )
 ```
 
-3D ECEF 座標フィールドへの球距離検索。中心 `(x, y, z)` から `radius_m` メートル以内
+3D ECEF 座標フィールドへの球距離検索。中心 `(x, y, z)` から `distance_m` メートル以内
 の座標を持つドキュメントを返します。ECEF の理論については
 [Geo3d の概念](../concepts/geo3d.md) を参照。
 

--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -148,10 +148,10 @@ Laurus::NumericRangeQuery.new(field, min: nil, max: nil)
 ### GeoDistanceQuery
 
 ```ruby
-Laurus::GeoDistanceQuery.within_radius(field, lat, lon, distance_km)
+Laurus::GeoDistanceQuery.within_radius(field, lat, lon, distance_m)
 ```
 
-地理的距離検索（半径指定）。指定した地点から `distance_km` キロメートル以内の
+地理的距離検索（半径指定）。指定した地点から `distance_m` メートル以内の
 `(lat, lon)` 座標を持つドキュメントを返します。
 
 ### GeoBoundingBoxQuery
@@ -168,10 +168,10 @@ Laurus::GeoBoundingBoxQuery.within_bounding_box(
 ### Geo3dDistanceQuery
 
 ```ruby
-Laurus::Geo3dDistanceQuery.within_sphere(field, x, y, z, radius_m)
+Laurus::Geo3dDistanceQuery.within_sphere(field, x, y, z, distance_m)
 ```
 
-3D ECEF 座標フィールドへの球距離検索。中心 `(x, y, z)` から `radius_m` メートル以内
+3D ECEF 座標フィールドへの球距離検索。中心 `(x, y, z)` から `distance_m` メートル以内
 の座標を持つドキュメントを返します。ECEF の理論については
 [Geo3d の概念](../concepts/geo3d.md) を参照。
 

--- a/docs/ja/src/laurus-server/grpc_api.md
+++ b/docs/ja/src/laurus-server/grpc_api.md
@@ -350,7 +350,7 @@ rpc SearchStream(SearchRequest) returns (stream SearchResult);
 
 3D ECEF の地理クエリは `SearchRequest.query` に渡す Lexical DSL 文字列で表現します。専用のメッセージ型はなく、コアライブラリで使用される DSL 形式がそのまま gRPC 経由でも動作します。3 種類の形式があります（構文の詳細は [Query DSL → 3D 地理クエリ](../concepts/query_dsl.md#3d-geographic-queries-geo3d_) を参照）:
 
-- `position:geo3d_distance(x, y, z, radius_m)` — `(x, y, z)` を中心とした半径（メートル単位）の球
+- `position:geo3d_distance(x, y, z, distance_m)` — `(x, y, z)` を中心とした最大距離（メートル単位）の球
 - `position:geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)` — 3D 軸並行バウンディングボックス
 - `position:geo3d_nearest(x, y, z, k)` — `(x, y, z)` に最も近い k 個の近傍点
 

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -101,16 +101,16 @@ DSL 文字列クエリで検索します。
   - `limit`, `offset` (number, 省略可)
 - **戻り値:** `Promise<SearchResult[]>`
 
-#### `searchGeo3dDistance(field, x, y, z, radiusM, limit?, offset?)`
+#### `searchGeo3dDistance(field, x, y, z, distanceM, limit?, offset?)`
 
-3D ECEF 座標フィールドへの球距離検索。中心 `(x, y, z)` から `radiusM` メートル以内
+3D ECEF 座標フィールドへの球距離検索。中心 `(x, y, z)` から `distanceM` メートル以内
 の座標を持つドキュメントを返します。ECEF の理論については
 [Geo3d の概念](../concepts/geo3d.md) を参照。
 
 - **引数:**
   - `field` (string) -- Geo3d フィールド名
   - `x`, `y`, `z` (number) -- 中心 ECEF 座標（メートル）
-  - `radiusM` (number) -- 球の半径（メートル）
+  - `distanceM` (number) -- 中心からの最大距離（メートル）
   - `limit`, `offset` (number, 省略可)
 - **戻り値:** `Promise<SearchResult[]>`
 

--- a/docs/src/concepts/geo3d.md
+++ b/docs/src/concepts/geo3d.md
@@ -120,7 +120,7 @@ on top of the shared 3D BKD-Tree.
 
 ### Sphere (radius) — `Geo3dDistanceQuery`
 
-Find every document whose stored point lies within `radius_m` metres of a
+Find every document whose stored point lies within `distance_m` metres of a
 centre point. Score is `1 - distance / radius`, clamped to `[0, 1]`.
 
 ```rust
@@ -200,7 +200,7 @@ position:geo3d_nearest(-3955182, 3350553, 3700276, 10)
 
 | Form | Arguments |
 | :--- | :--- |
-| `geo3d_distance(x, y, z, radius_m)` | centre `(x, y, z)` and search radius in metres |
+| `geo3d_distance(x, y, z, distance_m)` | centre `(x, y, z)` and maximum distance in metres |
 | `geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)` | two opposite corners of the AABB |
 | `geo3d_nearest(x, y, z, k)` | centre `(x, y, z)` and the integer `k` |
 

--- a/docs/src/concepts/query_dsl.md
+++ b/docs/src/concepts/query_dsl.md
@@ -96,23 +96,23 @@ price:[* TO 100]
 
 Two function-style forms target `Geo` (2D latitude / longitude) fields. All
 arguments are signed floats; latitudes / longitudes are in degrees and the
-radius is in kilometres:
+distance is in metres:
 
 ```text
-location:geo_distance(lat, lon, distance_km)
+location:geo_distance(lat, lon, distance_m)
 location:geo_bbox(min_lat, min_lon, max_lat, max_lon)
 ```
 
 | Form | Behaviour |
 | :--- | :--- |
-| `geo_distance(lat, lon, distance_km)` | All docs whose stored `(lat, lon)` lies within `distance_km` kilometres of the given centre. |
+| `geo_distance(lat, lon, distance_m)` | All docs whose stored `(lat, lon)` lies within `distance_m` metres of the given centre. |
 | `geo_bbox(min_lat, min_lon, max_lat, max_lon)` | All docs whose stored `(lat, lon)` lies inside the axis-aligned latitude / longitude rectangle. |
 
 Examples:
 
 ```text
-# Within 10 km of Tokyo (35.6895, 139.6917)
-location:geo_distance(35.6895, 139.6917, 10)
+# Within 10 km (= 10 000 m) of Tokyo (35.6895, 139.6917)
+location:geo_distance(35.6895, 139.6917, 10000)
 
 # Inside an axis-aligned lat/lon bounding box
 location:geo_bbox(35.0, 139.0, 36.0, 140.0)
@@ -128,14 +128,14 @@ Three function-style forms target `Geo3d` (3D ECEF Cartesian) fields. All
 arguments are signed floats in metres, except `k` (an unsigned integer):
 
 ```text
-position:geo3d_distance(x, y, z, radius_m)
+position:geo3d_distance(x, y, z, distance_m)
 position:geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)
 position:geo3d_nearest(x, y, z, k)
 ```
 
 | Form | Behaviour |
 | :--- | :--- |
-| `geo3d_distance(x, y, z, radius_m)` | All docs whose stored point lies within `radius_m` metres of `(x, y, z)`. |
+| `geo3d_distance(x, y, z, distance_m)` | All docs whose stored point lies within `distance_m` metres of `(x, y, z)`. |
 | `geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)` | All docs whose stored point lies inside the axis-aligned 3D box. |
 | `geo3d_nearest(x, y, z, k)` | The `k` nearest docs to `(x, y, z)` by Euclidean distance. |
 

--- a/docs/src/concepts/search/lexical_search.md
+++ b/docs/src/concepts/search/lexical_search.md
@@ -162,8 +162,8 @@ Matches documents by 2D geographic location (WGS84 latitude / longitude).
 ```rust
 use laurus::lexical::query::geo::GeoQuery;
 
-// Find documents within 10km of Tokyo Station (35.6812, 139.7671)
-let query = GeoQuery::within_radius("location", 35.6812, 139.7671, 10.0)?; // radius in kilometers
+// Find documents within 10 km (= 10 000 m) of Tokyo Station (35.6812, 139.7671)
+let query = GeoQuery::within_radius("location", 35.6812, 139.7671, 10_000.0)?; // distance in metres
 
 // Find documents within a bounding box (min_lat, min_lon, max_lat, max_lon)
 let query = GeoQuery::within_bounding_box(

--- a/docs/src/laurus-mcp/tools.md
+++ b/docs/src/laurus-mcp/tools.md
@@ -313,7 +313,7 @@ Search documents using the laurus unified query DSL. Supports lexical search, ve
 
 | Query | Description |
 | :--- | :--- |
-| `position:geo3d_distance(x, y, z, radius_m)` | Sphere with center `(x, y, z)` and radius in meters |
+| `position:geo3d_distance(x, y, z, distance_m)` | Sphere with center `(x, y, z)` and maximum distance in meters |
 | `position:geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)` | 3D axis-aligned bounding box |
 | `position:geo3d_nearest(x, y, z, k)` | k nearest neighbors to `(x, y, z)` |
 

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -155,7 +155,7 @@ open bound. `numericType` selects the underlying range type
 
 ```typescript
 GeoDistanceQuery.withinRadius(
-  field: string, lat: number, lon: number, distanceKm: number,
+  field: string, lat: number, lon: number, distanceM: number,
 ): GeoDistanceQuery
 ```
 
@@ -179,12 +179,12 @@ Geographic bounding-box search.
 Geo3dDistanceQuery.withinSphere(
   field: string,
   x: number, y: number, z: number,
-  radiusM: number,
+  distanceM: number,
 ): Geo3dDistanceQuery
 ```
 
 Sphere search over a 3D ECEF point field. Returns documents whose `(x, y, z)`
-coordinate is within `radiusM` metres of the centre. See
+coordinate is within `distanceM` metres of the centre. See
 [Geo3d concepts](../concepts/geo3d.md) for ECEF theory.
 
 ### Geo3dBoundingBoxQuery

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -154,12 +154,12 @@ Matches numeric values in the range `[$min, $max]`. Pass `null` for an open boun
 
 ```php
 \Laurus\GeoDistanceQuery::withinRadius(
-    string $field, float $lat, float $lon, float $distanceKm,
+    string $field, float $lat, float $lon, float $distanceM,
 ): GeoDistanceQuery
 ```
 
 Geo-distance (radius) search. Returns documents whose `(lat, lon)` coordinate
-is within `$distanceKm` kilometres of the given point.
+is within `$distanceM` metres of the given point.
 
 ### GeoBoundingBoxQuery
 
@@ -180,12 +180,12 @@ inside the axis-aligned `[$minLat, $maxLat] × [$minLon, $maxLon]` rectangle.
 \Laurus\Geo3dDistanceQuery::withinSphere(
     string $field,
     float $x, float $y, float $z,
-    float $radiusM,
+    float $distanceM,
 ): Geo3dDistanceQuery
 ```
 
 Sphere search over a 3D ECEF point field. Returns documents whose `(x, y, z)`
-coordinate is within `$radiusM` metres of the centre. See
+coordinate is within `$distanceM` metres of the centre. See
 [Geo3d concepts](../concepts/geo3d.md) for ECEF theory.
 
 ### Geo3dBoundingBoxQuery

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -158,12 +158,12 @@ float) is inferred from the Python type of `min`/`max`.
 
 ```python
 GeoDistanceQuery.within_radius(
-    field: str, lat: float, lon: float, distance_km: float,
+    field: str, lat: float, lon: float, distance_m: float,
 )
 ```
 
 Geo-distance (radius) search. Returns documents whose `(lat, lon)` coordinate
-is within `distance_km` kilometres of the given point.
+is within `distance_m` metres of the given point.
 
 ### GeoBoundingBoxQuery
 
@@ -182,12 +182,12 @@ inside the axis-aligned `[min_lat, max_lat] × [min_lon, max_lon]` rectangle.
 
 ```python
 Geo3dDistanceQuery.within_sphere(
-    field: str, x: float, y: float, z: float, radius_m: float,
+    field: str, x: float, y: float, z: float, distance_m: float,
 )
 ```
 
 Sphere search over a 3D ECEF point field. Returns documents whose `(x, y, z)`
-coordinate is within `radius_m` metres of the centre. See
+coordinate is within `distance_m` metres of the centre. See
 [Geo3d concepts](../concepts/geo3d.md) for ECEF theory.
 
 ### Geo3dBoundingBoxQuery

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -153,11 +153,11 @@ Matches numeric values in the range `[min, max]`. Pass `nil` for an open bound. 
 ### GeoDistanceQuery
 
 ```ruby
-Laurus::GeoDistanceQuery.within_radius(field, lat, lon, distance_km)
+Laurus::GeoDistanceQuery.within_radius(field, lat, lon, distance_m)
 ```
 
 Geo-distance (radius) search. Returns documents whose `(lat, lon)` coordinate
-is within `distance_km` kilometres of the given point.
+is within `distance_m` metres of the given point.
 
 ### GeoBoundingBoxQuery
 
@@ -173,11 +173,11 @@ inside the axis-aligned `[min_lat, max_lat] × [min_lon, max_lon]` rectangle.
 ### Geo3dDistanceQuery
 
 ```ruby
-Laurus::Geo3dDistanceQuery.within_sphere(field, x, y, z, radius_m)
+Laurus::Geo3dDistanceQuery.within_sphere(field, x, y, z, distance_m)
 ```
 
 Sphere search over a 3D ECEF point field. Returns documents whose `(x, y, z)`
-coordinate is within `radius_m` metres of the centre. See
+coordinate is within `distance_m` metres of the centre. See
 [Geo3d concepts](../concepts/geo3d.md) for ECEF theory.
 
 ### Geo3dBoundingBoxQuery

--- a/docs/src/laurus-server/grpc_api.md
+++ b/docs/src/laurus-server/grpc_api.md
@@ -347,7 +347,7 @@ At least one of `query` or `query_vectors` must be provided.
 
 3D ECEF geographic queries are expressed in the lexical DSL string passed via `SearchRequest.query`. There is no dedicated message type — the same DSL forms used by the core library work over gRPC. Three forms are available (see [Query DSL → 3D Geographic Queries](../concepts/query_dsl.md#3d-geographic-queries-geo3d_) for full syntax):
 
-- `position:geo3d_distance(x, y, z, radius_m)` — sphere centered at `(x, y, z)` with radius in meters
+- `position:geo3d_distance(x, y, z, distance_m)` — sphere centered at `(x, y, z)` with maximum distance in meters
 - `position:geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)` — 3D axis-aligned bounding box
 - `position:geo3d_nearest(x, y, z, k)` — k nearest neighbours to `(x, y, z)`
 

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -103,16 +103,16 @@ Search by text (embedded by the registered embedder).
   - `limit`, `offset` (number, optional)
 - **Returns:** `Promise<SearchResult[]>`
 
-#### `searchGeo3dDistance(field, x, y, z, radiusM, limit?, offset?)`
+#### `searchGeo3dDistance(field, x, y, z, distanceM, limit?, offset?)`
 
 Sphere search over a 3D ECEF point field. Returns documents whose `(x, y, z)`
-coordinate is within `radiusM` metres of the centre. See
+coordinate is within `distanceM` metres of the centre. See
 [Geo3d concepts](../concepts/geo3d.md) for ECEF theory.
 
 - **Parameters:**
   - `field` (string) -- Geo3d field name.
   - `x`, `y`, `z` (number) -- Centre ECEF coordinate (metres).
-  - `radiusM` (number) -- Sphere radius (metres).
+  - `distanceM` (number) -- Maximum distance from the centre (metres).
   - `limit`, `offset` (number, optional)
 - **Returns:** `Promise<SearchResult[]>`
 

--- a/laurus-nodejs/src/query.rs
+++ b/laurus-nodejs/src/query.rs
@@ -391,7 +391,7 @@ impl JsNumericRangeQuery {
 /// const { GeoDistanceQuery } = require("laurus-nodejs");
 ///
 /// // Radius search: within 100 km of San Francisco
-/// const q = GeoDistanceQuery.withinRadius("location", 37.77, -122.42, 100.0);
+/// const q = GeoDistanceQuery.withinRadius("location", 37.77, -122.42, 100_000.0);
 /// ```
 #[derive(Clone)]
 #[napi(js_name = "GeoDistanceQuery")]
@@ -399,7 +399,7 @@ pub struct JsGeoDistanceQuery {
     pub(crate) field: String,
     pub(crate) lat: f64,
     pub(crate) lon: f64,
-    pub(crate) distance_km: f64,
+    pub(crate) distance_m: f64,
 }
 
 #[napi]
@@ -411,14 +411,14 @@ impl JsGeoDistanceQuery {
     /// * `field` - Geo field name.
     /// * `lat` - Center latitude.
     /// * `lon` - Center longitude.
-    /// * `distance_km` - Search radius in kilometers.
+    /// * `distance_m` - Maximum distance from the centre in meters.
     #[napi(factory)]
-    pub fn within_radius(field: String, lat: f64, lon: f64, distance_km: f64) -> Self {
+    pub fn within_radius(field: String, lat: f64, lon: f64, distance_m: f64) -> Self {
         Self {
             field,
             lat,
             lon,
-            distance_km,
+            distance_m,
         }
     }
 }
@@ -429,7 +429,7 @@ impl JsGeoDistanceQuery {
             &self.field,
             self.lat,
             self.lon,
-            self.distance_km,
+            self.distance_m,
         )?))
     }
 }
@@ -505,7 +505,7 @@ impl JsGeoBoundingBoxQuery {
 // ---------------------------------------------------------------------------
 
 /// 3D ECEF sphere query: matches documents whose stored `(x, y, z)` point
-/// lies within `radius_m` meters of the given centre.
+/// lies within `distance_m` meters of the given centre.
 ///
 /// ## Example
 ///
@@ -522,7 +522,7 @@ pub struct JsGeo3dDistanceQuery {
     pub(crate) x: f64,
     pub(crate) y: f64,
     pub(crate) z: f64,
-    pub(crate) radius_m: f64,
+    pub(crate) distance_m: f64,
 }
 
 #[napi]
@@ -533,15 +533,16 @@ impl JsGeo3dDistanceQuery {
     ///
     /// * `field` - Geo3d field name.
     /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
-    /// * `radius_m` - Sphere radius in meters.
+    /// * `distance_m` - Maximum distance from the centre in meters
+    ///   (i.e. the search sphere's radius).
     #[napi(factory)]
-    pub fn within_sphere(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
+    pub fn within_sphere(field: String, x: f64, y: f64, z: f64, distance_m: f64) -> Self {
         Self {
             field,
             x,
             y,
             z,
-            radius_m,
+            distance_m,
         }
     }
 }
@@ -551,7 +552,7 @@ impl JsGeo3dDistanceQuery {
         Box::new(Geo3dDistanceQuery::new(
             &self.field,
             GeoEcefPoint::new(self.x, self.y, self.z),
-            self.radius_m,
+            self.distance_m,
         ))
     }
 }

--- a/laurus-php/examples/lexical_search.php
+++ b/laurus-php/examples/lexical_search.php
@@ -221,7 +221,7 @@ echo "PART 6: GeoDistanceQuery / GeoBoundingBoxQuery" . PHP_EOL;
 echo str_repeat("=", 60) . PHP_EOL;
 
 echo PHP_EOL . "[6a] Within 100 km of Paris (48.86, 2.35):" . PHP_EOL;
-print_results($index->search(GeoDistanceQuery::withinRadius("location", 48.8566, 2.3522, 100.0), 5));
+print_results($index->search(GeoDistanceQuery::withinRadius("location", 48.8566, 2.3522, 100_000.0), 5));
 
 echo PHP_EOL . "[6b] Bounding box — Europe (47, -1) to (53, 14):" . PHP_EOL;
 print_results($index->search(GeoBoundingBoxQuery::withinBoundingBox("location", 47.0, -1.0, 53.0, 14.0), 5));

--- a/laurus-php/src/query.rs
+++ b/laurus-php/src/query.rs
@@ -445,7 +445,7 @@ pub struct PhpGeoDistanceQuery {
     pub field: String,
     pub lat: f64,
     pub lon: f64,
-    pub distance_km: f64,
+    pub distance_m: f64,
 }
 
 #[php_impl]
@@ -457,21 +457,21 @@ impl PhpGeoDistanceQuery {
     /// * `field` - Geo field name.
     /// * `lat` - Center latitude.
     /// * `lon` - Center longitude.
-    /// * `distance_km` - Search radius in kilometers.
-    pub fn within_radius(field: String, lat: f64, lon: f64, distance_km: f64) -> Self {
+    /// * `distance_m` - Maximum distance from the centre in meters.
+    pub fn within_radius(field: String, lat: f64, lon: f64, distance_m: f64) -> Self {
         Self {
             field,
             lat,
             lon,
-            distance_km,
+            distance_m,
         }
     }
 
     /// Return a string representation.
     pub fn __to_string(&self) -> String {
         format!(
-            "GeoDistanceQuery.within_radius(field='{}', lat={}, lon={}, distance_km={})",
-            self.field, self.lat, self.lon, self.distance_km
+            "GeoDistanceQuery.within_radius(field='{}', lat={}, lon={}, distance_m={})",
+            self.field, self.lat, self.lon, self.distance_m
         )
     }
 }
@@ -483,7 +483,7 @@ impl PhpGeoDistanceQuery {
             &self.field,
             self.lat,
             self.lon,
-            self.distance_km,
+            self.distance_m,
         )?))
     }
 }
@@ -558,7 +558,7 @@ impl PhpGeoBoundingBoxQuery {
 
 /// 3D ECEF sphere query (`Laurus\Geo3dDistanceQuery`).
 ///
-/// Returns documents whose 3D ECEF point lies within `radius_m` meters of the
+/// Returns documents whose 3D ECEF point lies within `distance_m` meters of the
 /// query centre. Construct via the `withinSphere` static factory.
 #[php_class]
 #[php(name = "Laurus\\Geo3dDistanceQuery")]
@@ -567,7 +567,7 @@ pub struct PhpGeo3dDistanceQuery {
     pub x: f64,
     pub y: f64,
     pub z: f64,
-    pub radius_m: f64,
+    pub distance_m: f64,
 }
 
 #[php_impl]
@@ -580,22 +580,23 @@ impl PhpGeo3dDistanceQuery {
     /// * `x` - Centre ECEF X coordinate (meters).
     /// * `y` - Centre ECEF Y coordinate (meters).
     /// * `z` - Centre ECEF Z coordinate (meters).
-    /// * `radius_m` - Sphere radius in meters.
-    pub fn within_sphere(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
+    /// * `distance_m` - Maximum distance from the centre in meters
+    ///   (i.e. the search sphere's radius).
+    pub fn within_sphere(field: String, x: f64, y: f64, z: f64, distance_m: f64) -> Self {
         Self {
             field,
             x,
             y,
             z,
-            radius_m,
+            distance_m,
         }
     }
 
     /// Return a string representation.
     pub fn __to_string(&self) -> String {
         format!(
-            "Geo3dDistanceQuery(field='{}', x={}, y={}, z={}, radius_m={})",
-            self.field, self.x, self.y, self.z, self.radius_m
+            "Geo3dDistanceQuery(field='{}', x={}, y={}, z={}, distance_m={})",
+            self.field, self.x, self.y, self.z, self.distance_m
         )
     }
 }
@@ -606,7 +607,7 @@ impl PhpGeo3dDistanceQuery {
         Box::new(Geo3dDistanceQuery::new(
             &self.field,
             GeoEcefPoint::new(self.x, self.y, self.z),
-            self.radius_m,
+            self.distance_m,
         ))
     }
 }

--- a/laurus-python/README.md
+++ b/laurus-python/README.md
@@ -78,9 +78,9 @@ index = laurus.Index(path="./myindex", schema=schema)
 | `FuzzyQuery(field, term, max_edits)` | Approximate term match |
 | `WildcardQuery(field, pattern)` | Wildcard pattern match (`*`, `?`) |
 | `NumericRangeQuery(field, min, max)` | Numeric range (int or float) |
-| `GeoDistanceQuery.within_radius(field, lat, lon, distance_km)` | Geo-distance radius search |
+| `GeoDistanceQuery.within_radius(field, lat, lon, distance_m)` | Geo-distance radius search |
 | `GeoBoundingBoxQuery.within_bounding_box(field, min_lat, min_lon, max_lat, max_lon)` | Geo bounding-box search |
-| `Geo3dDistanceQuery.within_sphere(field, x, y, z, radius_m)` | 3D ECEF sphere search |
+| `Geo3dDistanceQuery.within_sphere(field, x, y, z, distance_m)` | 3D ECEF sphere search |
 | `Geo3dBoundingBoxQuery.within_box(field, min_x, min_y, min_z, max_x, max_y, max_z)` | 3D ECEF AABB search |
 | `Geo3dNearestQuery.k_nearest(field, x, y, z, k)` | 3D ECEF k-nearest neighbours |
 | `BooleanQuery(must, should, must_not)` | Compound boolean logic |

--- a/laurus-python/README_ja.md
+++ b/laurus-python/README_ja.md
@@ -78,9 +78,9 @@ index = laurus.Index(path="./myindex", schema=schema)
 | `FuzzyQuery(field, term, max_edits)` | 近似一致検索 |
 | `WildcardQuery(field, pattern)` | ワイルドカード検索（`*`、`?`） |
 | `NumericRangeQuery(field, min, max)` | 数値範囲検索（int または float） |
-| `GeoDistanceQuery.within_radius(field, lat, lon, distance_km)` | 地理的距離検索（半径指定） |
+| `GeoDistanceQuery.within_radius(field, lat, lon, distance_m)` | 地理的距離検索（半径指定） |
 | `GeoBoundingBoxQuery.within_bounding_box(field, min_lat, min_lon, max_lat, max_lon)` | 地理的範囲検索（バウンディングボックス） |
-| `Geo3dDistanceQuery.within_sphere(field, x, y, z, radius_m)` | 3D ECEF 球距離検索 |
+| `Geo3dDistanceQuery.within_sphere(field, x, y, z, distance_m)` | 3D ECEF 球距離検索 |
 | `Geo3dBoundingBoxQuery.within_box(field, min_x, min_y, min_z, max_x, max_y, max_z)` | 3D ECEF AABB 検索 |
 | `Geo3dNearestQuery.k_nearest(field, x, y, z, k)` | 3D ECEF k 最近傍検索 |
 | `BooleanQuery(must, should, must_not)` | 複合ブール検索 |

--- a/laurus-python/examples/lexical_search.py
+++ b/laurus-python/examples/lexical_search.py
@@ -235,7 +235,7 @@ def main() -> None:
     _print_results(
         index.search(
             laurus.GeoDistanceQuery.within_radius(
-                "location", 37.7749, -122.4194, 100.0
+                "location", 37.7749, -122.4194, 100_000.0
             ),
             limit=5,
         )

--- a/laurus-python/src/query.rs
+++ b/laurus-python/src/query.rs
@@ -376,14 +376,14 @@ impl PyNumericRangeQuery {
 ///
 /// ```python
 /// # Within 100 km of San Francisco
-/// q = laurus.GeoDistanceQuery.within_radius("location", 37.77, -122.42, 100.0)
+/// q = laurus.GeoDistanceQuery.within_radius("location", 37.77, -122.42, 100_000.0)
 /// ```
 #[pyclass(name = "GeoDistanceQuery")]
 pub struct PyGeoDistanceQuery {
     pub field: String,
     pub lat: f64,
     pub lon: f64,
-    pub distance_km: f64,
+    pub distance_m: f64,
 }
 
 #[pymethods]
@@ -394,21 +394,21 @@ impl PyGeoDistanceQuery {
     ///     field: Geo field name.
     ///     lat: Center latitude.
     ///     lon: Center longitude.
-    ///     distance_km: Search radius in kilometers.
+    ///     distance_m: Maximum distance from the centre in meters.
     #[staticmethod]
-    pub fn within_radius(field: String, lat: f64, lon: f64, distance_km: f64) -> Self {
+    pub fn within_radius(field: String, lat: f64, lon: f64, distance_m: f64) -> Self {
         Self {
             field,
             lat,
             lon,
-            distance_km,
+            distance_m,
         }
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "GeoDistanceQuery.within_radius(field='{}', lat={}, lon={}, distance_km={})",
-            self.field, self.lat, self.lon, self.distance_km
+            "GeoDistanceQuery.within_radius(field='{}', lat={}, lon={}, distance_m={})",
+            self.field, self.lat, self.lon, self.distance_m
         )
     }
 }
@@ -419,7 +419,7 @@ impl PyGeoDistanceQuery {
             &self.field,
             self.lat,
             self.lon,
-            self.distance_km,
+            self.distance_m,
         )?))
     }
 }
@@ -498,7 +498,7 @@ impl PyGeoBoundingBoxQuery {
 // ---------------------------------------------------------------------------
 
 /// 3D ECEF sphere query: matches documents whose stored `(x, y, z)` point
-/// lies within `radius_m` meters of the given centre.
+/// lies within `distance_m` meters of the given centre.
 ///
 /// ## Example
 ///
@@ -513,7 +513,7 @@ pub struct PyGeo3dDistanceQuery {
     pub x: f64,
     pub y: f64,
     pub z: f64,
-    pub radius_m: f64,
+    pub distance_m: f64,
 }
 
 #[pymethods]
@@ -523,22 +523,23 @@ impl PyGeo3dDistanceQuery {
     /// Args:
     ///     field: Geo3d field name.
     ///     x, y, z: Centre coordinates in ECEF meters.
-    ///     radius_m: Sphere radius in meters.
+    ///     distance_m: Maximum distance from the centre in meters
+    ///         (i.e. the search sphere's radius).
     #[staticmethod]
-    pub fn within_sphere(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
+    pub fn within_sphere(field: String, x: f64, y: f64, z: f64, distance_m: f64) -> Self {
         Self {
             field,
             x,
             y,
             z,
-            radius_m,
+            distance_m,
         }
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "Geo3dDistanceQuery.within_sphere(field='{}', x={}, y={}, z={}, radius_m={})",
-            self.field, self.x, self.y, self.z, self.radius_m
+            "Geo3dDistanceQuery.within_sphere(field='{}', x={}, y={}, z={}, distance_m={})",
+            self.field, self.x, self.y, self.z, self.distance_m
         )
     }
 }
@@ -548,7 +549,7 @@ impl PyGeo3dDistanceQuery {
         Box::new(Geo3dDistanceQuery::new(
             &self.field,
             GeoEcefPoint::new(self.x, self.y, self.z),
-            self.radius_m,
+            self.distance_m,
         ))
     }
 }

--- a/laurus-ruby/examples/lexical_search.rb
+++ b/laurus-ruby/examples/lexical_search.rb
@@ -208,7 +208,7 @@ def main
   puts "=" * 60
 
   puts "\n[6a] Within 100 km of San Francisco (37.77, -122.42):"
-  print_results(index.search(Laurus::GeoDistanceQuery.within_radius("location", 37.7749, -122.4194, 100.0), limit: 5))
+  print_results(index.search(Laurus::GeoDistanceQuery.within_radius("location", 37.7749, -122.4194, 100_000.0), limit: 5))
 
   puts "\n[6b] Bounding box — US West Coast (33, -123) to (48, -117):"
   print_results(index.search(Laurus::GeoBoundingBoxQuery.within_bounding_box("location", 33.0, -123.0, 48.0, -117.0), limit: 5))

--- a/laurus-ruby/src/query.rs
+++ b/laurus-ruby/src/query.rs
@@ -441,7 +441,7 @@ pub struct RbGeoDistanceQuery {
     pub field: String,
     pub lat: f64,
     pub lon: f64,
-    pub distance_km: f64,
+    pub distance_m: f64,
 }
 
 impl RbGeoDistanceQuery {
@@ -452,20 +452,20 @@ impl RbGeoDistanceQuery {
     /// * `field` - Geo field name.
     /// * `lat` - Center latitude.
     /// * `lon` - Center longitude.
-    /// * `distance_km` - Search radius in kilometers.
-    fn within_radius(field: String, lat: f64, lon: f64, distance_km: f64) -> Self {
+    /// * `distance_m` - Maximum distance from the centre in meters.
+    fn within_radius(field: String, lat: f64, lon: f64, distance_m: f64) -> Self {
         Self {
             field,
             lat,
             lon,
-            distance_km,
+            distance_m,
         }
     }
 
     fn inspect(&self) -> String {
         format!(
-            "GeoDistanceQuery.within_radius(field='{}', lat={}, lon={}, distance_km={})",
-            self.field, self.lat, self.lon, self.distance_km
+            "GeoDistanceQuery.within_radius(field='{}', lat={}, lon={}, distance_m={})",
+            self.field, self.lat, self.lon, self.distance_m
         )
     }
 }
@@ -477,7 +477,7 @@ impl RbGeoDistanceQuery {
             &self.field,
             self.lat,
             self.lon,
-            self.distance_km,
+            self.distance_m,
         )?))
     }
 }
@@ -550,14 +550,14 @@ impl RbGeoBoundingBoxQuery {
 /// 3D ECEF sphere query (`Laurus::Geo3dDistanceQuery`).
 ///
 /// Matches every document whose stored `(x, y, z)` point lies within
-/// `radius_m` meters of the given centre.
+/// `distance_m` meters of the given centre.
 #[magnus::wrap(class = "Laurus::Geo3dDistanceQuery")]
 pub struct RbGeo3dDistanceQuery {
     pub field: String,
     pub x: f64,
     pub y: f64,
     pub z: f64,
-    pub radius_m: f64,
+    pub distance_m: f64,
 }
 
 impl RbGeo3dDistanceQuery {
@@ -567,21 +567,22 @@ impl RbGeo3dDistanceQuery {
     ///
     /// * `field` - Geo3d field name.
     /// * `x`, `y`, `z` - Centre coordinates in ECEF meters.
-    /// * `radius_m` - Sphere radius in meters.
-    fn within_sphere(field: String, x: f64, y: f64, z: f64, radius_m: f64) -> Self {
+    /// * `distance_m` - Maximum distance from the centre in meters
+    ///   (i.e. the search sphere's radius).
+    fn within_sphere(field: String, x: f64, y: f64, z: f64, distance_m: f64) -> Self {
         Self {
             field,
             x,
             y,
             z,
-            radius_m,
+            distance_m,
         }
     }
 
     fn inspect(&self) -> String {
         format!(
-            "Geo3dDistanceQuery.within_sphere(field='{}', x={}, y={}, z={}, radius_m={})",
-            self.field, self.x, self.y, self.z, self.radius_m
+            "Geo3dDistanceQuery.within_sphere(field='{}', x={}, y={}, z={}, distance_m={})",
+            self.field, self.x, self.y, self.z, self.distance_m
         )
     }
 }
@@ -592,7 +593,7 @@ impl RbGeo3dDistanceQuery {
         Box::new(Geo3dDistanceQuery::new(
             &self.field,
             GeoEcefPoint::new(self.x, self.y, self.z),
-            self.radius_m,
+            self.distance_m,
         ))
     }
 }

--- a/laurus-wasm/src/index.rs
+++ b/laurus-wasm/src/index.rs
@@ -357,7 +357,8 @@ impl WasmIndex {
     ///
     /// * `field` - The Geo3d field name.
     /// * `x`, `y`, `z` - Sphere centre in ECEF meters.
-    /// * `radius_m` - Sphere radius in meters.
+    /// * `distance_m` - Maximum distance from the centre in meters
+    ///   (i.e. the search sphere's radius).
     /// * `limit` - Maximum number of results (default 10).
     /// * `offset` - Pagination offset (default 0).
     #[wasm_bindgen(js_name = "searchGeo3dDistance")]
@@ -368,7 +369,7 @@ impl WasmIndex {
         x: f64,
         y: f64,
         z: f64,
-        radius_m: f64,
+        distance_m: f64,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> Result<JsValue, JsValue> {
@@ -377,7 +378,7 @@ impl WasmIndex {
             x,
             y,
             z,
-            radius_m,
+            distance_m,
         });
         let request = build_lexical_request(
             &query,

--- a/laurus-wasm/src/query.rs
+++ b/laurus-wasm/src/query.rs
@@ -180,7 +180,7 @@ pub struct JsGeoDistanceQuery {
     pub field: String,
     pub lat: f64,
     pub lon: f64,
-    pub distance_km: f64,
+    pub distance_m: f64,
 }
 
 impl JsGeoDistanceQuery {
@@ -189,7 +189,7 @@ impl JsGeoDistanceQuery {
             &self.field,
             self.lat,
             self.lon,
-            self.distance_km,
+            self.distance_m,
         )?))
     }
 }
@@ -229,7 +229,7 @@ pub struct JsGeo3dDistanceQuery {
     pub x: f64,
     pub y: f64,
     pub z: f64,
-    pub radius_m: f64,
+    pub distance_m: f64,
 }
 
 impl JsGeo3dDistanceQuery {
@@ -237,7 +237,7 @@ impl JsGeo3dDistanceQuery {
         Box::new(Geo3dDistanceQuery::new(
             &self.field,
             GeoEcefPoint::new(self.x, self.y, self.z),
-            self.radius_m,
+            self.distance_m,
         ))
     }
 }

--- a/laurus/src/data.rs
+++ b/laurus/src/data.rs
@@ -100,10 +100,10 @@ impl GeoPoint {
         Ok(GeoPoint { lat, lon })
     }
 
-    /// Great-circle distance to another point in kilometers, using the
-    /// Haversine formula on a sphere of mean Earth radius (6371 km).
+    /// Great-circle distance to another point in meters, using the
+    /// Haversine formula on a sphere of mean Earth radius (6 371 000 m).
     pub fn distance_to(&self, other: &GeoPoint) -> f64 {
-        const EARTH_RADIUS_KM: f64 = 6371.0;
+        const EARTH_RADIUS_M: f64 = 6_371_000.0;
 
         let lat1_rad = self.lat.to_radians();
         let lat2_rad = other.lat.to_radians();
@@ -114,7 +114,7 @@ impl GeoPoint {
             + lat1_rad.cos() * lat2_rad.cos() * (delta_lon / 2.0).sin().powi(2);
         let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
 
-        EARTH_RADIUS_KM * c
+        EARTH_RADIUS_M * c
     }
 
     /// Initial bearing toward `other`, in degrees in `[0, 360)` clockwise

--- a/laurus/src/lexical/query/geo.rs
+++ b/laurus/src/lexical/query/geo.rs
@@ -74,7 +74,7 @@ impl GeoBoundingBox {
     }
 
     /// Greatest great-circle distance from the box's center to any of its
-    /// four corners, in kilometers.
+    /// four corners, in meters.
     pub fn max_distance_from_center(&self) -> f64 {
         let center = self.center();
         let sw = self.min;
@@ -98,19 +98,19 @@ pub struct GeoDistanceQuery {
     field: String,
     /// Center point for the search
     center: GeoPoint,
-    /// Maximum distance in kilometers
-    distance_km: f64,
+    /// Maximum distance in meters
+    distance_m: f64,
     /// Boost factor for the query
     boost: f32,
 }
 
 impl GeoDistanceQuery {
     /// Create a new geo distance query.
-    pub fn new<F: Into<String>>(field: F, center: GeoPoint, distance_km: f64) -> Self {
+    pub fn new<F: Into<String>>(field: F, center: GeoPoint, distance_m: f64) -> Self {
         GeoDistanceQuery {
             field: field.into(),
             center,
-            distance_km,
+            distance_m,
             boost: 1.0,
         }
     }
@@ -126,7 +126,7 @@ impl GeoDistanceQuery {
     /// * `field` - The field containing geographical coordinates.
     /// * `lat` - Center latitude in degrees (`-90` to `90`).
     /// * `lon` - Center longitude in degrees (`-180` to `180`).
-    /// * `distance_km` - Search radius in kilometres.
+    /// * `distance_m` - Maximum distance from the centre in meters.
     ///
     /// # Example
     ///
@@ -134,16 +134,16 @@ impl GeoDistanceQuery {
     /// use laurus::lexical::query::GeoDistanceQuery;
     ///
     /// let query =
-    ///     GeoDistanceQuery::within_radius("location", 40.7128, -74.0060, 10.0).unwrap();
+    ///     GeoDistanceQuery::within_radius("location", 40.7128, -74.0060, 10_000.0).unwrap();
     /// ```
     pub fn within_radius<F: Into<String>>(
         field: F,
         lat: f64,
         lon: f64,
-        distance_km: f64,
+        distance_m: f64,
     ) -> Result<Self> {
         let center = GeoPoint::try_new(lat, lon)?;
-        Ok(GeoDistanceQuery::new(field, center, distance_km))
+        Ok(GeoDistanceQuery::new(field, center, distance_m))
     }
 
     /// Set the boost factor.
@@ -162,9 +162,9 @@ impl GeoDistanceQuery {
         self.center
     }
 
-    /// Get the search distance.
-    pub fn distance_km(&self) -> f64 {
-        self.distance_km
+    /// Get the search distance in meters.
+    pub fn distance_m(&self) -> f64 {
+        self.distance_m
     }
 
     /// Find matching documents and their distances using spatial indexing.
@@ -186,18 +186,18 @@ impl GeoDistanceQuery {
             seen_docs.insert(doc_id);
 
             let distance = self.center.distance_to(&point);
-            if distance <= self.distance_km {
+            if distance <= self.distance_m {
                 let score = if distance == 0.0 {
                     1.0
                 } else {
                     // Simple inverse distance scoring
-                    (1.0 - (distance / self.distance_km)).max(0.0) as f32
+                    (1.0 - (distance / self.distance_m)).max(0.0) as f32
                 };
 
                 matches.push(GeoMatch {
                     doc_id,
                     point,
-                    distance_km: distance,
+                    distance_m: distance,
                     relevance_score: score,
                 });
             }
@@ -205,8 +205,8 @@ impl GeoDistanceQuery {
 
         // Sort by distance (closest first), then by relevance score
         matches.sort_by(|a, b| {
-            a.distance_km
-                .partial_cmp(&b.distance_km)
+            a.distance_m
+                .partial_cmp(&b.distance_m)
                 .unwrap_or(std::cmp::Ordering::Equal)
                 .then_with(|| {
                     b.relevance_score
@@ -221,12 +221,12 @@ impl GeoDistanceQuery {
     /// Create a bounding box for efficient spatial filtering.
     fn create_bounding_box(&self) -> GeoBoundingBox {
         // Approximate degree distance at the center latitude
-        let lat_deg_km = 111.0; // ~111 km per degree latitude
+        let lat_deg_m = 111_000.0; // ~111 km (= 111 000 m) per degree latitude
         // At poles cos(lat) ≈ 0 → clamp to avoid division by zero
-        let lon_deg_km = (111.0 * self.center.lat.to_radians().cos()).max(0.001);
+        let lon_deg_m = (111_000.0 * self.center.lat.to_radians().cos()).max(1.0);
 
-        let lat_delta = self.distance_km / lat_deg_km;
-        let lon_delta = self.distance_km / lon_deg_km;
+        let lat_delta = self.distance_m / lat_deg_m;
+        let lon_delta = self.distance_m / lon_deg_m;
 
         // Clamp to the valid lat/lon ranges so the resulting GeoPoints are
         // always in-range (the infallible `GeoPoint::new` debug-asserts).
@@ -305,7 +305,7 @@ impl GeoDistanceQuery {
                         if bounding_box.contains(&geo_point) {
                             let distance = self.center.distance_to(&geo_point);
                             // Double-check with exact distance calculation
-                            if distance <= self.distance_km {
+                            if distance <= self.distance_m {
                                 candidates.push((doc_id, geo_point));
                             }
                         }
@@ -321,28 +321,28 @@ impl GeoDistanceQuery {
 #[cfg(test)]
 impl GeoDistanceQuery {
     /// Calculate relevance score based on distance (closer = higher score).
-    fn calculate_distance_score(&self, distance_km: f64) -> f32 {
-        if distance_km > self.distance_km {
+    fn calculate_distance_score(&self, distance_m: f64) -> f32 {
+        if distance_m > self.distance_m {
             return 0.0;
         }
 
         // Linear decay: score = 1.0 at center, 0.0 at max distance
-        let normalized_distance = distance_km / self.distance_km;
+        let normalized_distance = distance_m / self.distance_m;
         (1.0 - normalized_distance) as f32
     }
 
     /// Calculate enhanced relevance score with multiple factors.
-    fn calculate_distance_score_enhanced(&self, distance_km: f64, point: &GeoPoint) -> f32 {
-        if distance_km > self.distance_km {
+    fn calculate_distance_score_enhanced(&self, distance_m: f64, point: &GeoPoint) -> f32 {
+        if distance_m > self.distance_m {
             return 0.0;
         }
 
         // Base distance score (exponential decay for better distance weighting)
-        let normalized_distance = distance_km / self.distance_km;
+        let normalized_distance = distance_m / self.distance_m;
         let base_score = (-2.0 * normalized_distance).exp() as f32;
 
-        // Precision bonus for exact location matches
-        let precision_bonus = if distance_km < 0.1 { 0.1 } else { 0.0 };
+        // Precision bonus for exact location matches (within 100 m)
+        let precision_bonus = if distance_m < 100.0 { 0.1 } else { 0.0 };
 
         // Geographic relevance bonus (e.g., prefer points in certain regions)
         let geo_bonus = self.calculate_geographic_relevance(point);
@@ -416,13 +416,13 @@ impl Query for GeoDistanceQuery {
 
     fn description(&self) -> String {
         format!(
-            "GeoDistanceQuery(field: {}, center: {:?}, distance: {}km)",
-            self.field, self.center, self.distance_km
+            "GeoDistanceQuery(field: {}, center: {:?}, distance: {}m)",
+            self.field, self.center, self.distance_m
         )
     }
 
     fn is_empty(&self, _reader: &dyn LexicalIndexReader) -> Result<bool> {
-        Ok(self.distance_km <= 0.0)
+        Ok(self.distance_m <= 0.0)
     }
 
     fn cost(&self, reader: &dyn LexicalIndexReader) -> Result<u64> {
@@ -556,7 +556,7 @@ impl GeoBoundingBoxQuery {
                 matches.push(GeoMatch {
                     doc_id,
                     point,
-                    distance_km: distance,
+                    distance_m: distance,
                     relevance_score,
                 });
             }
@@ -567,7 +567,7 @@ impl GeoBoundingBoxQuery {
             b.relevance_score
                 .partial_cmp(&a.relevance_score)
                 .unwrap()
-                .then_with(|| a.distance_km.partial_cmp(&b.distance_km).unwrap())
+                .then_with(|| a.distance_m.partial_cmp(&b.distance_m).unwrap())
         });
 
         Ok(matches)
@@ -679,8 +679,8 @@ impl GeoBoundingBoxQuery {
 
         // Distance from center as a fraction of the bounding box diagonal
         let distance_to_center = center.distance_to(point);
-        let diagonal_km = ((width * 111.0).powi(2) + (height * 111.0).powi(2)).sqrt();
-        let normalized_distance = distance_to_center / diagonal_km;
+        let diagonal_m = ((width * 111_000.0).powi(2) + (height * 111_000.0).powi(2)).sqrt();
+        let normalized_distance = distance_to_center / diagonal_m;
 
         // Base score: higher for points closer to center
         let base_score = (1.0 - normalized_distance.min(1.0)) as f32;
@@ -728,7 +728,7 @@ impl GeoBoundingBoxQuery {
             GeoPoint::new(bbox.min.lat, bbox.max.lon), // SE
         ];
 
-        let corner_threshold_km = 1.0; // Within 1km of corner
+        let corner_threshold_m = 1_000.0; // Within 1 km (= 1 000 m) of corner
         let mut min_corner_distance = f64::INFINITY;
 
         for corner in &corners {
@@ -736,7 +736,7 @@ impl GeoBoundingBoxQuery {
             min_corner_distance = min_corner_distance.min(distance);
         }
 
-        if min_corner_distance < corner_threshold_km {
+        if min_corner_distance < corner_threshold_m {
             0.1 // Corner bonus
         } else {
             0.0
@@ -796,8 +796,8 @@ pub struct GeoMatch {
     pub doc_id: u64,
     /// Geographical point of the document
     pub point: GeoPoint,
-    /// Distance from query center in kilometers
-    pub distance_km: f64,
+    /// Distance from query center in meters
+    pub distance_m: f64,
     /// Relevance score based on distance
     pub relevance_score: f32,
 }
@@ -816,8 +816,8 @@ impl GeoMatcher {
     pub fn new(mut matches: Vec<GeoMatch>) -> Self {
         // Sort matches by distance (closest first)
         matches.sort_by(|a, b| {
-            a.distance_km
-                .partial_cmp(&b.distance_km)
+            a.distance_m
+                .partial_cmp(&b.distance_m)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
@@ -936,8 +936,8 @@ mod tests {
         let la = GeoPoint::try_new(34.0522, -118.2437).unwrap();
 
         let distance = nyc.distance_to(&la);
-        // Distance between NYC and LA is approximately 3,944 km
-        assert!((distance - 3944.0).abs() < 100.0); // Allow some tolerance
+        // Distance between NYC and LA is approximately 3 944 km (3 944 000 m)
+        assert!((distance - 3_944_000.0).abs() < 100_000.0); // Allow ~100 km tolerance
     }
 
     #[test]
@@ -970,24 +970,24 @@ mod tests {
     #[test]
     fn test_geo_distance_query() {
         let center = GeoPoint::try_new(40.7128, -74.0060).unwrap();
-        let query = GeoDistanceQuery::new("location", center, 10.0).with_boost(1.5);
+        let query = GeoDistanceQuery::new("location", center, 10_000.0).with_boost(1.5);
 
         assert_eq!(query.field(), "location");
         assert_eq!(query.center(), center);
-        assert_eq!(query.distance_km(), 10.0);
+        assert_eq!(query.distance_m(), 10_000.0);
         assert_eq!(query.boost(), 1.5);
     }
 
     #[test]
     fn test_geo_distance_scoring() {
         let center = GeoPoint::try_new(0.0, 0.0).unwrap();
-        let query = GeoDistanceQuery::new("location", center, 10.0);
+        let query = GeoDistanceQuery::new("location", center, 10_000.0);
 
-        // Test scoring at different distances
+        // Test scoring at different distances (meters)
         assert_eq!(query.calculate_distance_score(0.0), 1.0); // At center
-        assert_eq!(query.calculate_distance_score(5.0), 0.5); // Half distance
-        assert_eq!(query.calculate_distance_score(10.0), 0.0); // At max distance
-        assert_eq!(query.calculate_distance_score(15.0), 0.0); // Beyond max distance
+        assert_eq!(query.calculate_distance_score(5_000.0), 0.5); // Half distance
+        assert_eq!(query.calculate_distance_score(10_000.0), 0.0); // At max distance
+        assert_eq!(query.calculate_distance_score(15_000.0), 0.0); // Beyond max distance
     }
 
     #[test]
@@ -1004,18 +1004,19 @@ mod tests {
 
     #[test]
     fn test_geo_distance_query_within_radius_factory() {
-        let query = GeoDistanceQuery::within_radius("location", 40.7128, -74.0060, 10.0).unwrap();
+        let query =
+            GeoDistanceQuery::within_radius("location", 40.7128, -74.0060, 10_000.0).unwrap();
 
         assert_eq!(query.field(), "location");
         assert_eq!(query.center().lat, 40.7128);
         assert_eq!(query.center().lon, -74.0060);
-        assert_eq!(query.distance_km(), 10.0);
+        assert_eq!(query.distance_m(), 10_000.0);
     }
 
     #[test]
     fn test_geo_distance_query_within_radius_invalid_lat() {
         // Latitude outside [-90, 90] is rejected by GeoPoint::try_new.
-        let err = GeoDistanceQuery::within_radius("location", 95.0, 0.0, 10.0).unwrap_err();
+        let err = GeoDistanceQuery::within_radius("location", 95.0, 0.0, 10_000.0).unwrap_err();
         assert!(format!("{err}").to_lowercase().contains("lat"));
     }
 
@@ -1047,13 +1048,13 @@ mod tests {
             GeoMatch {
                 doc_id: 3,
                 point: GeoPoint::try_new(0.0, 0.0).unwrap(),
-                distance_km: 1.0,
+                distance_m: 1_000.0,
                 relevance_score: 0.9,
             },
             GeoMatch {
                 doc_id: 1,
                 point: GeoPoint::try_new(0.0, 0.0).unwrap(),
-                distance_km: 2.0,
+                distance_m: 2_000.0,
                 relevance_score: 0.8,
             },
         ];
@@ -1061,7 +1062,7 @@ mod tests {
         let mut matcher = GeoMatcher::new(matches);
 
         // Should return documents in distance-sorted order (closest first)
-        // After sorting: doc_id: 3 (1.0km) comes before doc_id: 1 (2.0km)
+        // After sorting: doc_id: 3 (1 km) comes before doc_id: 1 (2 km)
         assert_eq!(matcher.doc_id(), 3); // Initial position: closest document
 
         assert!(matcher.next().unwrap()); // Move to next
@@ -1075,7 +1076,7 @@ mod tests {
         let matches = vec![GeoMatch {
             doc_id: 1,
             point: GeoPoint::try_new(0.0, 0.0).unwrap(),
-            distance_km: 1.0,
+            distance_m: 1_000.0,
             relevance_score: 0.9,
         }];
 
@@ -1090,19 +1091,19 @@ mod tests {
     #[test]
     fn test_enhanced_distance_scoring() {
         let center = GeoPoint::try_new(40.7128, -74.0060).unwrap(); // NYC
-        let query = GeoDistanceQuery::new("location", center, 10.0);
+        let query = GeoDistanceQuery::new("location", center, 10_000.0);
 
-        // Test point very close to center
+        // Test point very close to centre (50 m away)
         let close_point = GeoPoint::try_new(40.7130, -74.0062).unwrap();
-        let close_score = query.calculate_distance_score_enhanced(0.05, &close_point);
+        let close_score = query.calculate_distance_score_enhanced(50.0, &close_point);
 
-        // Test point at moderate distance
+        // Test point at moderate distance (1 km)
         let mid_point = GeoPoint::try_new(40.7200, -74.0100).unwrap();
-        let mid_score = query.calculate_distance_score_enhanced(1.0, &mid_point);
+        let mid_score = query.calculate_distance_score_enhanced(1_000.0, &mid_point);
 
-        // Test point at max distance
+        // Test point at almost max distance (9 km)
         let far_point = GeoPoint::try_new(40.8000, -74.1000).unwrap();
-        let far_score = query.calculate_distance_score_enhanced(9.0, &far_point);
+        let far_score = query.calculate_distance_score_enhanced(9_000.0, &far_point);
 
         // Scores should decrease with distance, and close points should get precision bonus
         assert!(close_score > mid_score);
@@ -1142,7 +1143,7 @@ mod tests {
     #[test]
     fn test_spatial_bounding_box_creation() {
         let center = GeoPoint::try_new(40.7128, -74.0060).unwrap(); // NYC
-        let query = GeoDistanceQuery::new("location", center, 5.0); // 5km radius
+        let query = GeoDistanceQuery::new("location", center, 5_000.0); // 5 km radius
 
         let bbox = query.create_bounding_box();
 
@@ -1155,15 +1156,16 @@ mod tests {
         assert!(height > 0.0 && height < 1.0);
 
         // The center should be approximately in the middle of the bounding box
+        // (within ~1 km).
         let bbox_center = bbox.center();
         let center_distance = center.distance_to(&bbox_center);
-        assert!(center_distance < 1.0); // Should be very close
+        assert!(center_distance < 1_000.0);
     }
 
     #[test]
     fn test_geographic_relevance_calculation() {
         let center = GeoPoint::try_new(40.7128, -74.0060).unwrap();
-        let query = GeoDistanceQuery::new("location", center, 10.0);
+        let query = GeoDistanceQuery::new("location", center, 10_000.0);
 
         // Test temperate zone bonus
         let temperate_point = GeoPoint::try_new(45.0, 0.0).unwrap(); // Temperate zone

--- a/laurus/src/lexical/query/geo3d.rs
+++ b/laurus/src/lexical/query/geo3d.rs
@@ -11,7 +11,7 @@
 //! # Implemented queries
 //!
 //! - [`Geo3dDistanceQuery`] — sphere-radius search: every doc whose stored
-//!   ECEF point lies within `radius_m` meters of the query center.
+//!   ECEF point lies within `distance_m` meters of the query center.
 //! - [`Geo3dBoundingBoxQuery`] — 3D axis-aligned box search: every doc
 //!   whose stored ECEF point falls inside the closed `[min, max]` box.
 //! - [`Geo3dNearestQuery`] — k-nearest-neighbour search: the `k` docs
@@ -46,8 +46,8 @@ use crate::lexical::reader::LexicalIndexReader;
 /// A 3D distance (sphere) query against an ECEF-typed field.
 ///
 /// Matches every document whose stored [`GeoEcefPoint`] lies within
-/// `radius_m` meters of `center`. Distance is straight-line Euclidean in
-/// ECEF space; a `radius_m` of 1000 means "within 1 km of `center`",
+/// `distance_m` meters of `center`. Distance is straight-line Euclidean in
+/// ECEF space; a `distance_m` of 1000 means "within 1 km of `center`",
 /// regardless of latitude or altitude.
 ///
 /// Scoring follows the same shape as the 2D
@@ -63,8 +63,8 @@ pub struct Geo3dDistanceQuery {
     field: String,
     /// Center point of the search sphere.
     center: GeoEcefPoint,
-    /// Sphere radius in meters.
-    radius_m: f64,
+    /// Maximum distance from `center` in meters (sphere radius).
+    distance_m: f64,
     /// Boost factor applied to the final score.
     boost: f32,
 }
@@ -72,14 +72,15 @@ pub struct Geo3dDistanceQuery {
 impl Geo3dDistanceQuery {
     /// Construct a new query.
     ///
-    /// `radius_m` is interpreted as straight-line distance in ECEF meters.
-    /// Negative or zero radii produce a query that matches no documents
-    /// (see [`Geo3dDistanceQuery::is_empty`]).
-    pub fn new<F: Into<String>>(field: F, center: GeoEcefPoint, radius_m: f64) -> Self {
+    /// `distance_m` is interpreted as straight-line distance in ECEF meters
+    /// and represents the maximum distance from `center` (i.e. the search
+    /// sphere's radius). Negative or zero values produce a query that matches
+    /// no documents (see [`Geo3dDistanceQuery::is_empty`]).
+    pub fn new<F: Into<String>>(field: F, center: GeoEcefPoint, distance_m: f64) -> Self {
         Self {
             field: field.into(),
             center,
-            radius_m,
+            distance_m,
             boost: 1.0,
         }
     }
@@ -100,9 +101,9 @@ impl Geo3dDistanceQuery {
         self.center
     }
 
-    /// Search radius in meters.
-    pub fn radius_m(&self) -> f64 {
-        self.radius_m
+    /// Maximum distance from `center` in meters (sphere radius).
+    pub fn distance_m(&self) -> f64 {
+        self.distance_m
     }
 
     /// Run the query against `reader` and return the matches sorted by
@@ -113,10 +114,10 @@ impl Geo3dDistanceQuery {
             return Ok(matches);
         };
 
-        let mut visitor = SphereVisitor::new(self.center, self.radius_m);
+        let mut visitor = SphereVisitor::new(self.center, self.distance_m);
         bkd.intersect(&mut visitor)?;
 
-        let radius = self.radius_m;
+        let radius = self.distance_m;
         for hit in visitor.hits {
             let distance = hit.distance_sq.sqrt();
             let score = if hit.from_inside_cell {
@@ -169,7 +170,7 @@ pub struct Geo3dMatch {
 }
 
 /// `IntersectVisitor` that collects every doc whose stored point lies
-/// within a sphere of radius `radius_m` centered at `center`.
+/// within a sphere of radius `distance_m` centered at `center`.
 ///
 /// The classification logic uses [`AABB::min_distance_sq_to_point`] (for
 /// the Outside test) and [`AABB::max_distance_sq_to_point`] (for the
@@ -376,13 +377,13 @@ impl Query for Geo3dDistanceQuery {
 
     fn description(&self) -> String {
         format!(
-            "Geo3dDistanceQuery(field: {}, center: {:?}, radius: {}m)",
-            self.field, self.center, self.radius_m
+            "Geo3dDistanceQuery(field: {}, center: {:?}, distance: {}m)",
+            self.field, self.center, self.distance_m
         )
     }
 
     fn is_empty(&self, _reader: &dyn LexicalIndexReader) -> Result<bool> {
-        Ok(self.radius_m <= 0.0)
+        Ok(self.distance_m <= 0.0)
     }
 
     fn cost(&self, reader: &dyn LexicalIndexReader) -> Result<u64> {
@@ -954,7 +955,7 @@ mod tests {
             .with_boost(2.0);
         assert_eq!(q.field(), "position");
         assert_eq!(q.center(), GeoEcefPoint::new(1.0, 2.0, 3.0));
-        assert_eq!(q.radius_m(), 500.0);
+        assert_eq!(q.distance_m(), 500.0);
         assert_eq!(q.boost(), 2.0);
         let cloned = q.clone_box();
         assert!(cloned.description().contains("Geo3dDistanceQuery"));

--- a/laurus/src/lexical/query/parser.pest
+++ b/laurus/src/lexical/query/parser.pest
@@ -26,7 +26,7 @@ field_query = { field ~ ":" ~ field_value }
 field_value = { geo3d_query | geo_query | range_query | phrase_query | fuzzy_term | wildcard_term | simple_term }
 
 // 3D geo queries (ECEF Cartesian coordinates, meters):
-//   field:geo3d_distance(x, y, z, radius_m)
+//   field:geo3d_distance(x, y, z, distance_m)
 //   field:geo3d_bbox(min_x, min_y, min_z, max_x, max_y, max_z)
 //   field:geo3d_nearest(x, y, z, k)
 geo3d_query = { geo3d_distance | geo3d_bbox | geo3d_nearest }
@@ -41,7 +41,7 @@ geo3d_nearest = {
 }
 
 // 2D geo queries (latitude / longitude in degrees, distance in km):
-//   field:geo_distance(lat, lon, distance_km)
+//   field:geo_distance(lat, lon, distance_m)
 //   field:geo_bbox(min_lat, min_lon, max_lat, max_lon)
 geo_query = { geo_distance | geo_bbox }
 geo_distance = {

--- a/laurus/src/lexical/query/parser.rs
+++ b/laurus/src/lexical/query/parser.rs
@@ -410,17 +410,17 @@ impl LexicalQueryParser {
         pair: pest::iterators::Pair<Rule>,
         field: &str,
     ) -> Result<Box<dyn Query>> {
-        // Grammar guarantees four signed_float arguments: x, y, z, radius_m.
+        // Grammar guarantees four signed_float arguments: x, y, z, distance_m.
         let args = collect_signed_floats(pair)?;
         if args.len() != 4 {
             return Err(LaurusError::parse(format!(
-                "geo3d_distance expects 4 numeric arguments (x, y, z, radius_m), got {}",
+                "geo3d_distance expects 4 numeric arguments (x, y, z, distance_m), got {}",
                 args.len()
             )));
         }
         let center = GeoEcefPoint::new(args[0], args[1], args[2]);
-        let radius_m = args[3];
-        Ok(Box::new(Geo3dDistanceQuery::new(field, center, radius_m)))
+        let distance_m = args[3];
+        Ok(Box::new(Geo3dDistanceQuery::new(field, center, distance_m)))
     }
 
     fn parse_geo3d_bbox(
@@ -518,11 +518,11 @@ impl LexicalQueryParser {
         pair: pest::iterators::Pair<Rule>,
         field: &str,
     ) -> Result<Box<dyn Query>> {
-        // Grammar: lat, lon, distance_km.
+        // Grammar: lat, lon, distance_m.
         let args = collect_signed_floats(pair)?;
         if args.len() != 3 {
             return Err(LaurusError::parse(format!(
-                "geo_distance expects 3 numeric arguments (lat, lon, distance_km), got {}",
+                "geo_distance expects 3 numeric arguments (lat, lon, distance_m), got {}",
                 args.len()
             )));
         }

--- a/laurus/tests/bkd_integration_test.rs
+++ b/laurus/tests/bkd_integration_test.rs
@@ -153,13 +153,13 @@ fn test_geo_bkd_query() {
 
     let reader = writer.build_reader().unwrap();
 
-    // Distance query: Near Tokyo (within 50km) -> Should match Tokyo (0km) and Yokohama (~30km)
-    let query = GeoDistanceQuery::new("location", tokyo, 50.0);
+    // Distance query: Near Tokyo (within 50 km) -> Should match Tokyo (0 km) and Yokohama (~30 km)
+    let query = GeoDistanceQuery::new("location", tokyo, 50_000.0);
     let matched_docs = collect_matcher_results(query.matcher(&*reader).unwrap());
     assert_eq!(matched_docs, vec![0, 1]);
 
-    // Near Osaka (within 20km) -> Should match Osaka
-    let query_osaka = GeoDistanceQuery::new("location", osaka, 20.0);
+    // Near Osaka (within 20 km) -> Should match Osaka
+    let query_osaka = GeoDistanceQuery::new("location", osaka, 20_000.0);
     let matched_osaka = collect_matcher_results(query_osaka.matcher(&*reader).unwrap());
     assert_eq!(matched_osaka, vec![2]);
 }


### PR DESCRIPTION
## Summary

The 2D `geo_distance` query took its radius in kilometers (`distance_km`) while the new 3D `geo3d_distance` took it in meters as `radius_m`. The inconsistency was visible across the DSL and all five language bindings.

This PR aligns laurus with the modern industry standard — PostGIS `geography`, MongoDB GeoJSON, Lucene `Geo3DPoint`, Google S2 — by using **meters everywhere**.

## Changes

### Core ([laurus/src](laurus/src/))

- [`GeoPoint::distance_to`](laurus/src/data.rs) returns meters (`EARTH_RADIUS_M = 6_371_000.0`).
- [`GeoDistanceQuery::distance_km`](laurus/src/lexical/query/geo.rs) → `distance_m`; constructor parameter, getter, scoring, and bounding-box helpers all switch to meters (`lat_deg_m = 111_000.0`).
- [`GeoMatch::distance_km`](laurus/src/lexical/query/geo.rs) → `distance_m`.
- [`Geo3dDistanceQuery::radius_m`](laurus/src/lexical/query/geo3d.rs) → `distance_m` so the argument name matches the DSL function name (`geo3d_distance`).
  - Note: `Geo3dNearestQuery::initial_radius_m` / `max_radius_m` intentionally keep "radius" semantics since they describe the expanding-cone search algorithm's probe radii rather than a distance filter.
- DSL grammar comments and parser error messages updated to `distance_m`.
- Core unit tests and the BKD integration test were updated to use meter values (`10.0` → `10_000.0`, etc.).

### Bindings

All five bindings (Python / Node.js / Ruby / WASM / PHP) renamed the public parameter / field / doc-comment:

- `GeoDistanceQuery`: `distance_km` → `distance_m` (`distanceKm` → `distanceM` in camelCase bindings).
- `Geo3dDistanceQuery`: `radius_m` → `distance_m` (`radiusM` → `distanceM`).
- WASM `Index::searchGeo3dDistance(field, x, y, z, distanceM, ...)`.

### Examples / READMEs

Lexical-search examples in Python / Ruby / PHP and the Python README tables were updated from `100.0` to `100_000.0` so the "within 100 km" behavior is preserved under the new unit.

### Documentation

- DSL reference ([`concepts/query_dsl.md`](docs/src/concepts/query_dsl.md), en + ja) and the lexical-search guide updated.
- All five binding `api_reference.md` files (en + ja) updated.
- [`laurus-server/grpc_api.md`](docs/src/laurus-server/grpc_api.md) and [`laurus-mcp/tools.md`](docs/src/laurus-mcp/tools.md) (en + ja) updated.

## Breaking change

This is a breaking API change for:

- `GeoDistanceQuery` / `Geo3dDistanceQuery` constructors and factories
- The `geo_distance` / `geo3d_distance` DSL forms
- The WASM `searchGeo3dDistance` method
- Internal `GeoPoint::distance_to` (now meters)
- `GeoMatch::distance_m` field name

Callers passing literal km values must multiply by 1000. Acceptable as the project is pre-1.0; this is the right window to land it before the API stabilizes.

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo test -p laurus` (all targets, geo + bkd_integration green)
- [x] `cargo check -p laurus -p laurus-python -p laurus-nodejs -p laurus-wasm -p laurus-php`
- [x] `cargo clippy -p laurus -p laurus-python -p laurus-nodejs -p laurus-wasm -p laurus-php -- -D warnings`
- [x] `cargo fmt --check`
- [x] `markdownlint-cli2 "docs/src/**/*.md" "docs/ja/src/**/*.md"` (152 files, 0 errors)