### PR TITLE
fix(parser): accept Unicode letters and numbers as bare query terms

### DIFF
--- a/laurus/src/lexical/query/parser.pest
+++ b/laurus/src/lexical/query/parser.pest
@@ -71,9 +71,12 @@ fuzzy_term = { term ~ "~" ~ fuzziness? ~ boost? }
 fuzziness = { number }
 
 // Wildcard queries: te?t or test*
+// Use Unicode `LETTER | NUMBER` so CJK / Cyrillic / Greek terms are accepted
+// alongside ASCII. `LETTER` and `NUMBER` general categories together
+// cover the cases users actually write.
 wildcard_term = { wildcard_pattern ~ boost? }
 wildcard_pattern = @{
-    (ASCII_ALPHANUMERIC | "_")* ~ wildcard_char ~ (ASCII_ALPHANUMERIC | "_" | wildcard_char)*
+    (LETTER | NUMBER | "_")* ~ wildcard_char ~ (LETTER | NUMBER | "_" | wildcard_char)*
 }
 wildcard_char = { "?" | "*" }
 
@@ -87,15 +90,19 @@ term_query = { field_value }
 boost = { "^" ~ boost_value }
 boost_value = @{ number ~ ("." ~ number)? }
 
-// Field name
+// Field name (ASCII-only on purpose; field identifiers stay portable)
 field = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | ".")* }
 
 // Term (word)
+// `LETTER | NUMBER` is Unicode-aware (Letter / Number general categories),
+// so CJK / Cyrillic / Greek / accented Latin etc. all parse as bare
+// terms without requiring quoting. `boolean_op` keywords (AND / OR)
+// remain whitespace-bounded as before.
 term = @{ escaped_char+ | unescaped_term }
-unescaped_term = @{ (ASCII_ALPHANUMERIC | "_" | "-")+ }
+unescaped_term = @{ (LETTER | NUMBER | "_" | "-")+ }
 escaped_char = @{ "\\" ~ special_char | normal_char }
 special_char = { "+" | "-" | "!" | "(" | ")" | "{" | "}" | "[" | "]" | "^" | "\"" | "~" | "*" | "?" | ":" | "\\" | "/" }
-normal_char = @{ ASCII_ALPHANUMERIC | "_" | "-" }
+normal_char = @{ LETTER | NUMBER | "_" | "-" }
 
 // Quoted string
 quoted_string = { "\"" ~ quoted_content ~ "\"" }

--- a/laurus/src/lexical/query/parser.rs
+++ b/laurus/src/lexical/query/parser.rs
@@ -956,6 +956,41 @@ mod tests {
     }
 
     #[test]
+    fn test_unquoted_cjk_term() {
+        // Bare CJK / Cyrillic / Greek terms must parse without quoting.
+        // Previously the grammar restricted unescaped terms to
+        // ASCII_ALPHANUMERIC, so `日本語` would surface a pest "expected
+        // clause" error to the user.
+        let parser = create_test_parser().with_default_field("content");
+
+        for term in ["日本語", "形態素", "Привет", "Ελληνικά", "café"] {
+            let query = parser
+                .parse(term)
+                .unwrap_or_else(|e| panic!("failed to parse {term:?}: {e}"));
+            assert!(
+                format!("{query:?}").contains("TermQuery"),
+                "expected TermQuery for {term:?}, got {query:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_unquoted_cjk_field_query() {
+        // CJK term following an ASCII field name and colon.
+        let parser = create_test_parser().with_default_field("content");
+        let query = parser.parse("title:形態素").unwrap();
+        assert!(format!("{query:?}").contains("TermQuery"));
+    }
+
+    #[test]
+    fn test_unquoted_cjk_boolean() {
+        // Whitespace-bounded boolean ops still kick in between CJK terms.
+        let parser = create_test_parser().with_default_field("content");
+        let query = parser.parse("形態素 AND 解析").unwrap();
+        assert!(format!("{query:?}").contains("BooleanQuery"));
+    }
+
+    #[test]
     fn test_multiple_default_fields() {
         let parser =
             create_test_parser().with_default_fields(vec!["title".to_string(), "body".to_string()]);


### PR DESCRIPTION
## Summary

The lexical query grammar restricted unescaped terms to `ASCII_ALPHANUMERIC`, so any non-ASCII bare term — Japanese, Chinese, Korean, Cyrillic, Greek, Arabic, even accented Latin like `café` — surfaced

```text
Parse error:
 --> 1:1
  |
1 | 日本語
  | ^---
  |
  = expected clause
```

at the user level. Quoting (`"日本語"`) side-stepped it via `phrase_query`, but that is hostile UX for the Japanese demo shipped in #380.

Replace `ASCII_ALPHANUMERIC` inside `unescaped_term`, `normal_char`, and `wildcard_pattern` with the Unicode `LETTER | NUMBER` alternation (general categories L and N). Field names stay ASCII-only on purpose, and whitespace-bounded `AND` / `OR` operators are unaffected.

## Test plan

- [x] `cargo test -p laurus --lib` → 799 passed (796 + 3 new)
  - `test_unquoted_cjk_term` covers `日本語`, `形態素`, `Привет`, `Ελληνικά`, `café`
  - `test_unquoted_cjk_field_query` covers `title:形態素`
  - `test_unquoted_cjk_boolean` covers `形態素 AND 解析`
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` → 0
- [x] `cargo fmt --all -- --check` → 0

Refs #380