### PR TITLE
bench(scoring): add direct micro-benches for BM25ScoringFunction and weighted cosine (#417)

### DIFF
--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -166,6 +166,14 @@ harness = false
 name = "synonym_bench"
 harness = false
 
+[[bench]]
+name = "bm25_scoring_bench"
+harness = false
+
+[[bench]]
+name = "cosine_similarity_bench"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 # Tests use `embedded://*` URIs to load lindera dictionaries. Cargo's feature

--- a/laurus/benches/bm25_scoring_bench.rs
+++ b/laurus/benches/bm25_scoring_bench.rs
@@ -1,0 +1,188 @@
+//! Criterion benchmarks for [`BM25ScoringFunction::score`] from
+//! `lexical::search::scoring::bm25`.
+//!
+//! This is the audit target tracked under #402 (precompute IDF per query and
+//! switch term lookups to `TermId`). Note that this is a **different** code
+//! path from `BM25Scorer` in `lexical::query::scorer`, which is benchmarked
+//! by `search_perf.rs::bench_bm25_scoring`.
+//!
+//! # Scope
+//!
+//! - Direct micro-bench of `BM25ScoringFunction::score(query_terms, doc_stats,
+//!   collection_stats, config)`.
+//! - Sweep: `query_terms.len() ∈ {1, 5, 10}` × `candidate_count ∈ {100, 10k,
+//!   100k}`.
+//! - Each iteration runs `score()` once per candidate against the same query,
+//!   so the timed work scales with `query_len * candidate_count` — exactly
+//!   what #402 will reduce.
+//! - Inputs are deterministic via `common::DEFAULT_SEED`; vocabulary is 100
+//!   synthetic terms (`term_<i>`) shared between query, document term
+//!   frequencies, and collection document frequencies.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench bm25_scoring_bench
+//! ```
+//!
+//! Filter by case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench bm25_scoring_bench -- "qterms_5/100000"
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench bm25_scoring_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
+
+use std::collections::HashMap;
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use laurus::lexical::search::scoring::bm25::{
+    BM25ScoringFunction, CollectionStats, DocumentStats, ScoringConfig, ScoringFunction,
+};
+
+use common::{DEFAULT_SEED, lcg_next_unit};
+
+/// Vocabulary size for the synthetic corpus. Picked to be larger than the
+/// largest `query_terms.len()` swept (10) by an order of magnitude so that
+/// query terms span a non-trivial slice of the document-frequency map.
+const VOCAB_SIZE: usize = 100;
+
+/// Average document length used to populate `CollectionStats::avg_doc_length`
+/// and the per-document `doc_length`. Mirrors a typical short-text field.
+const AVG_DOC_LENGTH: f64 = 100.0;
+
+/// Total document count reported in `CollectionStats::total_docs`. Affects
+/// IDF magnitude but not the per-call scoring cost.
+const TOTAL_DOCS: u64 = 1_000_000;
+
+/// Build the static vocabulary `["term_0", "term_1", …, "term_VOCAB_SIZE-1"]`.
+fn build_vocab() -> Vec<String> {
+    (0..VOCAB_SIZE).map(|i| format!("term_{i}")).collect()
+}
+
+/// Pick `n` query terms from `vocab` using a deterministic LCG step.
+/// The same seed produces the same query across runs so two `cargo bench`
+/// invocations are directly comparable.
+fn build_query(vocab: &[String], n: usize, state: &mut u64) -> Vec<String> {
+    (0..n)
+        .map(|_| {
+            let pick = (lcg_next_unit(state) * VOCAB_SIZE as f32) as usize % VOCAB_SIZE;
+            vocab[pick].clone()
+        })
+        .collect()
+}
+
+/// Build a collection-wide stats object whose `document_frequencies` is
+/// populated for every term in `vocab`. Frequencies follow a smooth
+/// pseudo-random distribution in `[1, total_docs)` so IDF varies per term.
+fn build_collection_stats(vocab: &[String]) -> CollectionStats {
+    let mut state = DEFAULT_SEED.wrapping_add(0xC011_EC71);
+    let mut document_frequencies = HashMap::with_capacity(vocab.len());
+    for term in vocab {
+        let df = (lcg_next_unit(&mut state) * (TOTAL_DOCS as f32 - 1.0)) as u64 + 1;
+        document_frequencies.insert(term.clone(), df);
+    }
+    CollectionStats {
+        total_docs: TOTAL_DOCS,
+        avg_doc_length: AVG_DOC_LENGTH,
+        avg_field_lengths: HashMap::new(),
+        document_frequencies,
+        field_document_frequencies: HashMap::new(),
+    }
+}
+
+/// Build `count` per-document stats objects. Each document's
+/// `term_frequencies` covers the full vocabulary with a deterministic
+/// pseudo-random TF in `[0, 10]`. Document length tracks `AVG_DOC_LENGTH`
+/// with light variance so the BM25 length-normalisation factor varies.
+fn build_doc_stats(vocab: &[String], count: usize) -> Vec<DocumentStats> {
+    let mut state = DEFAULT_SEED.wrapping_add(0xD0C57A75);
+    (0..count)
+        .map(|i| {
+            let mut term_frequencies = HashMap::with_capacity(vocab.len());
+            for term in vocab {
+                let tf = (lcg_next_unit(&mut state) * 10.0) as u64;
+                term_frequencies.insert(term.clone(), tf);
+            }
+            let doc_length = AVG_DOC_LENGTH as u64
+                + ((lcg_next_unit(&mut state) * 50.0) as u64).saturating_sub(25);
+            DocumentStats {
+                doc_id: i as u32,
+                doc_length,
+                field_lengths: HashMap::new(),
+                term_frequencies,
+                field_term_frequencies: HashMap::new(),
+            }
+        })
+        .collect()
+}
+
+fn bench_bm25_score(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bm25_scoring/score");
+
+    let scorer = BM25ScoringFunction;
+    let config = ScoringConfig::default();
+    let vocab = build_vocab();
+    let collection = build_collection_stats(&vocab);
+
+    // Build the candidate document sets once per `n_candidates` so the
+    // (expensive) HashMap-construction cost is not repeated for every
+    // `n_qterms` value. The score() call itself is what we measure.
+    for &n_candidates in &[100usize, 10_000, 100_000] {
+        let docs = build_doc_stats(&vocab, n_candidates);
+
+        for &n_qterms in &[1usize, 5, 10] {
+            let mut state = DEFAULT_SEED.wrapping_add(n_qterms as u64);
+            let query = build_query(&vocab, n_qterms, &mut state);
+
+            // One-time sanity check: scoring at least one document must
+            // yield a finite value. Note: BM25 IDF can be negative when a
+            // term's document frequency exceeds half the collection, so a
+            // negative score is legitimate; only NaN / Inf indicate broken
+            // inputs.
+            let probe = scorer
+                .score(&query, &docs[0], &collection, &config)
+                .expect("scoring probe must not error");
+            assert!(
+                probe.is_finite(),
+                "BM25 probe score must be finite, got {probe}"
+            );
+
+            group.throughput(Throughput::Elements(n_candidates as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("qterms_{n_qterms}/{n_candidates}")),
+                &(),
+                |b, _| {
+                    b.iter(|| {
+                        for doc in &docs {
+                            let score = scorer
+                                .score(
+                                    black_box(&query),
+                                    black_box(doc),
+                                    black_box(&collection),
+                                    black_box(&config),
+                                )
+                                .unwrap();
+                            black_box(score);
+                        }
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_bm25_score);
+criterion_main!(benches);

--- a/laurus/benches/cosine_similarity_bench.rs
+++ b/laurus/benches/cosine_similarity_bench.rs
@@ -1,0 +1,118 @@
+//! Criterion benchmarks for [`AdvancedSimilarityMetric::WeightedCosine`]
+//! from `vector::search::scoring::similarity`.
+//!
+//! This is the audit target tracked under #414 (precompute the query-side
+//! cosine norm once per search). Note that this is a **different** code path
+//! from `DistanceMetric::Cosine` in `vector::core::distance`, which is
+//! benchmarked by `distance_bench.rs`. The advanced metric supports
+//! per-dimension weights, recomputes both norms per call, and clamps the
+//! output to `[0, 1]`.
+//!
+//! # Scope
+//!
+//! - Direct micro-bench of `AdvancedSimilarityMetric::WeightedCosine.similarity(a, b, Some(weights))`.
+//! - Sweep: `dim ∈ {64, 128, 384, 768, 1024}` × `candidate_count ∈ {1, 100, 10k}`.
+//! - Each iteration runs `similarity()` once per candidate against the same
+//!   query, so the timed work scales with `dim * candidate_count` — exactly
+//!   what #414 will reduce by caching the query-side norm.
+//! - Inputs are deterministic via `common::DEFAULT_SEED`. Components are in
+//!   `[0, 1)`; weights are uniform 1.0 (the documented default-equivalent
+//!   shape — perf-sensitive code path is identical to the unweighted case
+//!   and #414 covers both).
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench cosine_similarity_bench
+//! ```
+//!
+//! Filter by case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench cosine_similarity_bench -- "dim_768/10000"
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench cosine_similarity_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use laurus::vector::core::vector::Vector;
+use laurus::vector::search::scoring::similarity::AdvancedSimilarityMetric;
+
+use common::{DEFAULT_SEED, lcg_vec_unit};
+
+/// Build a deterministic query vector. Uses a separate seed offset so the
+/// query is not byte-identical to a corpus member.
+fn build_query(dim: usize) -> Vector {
+    let mut state = DEFAULT_SEED.wrapping_add(0xC053_1EA1);
+    Vector::new(lcg_vec_unit(&mut state, dim))
+}
+
+/// Build `count` deterministic candidate vectors of length `dim`.
+fn build_candidates(dim: usize, count: usize) -> Vec<Vector> {
+    let mut state = DEFAULT_SEED;
+    (0..count)
+        .map(|_| Vector::new(lcg_vec_unit(&mut state, dim)))
+        .collect()
+}
+
+fn bench_weighted_cosine(c: &mut Criterion) {
+    let mut group = c.benchmark_group("weighted_cosine_similarity");
+
+    let metric = AdvancedSimilarityMetric::WeightedCosine;
+
+    for &dim in &[64usize, 128, 384, 768, 1024] {
+        let weights: Vec<f32> = vec![1.0; dim];
+        let query = build_query(dim);
+
+        for &n_candidates in &[1usize, 100, 10_000] {
+            let candidates = build_candidates(dim, n_candidates);
+
+            // One-time sanity check: similarity must be in [0, 1] (the
+            // metric clamps internally) and finite. Failure means inputs
+            // are degenerate (zero vector).
+            let probe = metric
+                .similarity(&query, &candidates[0], Some(&weights))
+                .expect("cosine probe must not error");
+            assert!(
+                probe.is_finite() && (0.0..=1.0).contains(&probe),
+                "cosine probe must be finite and within [0, 1], got {probe}"
+            );
+
+            group.throughput(Throughput::Elements(n_candidates as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("dim_{dim}/{n_candidates}")),
+                &(),
+                |b, _| {
+                    b.iter(|| {
+                        for cand in &candidates {
+                            let s = metric
+                                .similarity(
+                                    black_box(&query),
+                                    black_box(cand),
+                                    black_box(Some(&weights)),
+                                )
+                                .unwrap();
+                            black_box(s);
+                        }
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_weighted_cosine);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Add two new benchmark files that directly target the audited code paths for #402 (BM25 IDF precompute) and #414 (cosine query-norm cache). Both are unblockers — without them, the corresponding perf PRs cannot post a meaningful before/after number.

### `benches/bm25_scoring_bench.rs`

Measures `BM25ScoringFunction::score` from `lexical::search::scoring::bm25`. The existing `search_perf::bench_bm25_scoring` measures a **different struct** (`BM25Scorer` in `lexical::query::scorer`) that is not the audit target for #402.

- Sweep: query-term count {1, 5, 10} × candidate count {100, 10k, 100k}.
- Deterministic LCG-generated `DocumentStats` / `CollectionStats` over a 100-term synthetic vocabulary.
- One-time sanity assert verifies the probe score is finite (note: BM25 IDF can be legitimately negative when `df > total_docs/2`, so the assert intentionally allows negative values).

### `benches/cosine_similarity_bench.rs`

Measures `AdvancedSimilarityMetric::WeightedCosine.similarity`, the only public entry point to the private `weighted_cosine_similarity` helper in `vector::search::scoring::similarity`. The existing `distance_bench` / `cosine_distance_batch` measures `DistanceMetric::Cosine`, a **different code path**.

- Sweep: dim {64, 128, 384, 768, 1024} × candidate count {1, 100, 10k}.
- Includes non-multiple-of-8 dimensions (384) and the typical embedding sizes (768, 1024).
- One-time sanity assert verifies the probe is in `[0, 1]` (the metric clamps internally).

### Hygiene

Both benches conform to the #427 hygiene policy:

- Deterministic seeds via `common::DEFAULT_SEED`.
- File-level doc-comment headers documenting scope, sweep, run command, and the relationship to other benches.
- One-time sanity assert outside the timed `b.iter` loop.
- ``Throughput::Elements(candidate_count)`` for per-call comparability across sweep parameters.
- ``SAMPLE_SIZE_FAST`` (criterion default) since each call is sub-µs to single-µs.

### Cargo.toml

Register the two new benches with ``harness = false``.

## Test plan

- [x] ``cargo bench -p laurus --no-run`` — 10 benches build (was 8 + 2 new = 10)
- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass
- [x] ``cargo bench --bench bm25_scoring_bench -- "qterms_1/100"`` — runs, ~3.06 Melem/s
- [x] ``cargo bench --bench cosine_similarity_bench -- "dim_64/1$"`` — runs, ~83 ns / iter

Closes #417