### PR TITLE
ci(deploy-docs): trigger on laurus core and workspace manifest changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,7 +6,10 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'laurus/**'
       - 'laurus-wasm/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

The demo bundles `wasm-pack` output of laurus-wasm, which transitively depends on laurus. When a change lives only in `laurus/` (e.g. #386 fixed CJK / Cyrillic / Greek bare terms in the lexical query parser), the demo on Pages still serves the stale wasm and the fix is invisible without a manual `workflow_dispatch`.

Add `laurus/**`, `Cargo.toml`, and `Cargo.lock` to the deploy-docs paths trigger so core fixes that affect the deployed bundle redeploy automatically.

## Test plan

- [ ] After merge, deploy-docs auto-triggers from this PR's merge commit (which touches `.github/workflows/deploy-docs.yml`).
- [ ] Future PRs that only touch `laurus/**` will see deploy-docs run on merge.