### PR TITLE
feat(wasm-demo): sync geo markers with results, clearer bbox label, silence dtype warning

### DIFF
--- a/laurus-wasm/examples/geo/README.md
+++ b/laurus-wasm/examples/geo/README.md
@@ -23,17 +23,20 @@ python3 -m http.server 8080
 
 ## What this sample demonstrates
 
-- An OPFS-persistent geo index (`geo-demo-index-v1`) seeded with
+- An OPFS-persistent geo index (`geo-demo-index`) seeded with
   ~14 Tokyo points-of-interest on first visit
 - A schema with three Japanese-tokenised text fields
   (`title`, `description`, `category`), one geo field
   (`location` — indexed via the BKD tree) and one HNSW vector field
   (`embedding`, 384-dim multilingual MiniLM)
-- A search box that builds a unified DSL string. With *Restrict to
+- A search box that builds a unified DSL string. With *Filter by
   current map view* turned on, the user query is wrapped in
   parentheses and AND-combined with
   `location:geo_bbox(min_lat, min_lon, max_lat, max_lon)` derived
   from the current Leaflet bounds
+- Map markers track the search hits — non-matching points are
+  removed from the map after each query, so the visible pins always
+  mirror the result list
 - A clickable result list that pans the map and opens the popup of
   the corresponding marker
 

--- a/laurus-wasm/examples/geo/README_ja.md
+++ b/laurus-wasm/examples/geo/README_ja.md
@@ -24,17 +24,20 @@ python3 -m http.server 8080
 
 ## このサンプルでできること
 
-- OPFS 永続化された geo インデックス（`geo-demo-index-v1`）を
-  作成し、初回アクセス時に東京の観光スポット約 14 件を投入します
+- OPFS 永続化された geo インデックス（`geo-demo-index`）を作成し、
+  初回アクセス時に東京の観光スポット約 14 件を投入します
 - スキーマは日本語形態素解析対応のテキストフィールド 3 種
   （`title`、`description`、`category`）、geo フィールド 1 種
   （`location` — BKD ツリーでインデックス化）、HNSW ベクトル
   フィールド 1 種（`embedding`、multilingual MiniLM 384 次元）
 - 検索ボックスは統合クエリ DSL の文字列を生成します。
-  *Restrict to current map view* が ON のとき、入力クエリは括弧で
+  *Filter by current map view* が ON のとき、入力クエリは括弧で
   囲まれ、現在の Leaflet ビューから生成した
   `location:geo_bbox(min_lat, min_lon, max_lat, max_lon)` と AND
   結合されます
+- 地図のピンは検索結果と連動し、マッチしなかったポイントは
+  検索のたびに地図から取り除かれるため、表示されているピンは
+  常に結果リストと一致します
 - 結果リストの項目をクリックすると、地図上の該当マーカーが
   展開され、ビューがそのマーカーへパンします
 

--- a/laurus-wasm/examples/geo/index.html
+++ b/laurus-wasm/examples/geo/index.html
@@ -85,13 +85,16 @@
         <input type="text" id="query" placeholder="例: 公園 / 浅草 / embedding:&quot;夜景&quot;" disabled>
         <button id="search-btn" disabled>Search</button>
       </div>
-      <div class="row" style="margin-bottom: 0.5rem;">
+      <div class="row">
         <label class="toggle">
           <input type="checkbox" id="restrict-bbox" checked disabled>
-          Restrict to current map view
-          (<code>location:geo_bbox(...)</code>)
+          Filter by current map view
         </label>
       </div>
+      <p class="dsl-hint">
+        Adds <code>location:geo_bbox(min_lat, min_lon, max_lat, max_lon)</code>
+        (derived from the current Leaflet bounds) to your query.
+      </p>
       <ul class="results" id="results">
         <li class="empty">Loading sample data…</li>
       </ul>
