### PR TITLE
bench(lexical): add lexical indexing throughput benchmark suite (#442)

### DIFF
--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -190,6 +190,10 @@ harness = false
 name = "store_fetch_bench"
 harness = false
 
+[[bench]]
+name = "lexical_indexing_bench"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 # Tests use `embedded://*` URIs to load lindera dictionaries. Cargo's feature

--- a/laurus/benches/lexical_indexing_bench.rs
+++ b/laurus/benches/lexical_indexing_bench.rs
@@ -1,0 +1,406 @@
+//! Lexical indexing throughput benchmarks.
+//!
+//! Targets the audit gap that no bench previously measured the cost of
+//! `Engine::add_document` or `Engine::commit`. `lexical_search_bench`
+//! always called `build_engine(n)` inside its setup block, leaving the
+//! ingest path invisible.
+//!
+//! # Scope
+//!
+//! Four measurement scenarios:
+//!
+//! 1. **`bench_add_documents`** — pure `add_document` × N (no `commit`).
+//!    Reports per-doc latency for the in-memory buffering path. Sweep
+//!    `N ∈ {1k, 10k}` (LARGE adds 100k).
+//! 2. **`bench_commit`** — pre-buffer N docs, then time `commit()`. Shows
+//!    the segment-flush cost without the `add_document` overhead.
+//! 3. **`bench_bulk_ingest`** — `add × N + commit`. The user-visible
+//!    "how long to ingest N docs?" number.
+//! 4. **`bench_multi_segment_commit`** — `(add × K + commit) × M` so M
+//!    segments accumulate. M ∈ {2, 4, 8} at K = 1 000. Exposes the
+//!    cost of repeated commits and any auto-merge work the
+//!    `TieredMergePolicy` triggers (default `max_segments_per_tier = 4`,
+//!    so M = 8 typically crosses the merge threshold and the cost shape
+//!    differs from M = 2).
+//!
+//! Each scenario uses `iter_batched` with `BatchSize::SmallInput` so
+//! every timed iteration receives a fresh `Engine`. The Engine
+//! construction sits in `iter_batched` setup, outside the timing window.
+//!
+//! # Vocabulary
+//!
+//! Mirrors the 3-tier Zipf vocabulary in `lexical_search_bench.rs`. Kept
+//! local to this file for now; consolidate into `common.rs` if either
+//! file's vocabulary needs updating.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench lexical_indexing_bench                       # default sizes
+//! LAURUS_BENCH_LARGE=1 cargo bench --bench lexical_indexing_bench  # adds 100k
+//! ```
+//!
+//! Filter by case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench lexical_indexing_bench -- "bulk_ingest"
+//! cargo bench --bench lexical_indexing_bench -- "multi_segment/m_4"
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench lexical_indexing_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
+
+use std::sync::Arc;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use common::SAMPLE_SIZE_SLOW;
+
+use laurus::analysis::analyzer::analyzer::Analyzer;
+use laurus::analysis::analyzer::standard::StandardAnalyzer;
+use laurus::lexical::core::field::IntegerOption;
+use laurus::lexical::{TermQuery, TextOption};
+use laurus::storage::memory::MemoryStorageConfig;
+use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::{Document, Engine, LexicalSearchQuery, Result, Schema, SearchRequestBuilder};
+
+// ----------------------------------------------------------------------------
+// Vocabulary (mirrors lexical_search_bench.rs — keep in sync if either
+// file's vocab changes).
+// ----------------------------------------------------------------------------
+
+const COMMON_TERMS: &str = "search engine system data query";
+
+const TOPIC_PHRASES: &[&str] = &[
+    "rust programming language systems safety concurrency memory ownership",
+    "python data science machine learning artificial intelligence numpy",
+    "javascript web development frontend backend node react framework",
+    "database query optimization indexing performance search engine",
+    "network protocol distributed systems cloud computing infrastructure",
+    "security cryptography authentication authorization encryption",
+    "algorithms data structures sorting searching graph traversal",
+    "operating systems kernel processes threads scheduling memory",
+];
+
+const LONG_TAIL: &[&str] = &[
+    "compaction",
+    "histogram",
+    "lattice",
+    "registry",
+    "compiler",
+    "scheduler",
+    "interpreter",
+    "garbage",
+    "collector",
+    "allocator",
+    "telemetry",
+    "regression",
+    "snapshot",
+    "replication",
+    "consensus",
+    "quorum",
+    "leader",
+    "follower",
+    "hashicorp",
+    "kubernetes",
+    "docker",
+    "mesos",
+    "borg",
+    "raft",
+    "paxos",
+    "tantivy",
+    "lucene",
+    "solr",
+    "elasticsearch",
+    "qdrant",
+    "weaviate",
+    "milvus",
+    "embedding",
+    "transformer",
+    "attention",
+    "softmax",
+    "gradient",
+    "backprop",
+    "tensor",
+    "matrix",
+    "vector",
+    "scalar",
+    "tokenizer",
+    "lemmatizer",
+    "stemmer",
+    "synonym",
+    "antonym",
+    "wordnet",
+    "thesaurus",
+    "ontology",
+    "taxonomy",
+];
+
+const LONG_TAIL_PER_DOC: usize = 5;
+
+const CATEGORIES: &[&str] = &["programming", "data-science", "web", "database", "systems"];
+
+fn build_body(i: usize) -> String {
+    let topic = TOPIC_PHRASES[i % TOPIC_PHRASES.len()];
+
+    let mut tail_words = Vec::with_capacity(LONG_TAIL_PER_DOC);
+    for k in 0..LONG_TAIL_PER_DOC {
+        let idx = (i.wrapping_mul(7) + k * 11) % LONG_TAIL.len();
+        tail_words.push(LONG_TAIL[idx]);
+    }
+    let tail = tail_words.join(" ");
+
+    format!("Document {i} {COMMON_TERMS} {topic} {tail} should match relevant terms")
+}
+
+/// Build `n` `(id, Document)` pairs deterministically.
+fn build_documents(n: usize) -> Vec<(String, Document)> {
+    (0..n)
+        .map(|i| {
+            let body = build_body(i);
+            let doc = Document::builder()
+                .add_text("title", format!("Title for document {i}"))
+                .add_text("body", &body)
+                .add_text("category", CATEGORIES[i % CATEGORIES.len()])
+                .add_integer("year", 2020 + (i % 5) as i64)
+                .build();
+            (i.to_string(), doc)
+        })
+        .collect()
+}
+
+// ----------------------------------------------------------------------------
+// Engine helpers
+// ----------------------------------------------------------------------------
+
+fn memory_storage() -> Result<Arc<dyn Storage>> {
+    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+}
+
+async fn build_empty_engine() -> Result<Engine> {
+    let storage = memory_storage()?;
+    let analyzer: Arc<dyn Analyzer> = Arc::new(StandardAnalyzer::default());
+
+    let schema = Schema::builder()
+        .add_text_field("title", TextOption::default())
+        .add_text_field("body", TextOption::default())
+        .add_text_field("category", TextOption::default())
+        .add_integer_field("year", IntegerOption::default())
+        .add_default_field("body")
+        .build();
+
+    Engine::builder(storage, schema)
+        .analyzer(analyzer)
+        .build()
+        .await
+}
+
+fn ingest_corpus_sizes() -> Vec<usize> {
+    let mut sizes = vec![1000usize, 10_000];
+    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
+        sizes.push(100_000);
+    }
+    sizes
+}
+
+// ----------------------------------------------------------------------------
+// Benches
+// ----------------------------------------------------------------------------
+
+/// `add_document` × N, without `commit`. Measures the in-memory buffering
+/// path only.
+fn bench_add_documents(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("ingest/add_documents");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &ingest_corpus_sizes() {
+        // One-time sanity check: ingest once and confirm the engine
+        // contains the buffered docs (not committed, but `add_document`
+        // returned Ok). We do this by re-running setup + a single
+        // add_document and asserting it does not error.
+        {
+            let engine = rt.block_on(build_empty_engine()).unwrap();
+            let (id, doc) = build_documents(1).into_iter().next().unwrap();
+            rt.block_on(engine.add_document(&id, doc)).unwrap();
+        }
+
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let engine = rt.block_on(build_empty_engine()).unwrap();
+                    let docs = build_documents(n);
+                    (engine, docs)
+                },
+                |(engine, docs)| {
+                    rt.block_on(async {
+                        for (id, doc) in docs {
+                            engine.add_document(&id, doc).await.unwrap();
+                        }
+                    });
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+/// `commit` latency after N docs are pre-buffered.
+fn bench_commit(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("ingest/commit");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &[1000usize, 10_000] {
+        // Sanity: a fresh engine with N adds + commit makes the docs
+        // searchable.
+        {
+            let engine = rt.block_on(build_empty_engine()).unwrap();
+            let docs = build_documents(n);
+            rt.block_on(async {
+                for (id, doc) in docs {
+                    engine.add_document(&id, doc).await.unwrap();
+                }
+                engine.commit().await.unwrap();
+                let request = SearchRequestBuilder::new()
+                    .lexical_query(LexicalSearchQuery::Obj(Box::new(TermQuery::new(
+                        "body", "search",
+                    ))))
+                    .limit(10)
+                    .build();
+                let hits = engine.search(request).await.unwrap();
+                assert!(
+                    !hits.is_empty(),
+                    "commit probe must produce searchable docs at n={n}"
+                );
+            });
+        }
+
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let engine = rt.block_on(build_empty_engine()).unwrap();
+                    let docs = build_documents(n);
+                    rt.block_on(async {
+                        for (id, doc) in docs {
+                            engine.add_document(&id, doc).await.unwrap();
+                        }
+                    });
+                    engine
+                },
+                |engine| {
+                    rt.block_on(engine.commit()).unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+/// End-to-end `add × N + commit`. The user-visible "ingest N docs" cost.
+fn bench_bulk_ingest(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("ingest/bulk");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &ingest_corpus_sizes() {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let engine = rt.block_on(build_empty_engine()).unwrap();
+                    let docs = build_documents(n);
+                    (engine, docs)
+                },
+                |(engine, docs)| {
+                    rt.block_on(async {
+                        for (id, doc) in docs {
+                            engine.add_document(&id, doc).await.unwrap();
+                        }
+                        engine.commit().await.unwrap();
+                    });
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+/// `(add × K + commit) × M` so M segments accumulate. M = 8 typically
+/// crosses the default `TieredMergePolicy::max_segments_per_tier = 4`
+/// threshold, so the M-sweep also exposes any auto-merge work.
+fn bench_multi_segment_commit(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("ingest/multi_segment");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    let k_per_segment = 1000usize;
+
+    for &m in &[2usize, 4, 8] {
+        let total = m * k_per_segment;
+        group.throughput(Throughput::Elements(total as u64));
+        group.bench_with_input(BenchmarkId::new("m", m), &m, |b, &m| {
+            b.iter_batched(
+                || {
+                    let engine = rt.block_on(build_empty_engine()).unwrap();
+                    let batches: Vec<Vec<(String, Document)>> = (0..m)
+                        .map(|seg| {
+                            let start = seg * k_per_segment;
+                            (start..start + k_per_segment)
+                                .map(|i| {
+                                    let body = build_body(i);
+                                    let doc = Document::builder()
+                                        .add_text("title", format!("Title for document {i}"))
+                                        .add_text("body", &body)
+                                        .add_text("category", CATEGORIES[i % CATEGORIES.len()])
+                                        .add_integer("year", 2020 + (i % 5) as i64)
+                                        .build();
+                                    (i.to_string(), doc)
+                                })
+                                .collect()
+                        })
+                        .collect();
+                    (engine, batches)
+                },
+                |(engine, batches)| {
+                    rt.block_on(async {
+                        for batch in batches {
+                            for (id, doc) in batch {
+                                engine.add_document(&id, doc).await.unwrap();
+                            }
+                            engine.commit().await.unwrap();
+                        }
+                    });
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_add_documents,
+    bench_commit,
+    bench_bulk_ingest,
+    bench_multi_segment_commit,
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

The bench-hygiene umbrella (#429) covered every search-side hot path of perf umbrella #416, but **lexical indexing has been invisible**: `lexical_search_bench` calls `build_engine(n)` inside its setup block, so ``Engine::add_document`` and ``Engine::commit`` cost never enter timing.

Add `benches/lexical_indexing_bench.rs` with four scenarios so future ingest-side perf work has a quantitative surface.

### Scenarios

- **`bench_add_documents`** — pure ``add_document × N`` (no commit). Sweep ``N ∈ {1k, 10k}``; ``LAURUS_BENCH_LARGE=1`` adds 100k.
- **`bench_commit`** — pre-buffer N docs, time ``commit()`` in isolation.
- **`bench_bulk_ingest`** — ``add × N + commit`` — the user-visible "ingest N docs" wall time.
- **`bench_multi_segment_commit`** — ``(add × K + commit) × M`` with ``K=1000`` and ``M ∈ {2, 4, 8}``. ``M=8`` typically crosses the default ``TieredMergePolicy::max_segments_per_tier = 4`` threshold so the auto-merge cost is included.

### Pattern: `iter_batched` with rt.block_on

`Engine` is async-only and Criterion has no async ``iter_batched``. The setup is sync (``rt.block_on(build_empty_engine())``) and the routine wraps the ingest loop in another ``rt.block_on``. Each timed iteration receives a fresh `Engine`; engine construction sits outside timing.

### Vocabulary

Mirrors the 3-tier Zipf set from `lexical_search_bench.rs` (``COMMON_TERMS`` / ``TOPIC_PHRASES`` / ``LONG_TAIL``). Inline copy with a ``keep in sync`` header comment; consolidation into ``common.rs`` deferred.

### Sanity assert

`bench_commit`'s one-time probe ingests N docs + commit and verifies ``engine.search()`` returns hits, so a regression that silently drops documents is caught.

### Cargo.toml

Register the bench with ``harness = false``.

## Test plan

- [x] ``cargo bench -p laurus --bench lexical_indexing_bench --no-run`` — clean
- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass
- [x] Smoke ``add_documents/1000`` — 42 ms / 23.8 Kelem/s

This is the first item of the post-#429 coverage-gap umbrella (#446). A parallel issue for vector indexing throughput via the Engine API will follow shortly.

Closes #442