### PR TITLE
fix(wasm-demo): bump OPFS index version and add reset buttons

### DIFF
--- a/laurus-wasm/examples/index.html
+++ b/laurus-wasm/examples/index.html
@@ -286,7 +286,16 @@
     const DICT_NAME = 'ipadic';
     const DICT_URL = './dict/lindera-ipadic.zip';
     const ANALYZER_NAME = 'ja-ipadic';
-    const INDEX_NAME = 'ja-demo-index';
+    /**
+     * Bump the suffix whenever the persisted schema changes (field
+     * dimensionality, vector index type, etc.). Without a bump,
+     * returning visitors hit "Dimension mismatch: stored N, config M"
+     * because Index.open replays an OPFS-persisted index whose stored
+     * shape no longer matches the schema. v2 covers the addition of
+     * the 384-dim HNSW embedding field on top of the v1 (lexical-only)
+     * shape introduced with the OPFS demo.
+     */
+    const INDEX_NAME = 'ja-demo-index-v2';
 
     /** Multilingual MiniLM (paraphrase-multilingual-MiniLM-L12-v2) — 384-dim
      *  text embeddings that work cleanly for both Japanese and English

--- a/laurus-wasm/examples/index.html
+++ b/laurus-wasm/examples/index.html
@@ -234,6 +234,20 @@
       </ul>
     </div>
 
+    <!-- Maintenance -->
+    <div class="card">
+      <h2>Maintenance</h2>
+      <p class="dsl-hint">
+        Delete persisted state if you have stale data from a previous
+        demo version (for example, an older schema with a different
+        vector dimensionality). Reloads the page after clearing.
+      </p>
+      <div class="row">
+        <button id="reset-index-btn" type="button" onclick="resetIndex()" disabled>Reset index</button>
+        <button id="reset-all-btn" type="button" onclick="resetAll()" disabled>Reset everything (index + dictionary)</button>
+      </div>
+    </div>
+
     <!-- Add Document -->
     <div class="card">
       <h2>Add Document</h2>
@@ -278,6 +292,7 @@
       downloadDictionary,
       hasDictionary,
       loadDictionaryFiles,
+      removeDictionary,
     } from '../pkg/opfs.js';
     import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3';
 
@@ -550,6 +565,71 @@
 
       } catch (e) {
         appendLog(`Add error: ${e}`, 'err');
+        console.error(e);
+      }
+    };
+
+    // ------------------------------------------------------------------
+    // Maintenance — delete persisted OPFS state and reload
+    // ------------------------------------------------------------------
+    /**
+     * Index names that the demo has persisted across versions. Listed
+     * explicitly so we can clean up legacy directories left over from
+     * earlier demo iterations (different vector dimensionality, etc.).
+     */
+    const KNOWN_INDEX_NAMES = ['ja-demo-index', 'ja-demo-index-v2'];
+
+    /**
+     * Remove all known demo index directories from the OPFS root.
+     * The dictionary cache is preserved.
+     */
+    async function deleteAllIndexes() {
+      const root = await navigator.storage.getDirectory();
+      for (const name of KNOWN_INDEX_NAMES) {
+        try {
+          await root.removeEntry(name, { recursive: true });
+          appendLog(`Removed OPFS index "${name}".`, 'ok');
+        } catch (e) {
+          // Directory may not exist (e.g. v1 was never created).
+          if (e?.name !== 'NotFoundError') {
+            appendLog(`Failed to remove "${name}": ${e}`, 'err');
+          }
+        }
+      }
+    }
+
+    window.resetIndex = async function() {
+      if (!confirm('Delete the persisted index and reload? IPADIC and the embedding model stay cached.')) {
+        return;
+      }
+      try {
+        await deleteAllIndexes();
+        appendLog('Index reset complete. Reloading...', 'ok');
+        setTimeout(() => location.reload(), 250);
+      } catch (e) {
+        appendLog(`Reset failed: ${e}`, 'err');
+        console.error(e);
+      }
+    };
+
+    window.resetAll = async function() {
+      if (!confirm('Delete the index AND the IPADIC dictionary, then reload? The 16 MB dictionary will re-download on next visit.')) {
+        return;
+      }
+      try {
+        await deleteAllIndexes();
+        try {
+          await removeDictionary(DICT_NAME);
+          appendLog(`Removed OPFS dictionary "${DICT_NAME}".`, 'ok');
+        } catch (e) {
+          if (e?.name !== 'NotFoundError') {
+            appendLog(`Failed to remove dictionary: ${e}`, 'err');
+          }
+        }
+        appendLog('Full reset complete. Reloading...', 'ok');
+        setTimeout(() => location.reload(), 250);
+      } catch (e) {
+        appendLog(`Reset failed: ${e}`, 'err');
         console.error(e);
       }
     };


### PR DESCRIPTION
## Summary

Two related fixes for the OPFS-persistent demo state.

### 1. Bump persisted index name to v2

Returning visitors who loaded the lexical-only OPFS demo (between #383 and #388) hit on reload:

```
Index error: Dimension mismatch: stored 128, config 384
```

`Index.open` replays the persisted shape against the new schema, which now adds a 384-dim HNSW embedding field. Renaming to `ja-demo-index-v2` forces a fresh OPFS allocation. The legacy `ja-demo-index` directory stays in OPFS (and is cleaned up by the new "Reset" buttons described below).

The constant is annotated so future schema-shape changes always come with a suffix bump.

### 2. Maintenance card with reset buttons

Add two buttons in a new "Maintenance" card so users can clean up persisted state without diving into DevTools.

- **Reset index** — removes every known demo index (`ja-demo-index`, `ja-demo-index-v2`) and reloads. The IPADIC zip and the embedding model stay cached.
- **Reset everything** — additionally removes the IPADIC dictionary cache so the 16 MB zip re-downloads on next visit.

Both actions confirm via `confirm()` before deleting.

## Test plan

- [ ] Returning visitors with stale `ja-demo-index` no longer see the dimension mismatch.
- [ ] Click "Reset index": page reloads, sample docs are re-seeded into a fresh index, dictionary is not re-downloaded.
- [ ] Click "Reset everything": page reloads, IPADIC re-downloads, sample docs re-seeded.