### PR TITLE
fix(deploy-docs): place pkg/ at site root to match demo import paths

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -57,7 +57,12 @@ jobs:
         run: |
           mkdir -p docs/book/demo
           cp laurus-wasm/examples/index.html docs/book/demo/
-          cp -r laurus-wasm/pkg docs/book/demo/pkg
+          # The demo HTML imports `../pkg/laurus_wasm.js` and
+          # `../pkg/opfs.js`, so pkg/ must live at the site root
+          # (one level up from /demo/). This mirrors the local
+          # development layout where the demo is served from
+          # laurus-wasm/examples/ and pkg/ sits at laurus-wasm/pkg/.
+          cp -r laurus-wasm/pkg docs/book/pkg
 
       - name: Resolve lindera version from cargo metadata
         id: lindera_version


### PR DESCRIPTION
## Summary

The first deploy of #383 surfaced 404s for `/pkg/laurus_wasm.js` and `/pkg/opfs.js` when the demo at `/demo/index.html` tried to import them. The demo uses `import ... from '../pkg/...'`, which resolves to `/pkg/...` from `/demo/`, but the workflow was placing pkg at `/demo/pkg/`.

Move the wasm-pack output to `docs/book/pkg` so the deployed layout mirrors the local development layout (`laurus-wasm/examples/` + `../pkg/` resolves to `laurus-wasm/pkg/`).

## Test plan

- [ ] After merge, deploy succeeds.
- [ ] `curl -I` returns 200 for:
  - `https://mosuka.github.io/laurus/demo/`
  - `https://mosuka.github.io/laurus/pkg/laurus_wasm.js`
  - `https://mosuka.github.io/laurus/pkg/laurus_wasm_bg.wasm`
  - `https://mosuka.github.io/laurus/pkg/opfs.js`
  - `https://mosuka.github.io/laurus/demo/dict/lindera-ipadic.zip`
  - `https://mosuka.github.io/laurus/demo/dict/manifest.json`
- [ ] Open the demo in a fresh profile; IPADIC downloads, Japanese sample searches return hits.

Refs #380