### PR TITLE
feat(wasm-demo): restructure examples with geo sample and unidic dictionary

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -59,12 +59,18 @@ jobs:
       - name: Stage demo into Pages publish directory
         run: |
           mkdir -p docs/book/demo
-          cp laurus-wasm/examples/index.html docs/book/demo/
-          # The demo HTML imports `../pkg/laurus_wasm.js` and
-          # `../pkg/opfs.js`, so pkg/ must live at the site root
-          # (one level up from /demo/). This mirrors the local
-          # development layout where the demo is served from
-          # laurus-wasm/examples/ and pkg/ sits at laurus-wasm/pkg/.
+          # Copy every sample (and shared/) under docs/book/demo/.
+          # `cp -r src/. dest/` copies the *contents* of src into
+          # dest, mirroring the laurus-wasm/examples/ layout
+          # (landing page at /demo/, samples at /demo/lexical/,
+          # /demo/geo/, etc.).
+          cp -r laurus-wasm/examples/. docs/book/demo/
+          # Each sample HTML imports `../../pkg/laurus_wasm.js`
+          # and `../../pkg/opfs.js`, so pkg/ must live at the site
+          # root (two levels up from /demo/<sample>/). This mirrors
+          # the local development layout where samples are served
+          # from laurus-wasm/examples/<sample>/ and pkg/ sits at
+          # laurus-wasm/pkg/.
           cp -r laurus-wasm/pkg docs/book/pkg
 
       - name: Resolve lindera version from cargo metadata
@@ -79,18 +85,18 @@ jobs:
           echo "Resolved lindera version: $VERSION"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Download IPADIC dictionary
+      - name: Download UniDic dictionary
         run: |
           mkdir -p docs/book/demo/dict
-          curl -fsSL -o docs/book/demo/dict/lindera-ipadic.zip \
-            "https://github.com/lindera/lindera/releases/download/v${{ steps.lindera_version.outputs.version }}/lindera-ipadic-${{ steps.lindera_version.outputs.version }}.zip"
+          curl -fsSL -o docs/book/demo/dict/lindera-unidic.zip \
+            "https://github.com/lindera/lindera/releases/download/v${{ steps.lindera_version.outputs.version }}/lindera-unidic-${{ steps.lindera_version.outputs.version }}.zip"
           ls -la docs/book/demo/dict/
 
       - name: Generate dictionary manifest
         run: |
           cat > docs/book/demo/dict/manifest.json <<EOF
           {
-            "ipadic": "lindera-ipadic.zip",
+            "unidic": "lindera-unidic.zip",
             "lindera_version": "${{ steps.lindera_version.outputs.version }}"
           }
           EOF

--- a/laurus-wasm/README.md
+++ b/laurus-wasm/README.md
@@ -106,8 +106,22 @@ schema.setDefaultFields(["title", "body"]);
 
 ## Examples
 
-See the [examples/](examples/) directory for a full demo with
-Transformers.js embeddings and OPFS persistence.
+The [examples/](examples/) directory hosts several self-contained
+single-page demos. Open
+[`examples/index.html`](examples/index.html) for the landing page,
+or jump into a specific sample:
+
+- [`examples/basic/`](examples/basic/) — Basic Japanese hybrid
+  search (full-text + vector) via the unified query DSL with
+  Transformers.js embeddings.
+- [`examples/geo/`](examples/geo/) — Tokyo points-of-interest on a
+  Leaflet map, combining a viewport-driven
+  `location:geo_bbox(...)` constraint with text and embedding
+  queries.
+
+Shared assets (theme stylesheet, logger, dictionary loader,
+embedder helper) live under `examples/shared/` so each sample stays
+focused on its own behaviour.
 
 ## Building from Source
 
@@ -123,9 +137,9 @@ wasm-pack build --target web --release
 # Bundle the OPFS helper (./opfs subpath) into pkg/
 ./scripts/postbuild.sh
 
-# Serve the demo
+# Serve the demo landing page
 python3 -m http.server 8080
-# Open http://localhost:8080/examples/
+# Open http://localhost:8080/examples/ — pick a sample from there.
 ```
 
 The post-build script copies `js/opfs.js` and `js/opfs.d.ts` into `pkg/`

--- a/laurus-wasm/README_ja.md
+++ b/laurus-wasm/README_ja.md
@@ -106,8 +106,22 @@ schema.setDefaultFields(["title", "body"]);
 
 ## サンプル
 
-[examples/](examples/) ディレクトリに、Transformers.js エンベディングと
-OPFS 永続化を使用したデモがあります。
+[examples/](examples/) ディレクトリには、複数のシングルページ
+デモが配置されています。サンプル一覧トップは
+[`examples/index.html`](examples/index.html) です。個別のサンプル
+にも直接アクセスできます。
+
+- [`examples/basic/`](examples/basic/) — 統合クエリ DSL を用いた
+  日本語の基本的なハイブリッド検索（全文検索 + ベクトル検索、
+  Transformers.js エンベディング併用）
+- [`examples/geo/`](examples/geo/) — Leaflet 地図に東京の観光
+  スポットをプロットし、ビューポートから生成した
+  `location:geo_bbox(...)` をテキスト検索・ベクトル検索と組み
+  合わせるサンプル
+
+共通アセット（テーマスタイル、ロガー、辞書ローダー、Embedder
+ヘルパ）は `examples/shared/` 配下にまとめており、各サンプルは
+それぞれの本題に集中できる構成にしています。
 
 ## ソースからのビルド
 
@@ -123,9 +137,9 @@ wasm-pack build --target web --release
 # OPFS ヘルパ（./opfs サブパス）を pkg/ に同梱
 ./scripts/postbuild.sh
 
-# デモの起動
+# デモの起動（サンプル一覧トップ）
 python3 -m http.server 8080
-# http://localhost:8080/examples/ を開く
+# http://localhost:8080/examples/ を開いて、サンプルを選択
 ```
 
 ポストビルドスクリプトは `js/opfs.js` と `js/opfs.d.ts` を `pkg/` に

--- a/laurus-wasm/examples/README.md
+++ b/laurus-wasm/examples/README.md
@@ -1,41 +1,66 @@
-# Laurus WASM Demo
+# Laurus WASM — Samples
 
-A single-page application demonstrating full-text search in the browser
-using laurus-wasm.
+Each subdirectory under `examples/` is a self-contained
+single-page application that boots laurus-wasm directly from
+`../pkg/` and runs entirely in the browser. Open
+[`examples/index.html`](./index.html) in a local HTTP server for
+the landing page, or jump straight to a specific sample.
 
-## How to Run
+## Samples
 
-1. Build the WASM package:
+| Sample | What it shows |
+| --- | --- |
+| [`basic/`](./basic/) | Japanese full-text, vector, and hybrid search with the unified query DSL. Adds documents interactively. |
+| [`geo/`](./geo/) | Tokyo points-of-interest on a Leaflet map. Combines a bounding-box constraint (`location:geo_bbox(...)`) drawn from the current viewport with text and vector queries. |
 
-   ```bash
-   cd laurus-wasm
-   wasm-pack build --target web --dev
-   ```
+The [`shared/`](./shared/) directory holds assets reused by every
+sample (theme stylesheet, logger, dictionary loader, embedder
+helper).
 
-2. Serve the files with any HTTP server (WASM requires HTTP, not `file://`):
+## How to run
 
-   ```bash
-   # Python
-   python3 -m http.server 8080
+```bash
+cd laurus-wasm
+wasm-pack build --target web --dev
+./scripts/postbuild.sh
+```
 
-   # Node.js (npx)
-   npx serve .
-   ```
+The samples expect the UniDic zip (~52 MB) at
+`examples/dict/lindera-unidic.zip`. The deploy workflow fetches it
+automatically; for local development, download a matching version
+from the [Lindera releases][lindera-releases] and drop it under
+`examples/dict/`.
 
-3. Open <http://localhost:8080/examples/> in your browser.
+```bash
+# from the repository root
+mkdir -p laurus-wasm/examples/dict
+curl -fsSL -o laurus-wasm/examples/dict/lindera-unidic.zip \
+  "https://github.com/lindera/lindera/releases/download/v<version>/lindera-unidic-<version>.zip"
+```
 
-## What the Demo Does
+Then start any HTTP server (WASM cannot be loaded over `file://`):
 
-- Creates an OPFS-persistent search index with `title` and `body` fields
-  (data survives page reloads)
-- Seeds 8 sample documents on first visit; skips seeding when existing
-  data is loaded from OPFS
-- Uses Transformers.js (all-MiniLM-L6-v2) for real 384-dim semantic
-  embeddings via the callback embedder
-- Provides a search box with unified query DSL support:
-  - Lexical: `rust`, `title:wasm`, `"memory safety"`
-  - Vector: `embedding:"how to make code faster"`, `embedding:python`
-  - Hybrid: `rust embedding:"systems programming"`
-- Allows adding new documents interactively
-- Shows search results with relevance scores
-- Logs all operations in the console panel
+```bash
+# Python
+python3 -m http.server 8080
+# or Node
+npx serve .
+```
+
+Open <http://localhost:8080/examples/> in your browser.
+
+[lindera-releases]: https://github.com/lindera/lindera/releases
+
+## Adding a new sample
+
+1. Create `examples/<name>/index.html`. Import laurus-wasm from
+   `../../pkg/laurus_wasm.js` and use helpers from
+   `../shared/`.
+2. Add `examples/<name>/README.md` and `README_ja.md`.
+3. Link the new sample from this README and from the landing page
+   `examples/index.html`.
+4. The deploy workflow ([`.github/workflows/deploy-docs.yml`][deploy])
+   copies all of `examples/` into the published Pages site, so no CI
+   change is needed for additional samples.
+
+[deploy]: ../../.github/workflows/deploy-docs.yml

--- a/laurus-wasm/examples/README_ja.md
+++ b/laurus-wasm/examples/README_ja.md
@@ -1,41 +1,66 @@
-# Laurus WASM デモ
+# Laurus WASM — サンプル集
 
-laurus-wasm を使用したブラウザ上での全文検索を実演する
-シングルページアプリケーションです。
+`examples/` 直下の各サブディレクトリは、`../pkg/` から
+laurus-wasm を直接読み込み、ブラウザだけで動作する独立した
+シングルページアプリです。サンプル一覧トップとしては
+[`examples/index.html`](./index.html) をローカル HTTP サーバーで
+開いてください。個別のサンプルにも直接アクセスできます。
+
+## サンプル一覧
+
+| サンプル | 内容 |
+| --- | --- |
+| [`basic/`](./basic/) | 日本語の全文検索・ベクトル検索・ハイブリッド検索を統合クエリ DSL で実演します。ドキュメントの追加もインタラクティブに行えます。 |
+| [`geo/`](./geo/) | 東京の観光スポットを Leaflet 地図上にプロットし、ビューポートから `location:geo_bbox(...)` を生成してテキスト検索・ベクトル検索と組み合わせるサンプルです。 |
+
+[`shared/`](./shared/) には、全サンプルで再利用するアセット（テーマ
+スタイル、ロガー、辞書ローダー、Embedder ヘルパ）を配置しています。
 
 ## 実行方法
 
-1. WASM パッケージをビルドします:
+```bash
+cd laurus-wasm
+wasm-pack build --target web --dev
+./scripts/postbuild.sh
+```
 
-   ```bash
-   cd laurus-wasm
-   wasm-pack build --target web --dev
-   ```
+各サンプルは `examples/dict/lindera-unidic.zip`（約 52 MB）から
+UniDic を読み込みます。デプロイワークフローでは自動取得されます
+が、ローカル開発では [Lindera のリリース][lindera-releases] から
+バージョンの合う zip をダウンロードして `examples/dict/` に置いて
+ください。
 
-2. HTTP サーバーでファイルを配信します（WASM は `file://` では動作しません）:
+```bash
+# リポジトリのルートから実行
+mkdir -p laurus-wasm/examples/dict
+curl -fsSL -o laurus-wasm/examples/dict/lindera-unidic.zip \
+  "https://github.com/lindera/lindera/releases/download/v<version>/lindera-unidic-<version>.zip"
+```
 