@@ -324,6 +327,25 @@
     }
 
     /**
+     * Reconcile the markers shown on the map with the current
+     * search hits. Markers in `resultIds` are added if missing,
+     * everything else is removed. Keeping the marker objects in
+     * `markers` (only toggling map membership) preserves popup
+     * state and lets `highlightMarker` keep working after the
+     * marker is re-added.
+     */
+    function syncMarkersWithResults(resultIds) {
+      for (const [id, marker] of markers) {
+        const inResults = resultIds.has(id);
+        if (inResults && !map.hasLayer(marker)) {
+          map.addLayer(marker);
+        } else if (!inResults && map.hasLayer(marker)) {
+          map.removeLayer(marker);
+        }
+      }
+    }
+
+    /**
      * Build a unified DSL query string. The text portion (if any)
      * is left untouched so users can still write
      * `title:...` / `embedding:"..."`. The bbox clause is appended
@@ -360,6 +382,9 @@
         const results = await index.search(query);
         const elapsed = (performance.now() - t0).toFixed(1);
         logger.log(`"${query}" -> ${results.length} hit(s) in ${elapsed}ms`);
+
+        const resultIds = new Set(results.map((r) => r.id));
+        syncMarkersWithResults(resultIds);
 
         if (results.length === 0) {
           resultsEl.innerHTML = '<li class="empty">No results found in the current view.</li>';

--- a/laurus-wasm/examples/shared/embedder.js
+++ b/laurus-wasm/examples/shared/embedder.js
@@ -19,6 +19,13 @@ export const EMBEDDER_MODEL = 'Xenova/paraphrase-multilingual-MiniLM-L12-v2';
 export const EMBED_DIM = 384;
 
 /**
+ * Quantization dtype passed to Transformers.js. `q8` matches the
+ * WASM backend default while silencing the v3 warning that fires
+ * when the dtype is left unspecified.
+ */
+const EMBEDDER_DTYPE = 'q8';
+
+/**
  * Load the embedder pipeline. Returns an async function suitable
  * for use as a laurus-wasm callback embedder.
  *
@@ -27,9 +34,11 @@ export const EMBED_DIM = 384;
  * @returns {Promise<(text: string) => Promise<number[]>>}
  */
 export async function loadEmbedder({ logger } = {}) {
-  logger?.log?.(`Loading embedding model (${EMBEDDER_MODEL})...`);
+  logger?.log?.(`Loading embedding model (${EMBEDDER_MODEL}, dtype=${EMBEDDER_DTYPE})...`);
   const t0 = performance.now();
-  const pipe = await pipeline('feature-extraction', EMBEDDER_MODEL);
+  const pipe = await pipeline('feature-extraction', EMBEDDER_MODEL, {
+    dtype: EMBEDDER_DTYPE,
+  });
   const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
   logger?.ok?.(`Embedding model ready in ${elapsed}s.`);
 


### PR DESCRIPTION
## Summary

Three small follow-ups to PR #390 based on review feedback while playing with the deployed demo.

- **Sync geo markers with search results.** The Leaflet map now reconciles its visible markers with the current hits after every query, so non-matching points are removed from the map and reappear automatically when a later query brings them back. The result list and the map stay in lock-step.
- **Clearer bbox label.** Rename the toggle from `Restrict to current map view` to `Filter by current map view`, and move the `location:geo_bbox(...)` DSL hint into a separate description line so the label itself stays scannable. Inline styles introduced by the first iteration were removed (existing `.dsl-hint`/`.row` margins are sufficient).
- **Silence the Transformers.js v3 dtype warning.** Pass `dtype: 'q8'` explicitly to the `pipeline()` call. This matches the WASM backend's existing default — there is no behavioural change — but it stops the `dtype not specified for "model"` warning from showing up on first boot of either sample.

The marker-sync change applies to `geo/` only; the dtype change applies to both samples through `examples/shared/embedder.js`.

## Test plan

- [x] `node --input-type=module --check` on `examples/shared/embedder.js`
- [x] `markdownlint-cli2 'laurus-wasm/examples/**/*.md' 'laurus-wasm/README*.md'` — 0 errors
- [x] No remaining inline `style=` attributes in `examples/geo/index.html`
- [x] Local HTTP server: `examples/`, `examples/basic/`, `examples/geo/`, `examples/shared/*.js`, `pkg/laurus_wasm.js` all return 200
- [ ] After deploy, visit `/demo/geo/` in Chrome and verify:
  - The dtype warning no longer appears in the console
  - Searching for `公園` leaves only the park markers on the map
  - Re-searching with the box cleared (and *Filter by current map view* on) restores all in-view markers
  - Toggling the checkbox swaps the DSL between `query` and `(query) AND location:geo_bbox(...)`
  - Result-row clicks still pan the map and open the matching popup

Refs #390