### PR TITLE
fix(wasm): avoid */ in JSDoc-bound rustdoc comments

### DIFF
--- a/laurus-wasm/src/schema.rs
+++ b/laurus-wasm/src/schema.rs
@@ -369,7 +369,7 @@ impl WasmSchema {
     /// preset cannot resolve a filesystem path.
     ///
     /// ```javascript
-    /// const ja = JapaneseAnalyzer.fromBytes(/* ... */);
+    /// const ja = JapaneseAnalyzer.fromBytes(...);
     /// schema.addAnalyzer("ja-ipadic", ja);
     /// schema.addTextField("body", undefined, undefined, undefined, "ja-ipadic");
     /// ```


### PR DESCRIPTION
## Summary

Browser console reported

```
laurus_wasm.js:513 Uncaught SyntaxError: Unexpected token ')'
```

at module load time on the deployed demo. wasm-bindgen passes Rust ``` ///``` doc comments verbatim into the generated JSDoc block, so the placeholder snippet `JapaneseAnalyzer.fromBytes(/* ... */)` inside the `addAnalyzer` rustdoc closed the surrounding ``` /** ... */ ``` early at the inner ``` */ ``` and produced invalid JS.

Replace the placeholder with `(...)`. Verified via `node --check pkg/laurus_wasm.js` after `wasm-pack build` — clean.

## Test plan

- [ ] After merge, deploy succeeds.
- [ ] `node --check` on the deployed `/pkg/laurus_wasm.js` passes (we can `curl` it to verify).
- [ ] Open the demo in a fresh profile; the WASM module loads without a syntax error and the IPADIC download flow starts.

Refs #380