-   ```bash
-   # Python
-   python3 -m http.server 8080
+その後、任意の HTTP サーバーを起動します（WASM は `file://` では
+動作しません）。
 
-   # Node.js (npx)
-   npx serve .
-   ```
+```bash
+# Python
+python3 -m http.server 8080
+# または Node.js
+npx serve .
+```
 
-3. ブラウザで <http://localhost:8080/examples/> を開きます。
+ブラウザで <http://localhost:8080/examples/> を開きます。
 
-## デモの内容
+[lindera-releases]: https://github.com/lindera/lindera/releases
 
-- OPFS 永続化ストレージを使用した検索インデックスを作成
-  （ページリロード後もデータが保持されます）
-- 初回アクセス時に 8 件のサンプルドキュメントを投入。
-  既存データが OPFS にある場合はロードのみ
-- Transformers.js（all-MiniLM-L6-v2）による 384 次元セマンティック
-  Embedding をコールバック Embedder 経由で自動生成
-- 統合クエリ DSL 対応の検索ボックスを提供:
-  - Lexical 検索: `rust`、`title:wasm`、`"memory safety"`
-  - Vector 検索: `embedding:"how to make code faster"`、`embedding:python`
-  - Hybrid 検索: `rust embedding:"systems programming"`
-- 新しいドキュメントをインタラクティブに追加可能
-- 関連度スコア付きの検索結果を表示
-- すべての操作をコンソールパネルにログ出力
+## 新しいサンプルの追加方法
+
+1. `examples/<名前>/index.html` を作成。`../../pkg/laurus_wasm.js`
+   から laurus-wasm を、`../shared/` からヘルパを import します。
+2. `examples/<名前>/README.md` と `README_ja.md` を追加します。
+3. この README とランディング `examples/index.html` から新しい
+   サンプルへのリンクを追加します。
+4. デプロイワークフロー
+   ([`.github/workflows/deploy-docs.yml`][deploy]) が `examples/`
+   全体を公開先にコピーするため、サンプル追加時の CI 変更は
+   不要です。
+
+[deploy]: ../../.github/workflows/deploy-docs.yml

--- a/laurus-wasm/examples/basic/README.md
+++ b/laurus-wasm/examples/basic/README.md
@@ -1,0 +1,45 @@
+# Basic Hybrid Search Sample
+
+A single-page application demonstrating Japanese full-text, vector,
+and hybrid search in the browser using laurus-wasm. Data persists
+in OPFS across page reloads.
+
+See the [examples README](../README.md) for the full list of samples
+and the shared build instructions. The shortest path:
+
+```bash
+cd laurus-wasm
+wasm-pack build --target web --dev
+./scripts/postbuild.sh
+
+# Make the UniDic zip available at examples/dict/lindera-unidic.zip,
+# then serve from any HTTP server:
+python3 -m http.server 8080
+
+# Open http://localhost:8080/examples/basic/ in your browser.
+```
+
+## What this sample demonstrates
+
+- An OPFS-persistent search index with `title` and `body` fields
+  (data survives page reloads)
+- Seeding 8 sample documents on first visit; skipping the seed when
+  existing data is loaded from OPFS
+- Real 384-dim semantic embeddings produced by Transformers.js
+  (`paraphrase-multilingual-MiniLM-L12-v2`) via the callback embedder
+- A search box that speaks the unified query DSL:
+  - Lexical: `rust`, `title:wasm`, `"memory safety"`
+  - Vector: `embedding:"how to make code faster"`,
+    `embedding:python`
+  - Hybrid: `rust embedding:"systems programming"`
+- Adding new documents interactively
+- Showing search results with relevance scores
+- Logging all operations in the console panel
+
+## Layout
+
+This sample shares the dictionary loader, embedder, log helper, and
+theme stylesheet with the other samples through `examples/shared/`.
+The UniDic zip (~52 MB) is fetched from
+`examples/dict/lindera-unidic.zip` (one level up from this sample)
+so multiple samples can share the same cached dictionary.

--- a/laurus-wasm/examples/basic/README_ja.md
+++ b/laurus-wasm/examples/basic/README_ja.md
@@ -1,0 +1,46 @@
+# 基本的なハイブリッド検索サンプル
+
+laurus-wasm を使用したブラウザ上での日本語全文検索・ベクトル検索・
+ハイブリッド検索を実演するシングルページアプリケーションです。
+OPFS によるデータ永続化により、ページリロード後もデータが保持されます。
+
+サンプル一覧と共通のビルド手順は [examples README](../README_ja.md)
+を参照してください。最短手順は次の通りです。
+
+```bash
+cd laurus-wasm
+wasm-pack build --target web --dev
+./scripts/postbuild.sh
+
+# UniDic zip を examples/dict/lindera-unidic.zip に配置してから、
+# 任意の HTTP サーバーで配信します:
+python3 -m http.server 8080
+
+# ブラウザで http://localhost:8080/examples/basic/ を開きます。
+```
+
+## このサンプルでできること
+
+- OPFS 永続化ストレージを使用した検索インデックスを作成
+  （ページリロード後もデータが保持されます）
+- 初回アクセス時に 8 件のサンプルドキュメントを投入。
+  既存データが OPFS にある場合はロードのみ
+- Transformers.js（`paraphrase-multilingual-MiniLM-L12-v2`）による
+  384 次元セマンティック Embedding をコールバック Embedder 経由で
+  自動生成
+- 統合クエリ DSL 対応の検索ボックス:
+  - Lexical 検索: `rust`、`title:wasm`、`"memory safety"`
+  - Vector 検索: `embedding:"how to make code faster"`、
+    `embedding:python`
+  - Hybrid 検索: `rust embedding:"systems programming"`
+- 新しいドキュメントをインタラクティブに追加可能
+- 関連度スコア付きの検索結果を表示
+- すべての操作をコンソールパネルにログ出力
+
+## ファイル構成
+
+このサンプルは `examples/shared/` を経由して、辞書ローダー・
+Embedder・ログヘルパ・テーマスタイルを他のサンプルと共有しています。
+UniDic zip（約 52 MB）は `examples/dict/lindera-unidic.zip`（この
+サンプルから見て一階層上）から取得されるため、複数のサンプルで
+同じキャッシュ辞書を共有できます。

--- a/laurus-wasm/examples/basic/index.html
+++ b/laurus-wasm/examples/basic/index.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Laurus WASM — Basic Hybrid Search</title>
+  <link rel="stylesheet" href="../shared/theme.css">
+</head>
+<body>
+  <div class="container">
+    <p class="subtitle"><a href="../">&larr; All samples</a></p>
+
+    <h1>Basic Hybrid Search</h1>
+    <p class="subtitle">Japanese morphological search in the browser (OPFS persistent storage)</p>
+
+    <!-- Status -->
+    <div class="card">
+      <h2>Engine <span id="status" class="badge badge-loading">loading...</span></h2>
+      <div class="stats">
+        <div>Documents: <span id="doc-count">0</span></div>
+        <div>Analyzer: <span id="analyzer-mode">loading...</span></div>
+        <div>Embedder: <span id="embed-dim">loading...</span></div>
+        <div>Storage: <span id="storage-mode">OPFS</span></div>
+      </div>
+      <p class="dsl-hint">
+        On first visit the demo fetches the UniDic dictionary
+        (~52 MB) and the multilingual MiniLM embedding model
+        (~120 MB). Both are cached for offline reuse.
+      </p>
+    </div>
+
+    <!-- Search -->
+    <div class="card">
+      <h2>Search — Unified Query DSL</h2>
+      <p class="dsl-hint">
+        Lexical: <code>形態素</code> <code>title:検索</code> <code>"日本語"</code> &nbsp;
+        Vector: <code>embedding:"ブラウザで動く検索"</code> &nbsp;
+        Hybrid: <code>形態素 embedding:"日本語の検索"</code>
+      </p>
+      <div class="search-box">
+        <input type="text" id="query" placeholder='例: 形態素 / title:検索 / "日本語"' disabled>
+        <button id="search-btn" disabled>Search</button>
+      </div>
+      <ul class="results" id="results">
+        <li class="empty">Index some documents first, then search.</li>
+      </ul>
+    </div>
+
+    <!-- Maintenance -->
+    <div class="card">
+      <h2>Maintenance</h2>
+      <p class="dsl-hint">
+        Delete persisted state if you have stale data from a previous
+        demo version (for example, an older schema with a different
+        vector dimensionality). Reloads the page after clearing.
+      </p>
+      <div class="row">
+        <button id="reset-index-btn" class="secondary" type="button" disabled>Reset index</button>
+        <button id="reset-all-btn" class="secondary" type="button" disabled>Reset everything (index + dictionary)</button>
+      </div>
+    </div>
+
+    <!-- Add Document -->
+    <div class="card">
+      <h2>Add Document</h2>
+      <div class="add-form">
+        <div class="row">
+          <div class="field">
+            <label>ID</label>
+            <input type="text" id="doc-id" placeholder="doc1" disabled>
+          </div>
+          <div class="field">
+            <label>Title</label>
+            <input type="text" id="doc-title" placeholder="WebAssembly 入門" disabled>
+          </div>
+        </div>
+        <div>
+          <label>Body</label>
+          <textarea id="doc-body" placeholder="WebAssembly はブラウザで動作するバイナリ命令フォーマットです。" disabled></textarea>
+        </div>
+        <div class="row">
+          <button id="add-btn" disabled>Add &amp; Commit</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Log -->
+    <div class="card">
+      <h2>Log</h2>
+      <div class="log" id="log"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import init, { Index, Schema } from '../../pkg/laurus_wasm.js';
+    import { createLogger } from '../shared/log.js';
+    import {
+      ANALYZER_NAME,
+      buildJapaneseAnalyzer,
+      clearDictionary,
+      DICT_NAME,
+      ensureDictionary,
+    } from '../shared/dictionary.js';
+    import { EMBED_DIM, EMBEDDER_NAME, loadEmbedder } from '../shared/embedder.js';
+
+    /**
+     * OPFS directory holding the persisted index. If a returning
+     * visitor sees stale or empty results after a schema or analyzer
+     * change, the Reset buttons below clear this directory.
+     */
+    const INDEX_NAME = 'ja-demo-index';
+    const EMBED_FIELD = 'embedding';
+
+    const logger = createLogger('log');
+    const statusEl = document.getElementById('status');
+    const docCountEl = document.getElementById('doc-count');
+
+    let index = null;
+    let docCounter = 0;
+
+    async function boot() {
+      try {
+        logger.log('Initializing WASM module...');
+        const t0 = performance.now();
+        await init();
+        logger.ok(`WASM module loaded in ${((performance.now() - t0) / 1000).toFixed(1)}s.`);
+
+        await ensureDictionary({
+          logger,
+          setStatus: (text) => {
+            statusEl.textContent = text;
+          },
+        });
+
+        const embed = await loadEmbedder({ logger });
+        document.getElementById('embed-dim').textContent =
+          `${EMBED_DIM}-dim multilingual MiniLM`;
+
+        const analyzer = await buildJapaneseAnalyzer({ mode: 'normal' });
+        logger.ok('JapaneseAnalyzer built from OPFS-loaded UniDic.');
+        document.getElementById('analyzer-mode').textContent =
+          'JapaneseAnalyzer (UniDic)';
+
+        const schema = new Schema();
+        schema.addAnalyzer(ANALYZER_NAME, analyzer);
+        schema.addTextField('title', undefined, undefined, undefined, ANALYZER_NAME);
+        schema.addTextField('body', undefined, undefined, undefined, ANALYZER_NAME);
+        schema.addEmbedder(EMBEDDER_NAME, {
+          type: 'callback',
+          embed,
+        });
+        schema.addHnswField(
+          EMBED_FIELD,
+          EMBED_DIM,
+          undefined,
+          undefined,
+          undefined,
+          EMBEDDER_NAME,
+        );
+        schema.setDefaultFields(['title', 'body']);
+        logger.log(
+          `Schema: title + body (analyzer="${ANALYZER_NAME}"), `
+          + `${EMBED_FIELD} (HNSW, ${EMBED_DIM}-dim, embedder="${EMBEDDER_NAME}").`,
+        );
+
+        index = await Index.open(INDEX_NAME, schema);
+        logger.ok(`OPFS index "${INDEX_NAME}" opened.`);
+
+        const stats = index.stats();
+        docCounter = stats.documentCount;
+
+        if (docCounter > 0) {
+          logger.ok(
+            `Loaded ${docCounter} document(s) from OPFS — persisted from previous session.`,
+          );
+        } else {
+          const samples = [
+            { id: 'wasm-core', title: 'WebAssembly コア仕様', body: 'WebAssembly はスタックベース仮想マシン向けのバイナリ命令フォーマットで、ブラウザでネイティブに近い性能を発揮します。' },
+            { id: 'wasm-pack', title: 'wasm-pack ビルドツール', body: 'wasm-pack は Rust 製の WebAssembly パッケージのビルドと公開を支援します。npm との連携やバンドラ統合に対応しています。' },
+            { id: 'wasm-bindgen', title: 'wasm-bindgen 連携', body: 'wasm-bindgen は WebAssembly と JavaScript の双方向呼び出しを支えるツールで、DOM API やクロージャの橋渡しを自動生成します。' },
+            { id: 'opfs', title: 'OPFS 永続化ストレージ', body: 'Origin Private File System はブラウザ内で WebAssembly アプリ向けに高速かつ永続的なストレージを提供します。' },
+            { id: 'lindera', title: 'Lindera 形態素解析', body: 'Lindera は Rust 製の形態素解析ライブラリで、UniDic や IPADIC、ko-dic、cc-cedict を用いた日本語・韓国語・中国語の解析に対応します。' },
+            { id: 'unidic', title: 'UniDic 辞書', body: 'UniDic は国立国語研究所が整備する日本語形態素解析辞書で、短単位処理に基づく一貫した語形・品詞情報を提供します。' },
+            { id: 'laurus', title: 'Laurus 検索エンジン', body: 'Laurus は Rust で実装された統合検索ライブラリで、転置索引による全文検索と HNSW などのベクトル検索を組み合わせたハイブリッド検索を提供します。' },
+            { id: 'simd', title: 'WASM SIMD 命令', body: 'WebAssembly SIMD は 128 ビットのベクトル演算命令を追加し、画像処理や機械学習の推論を高速化します。' },
+          ];
+
+          logger.log('Indexing sample documents (embedding auto-computed by engine)...');
+          for (const doc of samples) {
+            await index.putDocument(doc.id, {
+              title: doc.title,
+              body: doc.body,
+              [EMBED_FIELD]: `${doc.title} ${doc.body}`,
+            });
+            docCounter++;
+          }
+          await index.commit();
+          logger.ok(`Indexed ${samples.length} documents and persisted to OPFS.`);
+        }
+
+        docCountEl.textContent = docCounter;
+        statusEl.textContent = 'ready';
+        statusEl.className = 'badge badge-ready';
+
+        for (const el of document.querySelectorAll('input, textarea, button')) {
+          el.disabled = false;
+        }
+        document.getElementById('doc-id').value = `doc${docCounter + 1}`;
+      } catch (e) {
+        logger.err(`Error: ${e}`);
+        statusEl.textContent = 'error';
+        statusEl.className = 'badge badge-error';
+        console.error(e);
+      }
+    }
+
+    async function doSearch() {
+      const query = document.getElementById('query').value.trim();
+      if (!query) {
+        return;
+      }
+
+      const resultsEl = document.getElementById('results');
+      try {
+        const t0 = performance.now();
+        const results = await index.search(query);
+        const elapsed = (performance.now() - t0).toFixed(1);
+
+        logger.log(`"${query}" -> ${results.length} hit(s) in ${elapsed}ms`);
+
+        if (results.length === 0) {
+          resultsEl.innerHTML = '<li class="empty">No results found.</li>';
+          return;
+        }
+
+        resultsEl.innerHTML = results
+          .map((r) => `
+            <li>
+              <div class="meta">
+                <span class="score">${r.score.toFixed(4)}</span>
+              </div>
+              <div class="title">${escapeHtml(r.document?.title ?? r.id)}</div>
+              <div class="body">${escapeHtml(r.document?.body ?? '')}</div>
+            </li>
+          `)
+          .join('');
+      } catch (e) {
+        logger.err(`Search error: ${e}`);
+        console.error(e);
+      }
+    }
+
+    async function addDocument() {
+      const id = document.getElementById('doc-id').value.trim();
+      const title = document.getElementById('doc-title').value.trim();
+      const body = document.getElementById('doc-body').value.trim();
+
+      if (!id || !title) {
+        logger.err('ID and Title are required.');
+        return;
+      }
+
+      try {
+        await index.putDocument(id, {
+          title,
+          body,
+          [EMBED_FIELD]: `${title} ${body}`,
+        });
+        await index.commit();
+        docCounter++;
+
+        docCountEl.textContent = docCounter;
+        logger.ok(`Added "${title}" (${id}) — embedding auto-computed`);
+
+        document.getElementById('doc-id').value = `doc${docCounter + 1}`;
+        document.getElementById('doc-title').value = '';
+        document.getElementById('doc-body').value = '';
+      } catch (e) {
+        logger.err(`Add error: ${e}`);
+        console.error(e);
+      }
+    }
+
+    const KNOWN_INDEX_NAMES = [INDEX_NAME];
+
+    async function deleteAllIndexes() {
+      const root = await navigator.storage.getDirectory();
+      for (const name of KNOWN_INDEX_NAMES) {
+        try {
+          await root.removeEntry(name, { recursive: true });
+          logger.ok(`Removed OPFS index "${name}".`);
+        } catch (e) {
+          if (e?.name !== 'NotFoundError') {
+            logger.err(`Failed to remove "${name}": ${e}`);
+          }
+        }
+      }
+    }
+
+    async function resetIndex() {
+      if (!confirm(
+        'Delete the persisted index and reload? '
+        + 'UniDic and the embedding model stay cached.',
+      )) {
+        return;
+      }
+      try {
+        await deleteAllIndexes();
+        logger.ok('Index reset complete. Reloading...');
+        setTimeout(() => location.reload(), 250);
+      } catch (e) {
+        logger.err(`Reset failed: ${e}`);
+        console.error(e);
+      }
+    }
+
+    async function resetAll() {
+      if (!confirm(
+        'Delete the index AND the UniDic dictionary, then reload? '
+        + 'The ~52 MB dictionary will re-download on next visit.',
+      )) {
+        return;
+      }
+      try {
+        await deleteAllIndexes();
+        if (await clearDictionary()) {
+          logger.ok(`Removed OPFS dictionary "${DICT_NAME}".`);
+        }
+        logger.ok('Full reset complete. Reloading...');
+        setTimeout(() => location.reload(), 250);
+      } catch (e) {
+        logger.err(`Reset failed: ${e}`);
+        console.error(e);
+      }
+    }
+
+    function escapeHtml(str) {
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
+
+    document.getElementById('search-btn').addEventListener('click', doSearch);
+    document.getElementById('query').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        doSearch();
+      }
+    });
+    document.getElementById('add-btn').addEventListener('click', addDocument);
+    document.getElementById('reset-index-btn').addEventListener('click', resetIndex);
+    document.getElementById('reset-all-btn').addEventListener('click', resetAll);
+
+    boot();
+  </script>
+</body>
+</html>

--- a/laurus-wasm/examples/geo/README.md
+++ b/laurus-wasm/examples/geo/README.md
@@ -1,0 +1,71 @@
+# Geo Search Sample
+
+A single-page application that combines lexical, vector, and
+geographic queries on top of laurus-wasm. Tokyo points-of-interest
+are plotted on a [Leaflet](https://leafletjs.com/) map; you can
+search them with text, embeddings, and a viewport-driven
+bounding-box constraint.
+
+See the [examples README](../README.md) for the full list of samples
+and the shared build instructions. The shortest path:
+
+```bash
+cd laurus-wasm
+wasm-pack build --target web --dev
+./scripts/postbuild.sh
+
+# Make the UniDic zip available at examples/dict/lindera-unidic.zip,
+# then serve from any HTTP server:
+python3 -m http.server 8080
+
+# Open http://localhost:8080/examples/geo/ in your browser.
+```
+
+## What this sample demonstrates
+
+- An OPFS-persistent geo index (`geo-demo-index-v1`) seeded with
+  ~14 Tokyo points-of-interest on first visit
+- A schema with three Japanese-tokenised text fields
+  (`title`, `description`, `category`), one geo field
+  (`location` — indexed via the BKD tree) and one HNSW vector field
+  (`embedding`, 384-dim multilingual MiniLM)
+- A search box that builds a unified DSL string. With *Restrict to
+  current map view* turned on, the user query is wrapped in
+  parentheses and AND-combined with
+  `location:geo_bbox(min_lat, min_lon, max_lat, max_lon)` derived
+  from the current Leaflet bounds
+- A clickable result list that pans the map and opens the popup of
+  the corresponding marker
+
+### Example queries
+
+| Toggle | Query | What it does |
+| --- | --- | --- |
+| ON | (empty) | Returns every point inside the current viewport. |
+| ON | `公園` | Lexical match on `公園` AND inside the viewport. |
+| ON | `embedding:"夜景がきれい"` | Semantic match AND inside the viewport. |
+| OFF | `title:浅草寺` | Pure lexical match across the entire dataset. |
+| OFF | `embedding:"街並みが歴史的"` | Pure semantic match across the entire dataset. |
+
+## Layout
+
+This sample shares the dictionary loader, embedder, log helper,
+and theme stylesheet with the other samples through
+`examples/shared/`. Leaflet itself is loaded from
+[`unpkg.com`][unpkg] with subresource integrity hashes; an offline
+build needs to vendor the assets locally.
+
+The OPFS dictionary key (`unidic`) is shared with the basic
+sample, so the ~52 MB UniDic zip is downloaded only once across
+samples.
+
+[unpkg]: https://unpkg.com/leaflet@1.9.4/
+
+## Caveats
+
+- Map tiles are fetched from OpenStreetMap. The browser must be
+  online for tiles to render even though laurus itself runs locally.
+- The `geo_bbox(...)` clause uses the wrapping latitude/longitude of
+  the current Leaflet view. Around the antimeridian (longitude
+  ±180°), the bbox is *not* unwrapped — Tokyo data is far enough
+  from the seam that this does not matter for the demo.

--- a/laurus-wasm/examples/geo/README_ja.md
+++ b/laurus-wasm/examples/geo/README_ja.md
@@ -1,0 +1,72 @@
+# 位置情報検索サンプル
+
+laurus-wasm 上で全文検索・ベクトル検索・地理空間検索を組み合わせる
+シングルページアプリです。東京の観光スポットを
+[Leaflet](https://leafletjs.com/) の地図にプロットし、テキスト・
+Embedding・地図ビューポートから生成した bbox（境界矩形）で絞り
+込めます。
+
+サンプル一覧と共通のビルド手順は
+[examples README](../README_ja.md) を参照してください。最短手順は
+次の通りです。
+
+```bash
+cd laurus-wasm
+wasm-pack build --target web --dev
+./scripts/postbuild.sh
+
+# UniDic zip を examples/dict/lindera-unidic.zip に配置してから、
+# 任意の HTTP サーバーで配信します:
+python3 -m http.server 8080
+
+# ブラウザで http://localhost:8080/examples/geo/ を開きます。
+```
+
+## このサンプルでできること
+
+- OPFS 永続化された geo インデックス（`geo-demo-index-v1`）を
+  作成し、初回アクセス時に東京の観光スポット約 14 件を投入します
+- スキーマは日本語形態素解析対応のテキストフィールド 3 種
+  （`title`、`description`、`category`）、geo フィールド 1 種
+  （`location` — BKD ツリーでインデックス化）、HNSW ベクトル
+  フィールド 1 種（`embedding`、multilingual MiniLM 384 次元）
+- 検索ボックスは統合クエリ DSL の文字列を生成します。
+  *Restrict to current map view* が ON のとき、入力クエリは括弧で
+  囲まれ、現在の Leaflet ビューから生成した
+  `location:geo_bbox(min_lat, min_lon, max_lat, max_lon)` と AND
+  結合されます
+- 結果リストの項目をクリックすると、地図上の該当マーカーが
+  展開され、ビューがそのマーカーへパンします
+
+### クエリ例
+
+| トグル | クエリ | 動作 |
+| --- | --- | --- |
+| ON | （空欄） | 現在のビューポート内の全ポイントを返します。 |
+| ON | `公園` | `公園` の語彙マッチ AND ビューポート内 |
+| ON | `embedding:"夜景がきれい"` | 意味マッチ AND ビューポート内 |
+| OFF | `title:浅草寺` | データセット全体に対する純粋な語彙マッチ |
+| OFF | `embedding:"街並みが歴史的"` | データセット全体に対する純粋な意味マッチ |
+
+## ファイル構成
+
+このサンプルは `examples/shared/` を経由して、辞書ローダー・
+Embedder・ログヘルパ・テーマスタイルを他のサンプルと共有します。
+Leaflet 本体は SRI ハッシュ付きで [`unpkg.com`][unpkg] から取得
+しています。オフラインビルドを行う場合はアセットをローカルに
+配置してください。
+
+OPFS の辞書キー（`unidic`）は basic サンプルと共有しているため、
+約 52 MB の UniDic zip はサンプルをまたいでも 1 回しかダウンロード
+されません。
+
+[unpkg]: https://unpkg.com/leaflet@1.9.4/
+
+## 注意事項
+
+- 地図タイルは OpenStreetMap から取得します。laurus 本体はローカル
+  で動作しますが、地図描画にはネットワーク接続が必要です。
+- `geo_bbox(...)` には現在の Leaflet ビューの緯度経度がそのまま
+  渡されます。経度 ±180° の境界線（日付変更線）はラップされません
+  が、東京のデータでは境界から十分離れているため本デモでは問題に
+  なりません。

--- a/laurus-wasm/examples/geo/index.html
+++ b/laurus-wasm/examples/geo/index.html
@@ -1,0 +1,578 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Laurus WASM — Geo Search Sample</title>
+  <link rel="stylesheet"
+        href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+        crossorigin="anonymous">
+  <link rel="stylesheet" href="../shared/theme.css">
+  <style>
+    .map-card {
+      padding: 0;
+      overflow: hidden;
+    }
+    #map {
+      width: 100%;
+      height: 420px;
+    }
+    .leaflet-container {
+      background: var(--code-bg);
+    }
+    .leaflet-popup-content-wrapper,
+    .leaflet-popup-tip {
+      background: var(--surface);
+      color: var(--text);
+    }
+    .leaflet-popup-content {
+      font-size: 0.85rem;
+    }
+    .leaflet-control-attribution {
+      background: rgba(15, 17, 23, 0.85) !important;
+      color: var(--muted) !important;
+    }
+    .leaflet-control-attribution a {
+      color: var(--accent) !important;
+    }
+  </style>
+</head>
+<body>
+  <div class="container container-wide">
+    <p class="subtitle"><a href="../">&larr; All samples</a></p>
+
+    <h1>Geo Search Sample</h1>
+    <p class="subtitle">
+      Tokyo points-of-interest with map-driven bounding-box search
+      combined with Japanese full-text and embedding queries.
+    </p>
+
+    <!-- Status -->
+    <div class="card">
+      <h2>Engine <span id="status" class="badge badge-loading">loading...</span></h2>
+      <div class="stats">
+        <div>Documents: <span id="doc-count">0</span></div>
+        <div>Analyzer: <span id="analyzer-mode">loading...</span></div>
+        <div>Embedder: <span id="embed-dim">loading...</span></div>
+        <div>Storage: <span id="storage-mode">OPFS</span></div>
+      </div>
+      <p class="dsl-hint">
+        On first visit the demo fetches the UniDic dictionary
+        (~52 MB) and the multilingual MiniLM embedding model
+        (~120 MB). Both are cached for offline reuse and shared with
+        the basic sample.
+      </p>
+    </div>
+
+    <!-- Map -->
+    <div class="card map-card">
+      <div id="map"></div>
+    </div>
+
+    <!-- Search -->
+    <div class="card">
+      <h2>Search</h2>
+      <p class="dsl-hint">
+        Text input is wrapped in the unified DSL. Examples:
+        <code>東京</code> <code>title:浅草寺</code>
+        <code>embedding:"夜景がきれいなスポット"</code>.
+        Toggle <em>Restrict to map view</em> to AND the query with a
+        <code>location:geo_bbox(...)</code> clause derived from the
+        current map viewport.
+      </p>
+      <div class="search-box">
+        <input type="text" id="query" placeholder="例: 公園 / 浅草 / embedding:&quot;夜景&quot;" disabled>
+        <button id="search-btn" disabled>Search</button>
+      </div>
+      <div class="row" style="margin-bottom: 0.5rem;">
+        <label class="toggle">
+          <input type="checkbox" id="restrict-bbox" checked disabled>
+          Restrict to current map view
+          (<code>location:geo_bbox(...)</code>)
+        </label>
+      </div>
+      <ul class="results" id="results">
+        <li class="empty">Loading sample data…</li>
+      </ul>
+    </div>
+
+    <!-- Maintenance -->
+    <div class="card">
+      <h2>Maintenance</h2>
+      <p class="dsl-hint">
+        Delete persisted state if you have stale data from a
+        previous demo version. Reloads the page after clearing.
+      </p>
+      <div class="row">
+        <button id="reset-index-btn" class="secondary" type="button" disabled>Reset geo index</button>
+        <button id="reset-all-btn" class="secondary" type="button" disabled>Reset everything (index + dictionary)</button>
+      </div>
+    </div>
+
+    <!-- Log -->
+    <div class="card">
+      <h2>Log</h2>
+      <div class="log" id="log"></div>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+          integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+          crossorigin="anonymous"></script>
+
+  <script type="module">
+    import init, { Index, Schema } from '../../pkg/laurus_wasm.js';
+    import { createLogger } from '../shared/log.js';
+    import {
+      ANALYZER_NAME,
+      buildJapaneseAnalyzer,
+      clearDictionary,
+      DICT_NAME,
+      ensureDictionary,
+    } from '../shared/dictionary.js';
+    import { EMBED_DIM, EMBEDDER_NAME, loadEmbedder } from '../shared/embedder.js';
+
+    /**
+     * OPFS directory holding the persisted geo index. Reset buttons
+     * below clear this directory if a schema or analyzer change
+     * makes the persisted shape incompatible.
+     */
+    const INDEX_NAME = 'geo-demo-index';
+    const LOCATION_FIELD = 'location';
+    const EMBED_FIELD = 'embedding';
+
+    /** Initial Tokyo points-of-interest seeded on first visit. */
+    const SAMPLES = [
+      {
+        id: 'tokyo-station',
+        title: '東京駅',
+        description: '赤レンガ造りの丸の内駅舎で知られる、首都圏の代表的なターミナル駅。',
+        category: '駅',
+        lat: 35.6812,
+        lon: 139.7671,
+      },
+      {
+        id: 'imperial-palace',
+        title: '皇居外苑',
+        description: '江戸城跡に整備された広大な公園。二重橋や芝生の広場が観光名所。',
+        category: '公園',
+        lat: 35.6852,
+        lon: 139.7528,
+      },
+      {
+        id: 'sensoji',
+        title: '浅草寺',
+        description: '雷門と仲見世通りで有名な、東京最古の寺院。下町情緒を味わえる。',
+        category: '寺社',
+        lat: 35.7148,
+        lon: 139.7967,
+      },
+      {
+        id: 'tokyo-skytree',
+        title: '東京スカイツリー',
+        description: '高さ634mの電波塔。展望デッキからは東京の夜景が一望できる。',
+        category: '展望',
+        lat: 35.7101,
+        lon: 139.8107,
+      },
+      {
+        id: 'ueno-park',
+        title: '上野恩賜公園',
+        description: '美術館や動物園が集まる広大な公園。春は桜の名所として賑わう。',
+        category: '公園',
+        lat: 35.7156,
+        lon: 139.7745,
+      },
+      {
+        id: 'akihabara',
+        title: '秋葉原電気街',
+        description: '電気店やアニメショップが密集する、世界的に有名なオタク文化の中心地。',
+        category: '商店街',
+        lat: 35.7022,
+        lon: 139.7745,
+      },
+      {
+        id: 'shinjuku-gyoen',
+        title: '新宿御苑',
+        description: '日本庭園・イギリス風景式庭園・フランス式整形庭園が共存する都心の庭園。',
+        category: '公園',
+        lat: 35.6852,
+        lon: 139.7100,
+      },
+      {
+        id: 'shibuya-scramble',
+        title: '渋谷スクランブル交差点',
+        description: '一度に最大3000人が行き交う、世界で最も有名な交差点のひとつ。',
+        category: '街並み',
+        lat: 35.6595,
+        lon: 139.7005,
+      },
+      {
+        id: 'meiji-jingu',
+        title: '明治神宮',
+        description: '原宿駅前の鎮守の杜に鎮座する、明治天皇と昭憲皇太后を祀る神社。',
+        category: '寺社',
+        lat: 35.6764,
+        lon: 139.6993,
+      },
+      {
+        id: 'roppongi-hills',
+        title: '六本木ヒルズ',
+        description: 'オフィス・住居・美術館・展望台が一体となった複合再開発地区。',
+        category: '展望',
+        lat: 35.6604,
+        lon: 139.7292,
+      },
+      {
+        id: 'tokyo-tower',
+        title: '東京タワー',
+        description: '芝公園にそびえる赤と白の電波塔。夜のライトアップが観光名物。',
+        category: '展望',
+        lat: 35.6586,
+        lon: 139.7454,
+      },
+      {
+        id: 'tsukiji',
+        title: '築地場外市場',
+        description: '寿司や海鮮丼の名店が並ぶ食の街。豊洲移転後も賑わいを保つ。',
+        category: '市場',
+        lat: 35.6654,
+        lon: 139.7707,
+      },
+      {
+        id: 'odaiba',
+        title: 'お台場海浜公園',
+        description: '東京湾を一望できるベイエリアの公園。レインボーブリッジの夜景が見どころ。',
+        category: '公園',
+        lat: 35.6298,
+        lon: 139.7745,
+      },
+      {
+        id: 'ginza',
+        title: '銀座中央通り',
+        description: '高級百貨店やブランド旗艦店が並ぶ、東京を代表する商業エリア。',
+        category: '商店街',
+        lat: 35.6717,
+        lon: 139.7650,
+      },
+    ];
+
+    const logger = createLogger('log');
+    const statusEl = document.getElementById('status');
+    const docCountEl = document.getElementById('doc-count');
+    const resultsEl = document.getElementById('results');
+    const restrictEl = document.getElementById('restrict-bbox');
+
+    let index = null;
+    /** @type {L.Map | null} */
+    let map = null;
+    /** @type {Map<string, L.Marker>} */
+    const markers = new Map();
+
+    function escapeHtml(str) {
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
+
+    /**
+     * Compute the great-circle distance (meters) between two
+     * lat/lon pairs using the haversine formula. Used only for
+     * displaying the distance from the map centre alongside each
+     * result; the actual filtering happens in the index.
+     */
+    function haversineMeters(a, b) {
+      const R = 6_371_000;
+      const phi1 = (a.lat * Math.PI) / 180;
+      const phi2 = (b.lat * Math.PI) / 180;
+      const dPhi = ((b.lat - a.lat) * Math.PI) / 180;
+      const dLambda = ((b.lon - a.lon) * Math.PI) / 180;
+      const h =
+        Math.sin(dPhi / 2) ** 2
+        + Math.cos(phi1) * Math.cos(phi2) * Math.sin(dLambda / 2) ** 2;
+      return 2 * R * Math.asin(Math.sqrt(h));
+    }
+
+    function initMap() {
+      map = L.map('map', { preferCanvas: false }).setView([35.682, 139.766], 12);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      }).addTo(map);
+
+      for (const doc of SAMPLES) {
+        const marker = L.marker([doc.lat, doc.lon])
+          .addTo(map)
+          .bindPopup(
+            `<strong>${escapeHtml(doc.title)}</strong><br>`
+            + `<small>${escapeHtml(doc.category)}</small><br>`
+            + `${escapeHtml(doc.description)}`,
+          );
+        markers.set(doc.id, marker);
+      }
+    }
+
+    function highlightMarker(id) {
+      const marker = markers.get(id);
+      if (!marker) {
+        return;
+      }
+      marker.openPopup();
+      map.panTo(marker.getLatLng(), { animate: true });
+    }
+
+    /**
+     * Build a unified DSL query string. The text portion (if any)
+     * is left untouched so users can still write
+     * `title:...` / `embedding:"..."`. The bbox clause is appended
+     * with AND when the restrict-to-view toggle is on.
+     */
+    function buildQuery(rawText) {
+      const text = rawText.trim();
+      if (!restrictEl.checked) {
+        return text;
+      }
+      const bounds = map.getBounds();
+      const minLat = bounds.getSouth();
+      const maxLat = bounds.getNorth();
+      const minLon = bounds.getWest();
+      const maxLon = bounds.getEast();
+      const bboxClause =
+        `${LOCATION_FIELD}:geo_bbox(${minLat.toFixed(6)}, ${minLon.toFixed(6)}, `
+        + `${maxLat.toFixed(6)}, ${maxLon.toFixed(6)})`;
+      if (!text) {
+        return bboxClause;
+      }
+      return `(${text}) AND ${bboxClause}`;
+    }
+
+    async function doSearch() {
+      const text = document.getElementById('query').value;
+      const query = buildQuery(text);
+      if (!query) {
+        return;
+      }
+
+      try {
+        const t0 = performance.now();
+        const results = await index.search(query);
+        const elapsed = (performance.now() - t0).toFixed(1);
+        logger.log(`"${query}" -> ${results.length} hit(s) in ${elapsed}ms`);
+
+        if (results.length === 0) {
+          resultsEl.innerHTML = '<li class="empty">No results found in the current view.</li>';
+          return;
+        }
+
+        const center = map.getCenter();
+        resultsEl.innerHTML = results
+          .map((r) => {
+            const doc = r.document ?? {};
+            const lat = typeof doc.location?.lat === 'number' ? doc.location.lat : null;
+            const lon = typeof doc.location?.lon === 'number' ? doc.location.lon : null;
+            let extra = '';
+            if (lat !== null && lon !== null) {
+              const meters = haversineMeters({ lat: center.lat, lon: center.lng }, { lat, lon });
+              const km = (meters / 1000).toFixed(2);
+              extra = `${km} km from view centre`;
+            }
+            return `
+              <li class="clickable" data-id="${escapeHtml(r.id)}">
+                <div class="meta">
+                  <span class="score">${r.score.toFixed(4)}</span>
+                  <span class="extra">${escapeHtml(doc.category ?? '')} · ${escapeHtml(extra)}</span>
+                </div>
+                <div class="title">${escapeHtml(doc.title ?? r.id)}</div>
+                <div class="body">${escapeHtml(doc.description ?? '')}</div>
+              </li>
+            `;
+          })
+          .join('');
+
+        for (const li of resultsEl.querySelectorAll('li.clickable')) {
+          li.addEventListener('click', () => {
+            for (const el of resultsEl.querySelectorAll('li.active')) {
+              el.classList.remove('active');
+            }
+            li.classList.add('active');
+            highlightMarker(li.dataset.id);
+          });
+        }
+      } catch (e) {
+        logger.err(`Search error: ${e}`);
+        console.error(e);
+      }
+    }
+
+    async function boot() {
+      try {
+        initMap();
+
+        logger.log('Initializing WASM module...');
+        const t0 = performance.now();
+        await init();
+        logger.ok(`WASM module loaded in ${((performance.now() - t0) / 1000).toFixed(1)}s.`);
+
+        await ensureDictionary({
+          logger,
+          setStatus: (text) => {
+            statusEl.textContent = text;
+          },
+        });
+
+        const embed = await loadEmbedder({ logger });
+        document.getElementById('embed-dim').textContent =
+          `${EMBED_DIM}-dim multilingual MiniLM`;
+
+        const analyzer = await buildJapaneseAnalyzer({ mode: 'normal' });
+        logger.ok('JapaneseAnalyzer built from OPFS-loaded UniDic.');
+        document.getElementById('analyzer-mode').textContent =
+          'JapaneseAnalyzer (UniDic)';
+
+        const schema = new Schema();
+        schema.addAnalyzer(ANALYZER_NAME, analyzer);
+        schema.addTextField('title', undefined, undefined, undefined, ANALYZER_NAME);
+        schema.addTextField('description', undefined, undefined, undefined, ANALYZER_NAME);
+        schema.addTextField('category', undefined, undefined, undefined, ANALYZER_NAME);
+        schema.addGeoField(LOCATION_FIELD, true, true);
+        schema.addEmbedder(EMBEDDER_NAME, {
+          type: 'callback',
+          embed,
+        });
+        schema.addHnswField(
+          EMBED_FIELD,
+          EMBED_DIM,
+          undefined,
+          undefined,
+          undefined,
+          EMBEDDER_NAME,
+        );
+        schema.setDefaultFields(['title', 'description', 'category']);
+        logger.log(
+          `Schema: title + description + category (analyzer="${ANALYZER_NAME}"), `
+          + `${LOCATION_FIELD} (geo, indexed), `
+          + `${EMBED_FIELD} (HNSW, ${EMBED_DIM}-dim, embedder="${EMBEDDER_NAME}").`,
+        );
+
+        index = await Index.open(INDEX_NAME, schema);
+        logger.ok(`OPFS index "${INDEX_NAME}" opened.`);
+
+        const stats = index.stats();
+        let docCounter = stats.documentCount;
+
+        if (docCounter > 0) {
+          logger.ok(
+            `Loaded ${docCounter} document(s) from OPFS — persisted from previous session.`,
+          );
+        } else {
+          logger.log('Indexing Tokyo points-of-interest...');
+          for (const doc of SAMPLES) {
+            await index.putDocument(doc.id, {
+              title: doc.title,
+              description: doc.description,
+              category: doc.category,
+              [LOCATION_FIELD]: { lat: doc.lat, lon: doc.lon },
+              [EMBED_FIELD]: `${doc.title} ${doc.description} ${doc.category}`,
+            });
+            docCounter++;
+          }
+          await index.commit();
+          logger.ok(`Indexed ${SAMPLES.length} documents and persisted to OPFS.`);
+        }
+
+        docCountEl.textContent = docCounter;
+        statusEl.textContent = 'ready';
+        statusEl.className = 'badge badge-ready';
+
+        for (const el of document.querySelectorAll('input, button')) {
+          el.disabled = false;
+        }
+        resultsEl.innerHTML = '<li class="empty">Search to filter the points above.</li>';
+
+        await doSearch();
+      } catch (e) {
+        logger.err(`Error: ${e}`);
+        statusEl.textContent = 'error';
+        statusEl.className = 'badge badge-error';
+        console.error(e);
+      }
+    }
+
+    /**
+     * Index names that the geo demo has persisted. Listed
+     * explicitly so we can clean up legacy directories left over
+     * from earlier demo iterations.
+     */
+    const KNOWN_INDEX_NAMES = [INDEX_NAME];
+
+    async function deleteAllIndexes() {
+      const root = await navigator.storage.getDirectory();
+      for (const name of KNOWN_INDEX_NAMES) {
+        try {
+          await root.removeEntry(name, { recursive: true });
+          logger.ok(`Removed OPFS index "${name}".`);
+        } catch (e) {
+          if (e?.name !== 'NotFoundError') {
+            logger.err(`Failed to remove "${name}": ${e}`);
+          }
+        }
+      }
+    }
+
+    async function resetIndex() {
+      if (!confirm(
+        'Delete the persisted geo index and reload? '
+        + 'UniDic and the embedding model stay cached.',
+      )) {
+        return;
+      }
+      try {
+        await deleteAllIndexes();
+        logger.ok('Index reset complete. Reloading...');
+        setTimeout(() => location.reload(), 250);
+      } catch (e) {
+        logger.err(`Reset failed: ${e}`);
+        console.error(e);
+      }
+    }
+
+    async function resetAll() {
+      if (!confirm(
+        'Delete the geo index AND the UniDic dictionary, then reload? '
+        + 'The ~52 MB dictionary will re-download on next visit.',
+      )) {
+        return;
+      }
+      try {
+        await deleteAllIndexes();
+        if (await clearDictionary()) {
+          logger.ok(`Removed OPFS dictionary "${DICT_NAME}".`);
+        }
+        logger.ok('Full reset complete. Reloading...');
+        setTimeout(() => location.reload(), 250);
+      } catch (e) {
+        logger.err(`Reset failed: ${e}`);
+        console.error(e);
+      }
+    }
+
+    document.getElementById('search-btn').addEventListener('click', doSearch);
+    document.getElementById('query').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        doSearch();
+      }
+    });
+    document.getElementById('reset-index-btn').addEventListener('click', resetIndex);
+    document.getElementById('reset-all-btn').addEventListener('click', resetAll);
+    restrictEl.addEventListener('change', () => {
+      if (index) {
+        doSearch();
+      }
+    });
+
+    boot();
+  </script>
+</body>
+</html>

--- a/laurus-wasm/examples/index.html
+++ b/laurus-wasm/examples/index.html
@@ -3,648 +3,77 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Laurus WASM Search Demo</title>
-  <style>
-    :root {
-      --bg: #0f1117;
-      --surface: #1a1d27;
-      --border: #2a2d3a;
-      --text: #e1e4ed;
-      --muted: #8b8fa3;
-      --accent: #6c8aff;
-      --accent-hover: #8ba3ff;
-      --success: #4ade80;
-      --code-bg: #131620;
-    }
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-      background: var(--bg);
-      color: var(--text);
-      line-height: 1.6;
-      min-height: 100vh;
-    }
-    .container {
-      max-width: 800px;
-      margin: 0 auto;
-      padding: 2rem 1.5rem;
-    }
-    h1 {
-      font-size: 1.75rem;
-      font-weight: 600;
-      margin-bottom: 0.25rem;
-    }
-    .subtitle {
-      color: var(--muted);
-      margin-bottom: 2rem;
-    }
-    .card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 1.5rem;
-      margin-bottom: 1.5rem;
-    }
-    .card h2 {
-      font-size: 1rem;
-      font-weight: 600;
-      margin-bottom: 1rem;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-    .badge {
-      font-size: 0.7rem;
-      padding: 2px 8px;
-      border-radius: 999px;
-      font-weight: 500;
-    }
-    .badge-ready { background: #1a3a2a; color: var(--success); }
-    .badge-loading { background: #3a2a1a; color: #fbbf24; }
-    .search-box {
-      display: flex;
-      gap: 0.5rem;
-      margin-bottom: 0.75rem;
-    }
-    input[type="text"] {
-      flex: 1;
-      padding: 0.625rem 1rem;
-      background: var(--code-bg);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      color: var(--text);
-      font-size: 0.9rem;
-      outline: none;
-      transition: border-color 0.2s;
-    }
-    input[type="text"]:focus {
-      border-color: var(--accent);
-    }
-    button {
-      padding: 0.625rem 1.25rem;
-      background: var(--accent);
-      color: #fff;
-      border: none;
-      border-radius: 8px;
-      font-size: 0.9rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: background 0.2s;
-      white-space: nowrap;
-    }
-    button:hover { background: var(--accent-hover); }
-    button:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-    .results {
-      list-style: none;
-    }
-    .results li {
-      padding: 0.75rem 1rem;
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      margin-bottom: 0.5rem;
-      background: var(--code-bg);
-    }
-    .results li .meta {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-    .results li .score {
-      color: var(--accent);
-      font-size: 0.8rem;
-      font-weight: 500;
-    }
-    .results li .title {
-      font-weight: 600;
-    }
-    .results li .body {
-      color: var(--muted);
-      font-size: 0.85rem;
-      margin-top: 0.25rem;
-    }
-    .empty {
-      color: var(--muted);
-      text-align: center;
-      padding: 1rem;
-      font-size: 0.9rem;
-    }
-    .stats {
-      display: flex;
-      gap: 1.5rem;
-      color: var(--muted);
-      font-size: 0.85rem;
-    }
-    .stats span { color: var(--text); font-weight: 600; }
-    .add-form {
-      display: grid;
-      gap: 0.5rem;
-    }
-    .add-form .row {
-      display: flex;
-      gap: 0.5rem;
-    }
-    .add-form label {
-      font-size: 0.8rem;
-      color: var(--muted);
-      margin-bottom: 0.125rem;
-    }
-    .add-form .field {
-      flex: 1;
-    }
-    textarea {
-      width: 100%;
-      padding: 0.625rem 1rem;
-      background: var(--code-bg);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      color: var(--text);
-      font-size: 0.9rem;
-      font-family: inherit;
-      resize: vertical;
-      min-height: 60px;
-      outline: none;
-      transition: border-color 0.2s;
-    }
-    textarea:focus { border-color: var(--accent); }
-    .log {
-      font-family: 'SF Mono', 'Fira Code', monospace;
-      font-size: 0.8rem;
-      color: var(--muted);
-      background: var(--code-bg);
-      border-radius: 8px;
-      padding: 1rem;
-      max-height: 150px;
-      overflow-y: auto;
-      white-space: pre-wrap;
-      word-break: break-all;
-    }
-    .log .ok { color: var(--success); }
-    .log .err { color: #f87171; }
-    .dsl-hint {
-      color: var(--muted);
-      font-size: 0.8rem;
-      margin-bottom: 0.75rem;
-    }
-    .dsl-hint code {
-      background: var(--code-bg);
-      padding: 1px 5px;
-      border-radius: 4px;
-      font-size: 0.78rem;
-    }
-  </style>
+  <title>Laurus WASM — Samples</title>
+  <link rel="stylesheet" href="shared/theme.css">
 </head>
 <body>
   <div class="container">
-    <h1>Laurus WASM Search Demo</h1>
-    <p class="subtitle">Japanese morphological search in the browser (OPFS persistent storage)</p>
+    <h1>Laurus WASM Samples</h1>
+    <p class="subtitle">
+      Browser-side search built on the laurus-wasm package
+      (Rust → WebAssembly). Each sample below boots the engine
+      directly from <code>../pkg/</code>, persists data in OPFS, and
+      ships its own UI.
+    </p>
 
-    <!-- Status -->
     <div class="card">
-      <h2>Engine <span id="status" class="badge badge-loading">loading...</span></h2>
-      <div class="stats">
-        <div>Documents: <span id="doc-count">0</span></div>
-        <div>Analyzer: <span id="analyzer-mode">loading...</span></div>
-        <div>Embedder: <span id="embed-dim">loading...</span></div>
-        <div>Storage: <span id="storage-mode">OPFS</span></div>
-      </div>
-      <p class="dsl-hint">
-        On first visit the demo fetches the IPADIC dictionary (~16 MB)
-        and the multilingual MiniLM embedding model (~120 MB). Both are
-        cached for offline reuse.
-      </p>
-    </div>
-
-    <!-- Search -->
-    <div class="card">
-      <h2>Search — Unified Query DSL</h2>
-      <p class="dsl-hint">
-        Lexical: <code>形態素</code> <code>title:検索</code> <code>"日本語"</code> &nbsp;
-        Vector: <code>embedding:"ブラウザで動く検索"</code> &nbsp;
-        Hybrid: <code>形態素 embedding:"日本語の検索"</code>
-      </p>
-      <div class="search-box">
-        <input type="text" id="query" placeholder='例: 形態素 / title:検索 / "日本語"' disabled>
-        <button id="search-btn" onclick="doSearch()" disabled>Search</button>
-      </div>
-      <ul class="results" id="results">
-        <li class="empty">Index some documents first, then search.</li>
+      <h2>Available samples</h2>
+      <ul class="sample-list">
+        <li>
+          <a href="basic/">
+            <div class="sample-title">Basic Hybrid Search</div>
+            <div class="sample-summary">
+              Japanese morphological full-text search combined with
+              384-dim semantic embeddings. Add documents
+              interactively and query with the unified DSL
+              (<code>title:wasm</code>, <code>embedding:"…"</code>,
+              hybrid).
+            </div>
+          </a>
+        </li>
+        <li>
+          <a href="geo/">
+            <div class="sample-title">Geo Search (map + bbox + embedding)</div>
+            <div class="sample-summary">
+              Tokyo points-of-interest plotted on Leaflet. Combine a
+              bounding-box constraint
+              (<code>location:geo_bbox(...)</code>) drawn from the
+              current map viewport with text and vector queries.
+            </div>
+          </a>
+        </li>
       </ul>
     </div>
 
-    <!-- Maintenance -->
     <div class="card">
-      <h2>Maintenance</h2>
+      <h2>How to run locally</h2>
       <p class="dsl-hint">
-        Delete persisted state if you have stale data from a previous
-        demo version (for example, an older schema with a different
-        vector dimensionality). Reloads the page after clearing.
+        Each sample loads <code>../pkg/laurus_wasm.js</code> and
+        <code>../pkg/opfs.js</code>, so you have to build the WASM
+        package first. The browser also needs HTTP — opening the HTML
+        with <code>file://</code> will not work.
       </p>
-      <div class="row">
-        <button id="reset-index-btn" type="button" onclick="resetIndex()" disabled>Reset index</button>
-        <button id="reset-all-btn" type="button" onclick="resetAll()" disabled>Reset everything (index + dictionary)</button>
-      </div>
+      <pre class="log">cd laurus-wasm
+wasm-pack build --target web --dev
+./scripts/postbuild.sh
+
+# Place the UniDic zip at examples/dict/lindera-unidic.zip
+# (the deploy workflow does this for the published demo).
+
+python3 -m http.server 8080
+# Then open http://localhost:8080/examples/ in your browser.</pre>
     </div>
 
-    <!-- Add Document -->
     <div class="card">
-      <h2>Add Document</h2>
-      <div class="add-form">
-        <div class="row">
-          <div class="field">
-            <label>ID</label>
-            <input type="text" id="doc-id" placeholder="doc1" disabled>
-          </div>
-          <div class="field">
-            <label>Title</label>
-            <input type="text" id="doc-title" placeholder="WebAssembly 入門" disabled>
-          </div>
-        </div>
-        <div>
-          <label>Body</label>
-          <textarea id="doc-body" placeholder="WebAssembly はブラウザで動作するバイナリ命令フォーマットです。" disabled></textarea>
-        </div>
-        <div class="row">
-          <button id="add-btn" onclick="addDocument()" disabled>Add &amp; Commit</button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Log -->
-    <div class="card">
-      <h2>Log</h2>
-      <div class="log" id="log"></div>
+      <h2>Layout</h2>
+      <p class="dsl-hint">
+        Shared assets live in <code>shared/</code> and are imported
+        by every sample with relative paths
+        (<code>../shared/...</code>). The UniDic zip is fetched from
+        <code>../dict/lindera-unidic.zip</code> so all samples share
+        a single OPFS-cached dictionary.
+      </p>
     </div>
   </div>
-
-  <script type="module">
-    // ------------------------------------------------------------------
-    // Import and initialize laurus-wasm
-    // ------------------------------------------------------------------
-    // Adjust the path to point to your wasm-pack output:
-    //   wasm-pack build --target web --release
-    //   ./scripts/postbuild.sh
-    // Then serve this file from the laurus-wasm directory.
-    import init, { Index, Schema, JapaneseAnalyzer } from '../pkg/laurus_wasm.js';
-    import {
-      downloadDictionary,
-      hasDictionary,
-      loadDictionaryFiles,
-      removeDictionary,
-    } from '../pkg/opfs.js';
-    import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3';
-
-    /** Dictionary configuration. The zip is fetched from the same origin
-     *  to avoid CORS issues with cross-origin GitHub Releases assets. */
-    const DICT_NAME = 'ipadic';
-    const DICT_URL = './dict/lindera-ipadic.zip';
-    const ANALYZER_NAME = 'ja-ipadic';
-    /**
-     * Bump the suffix whenever the persisted schema changes (field
-     * dimensionality, vector index type, etc.). Without a bump,
-     * returning visitors hit "Dimension mismatch: stored N, config M"
-     * because Index.open replays an OPFS-persisted index whose stored
-     * shape no longer matches the schema. v2 covers the addition of
-     * the 384-dim HNSW embedding field on top of the v1 (lexical-only)
-     * shape introduced with the OPFS demo.
-     */
-    const INDEX_NAME = 'ja-demo-index-v2';
-
-    /** Multilingual MiniLM (paraphrase-multilingual-MiniLM-L12-v2) — 384-dim
-     *  text embeddings that work cleanly for both Japanese and English
-     *  without requiring per-call prefixes. The model is downloaded
-     *  through Hugging Face Transformers.js on first use and cached by
-     *  the browser. ~120 MB compressed. */
-    const EMBEDDER_NAME = 'multilingual-minilm';
-    const EMBED_FIELD = 'embedding';
-    const EMBED_DIM = 384;
-
-    let index = null;
-    let docCounter = 0;
-    let embedder = null;
-
-    // ------------------------------------------------------------------
-    // Logging
-    // ------------------------------------------------------------------
-    const logEl = document.getElementById('log');
-    function appendLog(msg, cls = '') {
-      const line = document.createElement('span');
-      line.className = cls;
-      line.textContent = msg + '\n';
-      logEl.appendChild(line);
-      logEl.scrollTop = logEl.scrollHeight;
-    }
-
-    /**
-     * Ensure the IPADIC dictionary is present in OPFS, downloading it
-     * from the bundled zip on first visit.
-     */
-    async function ensureDictionary() {
-      if (await hasDictionary(DICT_NAME)) {
-        appendLog(`Dictionary "${DICT_NAME}" found in OPFS cache.`, 'ok');
-        return;
-      }
-      appendLog(`Downloading dictionary "${DICT_NAME}" from ${DICT_URL}...`);
-      const t0 = performance.now();
-      await downloadDictionary(DICT_URL, DICT_NAME, {
-        onProgress: ({ phase, loaded, total }) => {
-          if (phase === 'downloading' && total) {
-            const pct = ((loaded / total) * 100).toFixed(0);
-            const mb = (loaded / 1024 / 1024).toFixed(1);
-            const totalMb = (total / 1024 / 1024).toFixed(1);
-            const status = document.getElementById('status');
-            status.textContent = `downloading ${pct}% (${mb}/${totalMb} MB)`;
-          } else if (phase === 'extracting') {
-            document.getElementById('status').textContent = 'extracting...';
-          } else if (phase === 'storing') {
-            document.getElementById('status').textContent = 'storing to OPFS...';
-          }
-        },
-      });
-      const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
-      appendLog(`Dictionary downloaded and cached in OPFS in ${elapsed}s.`, 'ok');
-    }
-
-    /**
-     * Load the multilingual MiniLM model via Transformers.js. The first
-     * call triggers a ~120 MB download that the browser caches.
-     */
-    async function ensureEmbedder() {
-      appendLog('Loading embedding model (paraphrase-multilingual-MiniLM-L12-v2)...');
-      const t0 = performance.now();
-      embedder = await pipeline(
-        'feature-extraction',
-        'Xenova/paraphrase-multilingual-MiniLM-L12-v2',
-      );
-      const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
-      appendLog(`Embedding model ready in ${elapsed}s.`, 'ok');
-      document.getElementById('embed-dim').textContent = `${EMBED_DIM}-dim multilingual MiniLM`;
-    }
-
-    // ------------------------------------------------------------------
-    // Boot
-    // ------------------------------------------------------------------
-    async function boot() {
-      try {
-        appendLog('Initializing WASM module...');
-        const t0 = performance.now();
-        await init();
-        const wasmTime = ((performance.now() - t0) / 1000).toFixed(1);
-        appendLog(`WASM module loaded in ${wasmTime}s.`, 'ok');
-
-        // 1. Make sure IPADIC bytes are available in OPFS.
-        await ensureDictionary();
-
-        // 2. Load the multilingual MiniLM model for query / passage
-        //    embeddings. The browser caches the model after first load.
-        await ensureEmbedder();
-
-        // 3. Read the eight dictionary files back as Uint8Arrays and
-        //    construct the JapaneseAnalyzer in WASM.
-        const files = await loadDictionaryFiles(DICT_NAME);
-        const ja = JapaneseAnalyzer.fromBytes(
-          files.metadata,
-          files.dictDa,
-          files.dictVals,
-          files.dictWordsIdx,
-          files.dictWords,
-          files.matrixMtx,
-          files.charDef,
-          files.unk,
-          'normal',
-        );
-        appendLog('JapaneseAnalyzer built from OPFS-loaded IPADIC.', 'ok');
-        document.getElementById('analyzer-mode').textContent = 'JapaneseAnalyzer (IPADIC)';
-
-        // 4. Build schema. title / body are tokenized with the
-        //    runtime-registered Japanese analyzer; embedding is an HNSW
-        //    vector field auto-populated by the callback embedder.
-        const schema = new Schema();
-        schema.addAnalyzer(ANALYZER_NAME, ja);
-        schema.addTextField('title', undefined, undefined, undefined, ANALYZER_NAME);
-        schema.addTextField('body', undefined, undefined, undefined, ANALYZER_NAME);
-        schema.addEmbedder(EMBEDDER_NAME, {
-          type: 'callback',
-          embed: async (text) => {
-            const out = await embedder(text, { pooling: 'mean', normalize: true });
-            return Array.from(out.data);
-          },
-        });
-        schema.addHnswField(EMBED_FIELD, EMBED_DIM, undefined, undefined, undefined, EMBEDDER_NAME);
-        schema.setDefaultFields(['title', 'body']);
-        appendLog(`Schema: title + body (analyzer="${ANALYZER_NAME}"), ${EMBED_FIELD} (HNSW, ${EMBED_DIM}-dim, embedder="${EMBEDDER_NAME}").`);
-
-        // 5. Open OPFS-persistent index (data survives page reloads).
-        index = await Index.open(INDEX_NAME, schema);
-        appendLog(`OPFS index "${INDEX_NAME}" opened.`, 'ok');
-
-        const stats = index.stats();
-        docCounter = stats.documentCount;
-
-        if (docCounter > 0) {
-          appendLog(`Loaded ${docCounter} document(s) from OPFS — persisted from previous session.`, 'ok');
-        } else {
-          // Seed with Japanese sample documents on first visit.
-          const samples = [
-            { id: 'wasm-core', title: 'WebAssembly コア仕様', body: 'WebAssembly はスタックベース仮想マシン向けのバイナリ命令フォーマットで、ブラウザでネイティブに近い性能を発揮します。' },
-            { id: 'wasm-pack', title: 'wasm-pack ビルドツール', body: 'wasm-pack は Rust 製の WebAssembly パッケージのビルドと公開を支援します。npm との連携やバンドラ統合に対応しています。' },
-            { id: 'wasm-bindgen', title: 'wasm-bindgen 連携', body: 'wasm-bindgen は WebAssembly と JavaScript の双方向呼び出しを支えるツールで、DOM API やクロージャの橋渡しを自動生成します。' },
-            { id: 'opfs', title: 'OPFS 永続化ストレージ', body: 'Origin Private File System はブラウザ内で WebAssembly アプリ向けに高速かつ永続的なストレージを提供します。' },
-            { id: 'lindera', title: 'Lindera 形態素解析', body: 'Lindera は Rust 製の形態素解析ライブラリで、IPADIC や ko-dic、cc-cedict を用いた日本語・韓国語・中国語の解析に対応します。' },
-            { id: 'ipadic', title: 'IPADIC 辞書', body: 'IPADIC は MeCab 由来の日本語形態素解析辞書で、品詞・読み・基本形といった豊富な語彙情報を提供します。' },
-            { id: 'laurus', title: 'Laurus 検索エンジン', body: 'Laurus は Rust で実装された統合検索ライブラリで、転置索引による全文検索と HNSW などのベクトル検索を組み合わせたハイブリッド検索を提供します。' },
-            { id: 'simd', title: 'WASM SIMD 命令', body: 'WebAssembly SIMD は 128 ビットのベクトル演算命令を追加し、画像処理や機械学習の推論を高速化します。' },
-          ];
-
-          appendLog('Indexing sample documents (embedding auto-computed by engine)...');
-          for (const doc of samples) {
-            // Pass text in the embedding field — the engine invokes the
-            // registered callback embedder during ingestion.
-            await index.putDocument(doc.id, {
-              title: doc.title,
-              body: doc.body,
-              [EMBED_FIELD]: `${doc.title} ${doc.body}`,
-            });
-            docCounter++;
-          }
-          await index.commit();
-          appendLog(`Indexed ${samples.length} documents and persisted to OPFS.`, 'ok');
-        }
-
-        document.getElementById('doc-count').textContent = docCounter;
-        document.getElementById('status').textContent = 'ready';
-        document.getElementById('status').className = 'badge badge-ready';
-
-        for (const el of document.querySelectorAll('input, textarea, button')) {
-          el.disabled = false;
-        }
-        document.getElementById('doc-id').value = `doc${docCounter + 1}`;
-
-      } catch (e) {
-        appendLog(`Error: ${e}`, 'err');
-        document.getElementById('status').textContent = 'error';
-        document.getElementById('status').className = 'badge';
-        document.getElementById('status').style.cssText = 'background:#3a1a1a;color:#f87171';
-        console.error(e);
-      }
-    }
-
-    // ------------------------------------------------------------------
-    // Search
-    // ------------------------------------------------------------------
-    window.doSearch = async function() {
-      const query = document.getElementById('query').value.trim();
-      if (!query) return;
-
-      const resultsEl = document.getElementById('results');
-
-      try {
-        const t0 = performance.now();
-        const results = await index.search(query);
-        const elapsed = (performance.now() - t0).toFixed(1);
-
-        appendLog(`"${query}" -> ${results.length} hit(s) in ${elapsed}ms`);
-
-        if (results.length === 0) {
-          resultsEl.innerHTML = '<li class="empty">No results found.</li>';
-          return;
-        }
-
-        resultsEl.innerHTML = results.map(r => `
-          <li>
-            <div class="meta">
-              <span class="score">${r.score.toFixed(4)}</span>
-            </div>
-            <div class="title">${escapeHtml(r.document?.title ?? r.id)}</div>
-            <div class="body">${escapeHtml(r.document?.body ?? '')}</div>
-          </li>
-        `).join('');
-
-      } catch (e) {
-        appendLog(`Search error: ${e}`, 'err');
-        console.error(e);
-      }
-    };
-
-    // Search on Enter key
-    document.getElementById('query').addEventListener('keydown', e => {
-      if (e.key === 'Enter') window.doSearch();
-    });
-
-    // ------------------------------------------------------------------
-    // Add Document
-    // ------------------------------------------------------------------
-    window.addDocument = async function() {
-      const id = document.getElementById('doc-id').value.trim();
-      const title = document.getElementById('doc-title').value.trim();
-      const body = document.getElementById('doc-body').value.trim();
-
-      if (!id || !title) {
-        appendLog('ID and Title are required.', 'err');
-        return;
-      }
-
-      try {
-        await index.putDocument(id, {
-          title,
-          body,
-          [EMBED_FIELD]: `${title} ${body}`,
-        });
-        await index.commit();
-        docCounter++;
-
-        document.getElementById('doc-count').textContent = docCounter;
-        appendLog(`Added "${title}" (${id}) — embedding auto-computed`, 'ok');
-
-        // Reset form
-        document.getElementById('doc-id').value = `doc${docCounter + 1}`;
-        document.getElementById('doc-title').value = '';
-        document.getElementById('doc-body').value = '';
-
-      } catch (e) {
-        appendLog(`Add error: ${e}`, 'err');
-        console.error(e);
-      }
-    };
-
-    // ------------------------------------------------------------------
-    // Maintenance — delete persisted OPFS state and reload
-    // ------------------------------------------------------------------
-    /**
-     * Index names that the demo has persisted across versions. Listed
-     * explicitly so we can clean up legacy directories left over from
-     * earlier demo iterations (different vector dimensionality, etc.).
-     */
-    const KNOWN_INDEX_NAMES = ['ja-demo-index', 'ja-demo-index-v2'];
-
-    /**
-     * Remove all known demo index directories from the OPFS root.
-     * The dictionary cache is preserved.
-     */
-    async function deleteAllIndexes() {
-      const root = await navigator.storage.getDirectory();
-      for (const name of KNOWN_INDEX_NAMES) {
-        try {
-          await root.removeEntry(name, { recursive: true });
-          appendLog(`Removed OPFS index "${name}".`, 'ok');
-        } catch (e) {
-          // Directory may not exist (e.g. v1 was never created).
-          if (e?.name !== 'NotFoundError') {
-            appendLog(`Failed to remove "${name}": ${e}`, 'err');
-          }
-        }
-      }
-    }
-
-    window.resetIndex = async function() {
-      if (!confirm('Delete the persisted index and reload? IPADIC and the embedding model stay cached.')) {
-        return;
-      }
-      try {
-        await deleteAllIndexes();
-        appendLog('Index reset complete. Reloading...', 'ok');
-        setTimeout(() => location.reload(), 250);
-      } catch (e) {
-        appendLog(`Reset failed: ${e}`, 'err');
-        console.error(e);
-      }
-    };
-
-    window.resetAll = async function() {
-      if (!confirm('Delete the index AND the IPADIC dictionary, then reload? The 16 MB dictionary will re-download on next visit.')) {
-        return;
-      }
-      try {
-        await deleteAllIndexes();
-        try {
-          await removeDictionary(DICT_NAME);
-          appendLog(`Removed OPFS dictionary "${DICT_NAME}".`, 'ok');
-        } catch (e) {
-          if (e?.name !== 'NotFoundError') {
-            appendLog(`Failed to remove dictionary: ${e}`, 'err');
-          }
-        }
-        appendLog('Full reset complete. Reloading...', 'ok');
-        setTimeout(() => location.reload(), 250);
-      } catch (e) {
-        appendLog(`Reset failed: ${e}`, 'err');
-        console.error(e);
-      }
-    };
-
-    // ------------------------------------------------------------------
-    // Helpers
-    // ------------------------------------------------------------------
-    function escapeHtml(str) {
-      const div = document.createElement('div');
-      div.textContent = str;
-      return div.innerHTML;
-    }
-
-    // Boot
-    boot();
-  </script>
 </body>
 </html>

--- a/laurus-wasm/examples/shared/dictionary.js
+++ b/laurus-wasm/examples/shared/dictionary.js
@@ -1,0 +1,113 @@
+/*
+ * UniDic dictionary loader for the demo samples.
+ *
+ * Wraps the OPFS helpers exported by the laurus-wasm `pkg/opfs.js`
+ * postbuild bundle and the `JapaneseAnalyzer.fromBytes` constructor.
+ *
+ * The dictionary cache key (`DICT_NAME`) is intentionally shared
+ * across samples so that a returning visitor never re-downloads the
+ * ~52 MB UniDic zip just because they switched samples.
+ */
+
+import {
+  downloadDictionary,
+  hasDictionary,
+  loadDictionaryFiles,
+  removeDictionary,
+} from '../../pkg/opfs.js';
+import { JapaneseAnalyzer } from '../../pkg/laurus_wasm.js';
+
+/** Shared OPFS key for the UniDic dictionary. Do not rename. */
+export const DICT_NAME = 'unidic';
+
+/** Default analyzer registration name used by the samples. */
+export const ANALYZER_NAME = 'ja-unidic';
+
+/**
+ * Default location of the UniDic zip relative to each sample HTML.
+ * The CI deploy and the local development layout both place
+ * `dict/lindera-unidic.zip` at `examples/dict/`, so each sample
+ * references it via `../dict/lindera-unidic.zip`.
+ */
+export const DEFAULT_DICT_URL = '../dict/lindera-unidic.zip';
+
+/**
+ * Make sure the UniDic dictionary is present in OPFS, downloading
+ * the bundled zip on first visit. Reports progress through the
+ * supplied logger and an optional status DOM hook.
+ *
+ * @param {object} options
+ * @param {string} [options.url] - URL of the dictionary zip.
+ * @param {{log: Function, ok: Function, err: Function}} options.logger
+ * @param {(text: string) => void} [options.setStatus] - Optional status hook.
+ */
+export async function ensureDictionary({
+  url = DEFAULT_DICT_URL,
+  logger,
+  setStatus,
+} = {}) {
+  if (await hasDictionary(DICT_NAME)) {
+    logger?.ok?.(`Dictionary "${DICT_NAME}" found in OPFS cache.`);
+    return;
+  }
+  logger?.log?.(`Downloading dictionary "${DICT_NAME}" from ${url}...`);
+  const t0 = performance.now();
+  await downloadDictionary(url, DICT_NAME, {
+    onProgress: ({ phase, loaded, total }) => {
+      if (phase === 'downloading' && total) {
+        const pct = ((loaded / total) * 100).toFixed(0);
+        const mb = (loaded / 1024 / 1024).toFixed(1);
+        const totalMb = (total / 1024 / 1024).toFixed(1);
+        setStatus?.(`downloading ${pct}% (${mb}/${totalMb} MB)`);
+      } else if (phase === 'extracting') {
+        setStatus?.('extracting...');
+      } else if (phase === 'storing') {
+        setStatus?.('storing to OPFS...');
+      }
+    },
+  });
+  const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
+  logger?.ok?.(`Dictionary downloaded and cached in OPFS in ${elapsed}s.`);
+}
+
+/**
+ * Build a `JapaneseAnalyzer` from the UniDic bytes stored in OPFS.
+ * Call `ensureDictionary` first.
+ *
+ * @param {object} [options]
+ * @param {'normal' | 'search' | 'extended'} [options.mode] - Tokenizer mode.
+ * @returns {Promise<import('../../pkg/laurus_wasm.js').JapaneseAnalyzer>}
+ */
+export async function buildJapaneseAnalyzer({ mode = 'normal' } = {}) {
+  const files = await loadDictionaryFiles(DICT_NAME);
+  return JapaneseAnalyzer.fromBytes(
+    files.metadata,
+    files.dictDa,
+    files.dictVals,
+    files.dictWordsIdx,
+    files.dictWords,
+    files.matrixMtx,
+    files.charDef,
+    files.unk,
+    mode,
+  );
+}
+
+/**
+ * Remove the cached UniDic dictionary from OPFS. Swallows
+ * `NotFoundError` so callers can use this in idempotent cleanup
+ * helpers.
+ *
+ * @returns {Promise<boolean>} true if a directory was removed.
+ */
+export async function clearDictionary() {
+  try {
+    await removeDictionary(DICT_NAME);
+    return true;
+  } catch (e) {
+    if (e?.name === 'NotFoundError') {
+      return false;
+    }
+    throw e;
+  }
+}

--- a/laurus-wasm/examples/shared/embedder.js
+++ b/laurus-wasm/examples/shared/embedder.js
@@ -1,0 +1,40 @@
+/*
+ * Multilingual MiniLM embedder helper for the demo samples.
+ *
+ * Loads `Xenova/paraphrase-multilingual-MiniLM-L12-v2` via Hugging
+ * Face Transformers.js (CDN) and returns a callable that emits
+ * 384-dim L2-normalised embeddings. The model itself (~120 MB) is
+ * cached by the browser after first load.
+ */
+
+import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3';
+
+/** Embedder registration name used by the samples. */
+export const EMBEDDER_NAME = 'multilingual-minilm';
+
+/** Hugging Face model id. */
+export const EMBEDDER_MODEL = 'Xenova/paraphrase-multilingual-MiniLM-L12-v2';
+
+/** Output dimensionality of the model. Matches HNSW field config. */
+export const EMBED_DIM = 384;
+
+/**
+ * Load the embedder pipeline. Returns an async function suitable
+ * for use as a laurus-wasm callback embedder.
+ *
+ * @param {object} [options]
+ * @param {{log: Function, ok: Function}} [options.logger]
+ * @returns {Promise<(text: string) => Promise<number[]>>}
+ */
+export async function loadEmbedder({ logger } = {}) {
+  logger?.log?.(`Loading embedding model (${EMBEDDER_MODEL})...`);
+  const t0 = performance.now();
+  const pipe = await pipeline('feature-extraction', EMBEDDER_MODEL);
+  const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
+  logger?.ok?.(`Embedding model ready in ${elapsed}s.`);
+
+  return async (text) => {
+    const out = await pipe(text, { pooling: 'mean', normalize: true });
+    return Array.from(out.data);
+  };
+}

--- a/laurus-wasm/examples/shared/log.js
+++ b/laurus-wasm/examples/shared/log.js
@@ -1,0 +1,37 @@
+/*
+ * Lightweight log panel helper for the demo samples.
+ *
+ * Each sample has a `<div class="log" id="log"></div>` element where
+ * timestamped status lines are appended.
+ */
+
+/**
+ * Create a logger bound to the element with the given id.
+ *
+ * @param {string} elementId - The DOM id of the log container.
+ * @returns {{log: (msg: string, cls?: string) => void, ok: (msg: string) => void, err: (msg: string) => void}}
+ */
+export function createLogger(elementId = 'log') {
+  const el = document.getElementById(elementId);
+  if (!el) {
+    return {
+      log: () => {},
+      ok: () => {},
+      err: () => {},
+    };
+  }
+
+  function append(msg, cls = '') {
+    const line = document.createElement('span');
+    line.className = cls;
+    line.textContent = `${msg}\n`;
+    el.appendChild(line);
+    el.scrollTop = el.scrollHeight;
+  }
+
+  return {
+    log: (msg, cls = '') => append(msg, cls),
+    ok: (msg) => append(msg, 'ok'),
+    err: (msg) => append(msg, 'err'),
+  };
+}

--- a/laurus-wasm/examples/shared/theme.css
+++ b/laurus-wasm/examples/shared/theme.css
@@ -1,0 +1,364 @@
+/*
+ * Shared theme for laurus-wasm demo samples.
+ *
+ * Uses CSS custom properties so each sample can override individual
+ * tokens if needed. All samples should `@import` or `<link>` this
+ * stylesheet from `../shared/theme.css`.
+ */
+
+:root {
+  --bg: #0f1117;
+  --surface: #1a1d27;
+  --border: #2a2d3a;
+  --text: #e1e4ed;
+  --muted: #8b8fa3;
+  --accent: #6c8aff;
+  --accent-hover: #8ba3ff;
+  --success: #4ade80;
+  --warning: #fbbf24;
+  --danger: #f87171;
+  --code-bg: #131620;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.container-wide {
+  max-width: 1200px;
+}
+
+h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin-bottom: 2rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.badge-ready {
+  background: #1a3a2a;
+  color: var(--success);
+}
+
+.badge-loading {
+  background: #3a2a1a;
+  color: var(--warning);
+}
+
+.badge-error {
+  background: #3a1a1a;
+  color: var(--danger);
+}
+
+.search-box {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+input[type="text"],
+input[type="number"] {
+  flex: 1;
+  padding: 0.625rem 1rem;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+input[type="text"]:focus,
+input[type="number"]:focus {
+  border-color: var(--accent);
+}
+
+button {
+  padding: 0.625rem 1.25rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+button:hover {
+  background: var(--accent-hover);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+button.secondary:hover {
+  background: var(--surface);
+}
+
+.results {
+  list-style: none;
+}
+
+.results li {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  background: var(--code-bg);
+  cursor: default;
+}
+
+.results li.clickable {
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.results li.clickable:hover {
+  border-color: var(--accent);
+}
+
+.results li.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.results li .meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.results li .score {
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.results li .extra {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.results li .title {
+  font-weight: 600;
+}
+
+.results li .body {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+
+.empty {
+  color: var(--muted);
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.9rem;
+}
+
+.stats {
+  display: flex;
+  gap: 1.5rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.stats span {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.add-form {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.add-form .row,
+.row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.add-form label,
+label {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-bottom: 0.125rem;
+}
+
+.add-form .field {
+  flex: 1;
+}
+
+textarea {
+  width: 100%;
+  padding: 0.625rem 1rem;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 60px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+textarea:focus {
+  border-color: var(--accent);
+}
+
+.log {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.8rem;
+  color: var(--muted);
+  background: var(--code-bg);
+  border-radius: 8px;
+  padding: 1rem;
+  max-height: 150px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.log .ok {
+  color: var(--success);
+}
+
+.log .err {
+  color: var(--danger);
+}
+
+.dsl-hint {
+  color: var(--muted);
+  font-size: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
+.dsl-hint code {
+  background: var(--code-bg);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 0.78rem;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.toggle input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.sample-list {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+}
+
+.sample-list a {
+  display: block;
+  padding: 1.25rem 1.5rem;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.sample-list a:hover {
+  border-color: var(--accent);
+  background: var(--surface);
+  text-decoration: none;
+}
+
+.sample-list .sample-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  color: var(--text);
+}
+
+.sample-list .sample-summary {
+  color: var(--muted);
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Summary

- Split `laurus-wasm/examples/` into a multi-sample layout: `basic/` (renamed from the existing single-file demo), `geo/` (new), and `shared/` (theme stylesheet, log helper, dictionary loader, embedder helper).
- Add an `examples/index.html` landing page that lists every sample.
- New **geo** sample combines a Leaflet map of Tokyo points-of-interest with viewport-driven `location:geo_bbox(...)` constraints and the unified DSL (text + embedding queries).
- Switch the Japanese analyzer dictionary from IPADIC (~16 MB) to UniDic (~52 MB) across shared assets, samples, READMEs, and the deploy workflow. The OPFS dictionary key is shared between samples so the larger zip downloads only once.
- Drop the version suffix from `INDEX_NAME` and rely on the existing Reset UI to recover from analyzer/schema changes.
- `deploy-docs` now copies all of `laurus-wasm/examples/` into the Pages publish directory and fetches `lindera-unidic-X.Y.Z.zip`.

## New layout

```
laurus-wasm/examples/
├── index.html              # Landing page (sample list)
├── README.md / README_ja.md
├── basic/                  # Hybrid search (lexical + vector + embedding)
├── geo/                    # Map + bbox + embedding (new)
└── shared/                 # theme.css / log.js / dictionary.js / embedder.js
```

## Test plan

- [x] `cargo fmt --check`
- [x] `markdownlint-cli2 'laurus-wasm/examples/**/*.md' 'laurus-wasm/README*.md'` — 0 errors
- [x] `node --input-type=module --check` on `shared/*.js`
- [x] Local HTTP server: `examples/`, `examples/basic/`, `examples/geo/`, `shared/*`, `pkg/*` all return 200; `examples/lexical/` returns 404 (rename verified)
- [ ] Once deployed, browse `/demo/`, `/demo/basic/`, `/demo/geo/` in Chrome and verify:
  - First visit downloads the UniDic zip and embedding model
  - `basic/` indexes 8 sample docs and unified DSL queries work
  - `geo/` plots 14 Tokyo points on the map; toggling "Restrict to current map view" adds an `AND location:geo_bbox(...)` clause; result clicks pan and open the matching marker
  - Reset buttons clear the per-sample index and (optionally) the shared UniDic cache
- [ ] After deploy, `curl -I` `/demo/`, `/demo/basic/`, `/demo/geo/`, `/demo/shared/*.{css,js}`, `/demo/dict/lindera-unidic.zip`, `/demo/dict/manifest.json`, `/pkg/laurus_wasm.js`, `/pkg/opfs.js` and verify all return 200
- [ ] After deploy, `node --check` the published `pkg/laurus_wasm.js` to confirm no JSDoc-bound rustdoc syntax issues

## Notes

- Returning visitors who had `ja-demo-index-v2` from the previous IPADIC-based demo will need to click *Reset everything* once after this lands. The new `INDEX_NAME` is `ja-demo-index` (no suffix), so a fresh index is created automatically; the orphaned `v2` directory remains in OPFS until manual cleanup.
- Leaflet 1.9.4 is loaded from unpkg with subresource integrity hashes. OpenStreetMap tiles still require an internet connection even after the WASM/UniDic assets are cached.