### PR TITLE
bench(vector): scale vector_search_bench to 100k, ef_search sweep, multi-field (#423)

### DIFF
--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -6,22 +6,44 @@
 //! # Scope
 //!
 //! - End-to-end through `FlatVectorSearcher`, `IvfSearcher`, `HnswSearcher`.
-//! - 1 000 / 5 000 vectors at dim=128, single field, top-10. Larger scale,
-//!   `ef_search` sweep, and multi-field cases are tracked in #423.
+//! - Search corpus sweep: 1 000 / 5 000 by default; opt in to a 100 000
+//!   vector case via `LAURUS_BENCH_LARGE=1` (see "Large-corpus gate" below).
+//!   Construction benches stay at 1 000 / 5 000 to keep the default `cargo
+//!   bench` runtime under five minutes.
+//! - HNSW `ef_search` sweep: `bench_hnsw_ef_search_sweep` measures graph
+//!   search at fixed corpus 5 000, dim 128, `ef_search ∈ {16, 64, 128, 256,
+//!   512}`. Drives the visited-set hot path that #406 (replace
+//!   `HashSet<u64>` with bitmap) targets.
+//! - HNSW multi-field: `bench_hnsw_multi_field_search` builds 5 000 vectors
+//!   distributed across `field_a` (30 %), `field_b` (30 %), `field_c`
+//!   (40 %) and searches with `field_name("field_a")`. Drives the per-field
+//!   `vector_ids` cache hot path that #405 targets — today every search
+//!   linearly scans the full field list.
 //! - All inputs are deterministic via `common::DEFAULT_SEED` so two
-//!   consecutive runs produce comparable numbers.
+//!   consecutive runs produce comparable numbers (#427 hygiene).
+//!
+//! # Large-corpus gate
+//!
+//! Setting `LAURUS_BENCH_LARGE=1` adds a 100 000-vector case to
+//! `bench_flat_search`, `bench_ivf_search`, `bench_hnsw_fallback_search`,
+//! and `bench_hnsw_graph_search`. The 100 000-vector setup takes several
+//! seconds and per-iter search at 100 k can be tens of milliseconds, so
+//! this case is opt-in. Default runs (no env var) finish in well under
+//! five minutes on a typical workstation.
 //!
 //! # Run
 //!
 //! ```sh
-//! cargo bench --bench vector_search_bench
+//! cargo bench --bench vector_search_bench                          # default sizes
+//! LAURUS_BENCH_LARGE=1 cargo bench --bench vector_search_bench     # adds 100 k
 //! ```
 //!
 //! Filter by group / case (substring match against the criterion id):
 //!
 //! ```sh
 //! cargo bench --bench vector_search_bench -- "Flat Search"
-//! cargo bench --bench vector_search_bench -- "HNSW Search"
+//! cargo bench --bench vector_search_bench -- "ef_search/ef_64"
+//! cargo bench --bench vector_search_bench -- "Multi-field"
 //! ```
 //!
 //! Compile-only smoke check:
@@ -71,6 +93,37 @@ fn generate_vectors(count: usize, dim: usize) -> Vec<(u64, String, Vector)> {
         .collect()
 }
 
+/// Names of the three fields used by the multi-field bench.
+const MULTI_FIELD_NAMES: &[&str] = &["field_a", "field_b", "field_c"];
+
+/// Build deterministic vectors split 30 / 30 / 40 % across `field_a`,
+/// `field_b`, `field_c`. Used by `bench_hnsw_multi_field_search` to drive
+/// the per-field-cache hot path that #405 targets — searching with
+/// `field_name("field_a")` should only need to consider the 30 % of
+/// vectors tagged `field_a`, but today the implementation scans every
+/// (id, field_name) pair.
+fn generate_multi_field_vectors(count: usize, dim: usize) -> Vec<(u64, String, Vector)> {
+    let mut state = DEFAULT_SEED;
+    (0..count)
+        .map(|i| {
+            // 30 / 30 / 40 split based on i % 10.
+            let pct = i % 10;
+            let field = if pct < 3 {
+                MULTI_FIELD_NAMES[0] // field_a — 30 %
+            } else if pct < 6 {
+                MULTI_FIELD_NAMES[1] // field_b — 30 %
+            } else {
+                MULTI_FIELD_NAMES[2] // field_c — 40 %
+            };
+            (
+                i as u64,
+                field.to_string(),
+                generate_vector(&mut state, dim),
+            )
+        })
+        .collect()
+}
+
 /// Build a deterministic query vector. Uses a different starting seed from
 /// the corpus so the query is not byte-identical to a corpus member.
 fn generate_query(dim: usize) -> Vector {
@@ -80,6 +133,30 @@ fn generate_query(dim: usize) -> Vector {
 
 fn create_storage() -> Arc<dyn Storage> {
     StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default())).unwrap()
+}
+
+/// Default search-corpus sizes for Flat and IVF benches.
+/// `LAURUS_BENCH_LARGE=1` appends a 100 000-vector case so #405 / #406
+/// have a measurable target without ballooning the default `cargo bench`
+/// runtime past five minutes.
+fn search_corpus_sizes() -> Vec<usize> {
+    let mut sizes = vec![1000usize, 5000];
+    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
+        sizes.push(100_000);
+    }
+    sizes
+}
+
+/// HNSW-specific search-corpus sizes. Adds 50 000 over `search_corpus_sizes`
+/// because the fallback / graph search benches added that case in #421 to
+/// demonstrate path-specific scaling. `LAURUS_BENCH_LARGE=1` further
+/// appends 100 000.
+fn hnsw_corpus_sizes() -> Vec<usize> {
+    let mut sizes = vec![1000usize, 5000, 50_000];
+    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
+        sizes.push(100_000);
+    }
+    sizes
 }
 
 // ---------------------------------------------------------------------------
