### PR TITLE
fix(wasm-demo): require both text and bbox clauses in geo search

### DIFF
--- a/laurus-wasm/examples/geo/README.md
+++ b/laurus-wasm/examples/geo/README.md
@@ -30,10 +30,10 @@ python3 -m http.server 8080
   (`location` — indexed via the BKD tree) and one HNSW vector field
   (`embedding`, 384-dim multilingual MiniLM)
 - A search box that builds a unified DSL string. With *Filter by
-  current map view* turned on, the user query is wrapped in
-  parentheses and AND-combined with
-  `location:geo_bbox(min_lat, min_lon, max_lat, max_lon)` derived
-  from the current Leaflet bounds
+  current map view* turned on, the demo emits
+  `+(<query>) +location:geo_bbox(min_lat, min_lon, max_lat, max_lon)`
+  — both clauses are marked `+` (required) so a document has to
+  match the text *and* sit inside the current Leaflet bounds
 - Map markers track the search hits — non-matching points are
   removed from the map after each query, so the visible pins always
   mirror the result list

--- a/laurus-wasm/examples/geo/README_ja.md
+++ b/laurus-wasm/examples/geo/README_ja.md
@@ -31,10 +31,11 @@ python3 -m http.server 8080
   （`location` — BKD ツリーでインデックス化）、HNSW ベクトル
   フィールド 1 種（`embedding`、multilingual MiniLM 384 次元）
 - 検索ボックスは統合クエリ DSL の文字列を生成します。
-  *Filter by current map view* が ON のとき、入力クエリは括弧で
-  囲まれ、現在の Leaflet ビューから生成した
-  `location:geo_bbox(min_lat, min_lon, max_lat, max_lon)` と AND
-  結合されます
+  *Filter by current map view* が ON のときは
+  `+(<クエリ>) +location:geo_bbox(min_lat, min_lon, max_lat, max_lon)`
+  という文字列を投げます。両方の clause に `+`（必須）を付けて
+  いるため、テキスト条件と現在の Leaflet ビューポート条件の
+  どちらも満たすドキュメントだけがマッチします
 - 地図のピンは検索結果と連動し、マッチしなかったポイントは
   検索のたびに地図から取り除かれるため、表示されているピンは
   常に結果リストと一致します

--- a/laurus-wasm/examples/geo/index.html
+++ b/laurus-wasm/examples/geo/index.html
@@ -77,9 +77,9 @@
         Text input is wrapped in the unified DSL. Examples:
         <code>東京</code> <code>title:浅草寺</code>
         <code>embedding:"夜景がきれいなスポット"</code>.
-        Toggle <em>Restrict to map view</em> to AND the query with a
-        <code>location:geo_bbox(...)</code> clause derived from the
-        current map viewport.
+        With <em>Filter by current map view</em> on, the demo emits
+        <code>+(query) +location:geo_bbox(...)</code> so a document
+        must match both the text and the current map viewport.
       </p>
       <div class="search-box">
         <input type="text" id="query" placeholder="例: 公園 / 浅草 / embedding:&quot;夜景&quot;" disabled>
@@ -364,8 +364,16 @@
     /**
      * Build a unified DSL query string. The text portion (if any)
      * is left untouched so users can still write
-     * `title:...` / `embedding:"..."`. The bbox clause is appended
-     * with AND when the restrict-to-view toggle is on.
+     * `title:...` / `embedding:"..."`.
+     *
+     * When the restrict-to-view toggle is on, the text query and
+     * the bbox clause are combined with `+` (required) prefixes
+     * rather than the `AND` keyword. The DSL parser's `AND` only
+     * promotes the *following* clause to Must — the preceding
+     * clause stays at the default Should — so writing
+     * `(text) AND geo_bbox(...)` would let any document inside
+     * the bbox match regardless of the text. Explicit `+` makes
+     * both sides required, which is what users expect.
      */
     function buildQuery(rawText) {
       const text = rawText.trim();
@@ -383,7 +391,7 @@
       if (!text) {
         return bboxClause;
       }
-      return `(${text}) AND ${bboxClause}`;
+      return `+(${text}) +${bboxClause}`;
     }
 
     async function doSearch() {


### PR DESCRIPTION
## Summary

Switch the geo demo's `buildQuery` to emit `+(<text>) +location:geo_bbox(...)` instead of `(<text>) AND location:geo_bbox(...)`. Reported by the user while playing with the deployed demo: searching for `渋谷` with *Filter by current map view* on returned every Tokyo POI inside the viewport, not just 渋谷スクランブル交差点.

## Root cause

The DSL parser treats `AND` asymmetrically. From [`laurus/src/lexical/query/parser.rs:230-233`](https://github.com/mosuka/laurus/blob/main/laurus/src/lexical/query/parser.rs#L230-L233):

```rust
Rule::clause => {
    let (occur, query) = self.parse_clause(inner_pair, current_occur)?;
    terms.push((occur, query));
    // Reset to default so that the operator only applies to the
    // immediately following clause (e.g. "a AND b c" → a Must, b Must, c default).
    current_occur = self.default_occur;  // = Should (OR)
}
```

So `(渋谷) AND location:geo_bbox(...)` parses as `Should(渋谷) + Must(geo_bbox)`. Any document inside the bbox already satisfies the only Must clause; `渋谷` only contributes to scoring. That is why every viewport POI matched.

## Fix

Use `+` (required) prefixes on **both** clauses so the parser does not depend on the asymmetric `AND` keyword:

```diff
- return `(${text}) AND ${bboxClause}`;
+ return `+(${text}) +${bboxClause}`;
```

Documentation (English / Japanese READMEs and the inline DSL hint card) is updated to show the new query string.

The underlying parser bug — `a AND b` should be symmetric — will be addressed in a follow-up PR. This patch is independent: even after the parser is fixed, `+` is still the most explicit way to mark a clause required.

## Test plan

- [x] `markdownlint-cli2 'laurus-wasm/examples/**/*.md'` — 0 errors
- [x] No inline `style=` attributes in `examples/geo/index.html`
- [ ] After deploy, browse `/demo/geo/` and verify with the toggle on:
  - Searching `渋谷` returns only 渋谷スクランブル交差点 (and any other POI whose stored fields actually contain 渋谷)
  - Searching `公園` only returns the 公園-tagged POIs in view, not every POI in view
  - Empty query still returns all in-view POIs (single-clause case is unchanged)

Refs #390, #391, #392