### PR TITLE
bench: add vector indexing, hybrid search, and mutation benchmark suites (#443, #445, #448)

### DIFF
--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -194,6 +194,10 @@ harness = false
 name = "lexical_indexing_bench"
 harness = false
 
+[[bench]]
+name = "vector_indexing_bench"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 # Tests use `embedded://*` URIs to load lindera dictionaries. Cargo's feature

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -198,6 +198,10 @@ harness = false
 name = "vector_indexing_bench"
 harness = false
 
+[[bench]]
+name = "hybrid_search_bench"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 # Tests use `embedded://*` URIs to load lindera dictionaries. Cargo's feature

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -202,6 +202,10 @@ harness = false
 name = "hybrid_search_bench"
 harness = false
 
+[[bench]]
+name = "mutation_bench"
+harness = false
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 # Tests use `embedded://*` URIs to load lindera dictionaries. Cargo's feature

--- a/laurus/benches/hybrid_search_bench.rs
+++ b/laurus/benches/hybrid_search_bench.rs
@@ -1,0 +1,327 @@
+//! Hybrid (lexical + vector) search benchmarks.
+//!
+//! Targets the post-#429 coverage gap that `Engine::search` with both a
+//! `lexical_query` and a `vector_query` set was never benchmarked. The
+//! original audit (#416 item 8) flagged the fusion stage — particularly
+//! the dedup + score-merge across two top-K candidate lists — as a
+//! likely O(n²) hotspot. Without a hybrid surface, no fusion-side perf
+//! change can post a credible before / after.
+//!
+//! # Scope
+//!
+//! Three measurement scenarios:
+//!
+//! 1. **`bench_hybrid_rrf`** — `lexical_query + vector_query` with
+//!    `FusionAlgorithm::RRF { k: 60.0 }`, top-K = 10 at corpus 5 000.
+//! 2. **`bench_hybrid_weighted_sum`** — same shape, but
+//!    `FusionAlgorithm::WeightedSum { lexical_weight: 0.5,
+//!    vector_weight: 0.5 }` so cost-difference between fusion strategies
+//!    is measurable.
+//! 3. **`bench_hybrid_top_k_sweep`** — RRF fusion at fixed corpus 5 000,
+//!    K ∈ {10, 100, 500}. Larger K stresses the dedup / merge path the
+//!    most.
+//!
+//! Optional: `LAURUS_BENCH_LARGE=1` adds a 100 000-doc case.
+//!
+//! # Vocabulary
+//!
+//! Mirrors the 3-tier Zipf vocabulary used by `lexical_search_bench` and
+//! `lexical_indexing_bench`. Each document also carries a deterministic
+//! 128-d vector in the `embedding` HNSW field. Inline copy with a
+//! "keep in sync" comment; consolidation deferred.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench hybrid_search_bench
+//! LAURUS_BENCH_LARGE=1 cargo bench --bench hybrid_search_bench
+//! ```
+//!
+//! Filter by case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench hybrid_search_bench -- "rrf"
+//! cargo bench --bench hybrid_search_bench -- "top_k/k_500"
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench hybrid_search_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use common::{DEFAULT_SEED, SAMPLE_SIZE_FAST, lcg_vec_unit};
+
+use laurus::analysis::analyzer::analyzer::Analyzer;
+use laurus::analysis::analyzer::standard::StandardAnalyzer;
+use laurus::lexical::core::field::IntegerOption;
+use laurus::lexical::{TermQuery, TextOption};
+use laurus::storage::memory::MemoryStorageConfig;
+use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::field::HnswOption;
+use laurus::vector::core::vector::Vector;
+use laurus::vector::search::searcher::VectorSearchQuery;
+use laurus::vector::store::request::QueryVector;
+use laurus::{
+    Document, Engine, FusionAlgorithm, LexicalSearchQuery, Result, Schema, SearchRequest,
+    SearchRequestBuilder,
+};
+
+const DIM: usize = 128;
+const VECTOR_FIELD: &str = "embedding";
+
+const COMMON_TERMS: &str = "search engine system data query";
+
+const TOPIC_PHRASES: &[&str] = &[
+    "rust programming language systems safety concurrency memory ownership",
+    "python data science machine learning artificial intelligence numpy",
+    "javascript web development frontend backend node react framework",
+    "database query optimization indexing performance search engine",
+    "network protocol distributed systems cloud computing infrastructure",
+    "security cryptography authentication authorization encryption",
+    "algorithms data structures sorting searching graph traversal",
+    "operating systems kernel processes threads scheduling memory",
+];
+
+const LONG_TAIL: &[&str] = &[
+    "compaction",
+    "histogram",
+    "lattice",
+    "registry",
+    "compiler",
+    "scheduler",
+    "interpreter",
+    "garbage",
+    "collector",
+    "allocator",
+    "telemetry",
+    "regression",
+    "snapshot",
+    "replication",
+    "consensus",
+    "quorum",
+    "leader",
+    "follower",
+];
+
+const LONG_TAIL_PER_DOC: usize = 5;
+
+const CATEGORIES: &[&str] = &["programming", "data-science", "web", "database", "systems"];
+
+fn build_body(i: usize) -> String {
+    let topic = TOPIC_PHRASES[i % TOPIC_PHRASES.len()];
+
+    let mut tail_words = Vec::with_capacity(LONG_TAIL_PER_DOC);
+    for k in 0..LONG_TAIL_PER_DOC {
+        let idx = (i.wrapping_mul(7) + k * 11) % LONG_TAIL.len();
+        tail_words.push(LONG_TAIL[idx]);
+    }
+    let tail = tail_words.join(" ");
+
+    format!("Document {i} {COMMON_TERMS} {topic} {tail} should match relevant terms")
+}
+
+fn memory_storage() -> Result<Arc<dyn Storage>> {
+    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+}
+
+async fn build_hybrid_engine(n: usize) -> Result<Engine> {
+    let storage = memory_storage()?;
+    let analyzer: Arc<dyn Analyzer> = Arc::new(StandardAnalyzer::default());
+
+    let schema = Schema::builder()
+        .add_text_field("title", TextOption::default())
+        .add_text_field("body", TextOption::default())
+        .add_text_field("category", TextOption::default())
+        .add_integer_field("year", IntegerOption::default())
+        .add_hnsw_field(
+            VECTOR_FIELD,
+            HnswOption::new(DIM).distance(DistanceMetric::Cosine),
+        )
+        .add_default_field("body")
+        .build();
+
+    let engine = Engine::builder(storage, schema)
+        .analyzer(analyzer)
+        .build()
+        .await?;
+
+    let mut state = DEFAULT_SEED;
+    for i in 0..n {
+        let body = build_body(i);
+        let vec = lcg_vec_unit(&mut state, DIM);
+        let doc = Document::builder()
+            .add_text("title", format!("Title for document {i}"))
+            .add_text("body", &body)
+            .add_text("category", CATEGORIES[i % CATEGORIES.len()])
+            .add_integer("year", 2020 + (i % 5) as i64)
+            .add_vector(VECTOR_FIELD, vec)
+            .build();
+        engine.add_document(&i.to_string(), doc).await?;
+    }
+    engine.commit().await?;
+    Ok(engine)
+}
+
+fn corpus_sizes() -> Vec<usize> {
+    let mut sizes = vec![5_000usize];
+    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
+        sizes.push(100_000);
+    }
+    sizes
+}
+
+/// Build a deterministic dim-128 query vector. Uses a separate seed
+/// offset so the query is not byte-identical to a corpus member.
+fn build_query_vector() -> Vector {
+    let mut state = DEFAULT_SEED.wrapping_add(1);
+    Vector::new(lcg_vec_unit(&mut state, DIM))
+}
+
+/// Build a `SearchRequest` carrying both a lexical term query and a
+/// vector query, with the given fusion algorithm and top-K.
+fn build_hybrid_request(fusion: FusionAlgorithm, limit: usize) -> SearchRequest {
+    let lexical = LexicalSearchQuery::Obj(Box::new(TermQuery::new("body", "search")));
+    let vector = VectorSearchQuery::Vectors(vec![QueryVector {
+        vector: build_query_vector(),
+        weight: 1.0,
+        fields: Some(vec![VECTOR_FIELD.to_string()]),
+    }]);
+
+    SearchRequestBuilder::new()
+        .lexical_query(lexical)
+        .vector_query(vector)
+        .fusion_algorithm(fusion)
+        .limit(limit)
+        .build()
+}
+
+fn bench_hybrid_rrf(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("hybrid/rrf");
+    group.sample_size(SAMPLE_SIZE_FAST);
+
+    for &n in &corpus_sizes() {
+        let engine = rt.block_on(build_hybrid_engine(n)).unwrap();
+
+        // Sanity: hybrid search must produce non-empty fused results.
+        let probe = rt.block_on(async {
+            let req = build_hybrid_request(FusionAlgorithm::RRF { k: 60.0 }, 10);
+            engine.search(req).await.unwrap()
+        });
+        assert!(
+            !probe.is_empty(),
+            "rrf hybrid probe must return at least one fused hit at n={n}"
+        );
+
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.to_async(&rt).iter(|| {
+                let engine = &engine;
+                async move {
+                    let req = build_hybrid_request(FusionAlgorithm::RRF { k: 60.0 }, 10);
+                    black_box(engine.search(req).await.unwrap())
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_hybrid_weighted_sum(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("hybrid/weighted_sum");
+    group.sample_size(SAMPLE_SIZE_FAST);
+
+    for &n in &corpus_sizes() {
+        let engine = rt.block_on(build_hybrid_engine(n)).unwrap();
+
+        let probe = rt.block_on(async {
+            let req = build_hybrid_request(
+                FusionAlgorithm::WeightedSum {
+                    lexical_weight: 0.5,
+                    vector_weight: 0.5,
+                },
+                10,
+            );
+            engine.search(req).await.unwrap()
+        });
+        assert!(
+            !probe.is_empty(),
+            "weighted_sum hybrid probe must return at least one fused hit at n={n}"
+        );
+
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.to_async(&rt).iter(|| {
+                let engine = &engine;
+                async move {
+                    let req = build_hybrid_request(
+                        FusionAlgorithm::WeightedSum {
+                            lexical_weight: 0.5,
+                            vector_weight: 0.5,
+                        },
+                        10,
+                    );
+                    black_box(engine.search(req).await.unwrap())
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_hybrid_top_k_sweep(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("hybrid/top_k");
+    group.sample_size(SAMPLE_SIZE_FAST);
+
+    let n = 5_000usize;
+    let engine = rt.block_on(build_hybrid_engine(n)).unwrap();
+
+    let probe = rt.block_on(async {
+        let req = build_hybrid_request(FusionAlgorithm::RRF { k: 60.0 }, 10);
+        engine.search(req).await.unwrap()
+    });
+    assert!(
+        !probe.is_empty(),
+        "top_k hybrid probe must return at least one fused hit"
+    );
+
+    for &k in &[10usize, 100, 500] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("k_{k}")),
+            &k,
+            |b, &k| {
+                b.to_async(&rt).iter(|| {
+                    let engine = &engine;
+                    async move {
+                        let req = build_hybrid_request(FusionAlgorithm::RRF { k: 60.0 }, k);
+                        black_box(engine.search(req).await.unwrap())
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_hybrid_rrf,
+    bench_hybrid_weighted_sum,
+    bench_hybrid_top_k_sweep,
+);
+criterion_main!(benches);

--- a/laurus/benches/mutation_bench.rs
+++ b/laurus/benches/mutation_bench.rs
@@ -1,0 +1,310 @@
+//! Document mutation benchmarks: delete, update (put), delete-then-commit.
+//!
+//! Targets the post-#429 coverage gap that the mutation path
+//! (`Engine::delete_documents`, `Engine::put_document`, post-delete
+//! commit / compaction) was never benchmarked.
+//!
+//! # Scope
+//!
+//! Three measurement scenarios:
+//!
+//! 1. **`bench_delete_documents`** — pre-populate the engine with N
+//!    docs + commit, then time `delete_documents(id) × M` (no commit).
+//!    Reports per-delete latency. Sweep N ∈ {1k, 10k}, M = 100.
+//! 2. **`bench_put_document`** — pre-populate the engine with N docs,
+//!    then time `put_document(id, new_doc) × M`. `put_document` is the
+//!    "upsert" path (delete existing then re-add), so this measures
+//!    the combined cost. Sweep N ∈ {1k, 10k}, M = 100.
+//! 3. **`bench_delete_then_commit`** — pre-populate with N docs,
+//!    delete a fraction (10 %), then time the subsequent `commit()`.
+//!    Crosses the `DeletionConfig::auto_compaction` threshold for
+//!    larger N, so the cost shape includes any segment-rewrite work.
+//!    Sweep N ∈ {1k, 10k}.
+//!
+//! Schema-driven reindex (e.g. adding a field and timing the rebuild)
+//! is out of scope — no public API surfaces it directly today.
+//!
+//! # Vocabulary
+//!
+//! Mirrors the Zipf set from `lexical_search_bench` /
+//! `lexical_indexing_bench`. Inline copy with a "keep in sync" header.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench mutation_bench
+//! ```
+//!
+//! Filter by case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench mutation_bench -- "delete_documents/1000"
+//! cargo bench --bench mutation_bench -- "delete_then_commit"
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench mutation_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
+
+use std::sync::Arc;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use common::SAMPLE_SIZE_SLOW;
+
+use laurus::analysis::analyzer::analyzer::Analyzer;
+use laurus::analysis::analyzer::standard::StandardAnalyzer;
+use laurus::lexical::TextOption;
+use laurus::lexical::core::field::IntegerOption;
+use laurus::storage::memory::MemoryStorageConfig;
+use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::{Document, Engine, Result, Schema};
+
+const COMMON_TERMS: &str = "search engine system data query";
+
+const TOPIC_PHRASES: &[&str] = &[
+    "rust programming language systems safety concurrency memory ownership",
+    "python data science machine learning artificial intelligence numpy",
+    "javascript web development frontend backend node react framework",
+    "database query optimization indexing performance search engine",
+    "network protocol distributed systems cloud computing infrastructure",
+    "security cryptography authentication authorization encryption",
+    "algorithms data structures sorting searching graph traversal",
+    "operating systems kernel processes threads scheduling memory",
+];
+
+const LONG_TAIL: &[&str] = &[
+    "compaction",
+    "histogram",
+    "lattice",
+    "registry",
+    "compiler",
+    "scheduler",
+    "interpreter",
+    "garbage",
+    "collector",
+    "allocator",
+    "telemetry",
+    "regression",
+    "snapshot",
+    "replication",
+    "consensus",
+    "quorum",
+    "leader",
+    "follower",
+];
+
+const LONG_TAIL_PER_DOC: usize = 5;
+
+const CATEGORIES: &[&str] = &["programming", "data-science", "web", "database", "systems"];
+
+fn build_body(i: usize) -> String {
+    let topic = TOPIC_PHRASES[i % TOPIC_PHRASES.len()];
+
+    let mut tail_words = Vec::with_capacity(LONG_TAIL_PER_DOC);
+    for k in 0..LONG_TAIL_PER_DOC {
+        let idx = (i.wrapping_mul(7) + k * 11) % LONG_TAIL.len();
+        tail_words.push(LONG_TAIL[idx]);
+    }
+    let tail = tail_words.join(" ");
+
+    format!("Document {i} {COMMON_TERMS} {topic} {tail} should match relevant terms")
+}
+
+fn build_document(i: usize) -> Document {
+    let body = build_body(i);
+    Document::builder()
+        .add_text("title", format!("Title for document {i}"))
+        .add_text("body", &body)
+        .add_text("category", CATEGORIES[i % CATEGORIES.len()])
+        .add_integer("year", 2020 + (i % 5) as i64)
+        .build()
+}
+
+fn memory_storage() -> Result<Arc<dyn Storage>> {
+    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+}
+
+async fn build_populated_engine(n: usize) -> Result<Engine> {
+    let storage = memory_storage()?;
+    let analyzer: Arc<dyn Analyzer> = Arc::new(StandardAnalyzer::default());
+
+    let schema = Schema::builder()
+        .add_text_field("title", TextOption::default())
+        .add_text_field("body", TextOption::default())
+        .add_text_field("category", TextOption::default())
+        .add_integer_field("year", IntegerOption::default())
+        .add_default_field("body")
+        .build();
+
+    let engine = Engine::builder(storage, schema)
+        .analyzer(analyzer)
+        .build()
+        .await?;
+
+    for i in 0..n {
+        engine
+            .add_document(&i.to_string(), build_document(i))
+            .await?;
+    }
+    engine.commit().await?;
+    Ok(engine)
+}
+
+/// Number of mutation operations per timed iteration. 100 keeps each
+/// iteration's wall-time short enough that SAMPLE_SIZE_SLOW (10 samples)
+/// finishes promptly while still amortising any per-iteration noise.
+const M_OPS: usize = 100;
+
+// ----------------------------------------------------------------------------
+// 1. delete_documents
+// ----------------------------------------------------------------------------
+
+fn bench_delete_documents(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("mutation/delete_documents");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &[1000usize, 10_000] {
+        // Sanity: a fresh populated engine + delete must succeed.
+        {
+            let engine = rt.block_on(build_populated_engine(n)).unwrap();
+            rt.block_on(engine.delete_documents("0")).unwrap();
+        }
+
+        group.throughput(Throughput::Elements(M_OPS as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let engine = rt.block_on(build_populated_engine(n)).unwrap();
+                    // Pick M deterministic IDs spread evenly across the
+                    // corpus so every delete actually matches.
+                    let ids: Vec<String> =
+                        (0..M_OPS).map(|i| ((i * n) / M_OPS).to_string()).collect();
+                    (engine, ids)
+                },
+                |(engine, ids)| {
+                    rt.block_on(async {
+                        for id in ids {
+                            engine.delete_documents(&id).await.unwrap();
+                        }
+                    });
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+// ----------------------------------------------------------------------------
+// 2. put_document (upsert = delete + add)
+// ----------------------------------------------------------------------------
+
+fn bench_put_document(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("mutation/put_document");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &[1000usize, 10_000] {
+        // Sanity: put_document on an existing id replaces.
+        {
+            let engine = rt.block_on(build_populated_engine(n)).unwrap();
+            let new_doc = build_document(0);
+            rt.block_on(engine.put_document("0", new_doc)).unwrap();
+        }
+
+        group.throughput(Throughput::Elements(M_OPS as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let engine = rt.block_on(build_populated_engine(n)).unwrap();
+                    let updates: Vec<(String, Document)> = (0..M_OPS)
+                        .map(|i| {
+                            let id = ((i * n) / M_OPS).to_string();
+                            // Updated content: bump i so the new body
+                            // differs from the original.
+                            let new_doc = build_document(n + i);
+                            (id, new_doc)
+                        })
+                        .collect();
+                    (engine, updates)
+                },
+                |(engine, updates)| {
+                    rt.block_on(async {
+                        for (id, doc) in updates {
+                            engine.put_document(&id, doc).await.unwrap();
+                        }
+                    });
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+// ----------------------------------------------------------------------------
+// 3. delete-heavy + commit (may trigger auto-compaction)
+// ----------------------------------------------------------------------------
+
+fn bench_delete_then_commit(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("mutation/delete_then_commit");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &[1000usize, 10_000] {
+        let to_delete = n / 10; // delete 10 % of the corpus
+
+        // Sanity probe — sequence runs without error.
+        {
+            let engine = rt.block_on(build_populated_engine(n)).unwrap();
+            rt.block_on(async {
+                for i in 0..to_delete {
+                    engine.delete_documents(&i.to_string()).await.unwrap();
+                }
+                engine.commit().await.unwrap();
+            });
+        }
+
+        group.throughput(Throughput::Elements(to_delete as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let engine = rt.block_on(build_populated_engine(n)).unwrap();
+                    // Apply the delete batch in setup; only the commit
+                    // is timed below.
+                    rt.block_on(async {
+                        for i in 0..to_delete {
+                            engine.delete_documents(&i.to_string()).await.unwrap();
+                        }
+                    });
+                    engine
+                },
+                |engine| {
+                    rt.block_on(engine.commit()).unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_delete_documents,
+    bench_put_document,
+    bench_delete_then_commit,
+);
+criterion_main!(benches);

--- a/laurus/benches/vector_indexing_bench.rs
+++ b/laurus/benches/vector_indexing_bench.rs
@@ -1,0 +1,358 @@
+//! Vector indexing throughput benchmarks.
+//!
+//! Targets the post-#429 coverage gap that vector indexing was only
+//! partially measured. The existing `vector_search_bench::bench_*_construction`
+//! lumps `add_vectors + finalize` into a single timed call at small scale
+//! (1k / 5k); the `Engine::add_document` path with a vector field was not
+//! benchmarked at all.
+//!
+//! # Scope
+//!
+//! Four measurement scenarios:
+//!
+//! 1. **`bench_add_vectors`** — `ManagedVectorIndex::add_vectors` × N for
+//!    Flat / IVF / HNSW. Decomposed from `finalize` so each phase is
+//!    reportable separately. Sweep N ∈ {1k, 5k}; LARGE adds 50k.
+//! 2. **`bench_finalize`** — pre-buffer N vectors, then time
+//!    `finalize()` alone. Different shape per index type (Flat is
+//!    near-noop, IVF runs k-means, HNSW finalises the graph). N ∈ {1k, 5k}.
+//! 3. **`bench_bulk_index`** — `add_vectors + finalize` for the three
+//!    index types. Overlaps with the existing `bench_*_construction` in
+//!    `vector_search_bench`, but reports `Throughput::Elements` for
+//!    per-vector comparability and adds a 50k case under LARGE.
+//! 4. **`bench_engine_add_document`** — `Engine::add_document` with a
+//!    vector field, the high-level path that goes through schema
+//!    dispatch and per-field vector storage. HNSW only (the path is the
+//!    same for the other index types). N ∈ {1k, 10k}.
+//!
+//! Sweep dimension is fixed at 128. A standalone dimension sweep belongs
+//! in `distance_bench` and was already added there in #424.
+//!
+//! # Mock vs real I/O
+//!
+//! All benches use `MemoryStorage`. Disk-backed variants are tracked
+//! separately under #444.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo bench --bench vector_indexing_bench                       # default
+//! LAURUS_BENCH_LARGE=1 cargo bench --bench vector_indexing_bench  # +50k
+//! ```
+//!
+//! Filter by case (substring match against the criterion id):
+//!
+//! ```sh
+//! cargo bench --bench vector_indexing_bench -- "add_vectors/hnsw"
+//! cargo bench --bench vector_indexing_bench -- "engine_add_document"
+//! ```
+//!
+//! Compile-only smoke check:
+//!
+//! ```sh
+//! cargo bench --bench vector_indexing_bench --no-run
+//! ```
+//!
+//! See `benches/common.rs` for the suite-wide hygiene rules.
+
+mod common;
+
+use std::sync::Arc;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+use common::{DEFAULT_SEED, SAMPLE_SIZE_SLOW, lcg_vec_unit};
+
+use laurus::analysis::analyzer::analyzer::Analyzer;
+use laurus::analysis::analyzer::standard::StandardAnalyzer;
+use laurus::storage::memory::MemoryStorageConfig;
+use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::field::HnswOption;
+use laurus::vector::core::vector::Vector;
+use laurus::vector::index::ManagedVectorIndex;
+use laurus::vector::index::config::{
+    FlatIndexConfig, HnswIndexConfig, IvfIndexConfig, VectorIndexTypeConfig,
+};
+use laurus::{Document, Engine, Result, Schema};
+
+const DIM: usize = 128;
+
+/// Deterministic vector generation. Uses the suite-wide LCG so two runs
+/// produce byte-identical inputs.
+fn generate_vectors(count: usize) -> Vec<(u64, String, Vector)> {
+    let mut state = DEFAULT_SEED;
+    (0..count)
+        .map(|i| {
+            (
+                i as u64,
+                "field".to_string(),
+                Vector::new(lcg_vec_unit(&mut state, DIM)),
+            )
+        })
+        .collect()
+}
+
+fn create_storage() -> Arc<dyn Storage> {
+    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default())).unwrap()
+}
+
+/// Default sweep sizes for the low-level (`add_vectors` / `finalize` /
+/// `bulk_index`) benches. `LAURUS_BENCH_LARGE=1` appends 50_000 so the
+/// HNSW build cost at moderate scale is reachable without ballooning the
+/// default `cargo bench` runtime.
+fn ingest_corpus_sizes() -> Vec<usize> {
+    let mut sizes = vec![1000usize, 5000];
+    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
+        sizes.push(50_000);
+    }
+    sizes
+}
+
+/// Sizes for the (heavier) Engine-API path. The Engine ingest involves
+/// schema dispatch and per-doc bookkeeping on top of the raw vector
+/// indexing, so the runtime budget is tighter.
+fn engine_corpus_sizes() -> Vec<usize> {
+    let mut sizes = vec![1000usize, 10_000];
+    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
+        sizes.push(50_000);
+    }
+    sizes
+}
+
+fn flat_type_config() -> VectorIndexTypeConfig {
+    VectorIndexTypeConfig::Flat(FlatIndexConfig {
+        dimension: DIM,
+        distance_metric: DistanceMetric::Cosine,
+        ..Default::default()
+    })
+}
+
+fn ivf_type_config() -> VectorIndexTypeConfig {
+    VectorIndexTypeConfig::IVF(IvfIndexConfig {
+        dimension: DIM,
+        distance_metric: DistanceMetric::Cosine,
+        n_clusters: 10,
+        n_probe: 3,
+        ..Default::default()
+    })
+}
+
+fn hnsw_type_config() -> VectorIndexTypeConfig {
+    VectorIndexTypeConfig::HNSW(HnswIndexConfig {
+        dimension: DIM,
+        m: 16,
+        ef_construction: 200,
+        distance_metric: DistanceMetric::Cosine,
+        ..Default::default()
+    })
+}
+
+/// Build a fresh `ManagedVectorIndex` for the given index type.
+fn fresh_index(index_type: &VectorIndexTypeConfig, name: &'static str) -> ManagedVectorIndex {
+    let storage = create_storage();
+    ManagedVectorIndex::new(index_type.clone(), storage, name).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// 1. add_vectors only
+// ---------------------------------------------------------------------------
+
+fn bench_add_vectors(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ingest/add_vectors");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &ingest_corpus_sizes() {
+        let vectors = generate_vectors(n);
+
+        for (label, type_config_factory) in [
+            ("flat", flat_type_config as fn() -> VectorIndexTypeConfig),
+            ("ivf", ivf_type_config as fn() -> VectorIndexTypeConfig),
+            ("hnsw", hnsw_type_config as fn() -> VectorIndexTypeConfig),
+        ] {
+            // Sanity: a single add_vectors must succeed on a fresh index.
+            {
+                let mut index = fresh_index(&type_config_factory(), "vec_idx_probe");
+                index
+                    .add_vectors(vectors.clone())
+                    .expect("add_vectors probe must not error");
+            }
+
+            group.throughput(Throughput::Elements(n as u64));
+            group.bench_with_input(BenchmarkId::new(label, n), &n, |b, _| {
+                let vectors = vectors.clone();
+                b.iter_batched(
+                    || {
+                        let index = fresh_index(&type_config_factory(), "vec_idx_add");
+                        (index, vectors.clone())
+                    },
+                    |(mut index, vectors)| {
+                        index.add_vectors(vectors).unwrap();
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        }
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 2. finalize only
+// ---------------------------------------------------------------------------
+
+fn bench_finalize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ingest/finalize");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &[1000usize, 5000] {
+        let vectors = generate_vectors(n);
+
+        for (label, type_config_factory) in [
+            ("flat", flat_type_config as fn() -> VectorIndexTypeConfig),
+            ("ivf", ivf_type_config as fn() -> VectorIndexTypeConfig),
+            ("hnsw", hnsw_type_config as fn() -> VectorIndexTypeConfig),
+        ] {
+            group.throughput(Throughput::Elements(n as u64));
+            group.bench_with_input(BenchmarkId::new(label, n), &n, |b, _| {
+                let vectors = vectors.clone();
+                b.iter_batched(
+                    || {
+                        let mut index = fresh_index(&type_config_factory(), "vec_idx_fin");
+                        index.add_vectors(vectors.clone()).unwrap();
+                        index
+                    },
+                    |mut index| {
+                        index.finalize().unwrap();
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        }
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 3. Bulk: add_vectors + finalize
+// ---------------------------------------------------------------------------
+
+fn bench_bulk_index(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ingest/bulk");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &ingest_corpus_sizes() {
+        let vectors = generate_vectors(n);
+
+        for (label, type_config_factory) in [
+            ("flat", flat_type_config as fn() -> VectorIndexTypeConfig),
+            ("ivf", ivf_type_config as fn() -> VectorIndexTypeConfig),
+            ("hnsw", hnsw_type_config as fn() -> VectorIndexTypeConfig),
+        ] {
+            group.throughput(Throughput::Elements(n as u64));
+            group.bench_with_input(BenchmarkId::new(label, n), &n, |b, _| {
+                let vectors = vectors.clone();
+                b.iter_batched(
+                    || {
+                        let index = fresh_index(&type_config_factory(), "vec_idx_bulk");
+                        (index, vectors.clone())
+                    },
+                    |(mut index, vectors)| {
+                        index.add_vectors(vectors).unwrap();
+                        index.finalize().unwrap();
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        }
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 4. Engine API (Engine::add_document with vector field) — HNSW only
+// ---------------------------------------------------------------------------
+
+async fn build_vector_engine() -> Result<Engine> {
+    let storage = create_storage();
+    let analyzer: Arc<dyn Analyzer> = Arc::new(StandardAnalyzer::default());
+
+    let schema = Schema::builder()
+        .add_hnsw_field(
+            "embedding",
+            HnswOption::new(DIM).distance(DistanceMetric::Cosine),
+        )
+        .build();
+
+    Engine::builder(storage, schema)
+        .analyzer(analyzer)
+        .build()
+        .await
+}
+
+/// Build `n` `(id, Document)` pairs, each carrying a deterministic
+/// dim-128 vector in `embedding`.
+fn build_engine_vector_documents(n: usize) -> Vec<(String, Document)> {
+    let mut state = DEFAULT_SEED;
+    (0..n)
+        .map(|i| {
+            let vec = lcg_vec_unit(&mut state, DIM);
+            let doc = Document::builder().add_vector("embedding", vec).build();
+            (i.to_string(), doc)
+        })
+        .collect()
+}
+
+fn bench_engine_add_document(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("vector_ingest/engine_add_document");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &n in &engine_corpus_sizes() {
+        // Sanity: a single add_document with a vector field must succeed
+        // on a fresh engine.
+        {
+            let engine = rt.block_on(build_vector_engine()).unwrap();
+            let docs = build_engine_vector_documents(1);
+            rt.block_on(async {
+                for (id, doc) in docs {
+                    engine.add_document(&id, doc).await.unwrap();
+                }
+            });
+        }
+
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let engine = rt.block_on(build_vector_engine()).unwrap();
+                    let docs = build_engine_vector_documents(n);
+                    (engine, docs)
+                },
+                |(engine, docs)| {
+                    rt.block_on(async {
+                        for (id, doc) in docs {
+                            engine.add_document(&id, doc).await.unwrap();
+                        }
+                    });
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_add_vectors,
+    bench_finalize,
+    bench_bulk_index,
+    bench_engine_add_document,
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Closes three of the four post-#429 coverage gaps tracked under umbrella #446:

- ``benches/vector_indexing_bench.rs`` (#448) — vector indexing throughput
- ``benches/hybrid_search_bench.rs`` (#443) — hybrid (lexical + vector) fusion search
- ``benches/mutation_bench.rs`` (#445) — document delete / update / compaction

#444 (disk-backed PosixStorage gate) is intentionally split into a separate PR because it modifies existing benches rather than adding new files.

Each issue is in its own commit so individual review / revert is preserved.

## Per-issue summary

### #448 vector indexing throughput

Targets the gap that ``vector_search_bench::bench_*_construction`` lumped ``add_vectors + finalize`` and never measured the ``Engine::add_document`` path with a vector field.

Four scenarios:
- ``bench_add_vectors`` — Flat / IVF / HNSW, sweep N ∈ {1k, 5k} (LARGE +50k)
- ``bench_finalize`` — pre-buffer + finalize alone
- ``bench_bulk_index`` — add + finalize, ``Throughput::Elements`` for per-vector comparability
- ``bench_engine_add_document`` — full Engine API path (HNSW only)

Smoke: ``add_vectors/flat/1000`` → 207 µs / 4.8 Melem/s; ``engine_add_document/1000`` → 56 ms / 17.7 Kelem/s.

### #443 hybrid search

Targets the audit's flagged O(n²) dedup hotspot in fusion. Three scenarios:
- ``bench_hybrid_rrf`` — ``FusionAlgorithm::RRF { k: 60.0 }``
- ``bench_hybrid_weighted_sum`` — ``WeightedSum { lexical_weight: 0.5, vector_weight: 0.5 }``
- ``bench_hybrid_top_k_sweep`` — RRF, K ∈ {10, 100, 500}

Smoke: ``hybrid/rrf/5000`` → 2.2 ms / call.

### #445 mutation

Targets the gap that ``delete_documents`` / ``put_document`` / post-delete commit was never timed. Three scenarios:
- ``bench_delete_documents`` — 100 deletes per timed iteration
- ``bench_put_document`` — 100 upserts (delete + re-add)
- ``bench_delete_then_commit`` — delete 10 % then time ``commit()`` in isolation

Smoke: ``delete_documents/10000`` → 31 ms / 100 deletes / 10k corpus.

## Pattern consistency

All three new files follow the patterns established in #427 / #442:
- ``mod common;`` for shared LCG + sample-size constants
- ``iter_batched(BatchSize::SmallInput)`` so each timed iter starts from fresh state
- async surfaces wrapped via ``rt.block_on`` inside sync setup / routine
- One-time sanity assert outside the timed loop
- ``LAURUS_BENCH_LARGE=1`` gate where larger corpora are useful
- 3-tier Zipf vocab inline-copied with a "keep in sync" header (consolidation deferred)

## Cargo.toml

Register the three new benches with ``harness = false``.

## Test plan

- [x] ``cargo bench -p laurus --no-run`` — 18 benches build (was 15 + 3 new = 18)
- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass
- [x] Smokes per scenario as listed above

Closes #443, #445, #448.

After merge, only #444 remains under umbrella #446.