### PR TITLE
bench: cover HNSW fallback/graph paths and multi-segment posting merge (#421)

### DIFF
--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -174,6 +174,10 @@ harness = false
 name = "cosine_similarity_bench"
 harness = false
 
+[[bench]]
+name = "posting_merge_bench"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 # Tests use `embedded://*` URIs to load lindera dictionaries. Cargo's feature

--- a/laurus/benches/posting_merge_bench.rs
+++ b/laurus/benches/posting_merge_bench.rs
@@ -1,0 +1,145 @@
+//! Criterion benchmark for the multi-segment posting iterator merger.
+//!
+//! Targets [`MergedPostingIterator::next`] from
+//! `lexical::index::inverted::reader`. This is the audit target tracked
+//! under #412 (use a linear-scan posting merge for small segment counts;
+//! today every merge goes through `BinaryHeap`).
+//!
+//! # Scope
+//!
+//! - Synthetic micro-bench. Constructs `N` separate
+//!   [`InvertedIndexPostingIterator`]s with overlapping doc IDs
+//!   (interleaved across segments) so the merger has to interleave reads,
+//!   then drives the merged iterator's `next()` to exhaustion.
+//! - The bench bypasses `Engine` entirely so the auto-merge policy
+//!   (`TieredMergePolicy::max_segments_per_tier = 4`) cannot collapse
+//!   segments under our feet.
+//! - Sweep `N ∈ {1, 2, 4, 8, 16}` × fixed `postings_per_segment = 10_000`.
+//!   For `N = 1` the merger holds a single iterator, exposing the
+//!   `MergedPostingIterator` wrapper overhead even when no merging is
+//!   needed.
+//! - Inputs are deterministic: doc IDs are computed as
+//!   `i * N + segment_index` so every iter has a strictly-ascending
+//!   sequence and the global merged stream is also strictly ascending.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench posting_merge_bench
+//! ```
+//!
+//! Filter by N:
+//!
+//! ```sh
+//! cargo bench --bench posting_merge_bench -- "merge/8"
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench posting_merge_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use laurus::lexical::index::inverted::core::posting::Posting;
+use laurus::lexical::index::inverted::reader::{
+    InvertedIndexPostingIterator, MergedPostingIterator,
+};
+use laurus::lexical::reader::PostingIterator;
+
+/// Number of postings per synthetic segment. Picked large enough that the
+/// per-call overhead of `next()` dominates iteration setup, but small
+/// enough that the largest case (`N = 16` → 160k postings) runs in well
+/// under a second per iter.
+const POSTINGS_PER_SEGMENT: usize = 10_000;
+
+/// Build a single segment's posting list. Document IDs are
+/// `(start_doc_id, start_doc_id + stride, start_doc_id + 2 * stride, …)`
+/// so each segment's stream is strictly ascending and segments interleave
+/// when merged.
+fn build_segment_postings(start_doc_id: u64, stride: u64, count: usize) -> Vec<Posting> {
+    (0..count)
+        .map(|i| Posting::new(start_doc_id + (i as u64) * stride))
+        .collect()
+}
+
+/// Build `n` segment iterators ready to be passed to
+/// `MergedPostingIterator::new`. The `i`th segment owns doc IDs
+/// `{i, i + n, i + 2n, …}` so the merged stream visits doc IDs
+/// `0, 1, 2, …` in order, exercising the cross-segment selection logic on
+/// every step.
+fn build_segment_iterators(n: usize) -> Vec<Box<dyn PostingIterator>> {
+    (0..n)
+        .map(|seg_idx| {
+            let postings = build_segment_postings(seg_idx as u64, n as u64, POSTINGS_PER_SEGMENT);
+            Box::new(InvertedIndexPostingIterator::new(postings)) as Box<dyn PostingIterator>
+        })
+        .collect()
+}
+
+fn bench_merge(c: &mut Criterion) {
+    let mut group = c.benchmark_group("posting_merge/next");
+
+    for &n in &[1usize, 2, 4, 8, 16] {
+        let total_postings = (n * POSTINGS_PER_SEGMENT) as u64;
+
+        // One-time sanity check: a freshly built merged iterator must
+        // produce strictly ascending doc IDs and exhaust at exactly
+        // `n * POSTINGS_PER_SEGMENT` items. Failing this means the test
+        // data generator drifted out of sync with the merger contract.
+        let mut probe = MergedPostingIterator::new(build_segment_iterators(n))
+            .expect("merger probe must construct");
+        let mut last = None::<u64>;
+        let mut count = 0u64;
+        while probe
+            .next()
+            .expect("merger probe must not error during next()")
+        {
+            let doc = probe.doc_id();
+            if let Some(prev) = last {
+                assert!(
+                    doc >= prev,
+                    "merged stream must be non-decreasing (n={n}, prev={prev}, doc={doc})"
+                );
+            }
+            last = Some(doc);
+            count += 1;
+        }
+        assert_eq!(
+            count, total_postings,
+            "merged stream length mismatch at n={n}: expected {total_postings}, got {count}"
+        );
+
+        group.throughput(Throughput::Elements(total_postings));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("merge/{n}")),
+            &n,
+            |b, &n| {
+                b.iter_batched(
+                    || {
+                        MergedPostingIterator::new(build_segment_iterators(n))
+                            .expect("merger setup must succeed")
+                    },
+                    |mut merger| {
+                        while merger.next().unwrap() {
+                            black_box(merger.doc_id());
+                        }
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_merge);
+criterion_main!(benches);

--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -260,11 +260,18 @@ fn bench_ivf_search(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_hnsw_search_compare(c: &mut Criterion) {
-    let mut group = c.benchmark_group("HNSW Search");
+/// Benchmark the **fallback (linear-scan) path** of `HnswSearcher::search`.
+///
+/// `VectorIndexQuery::new` leaves `field_name` as `None`. The graph branch
+/// in `HnswSearcher::search` is gated on `Some(field_name)`, so a query
+/// without a field name short-circuits to the linear-scan fallback. This is
+/// the path #404 (drop the redundant `similarity()` + `distance()` pair)
+/// targets.
+fn bench_hnsw_fallback_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("HNSW Fallback Search");
     let dim = 128;
 
-    for &count in &[1000, 5000] {
+    for &count in &[1000, 5000, 50_000] {
         let vectors = generate_vectors(count, dim);
         let storage = create_storage();
         let config = HnswIndexConfig {
@@ -274,9 +281,12 @@ fn bench_hnsw_search_compare(c: &mut Criterion) {
             distance_metric: DistanceMetric::Cosine,
             ..Default::default()
         };
-        let mut index =
-            ManagedVectorIndex::new(VectorIndexTypeConfig::HNSW(config), storage, "hnsw_bench")
-                .unwrap();
+        let mut index = ManagedVectorIndex::new(
+            VectorIndexTypeConfig::HNSW(config),
+            storage,
+            "hnsw_fallback_bench",
+        )
+        .unwrap();
         index.add_vectors(vectors).unwrap();
         index.finalize().unwrap();
         index.write().unwrap();
@@ -286,17 +296,81 @@ fn bench_hnsw_search_compare(c: &mut Criterion) {
         let query = generate_query(dim);
 
         // Sanity check: the probe must return top-10 hits before timing.
+        // No field_name set → fallback (linear scan) path.
         let probe = searcher
             .search(&VectorIndexQuery::new(query.clone()).top_k(10))
             .unwrap();
         assert!(
             !probe.results.is_empty(),
-            "hnsw top-10 probe must return at least one hit at count={count}"
+            "hnsw fallback top-10 probe must return at least one hit at count={count}"
         );
 
+        group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::new("top10", count), &count, |b, _| {
             b.iter(|| {
                 let request = VectorIndexQuery::new(query.clone()).top_k(10);
+                searcher.search(&request).unwrap()
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark the **graph-traversal path** of `HnswSearcher::search`.
+///
+/// Setting `field_name` enables the graph branch (provided the reader has a
+/// graph and is downcastable to `HnswIndexReader`). This is the path that
+/// scales with `ef_search` rather than corpus size; #406 (replace the
+/// `HashSet<u64>` visited set with a bitmap) and #405 (per-field
+/// `vector_ids` cache) target this path.
+fn bench_hnsw_graph_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("HNSW Graph Search");
+    let dim = 128;
+
+    for &count in &[1000, 5000, 50_000] {
+        let vectors = generate_vectors(count, dim);
+        let storage = create_storage();
+        let config = HnswIndexConfig {
+            dimension: dim,
+            m: 16,
+            ef_construction: 200,
+            distance_metric: DistanceMetric::Cosine,
+            ..Default::default()
+        };
+        let mut index = ManagedVectorIndex::new(
+            VectorIndexTypeConfig::HNSW(config),
+            storage,
+            "hnsw_graph_bench",
+        )
+        .unwrap();
+        index.add_vectors(vectors).unwrap();
+        index.finalize().unwrap();
+        index.write().unwrap();
+
+        let reader = index.reader().unwrap();
+        let searcher = HnswSearcher::new(reader).unwrap();
+        let query = generate_query(dim);
+
+        // Sanity check: with field_name set, the graph branch must engage
+        // and return at least one hit.
+        let probe = searcher
+            .search(
+                &VectorIndexQuery::new(query.clone())
+                    .top_k(10)
+                    .field_name("field".to_string()),
+            )
+            .unwrap();
+        assert!(
+            !probe.results.is_empty(),
+            "hnsw graph top-10 probe must return at least one hit at count={count}"
+        );
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::new("top10", count), &count, |b, _| {
+            b.iter(|| {
+                let request = VectorIndexQuery::new(query.clone())
+                    .top_k(10)
+                    .field_name("field".to_string());
                 searcher.search(&request).unwrap()
             });
         });
@@ -311,6 +385,7 @@ criterion_group!(
     bench_hnsw_construction,
     bench_flat_search,
     bench_ivf_search,
-    bench_hnsw_search_compare,
+    bench_hnsw_fallback_search,
+    bench_hnsw_graph_search,
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

Add two missing measurement scenarios. Without these, the perf PRs that target them (#404, #406, #412) cannot post meaningful before/after numbers.

### `vector_search_bench.rs`

- **Rename** ``bench_hnsw_search_compare`` → ``bench_hnsw_fallback_search`` and document why the body actually measures the linear-scan **fallback** path. ``HnswSearcher::search`` short-circuits to fallback when the request has no ``field_name``; ``VectorIndexQuery::new`` leaves ``field_name`` as ``None``, so the existing bench was incidentally measuring fallback (not graph). The audit's claim that this bench measured the graph path was inaccurate.
- **Extend** the fallback sweep to 1k / 5k / **50k** vectors.
- **Add** ``bench_hnsw_graph_search`` that sets ``.field_name(\"field\")`` to force graph traversal. Same 1k / 5k / 50k sweep, dim 128, top-10.
- Both apply ``Throughput::Elements(count)`` for per-vector comparability.

### `posting_merge_bench.rs` (new)

- Construct ``N`` ``InvertedIndexPostingIterator`` instances with doc IDs interleaved across segments, wrap with ``MergedPostingIterator``, and drive ``next()`` to exhaustion. Bypasses ``Engine`` so the ``TieredMergePolicy`` auto-merge cannot collapse our deliberately separate segments.
- Sweep ``N ∈ {1, 2, 4, 8, 16}`` × 10k postings per segment.
- Uses ``iter_batched`` with ``BatchSize::SmallInput`` because the merger is single-pass.
- One-time sanity check verifies the merged stream length equals ``N * 10_000`` and doc IDs are non-decreasing.

### Cargo.toml

Register ``posting_merge_bench`` with ``harness = false``.

### Note on the rename

``bench_hnsw_search_compare``'s criterion id changes from ``\"HNSW Search\"`` to ``\"HNSW Fallback Search\"``. No saved baselines are expected to exist yet — the ``--save-baseline`` workflow itself was only documented yesterday in #428 / #433.

## Test plan

- [x] ``cargo bench -p laurus --no-run`` — 11 benches build (was 10 + 1 new = 11)
- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass
- [x] Smoke ``HNSW Fallback Search/top10/1000`` — 223 µs / 4.4 Melem/s
- [x] Smoke ``HNSW Graph Search/top10/1000`` — 145 µs / 6.8 Melem/s (graph faster than fallback as expected; gap will widen at 50k)
- [x] Smoke ``posting_merge/next/merge/1`` — 146 µs / 67 Melem/s

Closes #421