### PR TITLE
bench: add disk-backed (PosixStorage) gate via LAURUS_BENCH_DISK (#444)

### DIFF
--- a/laurus/benches/common.rs
+++ b/laurus/benches/common.rs
@@ -33,6 +33,12 @@
 
 #![allow(dead_code)]
 
+use std::sync::Arc;
+
+use laurus::storage::file::FileStorageConfig;
+use laurus::storage::memory::MemoryStorageConfig;
+use laurus::storage::{Storage, StorageConfig, StorageFactory};
+
 /// Default seed for deterministic LCG state. Used as the starting point in
 /// every bench so two runs of `cargo bench` produce identical inputs.
 pub const DEFAULT_SEED: u64 = 0xDEAD_BEEF_CAFE_F00D;
@@ -58,6 +64,40 @@ pub fn lcg_next(state: &mut u64) -> f64 {
         .wrapping_add(1_442_695_040_888_963_407);
     let bits = (*state >> 32) as u32;
     (bits as f64) * (1000.0 / (u32::MAX as f64))
+}
+
+/// Select the storage backend for a bench based on `LAURUS_BENCH_DISK`.
+///
+/// - **Default (env unset)**: returns an in-memory storage. This is what
+///   every bench used before #444 and is the right choice for
+///   microbenchmarks that want to remove I/O variance.
+/// - **`LAURUS_BENCH_DISK=1`**: returns a file-backed storage rooted in a
+///   freshly-created temp directory. Each call yields a distinct
+///   directory so concurrent benches do not collide.
+///
+/// The temp directory created in the disk-backed branch is intentionally
+/// **leaked** — `tempfile::TempDir::keep` keeps it on disk after the
+/// returned `Storage` is dropped. Bench runs accumulate a handful of
+/// directories under `$TMPDIR` and rely on OS-level `/tmp` cleanup
+/// (`systemd-tmpfiles`, reboots, etc.) rather than per-iteration cleanup.
+/// This is acceptable for benchmark runs and avoids the lifetime
+/// gymnastics of returning `(Storage, TempDir)` everywhere.
+///
+/// Disk numbers are sensitive to the host filesystem and OS page cache.
+/// They are useful for **comparing** in-tree changes (e.g. before / after
+/// a perf PR), not for absolute throughput claims. Document this caveat
+/// in any PR that posts numbers from `LAURUS_BENCH_DISK=1`.
+pub fn select_storage() -> Arc<dyn Storage> {
+    if std::env::var("LAURUS_BENCH_DISK").is_ok() {
+        let dir = tempfile::tempdir().expect("create temp dir for disk-backed bench storage");
+        let path = dir.keep();
+        let config = FileStorageConfig::new(path);
+        StorageFactory::create(StorageConfig::File(config))
+            .expect("instantiate file-backed storage for bench")
+    } else {
+        StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+            .expect("instantiate memory-backed storage for bench")
+    }
 }
 
 /// Inline LCG variant returning a deterministic `f32` in `[0, 1)`.

--- a/laurus/benches/hybrid_search_bench.rs
+++ b/laurus/benches/hybrid_search_bench.rs
@@ -60,14 +60,13 @@ use std::sync::Arc;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
-use common::{DEFAULT_SEED, SAMPLE_SIZE_FAST, lcg_vec_unit};
+use common::{DEFAULT_SEED, SAMPLE_SIZE_FAST, lcg_vec_unit, select_storage};
 
 use laurus::analysis::analyzer::analyzer::Analyzer;
 use laurus::analysis::analyzer::standard::StandardAnalyzer;
 use laurus::lexical::core::field::IntegerOption;
 use laurus::lexical::{TermQuery, TextOption};
-use laurus::storage::memory::MemoryStorageConfig;
-use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::storage::Storage;
 use laurus::vector::core::distance::DistanceMetric;
 use laurus::vector::core::field::HnswOption;
 use laurus::vector::core::vector::Vector;
@@ -132,8 +131,11 @@ fn build_body(i: usize) -> String {
     format!("Document {i} {COMMON_TERMS} {topic} {tail} should match relevant terms")
 }
 
+/// Bench-storage handle. Delegates to `common::select_storage()` so
+/// `LAURUS_BENCH_DISK=1` swaps the in-memory backend for a temp-dir
+/// `FileStorage` without changing call sites.
 fn memory_storage() -> Result<Arc<dyn Storage>> {
-    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+    Ok(select_storage())
 }
 
 async fn build_hybrid_engine(n: usize) -> Result<Engine> {

--- a/laurus/benches/lexical_indexing_bench.rs
+++ b/laurus/benches/lexical_indexing_bench.rs
@@ -62,14 +62,13 @@ use std::sync::Arc;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
-use common::SAMPLE_SIZE_SLOW;
+use common::{SAMPLE_SIZE_SLOW, select_storage};
 
 use laurus::analysis::analyzer::analyzer::Analyzer;
 use laurus::analysis::analyzer::standard::StandardAnalyzer;
 use laurus::lexical::core::field::IntegerOption;
 use laurus::lexical::{TermQuery, TextOption};
-use laurus::storage::memory::MemoryStorageConfig;
-use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::storage::Storage;
 use laurus::{Document, Engine, LexicalSearchQuery, Result, Schema, SearchRequestBuilder};
 
 // ----------------------------------------------------------------------------
@@ -181,8 +180,11 @@ fn build_documents(n: usize) -> Vec<(String, Document)> {
 // Engine helpers
 // ----------------------------------------------------------------------------
 
+/// Bench-storage handle. Delegates to `common::select_storage()` so
+/// `LAURUS_BENCH_DISK=1` swaps the in-memory backend for a temp-dir
+/// `FileStorage` without changing call sites.
 fn memory_storage() -> Result<Arc<dyn Storage>> {
-    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+    Ok(select_storage())
 }
 
 async fn build_empty_engine() -> Result<Engine> {

--- a/laurus/benches/lexical_search_bench.rs
+++ b/laurus/benches/lexical_search_bench.rs
@@ -76,14 +76,13 @@ use criterion::measurement::WallTime;
 use criterion::{BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
-use common::{SAMPLE_SIZE_FAST, SAMPLE_SIZE_SLOW};
+use common::{SAMPLE_SIZE_FAST, SAMPLE_SIZE_SLOW, select_storage};
 
 use laurus::analysis::analyzer::analyzer::Analyzer;
 use laurus::analysis::analyzer::standard::StandardAnalyzer;
 use laurus::lexical::core::field::IntegerOption;
 use laurus::lexical::{BooleanQuery, FuzzyQuery, PhraseQuery, TermQuery, TextOption};
-use laurus::storage::memory::MemoryStorageConfig;
-use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::storage::Storage;
 use laurus::{Document, Engine, LexicalSearchQuery, Result, Schema, SearchRequestBuilder};
 
 /// Words present in **every** document. Drives the high-document-frequency
@@ -224,9 +223,12 @@ fn build_body(i: usize) -> String {
     format!("Document {i} {COMMON_TERMS} {topic} {tail} should match relevant terms")
 }
 
-/// Create an in-memory storage backend.
+/// Bench-storage handle. Delegates to `common::select_storage()` so
+/// `LAURUS_BENCH_DISK=1` swaps the in-memory backend for a temp-dir
+/// `FileStorage` without changing call sites. The function still returns
+/// `Result` for compatibility with the existing async `build_engine`.
 fn memory_storage() -> Result<Arc<dyn Storage>> {
-    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+    Ok(select_storage())
 }
 
 /// Build a pre-populated engine with `n` documents using the 3-tier

--- a/laurus/benches/mutation_bench.rs
+++ b/laurus/benches/mutation_bench.rs
@@ -57,14 +57,13 @@ use std::sync::Arc;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
-use common::SAMPLE_SIZE_SLOW;
+use common::{SAMPLE_SIZE_SLOW, select_storage};
 
 use laurus::analysis::analyzer::analyzer::Analyzer;
 use laurus::analysis::analyzer::standard::StandardAnalyzer;
 use laurus::lexical::TextOption;
 use laurus::lexical::core::field::IntegerOption;
-use laurus::storage::memory::MemoryStorageConfig;
-use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::storage::Storage;
 use laurus::{Document, Engine, Result, Schema};
 
 const COMMON_TERMS: &str = "search engine system data query";
@@ -128,8 +127,11 @@ fn build_document(i: usize) -> Document {
         .build()
 }
 
+/// Bench-storage handle. Delegates to `common::select_storage()` so
+/// `LAURUS_BENCH_DISK=1` swaps the in-memory backend for a temp-dir
+/// `FileStorage` without changing call sites.
 fn memory_storage() -> Result<Arc<dyn Storage>> {
-    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+    Ok(select_storage())
 }
 
 async fn build_populated_engine(n: usize) -> Result<Engine> {

--- a/laurus/benches/vector_indexing_bench.rs
+++ b/laurus/benches/vector_indexing_bench.rs
@@ -62,12 +62,11 @@ use std::sync::Arc;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
-use common::{DEFAULT_SEED, SAMPLE_SIZE_SLOW, lcg_vec_unit};
+use common::{DEFAULT_SEED, SAMPLE_SIZE_SLOW, lcg_vec_unit, select_storage};
 
 use laurus::analysis::analyzer::analyzer::Analyzer;
 use laurus::analysis::analyzer::standard::StandardAnalyzer;
-use laurus::storage::memory::MemoryStorageConfig;
-use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::storage::Storage;
 use laurus::vector::core::distance::DistanceMetric;
 use laurus::vector::core::field::HnswOption;
 use laurus::vector::core::vector::Vector;
@@ -94,8 +93,11 @@ fn generate_vectors(count: usize) -> Vec<(u64, String, Vector)> {
         .collect()
 }
 
+/// Bench-storage handle. Delegates to `common::select_storage()` so
+/// `LAURUS_BENCH_DISK=1` swaps the in-memory backend for a temp-dir
+/// `FileStorage` without changing call sites.
 fn create_storage() -> Arc<dyn Storage> {
-    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default())).unwrap()
+    select_storage()
 }
 
 /// Default sweep sizes for the low-level (`add_vectors` / `finalize` /

--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -59,8 +59,7 @@ mod common;
 use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use laurus::storage::memory::MemoryStorageConfig;
-use laurus::storage::{Storage, StorageConfig, StorageFactory};
+use laurus::storage::Storage;
 use laurus::vector::core::distance::DistanceMetric;
 use laurus::vector::core::vector::Vector;
 use laurus::vector::index::ManagedVectorIndex;
@@ -71,7 +70,7 @@ use laurus::vector::{
     FlatVectorSearcher, HnswSearcher, IvfSearcher, VectorIndexQuery, VectorIndexSearcher,
 };
 
-use common::{DEFAULT_SEED, SAMPLE_SIZE_SLOW, lcg_vec_unit};
+use common::{DEFAULT_SEED, SAMPLE_SIZE_SLOW, lcg_vec_unit, select_storage};
 
 /// Build a deterministic `Vector` of length `dim`. The caller-supplied
 /// `state` advances per call, so successive vectors are different but the
@@ -131,8 +130,11 @@ fn generate_query(dim: usize) -> Vector {
     generate_vector(&mut state, dim)
 }
 
+/// Bench-storage handle. Delegates to `common::select_storage()` so
+/// `LAURUS_BENCH_DISK=1` swaps the in-memory backend for a temp-dir
+/// `FileStorage` without changing call sites.
 fn create_storage() -> Arc<dyn Storage> {
-    StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default())).unwrap()
+    select_storage()
 }
 
 /// Default search-corpus sizes for Flat and IVF benches.


### PR DESCRIPTION
## Summary

Closes the last item of umbrella #446. Existing search and indexing benches are now opt-in disk-backed: setting ``LAURUS_BENCH_DISK=1`` swaps ``MemoryStorage`` for a tempfile-managed ``FileStorage``, surfacing the I/O cost shape that #404 / #405 / #410 will reduce in production.

### `common.rs`

- Add ``select_storage()`` returning ``Arc<dyn Storage>``.
  - **Default branch (env unset)**: builds ``MemoryStorage`` — every existing default-run number is preserved.
  - **`LAURUS_BENCH_DISK=1` branch**: creates a unique temp dir via ``tempfile::tempdir()`` and wraps a ``FileStorage`` rooted there.
- ``TempDir`` is leaked via ``.keep()`` so each bench iteration's storage outlives the call without lifetime gymnastics on existing helpers. OS ``/tmp`` cleanup reclaims them between sessions.

### Existing benches

The local ``create_storage()`` / ``memory_storage()`` helpers in 6 benches now delegate to ``select_storage()``. Call sites and helper signatures are unchanged so the diff is mechanical. Removed redundant ``MemoryStorageConfig`` / ``StorageConfig`` / ``StorageFactory`` imports.

Touched: ``vector_search_bench``, ``vector_indexing_bench``, ``lexical_search_bench``, ``lexical_indexing_bench``, ``hybrid_search_bench``, ``mutation_bench``.

### Out of scope

- ``bkd_bench`` uses concrete ``Arc<MemoryStorage>`` (not ``Arc<dyn Storage>``); trait-object conversion is large and BKD is not an audit hot path.
- ``facet_bench`` / ``store_fetch_bench`` / ``highlight_bench`` / ``spell_correction_bench`` / ``synonym_bench`` / ``text_analysis_bench`` / ``search_perf`` / ``posting_merge_bench`` / ``distance_bench`` / ``bm25_scoring_bench`` / ``cosine_similarity_bench`` have no storage surface (mock readers or pure synthetic).

### Caveats (documented in `select_storage` doc comment)

- Disk numbers depend on host filesystem and OS page cache. Useful for **before / after** comparisons of in-tree changes, not absolute throughput claims.
- ``LAURUS_BENCH_DISK=1 + LAURUS_BENCH_LARGE=1`` together can take hours; users should filter to specific cases.

## Test plan

- [x] ``cargo bench -p laurus --no-run`` — 18 benches build (default, env unset)
- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass
- [x] Smoke ``Flat Search/top10/1000`` (default, env unset) — 146 µs (existing baseline preserved)
- [x] Smoke ``Flat Search/top10/1000`` (``LAURUS_BENCH_DISK=1``) — 143 µs (read path mmaps; per-query cost barely differs)
- [x] Smoke ``lexical_indexing bulk_ingest/1000`` (``LAURUS_BENCH_DISK=1``) — 6.78 s (vs ~50 ms memory; I/O dominates write path as expected — exactly the cost shape #410 will reduce)

After this lands, **umbrella #446 is fully resolved**.

Closes #444