### PR TITLE
revert: undo wasm demo Pages deploy (PR #377 + #378)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,9 +6,6 @@ on:
       - main
     paths:
       - 'docs/**'
-      - 'laurus/**'
-      - 'laurus-wasm/**'
-      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 jobs:
@@ -24,23 +21,6 @@ jobs:
         with:
           mdbook-version: 'latest'
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-
-      - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "stable-wasm32-unknown-unknown"
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Build laurus-wasm (web target)
-        working-directory: laurus-wasm
-        run: wasm-pack build --target web --release
 
       - name: Build Book (English)
         run: mdbook build docs
@@ -50,18 +30,6 @@ jobs:
 
       - name: Copy Japanese docs into publish directory
         run: cp -r target/docs/ja docs/book/ja
-
-      - name: Stage WASM demo into publish directory
-        run: |
-          mkdir -p docs/book/demo/pkg
-          cp -r laurus-wasm/pkg/. docs/book/demo/pkg/
-          # wasm-pack writes a `*` .gitignore inside pkg/. peaceiris/actions-gh-pages
-          # publishes via `git add --all`, so this .gitignore would silently exclude
-          # every generated binding from gh-pages. Drop it before deploy.
-          rm -f docs/book/demo/pkg/.gitignore
-          # Rewrite the relative `../pkg/...` import so the demo can sit at /demo/.
-          sed 's|\.\./pkg/laurus_wasm\.js|./pkg/laurus_wasm.js|g' \
-            laurus-wasm/examples/index.html > docs/book/demo/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary

The deploy-docs workflow on `main` is currently red. The wasm demo deployment introduced in #377 / #378 hits GitHub's per-file 100 MB git push limit:

```
remote: error: File demo/pkg/laurus_wasm_bg.wasm is 195.48 MB;
               this exceeds GitHub's file size limit of 100.00 MB
remote: error: GH001: Large files detected.
 ! [remote rejected] gh-pages -> gh-pages (pre-receive hook declined)
```

`peaceiris/actions-gh-pages` publishes via `git push`, so the 100 MB / file limit applies. The wasm artifact is ~195 MB on `main` today (suspected: `aws-lc-rs` is leaking into the `wasm32` build via `laurus`'s default features), which is over the limit and would also be a bad demo UX even if it could ship.

This PR reverts both #377 and #378 so the mdBook site keeps publishing cleanly while we figure out the right path forward.

## Follow-up tracked separately

Before re-attempting the demo deploy, two things need to happen:

1. **Slim the wasm at source** — audit `laurus`'s default features and ensure crypto / aws-lc-rs / similar are gated out of `wasm32` builds. Goal: bring the binary back to single-digit-tens of MB.
2. **Switch the deploy mechanism** to `actions/upload-pages-artifact` + `actions/deploy-pages` so we publish via the artifact pipeline rather than `git push`, sidestepping the per-file limit.

## Test plan

- [ ] Workflow run on `main` after merge succeeds and re-publishes mdBook (no `demo/`)
- [ ] `https://mosuka.github.io/laurus/` and `/ja/` continue to render correctly
- [ ] `https://mosuka.github.io/laurus/demo/` returns 404 (the half-published demo is gone) — peaceiris's `git rm -r *` step handles this cleanup on the next successful deploy