### PR TITLE
docs(benches): document --save-baseline workflow and benchmarking guide (#428)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,28 @@ build-laurus-wasm: ## Build laurus-wasm (wasm-pack, --target web)
 	cd laurus-wasm && wasm-pack build --target web --release
 
 # ── Benchmark ──────────────────────────────────────────────────────────────
+#
+# BENCH (optional) selects a single criterion bench by name, e.g.
+#   make bench BENCH=distance_bench
+# Without BENCH, every bench registered in laurus/Cargo.toml runs.
+#
+# bench-baseline saves the current run as a baseline named `main`. Run it on
+# the reference state (typically main).
+# bench-compare diffs the next run against that saved baseline. Run it on the
+# feature branch.
+#
+# Full workflow: docs/src/development/benchmarking.md.
+BENCH ?=
+BENCH_FLAG := $(if $(BENCH),--bench $(BENCH),)
 
-bench: ## Benchmark the project
-	cargo bench --bench bench
+bench: ## Run laurus benchmarks (BENCH=name selects one)
+	cargo bench -p laurus $(BENCH_FLAG)
+
+bench-baseline: ## Save the current results as the `main` baseline
+	cargo bench -p laurus $(BENCH_FLAG) -- --save-baseline main
+
+bench-compare: ## Compare against the `main` baseline saved earlier
+	cargo bench -p laurus $(BENCH_FLAG) -- --baseline main
 
 # ── Tag & Publish ──────────────────────────────────────────────────────────
 

--- a/docs/ja/src/SUMMARY.md
+++ b/docs/ja/src/SUMMARY.md
@@ -108,5 +108,6 @@
 # 開発ガイド
 
 - [ビルドとテスト](development/build_and_test.md)
+- [ベンチマーク](development/benchmarking.md)
 - [Feature Flags](development/feature_flags.md)
 - [プロジェクト構成](development/project_structure.md)

--- a/docs/ja/src/development/benchmarking.md
+++ b/docs/ja/src/development/benchmarking.md
@@ -1,0 +1,159 @@
+# ベンチマーク
+
+このガイドでは、laurus のベンチマークの実行方法、ベースライン（baseline）の保存と比較方法、プルリクエストでの結果報告方法について説明します。
+
+ベンチマークスイートは [`laurus/benches/`](https://github.com/mosuka/laurus/tree/main/laurus/benches) 配下にあり、[Criterion](https://github.com/bheisler/criterion.rs) で構築されています。衛生ルール（決定的シード、ファイル冒頭ドキュメント、sanity assert、`sample_size` ポリシー）は [`laurus/benches/common.rs`](https://github.com/mosuka/laurus/blob/main/laurus/benches/common.rs) で一元管理されています。
+
+## スイート一覧
+
+| ファイル | スコープ |
+| --- | --- |
+| `bkd_bench.rs` | BKD ツリーの範囲検索（range search）、交差判定（intersect）、構築（1D / 2D / 3D、10k / 100k / 1M ポイント） |
+| `distance_bench.rs` | `DistanceMetric::distance` の cosine / Euclidean / Manhattan / dot product（現状は単一次元、次元スイープは #424 で対応予定） |
+| `lexical_search_bench.rs` | `Engine::search` 経由のエンドツーエンド lexical 検索（term / boolean / phrase / fuzzy / DSL） |
+| `search_perf.rs` | Posting iterator の `skip_to`、`BM25Scorer::score`、SIMD バッチスコアリング、コンパクト posting 変換 |
+| `spell_correction_bench.rs` | `SpellingCorrector::correct`、各イテレーションごとに fresh corrector を渡す cold-state 計測 |
+| `synonym_bench.rs` | `SynonymDictionary::get_synonyms` のルックアップ（100 / 1k / 10k グループ）と構築コスト |
+| `text_analysis_bench.rs` | `StandardAnalyzer::analyze` のシングルドキュメントとバッチ（100 ドキュメント）解析 |
+| `vector_search_bench.rs` | Flat / IVF / HNSW の構築と検索（1k / 5k ベクタ、dim 128、top-10） |
+
+各ファイル冒頭の `//!` ドキュメントコメントにスコープ・シナリオ・フィルタ方法が書かれています。実行前に確認してください。
+
+## ベンチマークの実行
+
+単一ベンチファイルを実行：
+
+```bash
+cargo bench -p laurus --bench distance_bench
+```
+
+criterion id でフィルタ（部分一致）：
+
+```bash
+cargo bench -p laurus --bench distance_bench -- cosine
+cargo bench -p laurus --bench vector_search_bench -- "HNSW Search/top10"
+```
+
+コンパイル確認のみ（CI やリファクタリング時に有用）：
+
+```bash
+cargo bench -p laurus --bench distance_bench --no-run
+```
+
+ワークスペースの全ベンチを実行：
+
+```bash
+cargo bench -p laurus
+```
+
+## ベースラインの保存と比較
+
+Criterion は名前付きベースラインをサポートしており、フィーチャーブランチを `main`（または任意の参照状態）と比較できます。
+
+現在の状態を `main` という名前のベースラインとして保存：
+
+```bash
+cargo bench -p laurus --bench distance_bench -- --save-baseline main
+```
+
+その後の実行結果をベースラインと比較：
+
+```bash
+cargo bench -p laurus --bench distance_bench -- --baseline main
+```
+
+出力には `change:` 行がベンチマーク単位で表示され、変化率と判定（`No change in performance detected`、`Performance has improved`、`Performance has regressed`）が示されます。Criterion はベースラインを `target/criterion/<bench-id>/<baseline>/` 配下に保存します。
+
+perf PR の推奨フロー：
+
+1. `main`（または変更前の状態）で — `cargo bench --bench RELEVANT -- --save-baseline main`
+2. ブランチで変更を実装
+3. ブランチで — `cargo bench --bench RELEVANT -- --baseline main`
+4. `change:` 行を PR 説明にコピーする
+
+## 推奨環境
+
+µs / ns 単位のマイクロベンチマークはシステムノイズに敏感です。意味のある数値を得るには：
+
+- **CPU governor**: `performance` に設定（Linux）：
+
+  ```bash
+  sudo cpupower frequency-set -g performance
+  ```
+
+- **Turbo boost**: 周波数スケーリングが結果を歪めないように無効化：
+
+  ```bash
+  echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo   # Intel
+  ```
+
+  AMD システムや BIOS レベルの設定は異なるためベンダーのドキュメントを参照してください。
+
+- **バックグラウンド負荷**: ブラウザ・IDE・ビルドウォッチャー・Docker を停止する。CPU を共有するものは短時間ベンチを歪めます。
+
+- **コア固定（任意）**: 利用可能なら固定コアにピン留め：
+
+  ```bash
+  taskset -c 2 cargo bench -p laurus --bench distance_bench
+  ```
+
+- **再実行**: 2 回実行して比較する。チューニング済みマシンで ~5 % 以下の差はノイズ。共有ワークステーションでは ~5 % を超える差もノイズの可能性がある。1 回の実行結果を過大解釈しない。
+
+環境を安定化できない場合は、不安定な数値を権威ある数値として提示せず、PR で明示的に断ること（例:「共有ノート PC で測定、~10 % のノイズを想定」）。
+
+## Make ターゲット
+
+`Makefile` から共通エントリポイントを利用できます：
+
+```bash
+make bench             # cargo bench -p laurus
+make bench-baseline    # cargo bench -p laurus -- --save-baseline main
+make bench-compare     # cargo bench -p laurus -- --baseline main
+```
+
+単一ベンチを指定する場合は `BENCH=name` を渡します：
+
+```bash
+make bench BENCH=distance_bench
+make bench-baseline BENCH=distance_bench
+make bench-compare BENCH=distance_bench
+```
+
+## PR 説明テンプレート
+
+PR で計測可能なパフォーマンス変化を主張する場合、下記のようなテーブルを説明に貼り付けてください：
+
+```markdown
+## Performance
+
+Environment: <CPU モデル>, governor=performance, turbo disabled, dedicated machine.
+
+Baseline: `main` at <commit-sha>. After: this branch at <commit-sha>.
+
+| Bench | Before | After | Δ | Verdict |
+| --- | --- | --- | --- | --- |
+| `distance_metrics/cosine` | 4.20 µs | 3.10 µs | -26 % | improved |
+| `distance_metrics/euclidean` | 2.18 µs | 2.16 µs | -1 % | no change |
+
+Reproduce: `cargo bench -p laurus --bench distance_bench -- --baseline main`
+```
+
+比較が再現可能となるように、ベースラインと変更後の commit SHA を必ず含めてください。チューニング済みマシンで実行した場合でも環境を明示してください。
+
+## 新しいベンチマークの追加
+
+新規ベンチファイルを追加する際は、[`laurus/benches/common.rs`](https://github.com/mosuka/laurus/blob/main/laurus/benches/common.rs) のスイート全体衛生ルールに従ってください：
+
+1. `common::DEFAULT_SEED`（または `lcg_*` ヘルパ）で決定的シードを使う。`rand::rng()` は使わない。
+2. ファイル冒頭に `//!` ドキュメントコメントでスコープ・シナリオ・実行コマンド・フィルタ例を記載する。
+3. タイミング `b.iter` の外側で 1 度だけ `assert!` を実行し、空結果を出す regression を黙ってパスさせない。
+4. `SAMPLE_SIZE_FAST`（デフォルト、50 ms 以下の操作向け）または `SAMPLE_SIZE_SLOW`（構築パス向け）のいずれかを選ぶ。中間値は使わない。
+5. `laurus/Cargo.toml` に `[[bench]] name = "..." harness = false` で登録する。クレートは `autobenches = false` を設定しているため、`benches/` 配下のファイルは自動検出されない。
+
+ファイル間でヘルパを共有する必要がある場合は、`benches/common.rs` を拡張してコード重複を避けてください。
+
+## CI 連携
+
+現状、CI ではリグレッション検出のベンチジョブは実行していません。perf 系の PR は、推奨環境下で取得した baseline-vs-after 数値を手動で投稿することが想定されています。
+
+将来的には大きなリグレッションで失敗するスモークセットのベンチジョブを追加する案があり、アンブレラ Issue [#429](https://github.com/mosuka/laurus/issues/429) で追跡されています。

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -108,5 +108,6 @@
 # Development Guide
 
 - [Build & Test](development/build_and_test.md)
+- [Benchmarking](development/benchmarking.md)
 - [Feature Flags](development/feature_flags.md)
 - [Project Structure](development/project_structure.md)

--- a/docs/src/development/benchmarking.md
+++ b/docs/src/development/benchmarking.md
@@ -1,0 +1,159 @@
+# Benchmarking
+
+This guide describes how to run laurus benchmarks, how to capture and compare baselines, and how to report results in pull requests.
+
+The benchmark suite lives in [`laurus/benches/`](https://github.com/mosuka/laurus/tree/main/laurus/benches) and is built on [Criterion](https://github.com/bheisler/criterion.rs). Hygiene rules — deterministic seeds, file-level documentation, sanity asserts, and `sample_size` policy — are codified in [`laurus/benches/common.rs`](https://github.com/mosuka/laurus/blob/main/laurus/benches/common.rs).
+
+## Suite overview
+
+| File | Scope |
+| --- | --- |
+| `bkd_bench.rs` | BKD tree range search, intersect, and build (1D / 2D / 3D, 10k / 100k / 1M points) |
+| `distance_bench.rs` | `DistanceMetric::distance` for cosine, Euclidean, Manhattan, dot product (single dimension today; sweep tracked in #424) |
+| `lexical_search_bench.rs` | End-to-end lexical search through `Engine::search` for term, boolean, phrase, fuzzy, and DSL queries |
+| `search_perf.rs` | Posting iterator `skip_to`, `BM25Scorer::score`, SIMD batch scoring, compact posting conversion |
+| `spell_correction_bench.rs` | `SpellingCorrector::correct` with a fresh corrector per iteration (cold-state measurement) |
+| `synonym_bench.rs` | `SynonymDictionary::get_synonyms` lookup at 100 / 1k / 10k groups, plus build cost |
+| `text_analysis_bench.rs` | `StandardAnalyzer::analyze` single-document and batch (100 docs) |
+| `vector_search_bench.rs` | Flat / IVF / HNSW construction and search at 1k / 5k vectors, dim 128, top-10 |
+
+Each file declares its scope, scenarios, and how to filter in its top-of-file `//!` doc comment. Read it before running.
+
+## Running benchmarks
+
+Run a single bench file:
+
+```bash
+cargo bench -p laurus --bench distance_bench
+```
+
+Filter by criterion id (substring match):
+
+```bash
+cargo bench -p laurus --bench distance_bench -- cosine
+cargo bench -p laurus --bench vector_search_bench -- "HNSW Search/top10"
+```
+
+Compile-only smoke check (useful in CI or during refactors):
+
+```bash
+cargo bench -p laurus --bench distance_bench --no-run
+```
+
+Run every bench file in the workspace:
+
+```bash
+cargo bench -p laurus
+```
+
+## Saving and comparing baselines
+
+Criterion supports named baselines so you can compare a feature branch against `main` (or any other reference run).
+
+Save a baseline named `main` from your current state:
+
+```bash
+cargo bench -p laurus --bench distance_bench -- --save-baseline main
+```
+
+Compare a subsequent run against that baseline:
+
+```bash
+cargo bench -p laurus --bench distance_bench -- --baseline main
+```
+
+The output prints a `change:` line per benchmark with a percentage and a verdict (`No change in performance detected`, `Performance has improved`, `Performance has regressed`). Criterion stores baselines under `target/criterion/<bench-id>/<baseline>/`.
+
+Recommended flow for a perf PR:
+
+1. On `main` (or before any change) — `cargo bench --bench RELEVANT -- --save-baseline main`.
+2. Make the change on a branch.
+3. On the branch — `cargo bench --bench RELEVANT -- --baseline main`.
+4. Copy the `change:` lines into the PR description.
+
+## Recommended environment
+
+Microbenchmarks at the µs / ns scale are sensitive to system noise. For meaningful numbers:
+
+- **CPU governor**: set to `performance` (Linux):
+
+  ```bash
+  sudo cpupower frequency-set -g performance
+  ```
+
+- **Turbo boost**: disable so frequency scaling does not skew results:
+
+  ```bash
+  echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo   # Intel
+  ```
+
+  AMD systems and BIOS-level switches differ; consult vendor docs.
+
+- **Background load**: close browsers, IDEs, build watchers, and Docker. Anything sharing the CPU skews short-running benches.
+
+- **Pinning (optional)**: pin to a fixed core if available:
+
+  ```bash
+  taskset -c 2 cargo bench -p laurus --bench distance_bench
+  ```
+
+- **Repeat**: re-run twice and compare. Differences below ~5 % on a tuned machine are noise; differences above that on a shared workstation may also be noise. Do not over-interpret a single run.
+
+If you cannot stabilise the environment, say so explicitly in the PR (e.g. "measured on a shared laptop, expect ~10 % noise") rather than presenting unstable numbers as authoritative.
+
+## Make targets
+
+The `Makefile` exposes the common entry points:
+
+```bash
+make bench             # cargo bench -p laurus
+make bench-baseline    # cargo bench -p laurus -- --save-baseline main
+make bench-compare     # cargo bench -p laurus -- --baseline main
+```
+
+For a single bench, pass `BENCH=name`:
+
+```bash
+make bench BENCH=distance_bench
+make bench-baseline BENCH=distance_bench
+make bench-compare BENCH=distance_bench
+```
+
+## PR description template
+
+When a PR claims a measurable performance change, paste a table like the following into the description:
+
+```markdown
+## Performance
+
+Environment: <CPU model>, governor=performance, turbo disabled, dedicated machine.
+
+Baseline: `main` at <commit-sha>. After: this branch at <commit-sha>.
+
+| Bench | Before | After | Δ | Verdict |
+| --- | --- | --- | --- | --- |
+| `distance_metrics/cosine` | 4.20 µs | 3.10 µs | -26 % | improved |
+| `distance_metrics/euclidean` | 2.18 µs | 2.16 µs | -1 % | no change |
+
+Reproduce: `cargo bench -p laurus --bench distance_bench -- --baseline main`
+```
+
+Always include the commit SHAs of the baseline and the after-state so the comparison is reproducible. State the environment explicitly even when running on a tuned machine.
+
+## Adding a new benchmark
+
+When adding a new bench file, follow the suite-wide hygiene rules from [`laurus/benches/common.rs`](https://github.com/mosuka/laurus/blob/main/laurus/benches/common.rs):
+
+1. Use a deterministic seed via `common::DEFAULT_SEED` (or the `lcg_*` helpers). Never call `rand::rng()`.
+2. Add a top-of-file `//!` doc comment listing scope, scenarios, run command, and filter examples.
+3. Add a one-time sanity `assert!` outside the timed `b.iter` block so a regression that produces empty output cannot pass silently.
+4. Pick `SAMPLE_SIZE_FAST` (default, for sub-50 ms operations) or `SAMPLE_SIZE_SLOW` (construction paths). Do not invent intermediate values.
+5. Register the file in `laurus/Cargo.toml` with `[[bench]] name = "..." harness = false`. The crate sets `autobenches = false`, so files in `benches/` are not picked up automatically.
+
+If your bench needs to share helpers across files, extend `benches/common.rs` rather than duplicating code.
+
+## Continuous integration
+
+CI does not currently run a regression-detection bench job. Each perf-changing PR is expected to post baseline-vs-after numbers manually, captured under the recommended environment.
+
+A future iteration may add a smoke-set bench job that fails on large regressions; this is tracked under the umbrella issue [#429](https://github.com/mosuka/laurus/issues/429).


### PR DESCRIPTION
## Summary

- Add `docs/src/development/benchmarking.md` (English) and the Japanese translation under `docs/ja/src/development/benchmarking.md`. Both are registered in their respective `SUMMARY.md` under the Development Guide section.

- The guide covers:
  - Suite overview (8 bench files and their scope).
  - Running benchmarks (single, filter, no-run smoke, all).
  - Saving and comparing baselines (`--save-baseline main`, `--baseline main`).
  - Recommended environment (CPU governor, turbo boost, background load, `taskset`, repeat-and-compare discipline).
  - Make targets (`make bench`, `make bench-baseline`, `make bench-compare`, all accept `BENCH=name`).
  - PR description template with before / after / Δ / verdict columns and explicit environment / commit-SHA fields.
  - Adding a new bench (links to the #427 hygiene rules and `benches/common.rs`).
  - CI stance (manual numbers today; future smoke job tracked in the umbrella).

- Fix the broken `Makefile` ``bench`` target that still pointed at the now-deleted ``bench.rs`` after #426. Replace with ``cargo bench -p laurus`` and add ``bench-baseline`` / ``bench-compare``. All three accept ``BENCH=name`` to scope to a single criterion bench.

## Test plan

- [x] ``markdownlint-cli2 "docs/src/**/*.md"`` — 0 errors (77 files)
- [x] ``markdownlint-cli2 "docs/ja/src/**/*.md"`` — 0 errors (77 files)
- [x] ``mdbook build docs`` — success, ``docs/book/development/benchmarking.html`` is generated
- [x] ``mdbook build docs/ja`` — success, the Japanese page is generated under the configured ``build-dir``
- [x] ``make -n bench-baseline BENCH=distance_bench`` expands to ``cargo bench -p laurus --bench distance_bench -- --save-baseline main``
- [x] ``make -n bench-compare`` expands to ``cargo bench -p laurus -- --baseline main``

Local ``mdbook`` rebuild artifacts under ``docs/book/`` are intentionally excluded from this PR — ``deploy-docs.yml`` rebuilds and publishes them on push to ``main``.

Closes #428