### PR TITLE
fix(docs): drop wasm-pack pkg/.gitignore before publishing demo

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           mkdir -p docs/book/demo/pkg
           cp -r laurus-wasm/pkg/. docs/book/demo/pkg/
+          # wasm-pack writes a `*` .gitignore inside pkg/. peaceiris/actions-gh-pages
+          # publishes via `git add --all`, so this .gitignore would silently exclude
+          # every generated binding from gh-pages. Drop it before deploy.
+          rm -f docs/book/demo/pkg/.gitignore
           # Rewrite the relative `../pkg/...` import so the demo can sit at /demo/.
           sed 's|\.\./pkg/laurus_wasm\.js|./pkg/laurus_wasm.js|g' \
             laurus-wasm/examples/index.html > docs/book/demo/index.html


### PR DESCRIPTION
## Summary

Follow-up to #377. The merged deploy workflow built `laurus-wasm` correctly, but `https://mosuka.github.io/laurus/demo/` still 404'd on its first JS import:

```
GET https://mosuka.github.io/laurus/demo/pkg/laurus_wasm.js  net::ERR_ABORTED 404
```

`wasm-pack` writes a `*` `.gitignore` inside `pkg/` so the generated artifacts don't get committed to source repos. Our deploy step copies `laurus-wasm/pkg/` into `docs/book/demo/pkg/`, and `peaceiris/actions-gh-pages` publishes via `git add --all` — which honours the copied `.gitignore` and silently excluded every binding (`laurus_wasm.js`, `laurus_wasm_bg.wasm`, `snippets/`) from `gh-pages`. Only `demo/index.html` made it onto Pages, hence the 404.

This PR removes that `.gitignore` from the staged copy after `cp`, so the bindings actually land on `gh-pages`.

## Test plan

- [ ] Workflow run succeeds end-to-end on `main` after merge
- [ ] `https://mosuka.github.io/laurus/demo/pkg/laurus_wasm.js` returns 200
- [ ] `https://mosuka.github.io/laurus/demo/pkg/laurus_wasm_bg.wasm` returns 200
- [ ] `https://mosuka.github.io/laurus/demo/` boots, the search box returns results, and reload preserves OPFS state

Refs #377