### PR TITLE
ci(docs): publish laurus-wasm demo alongside mdBook on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'laurus/**'
+      - 'laurus-wasm/**'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 jobs:
@@ -21,6 +24,23 @@ jobs:
         with:
           mdbook-version: 'latest'
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "stable-wasm32-unknown-unknown"
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build laurus-wasm (web target)
+        working-directory: laurus-wasm
+        run: wasm-pack build --target web --release
 
       - name: Build Book (English)
         run: mdbook build docs
@@ -30,6 +50,14 @@ jobs:
 
       - name: Copy Japanese docs into publish directory
         run: cp -r target/docs/ja docs/book/ja
+
+      - name: Stage WASM demo into publish directory
+        run: |
+          mkdir -p docs/book/demo/pkg
+          cp -r laurus-wasm/pkg/. docs/book/demo/pkg/
+          # Rewrite the relative `../pkg/...` import so the demo can sit at /demo/.
+          sed 's|\.\./pkg/laurus_wasm\.js|./pkg/laurus_wasm.js|g' \
+            laurus-wasm/examples/index.html > docs/book/demo/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary

- Build `laurus-wasm` with `wasm-pack build --target web --release` inside the deploy-docs workflow and stage the demo under `docs/book/demo/` so the existing `peaceiris/actions-gh-pages` publish step uploads it together with the mdBook output.
- Rewrite the example's `../pkg/laurus_wasm.js` import to `./pkg/laurus_wasm.js` so the demo can sit at `/demo/` with its generated bindings under `/demo/pkg/`.
- Extend the workflow trigger paths with `laurus-wasm/**`, `laurus/**` (workspace dependency), and the workflow file itself, so changes that affect the demo or the WASM build also republish the site.

After this lands, the live demo will be available at `https://mosuka.github.io/laurus/demo/`.

The build pipeline mirrors the existing `build-wasm` / `publish-wasm-npm` jobs in `release.yml` (`dtolnay/rust-toolchain@v1` + `Swatinem/rust-cache@v2` + `wasm-pack` curl install).

## Test plan

- [ ] Workflow run for this branch (or after merge to `main`) succeeds end-to-end on `workflow_dispatch`
- [ ] `https://mosuka.github.io/laurus/demo/` loads `index.html`, fetches `pkg/laurus_wasm_bg.wasm`, and the search box returns results
- [ ] OPFS persistence works (reload the page and confirm seeded docs are kept)
- [ ] Existing mdBook URLs (`https://mosuka.github.io/laurus/` and `/ja/`) still render correctly