@@ -179,7 +256,7 @@ fn bench_flat_search(c: &mut Criterion) {
     let mut group = c.benchmark_group("Flat Search");
     let dim = 128;
 
-    for &count in &[1000, 5000] {
+    for &count in &search_corpus_sizes() {
         let vectors = generate_vectors(count, dim);
         let storage = create_storage();
         let config = FlatIndexConfig {
@@ -220,7 +297,7 @@ fn bench_ivf_search(c: &mut Criterion) {
     let mut group = c.benchmark_group("IVF Search");
     let dim = 128;
 
-    for &count in &[1000, 5000] {
+    for &count in &search_corpus_sizes() {
         let vectors = generate_vectors(count, dim);
         let storage = create_storage();
         let config = IvfIndexConfig {
@@ -271,7 +348,7 @@ fn bench_hnsw_fallback_search(c: &mut Criterion) {
     let mut group = c.benchmark_group("HNSW Fallback Search");
     let dim = 128;
 
-    for &count in &[1000, 5000, 50_000] {
+    for &count in &hnsw_corpus_sizes() {
         let vectors = generate_vectors(count, dim);
         let storage = create_storage();
         let config = HnswIndexConfig {
@@ -327,7 +404,7 @@ fn bench_hnsw_graph_search(c: &mut Criterion) {
     let mut group = c.benchmark_group("HNSW Graph Search");
     let dim = 128;
 
-    for &count in &[1000, 5000, 50_000] {
+    for &count in &hnsw_corpus_sizes() {
         let vectors = generate_vectors(count, dim);
         let storage = create_storage();
         let config = HnswIndexConfig {
@@ -378,6 +455,136 @@ fn bench_hnsw_graph_search(c: &mut Criterion) {
     group.finish();
 }
 
+/// HNSW search latency across an `ef_search` sweep at a fixed corpus.
+///
+/// `ef_search` controls the size of the dynamic candidate list during
+/// graph traversal — larger `ef` exhaustively explores more nodes per
+/// query, trading latency for recall. The visited-set hot path inside the
+/// inner loop scales linearly with the number of nodes touched, so this
+/// sweep is what #406 (replace `HashSet<u64>` with bitmap) targets.
+fn bench_hnsw_ef_search_sweep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("HNSW ef_search");
+    let dim = 128;
+    let count = 5000usize;
+
+    let vectors = generate_vectors(count, dim);
+    let storage = create_storage();
+    let config = HnswIndexConfig {
+        dimension: dim,
+        m: 16,
+        ef_construction: 200,
+        distance_metric: DistanceMetric::Cosine,
+        ..Default::default()
+    };
+    let mut index = ManagedVectorIndex::new(
+        VectorIndexTypeConfig::HNSW(config),
+        storage,
+        "hnsw_ef_bench",
+    )
+    .unwrap();
+    index.add_vectors(vectors).unwrap();
+    index.finalize().unwrap();
+    index.write().unwrap();
+
+    let reader = index.reader().unwrap();
+    let query = generate_query(dim);
+
+    for &ef in &[16usize, 64, 128, 256, 512] {
+        let mut searcher = HnswSearcher::new(reader.clone()).unwrap();
+        searcher.set_ef_search(ef);
+
+        // Sanity: graph traversal at this ef must yield at least one hit.
+        let probe = searcher
+            .search(
+                &VectorIndexQuery::new(query.clone())
+                    .top_k(10)
+                    .field_name("field".to_string()),
+            )
+            .unwrap();
+        assert!(
+            !probe.results.is_empty(),
+            "hnsw ef_search probe must return at least one hit at ef={ef}"
+        );
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("ef_{ef}/top10")),
+            &ef,
+            |b, _| {
+                b.iter(|| {
+                    let request = VectorIndexQuery::new(query.clone())
+                        .top_k(10)
+                        .field_name("field".to_string());
+                    searcher.search(&request).unwrap()
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// HNSW search filtered to a single field on a multi-field corpus.
+///
+/// The corpus is split 30 / 30 / 40 % across `field_a`, `field_b`,
+/// `field_c`. The query selects `field_a`, so only ~30 % of vectors are
+/// candidates. Today every search calls `vector_ids()` to fetch all
+/// `(id, field_name)` pairs and filters by string equality — wasted work
+/// proportional to the non-target field count. #405 (per-field
+/// `vector_ids` cache) targets this hot path.
+fn bench_hnsw_multi_field_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("HNSW Multi-field Search");
+    let dim = 128;
+    let count = 5000usize;
+
+    let vectors = generate_multi_field_vectors(count, dim);
+    let storage = create_storage();
+    let config = HnswIndexConfig {
+        dimension: dim,
+        m: 16,
+        ef_construction: 200,
+        distance_metric: DistanceMetric::Cosine,
+        ..Default::default()
+    };
+    let mut index = ManagedVectorIndex::new(
+        VectorIndexTypeConfig::HNSW(config),
+        storage,
+        "hnsw_multi_field_bench",
+    )
+    .unwrap();
+    index.add_vectors(vectors).unwrap();
+    index.finalize().unwrap();
+    index.write().unwrap();
+
+    let reader = index.reader().unwrap();
+    let searcher = HnswSearcher::new(reader).unwrap();
+    let query = generate_query(dim);
+
+    // Sanity: filtering to field_a (~30 % of corpus) must still hit.
+    let probe = searcher
+        .search(
+            &VectorIndexQuery::new(query.clone())
+                .top_k(10)
+                .field_name("field_a".to_string()),
+        )
+        .unwrap();
+    assert!(
+        !probe.results.is_empty(),
+        "hnsw multi-field probe must return at least one hit (field_a, count={count})"
+    );
+
+    group.throughput(Throughput::Elements(count as u64));
+    group.bench_function("field_a_30pct/top10", |b| {
+        b.iter(|| {
+            let request = VectorIndexQuery::new(query.clone())
+                .top_k(10)
+                .field_name("field_a".to_string());
+            searcher.search(&request).unwrap()
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_flat_construction,
@@ -387,5 +594,7 @@ criterion_group!(
     bench_ivf_search,
     bench_hnsw_fallback_search,
     bench_hnsw_graph_search,
+    bench_hnsw_ef_search_sweep,
+    bench_hnsw_multi_field_search,
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

Address the audit point that ``vector_search_bench`` could not surface wins for #405 (per-field ``vector_ids`` cache) or #406 (HNSW visited-set bitmap) at its prior 5 000-vector / single-field / fixed-ef shape. **This is the final Phase 2 item — closing it completes the entire bench-hygiene umbrella #429.**

### Helpers

- `generate_multi_field_vectors(count, dim)` splits the corpus 30 / 30 / 40 % across ``field_a`` / ``field_b`` / ``field_c`` (deterministic).
- `search_corpus_sizes()` returns ``[1000, 5000]`` by default; appends ``100_000`` under ``LAURUS_BENCH_LARGE=1``. Used by Flat / IVF search.
- `hnsw_corpus_sizes()` returns ``[1000, 5000, 50_000]`` by default (#421 added 50 k for HNSW fallback / graph scaling); appends ``100_000`` under ``LAURUS_BENCH_LARGE=1``.

Existing search benches now consume these helpers so the LARGE flag extends them automatically. Construction benches stay at 1k / 5k to keep default ``cargo bench`` under five minutes.

### New bench: `bench_hnsw_ef_search_sweep`

- Fixed corpus 5 000, dim 128, top-10.
- ``ef_search ∈ {16, 64, 128, 256, 512}``.
- Index built once; ``Arc::clone(&reader)`` gives each ``ef`` case its own ``HnswSearcher`` with ``set_ef_search(ef)``.
- Bench id: ``HNSW ef_search/ef_{ef}/top10``.
- Targets the visited-set hot path #406 will optimise.

### New bench: `bench_hnsw_multi_field_search`

- 5 000 vectors split 30 / 30 / 40 % across ``field_a`` / ``field_b`` / ``field_c``.
- Searches with ``field_name("field_a")`` so only ~30 % of vectors are candidates.
- Bench id: ``HNSW Multi-field Search/field_a_30pct/top10``.
- Targets the per-field ``vector_ids`` cache hot path #405 will optimise.

### Determinism

Already enforced by #427 — every input flows through ``common::DEFAULT_SEED`` + ``lcg_vec_unit``.

## Test plan

- [x] ``cargo bench -p laurus --bench vector_search_bench --no-run`` — clean
- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass
- [x] Smoke ``ef_search/ef_16/top10`` — 94.7 µs / 52.2 Melem/s
- [x] Smoke ``Multi-field/field_a_30pct/top10`` — 200 µs / 25.0 Melem/s (~1.5× the single-field graph search at the same corpus size; the excess is the wasted ``vector_ids`` scan #405 will remove)

Closes #423