### PR TITLE
bench(distance): add dimension sweep to distance_bench (include non-multiple-of-8 dims) (#424)

### DIFF
--- a/laurus/benches/distance_bench.rs
+++ b/laurus/benches/distance_bench.rs
@@ -1,15 +1,31 @@
 //! Criterion benchmarks for the [`DistanceMetric`] family.
 //!
-//! Compares Cosine, Euclidean, Manhattan, and DotProduct distances on a small
-//! warm-set of vectors at a fixed dimension.
+//! Compares Cosine, Euclidean, Manhattan, and DotProduct distances on a
+//! warm-set of vectors across multiple embedding dimensions.
 //!
 //! # Scope
 //!
 //! - Microbench of [`DistanceMetric::distance`] for the four built-in
 //!   metrics.
-//! - Single dimension, single batch size, single query × 100 targets.
-//! - Does **not** cover the SIMD-remainder path — that requires a
-//!   non-multiple-of-8 dimension sweep (tracked separately in #424).
+//! - **Dimension sweep**: 64, 100, 128, 384, 768, 1024.
+//!   - The SIMD body uses `wide::f32x8` (8-lane), so any dimension that
+//!     is a multiple of 8 has no scalar remainder.
+//!   - Multiples of 8: 64, 128, 384, 768, 1024 — the SIMD body covers
+//!     every element. Note that 384 (= 48 × 8) is a multiple of 8
+//!     despite being an off-power-of-two value; it is retained because
+//!     it matches a common embedding size (e.g. `all-MiniLM-L6-v2`).
+//!   - Non-multiple of 8: **100** (= 12 × 8 + 4) is the only dimension
+//!     in this sweep that exercises the SIMD remainder loop — the path
+//!     that #415 (vectorize SIMD remainder in distance kernels) targets.
+//!     If #415's effect needs to be measured at additional non-multiple
+//!     dimensions, extend `DIMS` accordingly.
+//! - Single batch size: 100 target vectors per query.
+//! - Reports `Throughput::Elements(100)` so the per-distance cost is
+//!   directly comparable across dimensions and metrics.
+//! - Bench id encodes the dimension and metric as `dim_{N}/{metric}` so
+//!   `cargo bench -- "dim_100"` filters all metrics for the non-8-multiple
+//!   case and `cargo bench -- "cosine"` filters cosine across every
+//!   dimension.
 //!
 //! # Run
 //!
@@ -17,10 +33,11 @@
 //! cargo bench --bench distance_bench
 //! ```
 //!
-//! Filter by metric (criterion id matches the metric name):
+//! Filter:
 //!
 //! ```sh
-//! cargo bench --bench distance_bench -- cosine
+//! cargo bench --bench distance_bench -- "dim_384"
+//! cargo bench --bench distance_bench -- "cosine"
 //! ```
 //!
 //! Compile-only smoke check:
@@ -33,9 +50,17 @@
 
 mod common;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use laurus::vector::DistanceMetric;
 use std::hint::black_box;
+
+/// Embedding dimensions to sweep. Mix of 8-byte multiples and non-multiples
+/// so the SIMD remainder path #415 targets has measurable cases.
+const DIMS: &[usize] = &[64, 100, 128, 384, 768, 1024];
+
+/// Number of target vectors compared against a single query per timed
+/// iteration. Reflected in `Throughput::Elements(NUM_TARGETS)`.
+const NUM_TARGETS: usize = 100;
 
 fn generate_test_vectors(count: usize, dimension: usize) -> Vec<Vec<f32>> {
     let mut vectors = Vec::with_capacity(count);
@@ -51,47 +76,52 @@ fn generate_test_vectors(count: usize, dimension: usize) -> Vec<Vec<f32>> {
 }
 
 fn bench_distances(c: &mut Criterion) {
-    let dimension = 128;
-    let vectors = generate_test_vectors(101, dimension);
-    let query = &vectors[0];
-    let targets = &vectors[1..101];
-
-    // One-time sanity check: every metric returns a finite, non-NaN value
-    // for the first target. Failing this means the bench premise is broken
-    // before we even start measuring.
-    for metric in [
-        DistanceMetric::Cosine,
-        DistanceMetric::Euclidean,
-        DistanceMetric::Manhattan,
-        DistanceMetric::DotProduct,
-    ] {
-        let probe = metric.distance(query, &targets[0]).unwrap();
-        assert!(
-            probe.is_finite(),
-            "{}: distance must be finite for the probe pair, got {probe}",
-            metric.name()
-        );
-    }
-
     let mut group = c.benchmark_group("distance_metrics");
+    group.throughput(Throughput::Elements(NUM_TARGETS as u64));
 
-    for metric in [
+    let metrics = [
         DistanceMetric::Cosine,
         DistanceMetric::Euclidean,
         DistanceMetric::Manhattan,
         DistanceMetric::DotProduct,
-    ] {
-        group.bench_function(metric.name(), |b| {
-            b.iter(|| {
-                for target in targets {
-                    let _ = black_box(
-                        metric
-                            .distance(black_box(query), black_box(target))
-                            .unwrap(),
-                    );
-                }
-            })
-        });
+    ];
+
+    for &dim in DIMS {
+        let vectors = generate_test_vectors(NUM_TARGETS + 1, dim);
+        let query = vectors[0].clone();
+        let targets: Vec<Vec<f32>> = vectors.into_iter().skip(1).collect();
+        debug_assert_eq!(targets.len(), NUM_TARGETS);
+
+        // One-time sanity check: every metric must return a finite,
+        // non-NaN distance for the first target. Failing this means the
+        // bench premise is broken before we start measuring.
+        for metric in metrics {
+            let probe = metric.distance(&query, &targets[0]).unwrap();
+            assert!(
+                probe.is_finite(),
+                "{} (dim={dim}): distance must be finite for the probe pair, got {probe}",
+                metric.name()
+            );
+        }
+
+        for metric in metrics {
+            let id = format!("dim_{dim}/{}", metric.name());
+            group.bench_with_input(
+                BenchmarkId::from_parameter(id),
+                &(query.clone(), targets.clone()),
+                |b, (query, targets)| {
+                    b.iter(|| {
+                        for target in targets {
+                            let _ = black_box(
+                                metric
+                                    .distance(black_box(query), black_box(target))
+                                    .unwrap(),
+                            );
+                        }
+                    })
+                },
+            );
+        }
     }
 
     group.finish();


### PR DESCRIPTION
## Summary

Replace the hard-coded ``dim = 128`` case in ``distance_bench.rs`` with a six-dimension sweep so #415 (vectorize SIMD remainder in distance kernels) has a measurable target.

### Sweep

``DIMS = [64, 100, 128, 384, 768, 1024]``.

The SIMD body uses ``wide::f32x8`` (8-lane), so any dimension that is a multiple of 8 has no scalar remainder. Of the swept dimensions, only ``dim = 100`` (= 12 × 8 + 4) actually exercises the SIMD remainder loop. ``dim = 384`` is retained because it matches a common embedding size (``all-MiniLM-L6-v2``), even though it **is** a multiple of 8 (= 48 × 8). The file header documents this explicitly so future readers do not assume 384 is a tail case.

### Bench id format

``dim_{N}/{metric}`` so ``cargo bench`` filters work in either direction:

```sh
cargo bench --bench distance_bench -- "dim_100"   # all metrics at 100
cargo bench --bench distance_bench -- "cosine"    # cosine across dims
```

### Throughput

``Throughput::Elements(100)`` is set on the bench group so per-distance cost is directly comparable across dimensions and metrics.

### Note on the criterion id rename

The criterion id changes from ``distance_metrics/cosine`` to ``distance_metrics/dim_128/cosine`` (etc). No saved baselines are expected for ``distance_bench`` yet — the ``--save-baseline`` workflow landed only yesterday in #428 / #433.

## Test plan

- [x] ``cargo bench -p laurus --bench distance_bench --no-run`` — clean
- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass
- [x] Smoke ``dim_64/cosine`` (8×) — 2.18 µs / 45.9 Melem/s
- [x] Smoke ``dim_100/cosine`` (non-8×, tail 4) — 3.35 µs / 29.85 Melem/s
- [x] Smoke ``dim_384/cosine`` (8×, common embedding) — 7.95 µs / 12.6 Melem/s

The dim=100 → dim=64 ratio (1.54×) tracks the dim ratio (1.56×) — SIMD body is linear and the tail loop is a small correction. The dim=384 → dim=64 ratio (3.6×) is sub-linear in the dim ratio (6×), confirming SIMD throughput dominates when there is no tail.

Closes #424