### PR TITLE
chore(benches): standardize hygiene (deterministic seeds, doc headers, sanity asserts) (#427)

### DIFF
--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -11,6 +11,7 @@ keywords = { workspace = true }
 categories = { workspace = true }
 license = { workspace = true }
 autoexamples = false
+autobenches = false
 
 [dependencies]
 ahash = { version = "0.8.12", features = [

--- a/laurus/benches/bkd_bench.rs
+++ b/laurus/benches/bkd_bench.rs
@@ -30,6 +30,8 @@
 //! across iterations. Synthetic data is generated with an inline LCG so
 //! the benches stay deterministic without pulling in `rand`.
 
+mod common;
+
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use laurus::lexical::index::structures::aabb::AABB;
 use laurus::lexical::index::structures::bkd_tree::{BKDReader, BKDTree, BKDWriter};
@@ -39,16 +41,7 @@ use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
 use std::hint::black_box;
 use std::sync::Arc;
 
-/// Inline LCG (numerical recipes constants) so the bench stays deterministic
-/// without pulling in `rand` as a dev dep.
-fn lcg_next(state: &mut u64) -> f64 {
-    *state = state
-        .wrapping_mul(6_364_136_223_846_793_005)
-        .wrapping_add(1_442_695_040_888_963_407);
-    // Take the high 32 bits and rescale to [0, 1000).
-    let bits = (*state >> 32) as u32;
-    (bits as f64) * (1000.0 / (u32::MAX as f64))
-}
+use common::{DEFAULT_SEED, lcg_next};
 
 /// Build an in-memory BKD tree of `n` random points in `num_dims` dimensions
 /// with coordinates uniformly distributed in `[0, 1000)`. Returns the open
@@ -57,7 +50,7 @@ fn build_tree(num_dims: usize, n: usize) -> BKDReader {
     let storage: Arc<MemoryStorage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
     let mut points: Vec<f64> = Vec::with_capacity(n * num_dims);
     let mut doc_ids: Vec<u64> = Vec::with_capacity(n);
-    let mut rng_state: u64 = 0xDEAD_BEEF_CAFE_F00D;
+    let mut rng_state: u64 = DEFAULT_SEED;
     for i in 0..n {
         for _ in 0..num_dims {
             points.push(lcg_next(&mut rng_state));
@@ -196,7 +189,7 @@ fn bench_build(c: &mut Criterion) {
                 // build, not data generation.
                 let mut points: Vec<f64> = Vec::with_capacity(n * num_dims);
                 let mut doc_ids: Vec<u64> = Vec::with_capacity(n);
-                let mut rng_state: u64 = 0xDEAD_BEEF_CAFE_F00D;
+                let mut rng_state: u64 = DEFAULT_SEED;
                 for i in 0..n {
                     for _ in 0..num_dims {
                         points.push(lcg_next(&mut rng_state));

--- a/laurus/benches/common.rs
+++ b/laurus/benches/common.rs
@@ -1,0 +1,80 @@
+//! Shared utilities and hygiene policy for the laurus benchmark suite.
+//!
+//! This module is included by every bench file via `mod common;` so the suite
+//! shares a single source of truth for deterministic randomness, sample sizes,
+//! and the contract every bench is expected to follow.
+//!
+//! # Hygiene rules (apply to every bench file in this directory)
+//!
+//! 1. **Deterministic input**: never use `rand::rng()` (OS-seeded). Use the
+//!    LCG helpers in this module so two consecutive runs produce comparable
+//!    numbers.
+//! 2. **File-level doc comment**: each bench file starts with a `//!` block
+//!    listing scope, scenarios, how to run, and how to filter.
+//! 3. **One-time sanity assert**: each top-level bench function calls the
+//!    measured code once before `b.iter` and asserts on the shape of the
+//!    result (e.g. result count > 0). This catches regressions that produce
+//!    empty output without affecting the timed loop.
+//! 4. **`sample_size` policy**: use [`SAMPLE_SIZE_FAST`] for cheap operations
+//!    (sub-50 ms per iter) and [`SAMPLE_SIZE_SLOW`] for slow construction
+//!    paths. Pick one of the two; do not invent intermediate values.
+//!
+//! # Recommended environment
+//!
+//! For stable measurements, run benches with the CPU governor set to
+//! `performance` and turbo boost disabled. Background load skews
+//! short-running benches significantly. If a bench's two consecutive runs
+//! diverge by more than 5 %, suspect environment noise before code.
+//!
+//! # Suppress unused warnings
+//!
+//! Each bench is its own compile unit and may use only a subset of these
+//! helpers. `#![allow(dead_code)]` keeps clippy quiet across the suite.
+
+#![allow(dead_code)]
+
+/// Default seed for deterministic LCG state. Used as the starting point in
+/// every bench so two runs of `cargo bench` produce identical inputs.
+pub const DEFAULT_SEED: u64 = 0xDEAD_BEEF_CAFE_F00D;
+
+/// `sample_size` for fast operations (search, distance, scoring loops). This
+/// is Criterion's default; spell it out explicitly so the policy is visible
+/// at the call site.
+pub const SAMPLE_SIZE_FAST: usize = 100;
+
+/// `sample_size` for slow construction paths (HNSW build, IVF training,
+/// engine population at large scale). Lowered from the default to keep
+/// `cargo bench` runtimes manageable.
+pub const SAMPLE_SIZE_SLOW: usize = 10;
+
+/// Inline LCG (numerical recipes constants) advancing `state` by one step
+/// and returning a deterministic value in `[0, 1000)`.
+///
+/// Used in places where the bench wants drop-in replacement for the existing
+/// `[0, 1000)` data range (e.g. BKD point coordinates).
+pub fn lcg_next(state: &mut u64) -> f64 {
+    *state = state
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    let bits = (*state >> 32) as u32;
+    (bits as f64) * (1000.0 / (u32::MAX as f64))
+}
+
+/// Inline LCG variant returning a deterministic `f32` in `[0, 1)`.
+///
+/// Suited to vector-component generation (cosine / dot-product workloads
+/// expect bounded magnitudes; the `[0, 1)` range mirrors what `rand::rng()`
+/// previously produced via the `Rng::random::<f32>()` call).
+pub fn lcg_next_unit(state: &mut u64) -> f32 {
+    *state = state
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    let bits = (*state >> 32) as u32;
+    (bits as f32) / (u32::MAX as f32)
+}
+
+/// Generate a deterministic `Vec<f32>` of length `dim` advancing the
+/// caller-provided LCG state. Components are in `[0, 1)`.
+pub fn lcg_vec_unit(state: &mut u64, dim: usize) -> Vec<f32> {
+    (0..dim).map(|_| lcg_next_unit(state)).collect()
+}

--- a/laurus/benches/distance_bench.rs
+++ b/laurus/benches/distance_bench.rs
@@ -1,3 +1,38 @@
+//! Criterion benchmarks for the [`DistanceMetric`] family.
+//!
+//! Compares Cosine, Euclidean, Manhattan, and DotProduct distances on a small
+//! warm-set of vectors at a fixed dimension.
+//!
+//! # Scope
+//!
+//! - Microbench of [`DistanceMetric::distance`] for the four built-in
+//!   metrics.
+//! - Single dimension, single batch size, single query × 100 targets.
+//! - Does **not** cover the SIMD-remainder path — that requires a
+//!   non-multiple-of-8 dimension sweep (tracked separately in #424).
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench distance_bench
+//! ```
+//!
+//! Filter by metric (criterion id matches the metric name):
+//!
+//! ```sh
+//! cargo bench --bench distance_bench -- cosine
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench distance_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use laurus::vector::DistanceMetric;
 use std::hint::black_box;
@@ -20,6 +55,23 @@ fn bench_distances(c: &mut Criterion) {
     let vectors = generate_test_vectors(101, dimension);
     let query = &vectors[0];
     let targets = &vectors[1..101];
+
+    // One-time sanity check: every metric returns a finite, non-NaN value
+    // for the first target. Failing this means the bench premise is broken
+    // before we even start measuring.
+    for metric in [
+        DistanceMetric::Cosine,
+        DistanceMetric::Euclidean,
+        DistanceMetric::Manhattan,
+        DistanceMetric::DotProduct,
+    ] {
+        let probe = metric.distance(query, &targets[0]).unwrap();
+        assert!(
+            probe.is_finite(),
+            "{}: distance must be finite for the probe pair, got {probe}",
+            metric.name()
+        );
+    }
 
     let mut group = c.benchmark_group("distance_metrics");
 

--- a/laurus/benches/lexical_search_bench.rs
+++ b/laurus/benches/lexical_search_bench.rs
@@ -1,7 +1,40 @@
 //! End-to-end lexical search benchmarks.
 //!
-//! Measures full query execution time including matching, scoring, and collection
-//! for various query types: TermQuery, BooleanQuery, PhraseQuery, FuzzyQuery.
+//! Measures full query execution time including matching, scoring, and
+//! collection for various query types: `TermQuery`, `BooleanQuery`,
+//! `PhraseQuery`, `FuzzyQuery`, and the DSL parser.
+//!
+//! # Scope
+//!
+//! - End-to-end through `Engine::search`, including async runtime overhead.
+//! - Corpus sizes 100, 1 000, 5 000 documents over a fixed 8-topic
+//!   vocabulary. Larger corpora and Zipf-distributed vocabulary are tracked
+//!   in #422.
+//! - One-time correctness assert verifies the probe query returns at least
+//!   one hit before the timed loop runs.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench lexical_search_bench
+//! ```
+//!
+//! Filter by group / case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench lexical_search_bench -- term_query
+//! cargo bench --bench lexical_search_bench -- boolean_query/should_or
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench lexical_search_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
 
 use std::hint::black_box;
 use std::sync::Arc;
@@ -82,6 +115,21 @@ fn bench_term_query(c: &mut Criterion) {
     for &n in &[100, 1000, 5000] {
         let engine = rt.block_on(build_engine(n)).unwrap();
 
+        // One-time sanity check: the probe query must return at least one
+        // hit. If this fires, the corpus / query pair drifted out of sync.
+        let probe = rt.block_on(async {
+            let query = Box::new(TermQuery::new("body", "programming"));
+            let request = SearchRequestBuilder::new()
+                .lexical_query(LexicalSearchQuery::Obj(query))
+                .limit(10)
+                .build();
+            engine.search(request).await.unwrap()
+        });
+        assert!(
+            !probe.is_empty(),
+            "term_query probe must return at least one hit at n={n}"
+        );
+
         group.bench_with_input(BenchmarkId::new("search", n), &n, |b, _| {
             b.to_async(&rt).iter(|| {
                 let engine = &engine;
@@ -102,6 +150,21 @@ fn bench_term_query(c: &mut Criterion) {
 fn bench_term_query_varying_limit(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let engine = rt.block_on(build_engine(5000)).unwrap();
+
+    // Sanity check: the largest limit must return more hits than the smallest.
+    let probe_small = rt.block_on(async {
+        let query = Box::new(TermQuery::new("body", "programming"));
+        let request = SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::Obj(query))
+            .limit(10)
+            .build();
+        engine.search(request).await.unwrap()
+    });
+    assert!(
+        !probe_small.is_empty(),
+        "term_query_limit probe must return at least one hit"
+    );
+
     let mut group = c.benchmark_group("lexical/term_query_limit");
 
     for &limit in &[10, 50, 100, 500] {
@@ -128,6 +191,22 @@ fn bench_boolean_query(c: &mut Criterion) {
 
     for &n in &[100, 1000, 5000] {
         let engine = rt.block_on(build_engine(n)).unwrap();
+
+        // Sanity check: the OR probe over three known terms must hit.
+        let probe = rt.block_on(async {
+            let mut bq = BooleanQuery::new();
+            bq.add_should(Box::new(TermQuery::new("body", "rust")));
+            bq.add_should(Box::new(TermQuery::new("body", "python")));
+            let request = SearchRequestBuilder::new()
+                .lexical_query(LexicalSearchQuery::Obj(Box::new(bq)))
+                .limit(10)
+                .build();
+            engine.search(request).await.unwrap()
+        });
+        assert!(
+            !probe.is_empty(),
+            "boolean_query OR probe must return at least one hit at n={n}"
+        );
 
         // MUST + MUST (AND)
         group.bench_with_input(BenchmarkId::new("must_and", n), &n, |b, _| {
@@ -191,6 +270,23 @@ fn bench_phrase_query(c: &mut Criterion) {
     for &n in &[100, 1000, 5000] {
         let engine = rt.block_on(build_engine(n)).unwrap();
 
+        // Sanity check: the two-term phrase probe must hit at least once.
+        let probe = rt.block_on(async {
+            let query = Box::new(PhraseQuery::new(
+                "body",
+                vec!["search".into(), "engine".into()],
+            ));
+            let request = SearchRequestBuilder::new()
+                .lexical_query(LexicalSearchQuery::Obj(query))
+                .limit(10)
+                .build();
+            engine.search(request).await.unwrap()
+        });
+        assert!(
+            !probe.is_empty(),
+            "phrase_query probe must return at least one hit at n={n}"
+        );
+
         group.bench_with_input(BenchmarkId::new("two_terms", n), &n, |b, _| {
             b.to_async(&rt).iter(|| {
                 let engine = &engine;
@@ -235,6 +331,20 @@ fn bench_fuzzy_query(c: &mut Criterion) {
     for &n in &[100, 1000, 5000] {
         let engine = rt.block_on(build_engine(n)).unwrap();
 
+        // Sanity check: the edit1 probe must match `programming`.
+        let probe = rt.block_on(async {
+            let query = Box::new(FuzzyQuery::new("body", "programing").max_edits(1));
+            let request = SearchRequestBuilder::new()
+                .lexical_query(LexicalSearchQuery::Obj(query))
+                .limit(10)
+                .build();
+            engine.search(request).await.unwrap()
+        });
+        assert!(
+            !probe.is_empty(),
+            "fuzzy_query probe must return at least one hit at n={n}"
+        );
+
         group.bench_with_input(BenchmarkId::new("edit1", n), &n, |b, _| {
             b.to_async(&rt).iter(|| {
                 let engine = &engine;
@@ -269,6 +379,20 @@ fn bench_fuzzy_query(c: &mut Criterion) {
 fn bench_dsl_query(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let engine = rt.block_on(build_engine(5000)).unwrap();
+
+    // Sanity check: the simple_term DSL probe must hit.
+    let probe = rt.block_on(async {
+        let request = SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::Dsl("body:programming".to_string()))
+            .limit(10)
+            .build();
+        engine.search(request).await.unwrap()
+    });
+    assert!(
+        !probe.is_empty(),
+        "dsl_query probe must return at least one hit"
+    );
+
     let mut group = c.benchmark_group("lexical/dsl_query");
 
     group.bench_function("simple_term", |b| {

--- a/laurus/benches/search_perf.rs
+++ b/laurus/benches/search_perf.rs
@@ -1,7 +1,38 @@
 //! Performance benchmarks for lexical search hot paths.
 //!
-//! Covers posting list traversal, BM25 scoring, SIMD batch scoring,
-//! and compact posting conversion.
+//! Covers posting list traversal, BM25 scoring, SIMD batch scoring, and
+//! compact posting conversion.
+//!
+//! # Scope
+//!
+//! - Microbench of `PostingIterator::skip_to`, `BM25Scorer::score`, the SIMD
+//!   batch scorers in `util::simd::numeric`, and `PostingList::to_compact`.
+//! - Note that `BM25Scorer` (`lexical::query::scorer`) is **distinct** from
+//!   `BM25ScoringFunction` (`lexical::search::scoring::bm25`) — the latter
+//!   is the audit target tracked in #402 and gets its own bench under #417.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench search_perf
+//! ```
+//!
+//! Filter by group / case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench search_perf -- skip_to
+//! cargo bench --bench search_perf -- batch_bm25
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench search_perf --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
 
 use std::hint::black_box;
 
@@ -32,6 +63,14 @@ fn bench_posting_skip_to(c: &mut Criterion) {
         let list = make_posting_list(size);
         let postings = list.postings.clone();
 
+        // Sanity check: the list must contain the expected number of
+        // postings before we time skip_to.
+        assert_eq!(
+            postings.len(),
+            size,
+            "posting_list size mismatch at size={size}"
+        );
+
         // Pick targets spread across the list.
         let targets: Vec<u64> = (0..100).map(|i| (i * (size as u64) * 3) / 100).collect();
 
@@ -58,6 +97,13 @@ fn bench_bm25_scoring(c: &mut Criterion) {
         /* total_docs */ 10_000, /* boost */ 1.0,
     );
 
+    // Sanity check: the probe score must be finite and positive.
+    let probe = scorer.score(0, 3.0, Some(150.0));
+    assert!(
+        probe.is_finite() && probe > 0.0,
+        "BM25Scorer probe score must be finite and positive, got {probe}"
+    );
+
     c.bench_function("BM25Scorer/score", |b| {
         b.iter(|| {
             // Score 1000 documents in a tight loop.
@@ -80,6 +126,21 @@ fn bench_bm25_batch_scoring(c: &mut Criterion) {
         let norms: Vec<f32> = (0..size).map(|i| 0.8 + (i as f32 * 0.001)).collect();
         let idfs: Vec<f32> = (0..size).map(|i| 1.0 + (i as f32 * 0.01)).collect();
         let boosts: Vec<f32> = vec![1.0; size];
+
+        // Sanity check: probe both batch helpers once to verify they return
+        // a vector of the expected length with finite values.
+        let probe_tf = batch_bm25_tf(&tfs, 1.2, &norms);
+        let probe_final = batch_bm25_final_score(&tfs, &idfs, &boosts);
+        assert_eq!(probe_tf.len(), size, "batch_bm25_tf length mismatch");
+        assert_eq!(
+            probe_final.len(),
+            size,
+            "batch_bm25_final_score length mismatch"
+        );
+        assert!(
+            probe_tf.iter().all(|v| v.is_finite()) && probe_final.iter().all(|v| v.is_finite()),
+            "batch BM25 outputs must be finite at size={size}"
+        );
 
         group.bench_with_input(BenchmarkId::new("batch_bm25_tf", size), &size, |b, _| {
             b.iter(|| {
@@ -117,6 +178,14 @@ fn bench_compact_posting(c: &mut Criterion) {
 
     for &size in &[100usize, 1_000, 10_000] {
         let list = make_posting_list(size);
+
+        // Sanity check: to_compact must round-trip the size.
+        let probe = list.to_compact();
+        assert_eq!(
+            probe.len(),
+            size,
+            "to_compact length mismatch at size={size}"
+        );
 
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
             b.iter(|| {

--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -2,6 +2,37 @@
 //!
 //! Compares construction and search performance across all three index types
 //! using the same dataset and query parameters.
+//!
+//! # Scope
+//!
+//! - End-to-end through `FlatVectorSearcher`, `IvfSearcher`, `HnswSearcher`.
+//! - 1 000 / 5 000 vectors at dim=128, single field, top-10. Larger scale,
+//!   `ef_search` sweep, and multi-field cases are tracked in #423.
+//! - All inputs are deterministic via `common::DEFAULT_SEED` so two
+//!   consecutive runs produce comparable numbers.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench vector_search_bench
+//! ```
+//!
+//! Filter by group / case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench vector_search_bench -- "Flat Search"
+//! cargo bench --bench vector_search_bench -- "HNSW Search"
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench vector_search_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
 
 use std::sync::Arc;
 
@@ -17,18 +48,34 @@ use laurus::vector::index::config::{
 use laurus::vector::{
     FlatVectorSearcher, HnswSearcher, IvfSearcher, VectorIndexQuery, VectorIndexSearcher,
 };
-use rand::RngExt;
 
-fn generate_random_vector(dim: usize) -> Vector {
-    let mut rng = rand::rng();
-    let data: Vec<f32> = (0..dim).map(|_| rng.random::<f32>()).collect();
-    Vector::new(data)
+use common::{DEFAULT_SEED, SAMPLE_SIZE_SLOW, lcg_vec_unit};
+
+/// Build a deterministic `Vector` of length `dim`. The caller-supplied
+/// `state` advances per call, so successive vectors are different but the
+/// whole sequence is reproducible.
+fn generate_vector(state: &mut u64, dim: usize) -> Vector {
+    Vector::new(lcg_vec_unit(state, dim))
 }
 
 fn generate_vectors(count: usize, dim: usize) -> Vec<(u64, String, Vector)> {
+    let mut state = DEFAULT_SEED;
     (0..count)
-        .map(|i| (i as u64, "field".to_string(), generate_random_vector(dim)))
+        .map(|i| {
+            (
+                i as u64,
+                "field".to_string(),
+                generate_vector(&mut state, dim),
+            )
+        })
         .collect()
+}
+
+/// Build a deterministic query vector. Uses a different starting seed from
+/// the corpus so the query is not byte-identical to a corpus member.
+fn generate_query(dim: usize) -> Vector {
+    let mut state = DEFAULT_SEED.wrapping_add(1);
+    generate_vector(&mut state, dim)
 }
 
 fn create_storage() -> Arc<dyn Storage> {
@@ -41,7 +88,7 @@ fn create_storage() -> Arc<dyn Storage> {
 
 fn bench_flat_construction(c: &mut Criterion) {
     let mut group = c.benchmark_group("Flat Construction");
-    group.sample_size(10);
+    group.sample_size(SAMPLE_SIZE_SLOW); // slow construction path
     let dim = 128;
 
     for &count in &[1000, 5000] {
@@ -68,7 +115,7 @@ fn bench_flat_construction(c: &mut Criterion) {
 
 fn bench_ivf_construction(c: &mut Criterion) {
     let mut group = c.benchmark_group("IVF Construction");
-    group.sample_size(10);
+    group.sample_size(SAMPLE_SIZE_SLOW); // slow construction path
     let dim = 128;
 
     for &count in &[1000, 5000] {
@@ -119,7 +166,16 @@ fn bench_flat_search(c: &mut Criterion) {
 
         let reader = index.reader().unwrap();
         let searcher = FlatVectorSearcher::new(reader).unwrap();
-        let query = generate_random_vector(dim);
+        let query = generate_query(dim);
+
+        // Sanity check: the probe must return top-10 hits before timing.
+        let probe = searcher
+            .search(&VectorIndexQuery::new(query.clone()).top_k(10))
+            .unwrap();
+        assert!(
+            !probe.results.is_empty(),
+            "flat top-10 probe must return at least one hit at count={count}"
+        );
 
         group.bench_with_input(BenchmarkId::new("top10", count), &count, |b, _| {
             b.iter(|| {
@@ -154,7 +210,16 @@ fn bench_ivf_search(c: &mut Criterion) {
 
         let reader = index.reader().unwrap();
         let searcher = IvfSearcher::new(reader).unwrap();
-        let query = generate_random_vector(dim);
+        let query = generate_query(dim);
+
+        // Sanity check: the probe must return top-10 hits before timing.
+        let probe = searcher
+            .search(&VectorIndexQuery::new(query.clone()).top_k(10))
+            .unwrap();
+        assert!(
+            !probe.results.is_empty(),
+            "ivf top-10 probe must return at least one hit at count={count}"
+        );
 
         group.bench_with_input(BenchmarkId::new("top10", count), &count, |b, _| {
             b.iter(|| {
@@ -189,7 +254,16 @@ fn bench_hnsw_search_compare(c: &mut Criterion) {
 
         let reader = index.reader().unwrap();
         let searcher = HnswSearcher::new(reader).unwrap();
-        let query = generate_random_vector(dim);
+        let query = generate_query(dim);
+
+        // Sanity check: the probe must return top-10 hits before timing.
+        let probe = searcher
+            .search(&VectorIndexQuery::new(query.clone()).top_k(10))
+            .unwrap();
+        assert!(
+            !probe.results.is_empty(),
+            "hnsw top-10 probe must return at least one hit at count={count}"
+        );
 
         group.bench_with_input(BenchmarkId::new("top10", count), &count, |b, _| {
             b.iter(|| {


### PR DESCRIPTION
## Summary

- Add `benches/common.rs` with a shared deterministic LCG, `sample_size` constants, and the suite-wide hygiene policy.
- Set `autobenches = false` so `common.rs` is not picked up as a bench target (mirrors the existing `autoexamples = false` convention).
- Replace `rand::rng()` (OS-seeded) in `vector_search_bench.rs` with the deterministic LCG.
- Add or expand file-level doc-comment headers on every retained bench (scope, scenarios, run / filter instructions, recommended environment).
- Add a one-time sanity `assert!` to every top-level bench function so a regression that produces empty output cannot pass silently.
- Switch `sample_size(10)` literals to the named `SAMPLE_SIZE_SLOW` constant on construction-path benches.

`bench.rs` and `hnsw_benchmark.rs` are intentionally skipped — they are slated for removal in #425 and #426 respectively, so styling them now would create churn.

## Test plan

- [x] ``cargo bench -p laurus --no-run`` — all 7 benches build
- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass
- [x] ``cargo bench -p laurus --bench distance_bench`` × 2 — most metrics within 5 %; ``dot_product`` ~8.5 % on a shared workstation, expected to converge under the recommended environment documented in ``common.rs``

Closes #427