### PR TITLE
perf(hnsw): drop redundant similarity()+distance() pair on fallback path (#404)

### DIFF
--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -72,14 +72,14 @@ impl VectorIndexSearcher for HnswSearcher {
 
         for (doc_id, field_name) in vector_ids.iter() {
             if let Ok(Some(vector)) = self.index_reader.get_vector(*doc_id, field_name) {
-                let similarity = self
-                    .index_reader
-                    .distance_metric()
-                    .similarity(&request.query.data, &vector.data)?;
-                let distance = self
-                    .index_reader
-                    .distance_metric()
-                    .distance(&request.query.data, &vector.data)?;
+                // Compute distance once and derive similarity from it.
+                // Calling `similarity()` would internally invoke `distance()`
+                // a second time on the same vector pair (the SIMD body runs
+                // twice), so the fallback path doubled its compute cost.
+                // The graph-search path at L308 already uses this pattern.
+                let metric = self.index_reader.distance_metric();
+                let distance = metric.distance(&request.query.data, &vector.data)?;
+                let similarity = metric.distance_to_similarity(distance);
                 candidates.push((*doc_id, field_name.clone(), similarity, distance, vector));
             }
         }


### PR DESCRIPTION
## Summary

`DistanceMetric::similarity()` internally calls `distance()` and then applies `distance_to_similarity()`. The fallback path in `HnswSearcher::search` was calling both `similarity()` and `distance()` back to back on the same `(query, vector)` pair, so the SIMD distance kernel ran **twice** per candidate.

Replace the pair with one `distance()` call followed by `distance_to_similarity()` (a pure arithmetic op). The graph-search path at the same call site (L308) already uses this pattern.

## Diff

`laurus/src/vector/index/hnsw/searcher.rs:75-82`. Net change: 4 lines of logic, +4 lines of explanatory comment.

## Performance

Bench: ``vector_search_bench::HNSW Fallback Search``, baseline saved on `main` before the change, comparison run on this branch. Memory storage, single threaded, criterion default sample_size.

| Bench | Before | After | Δ time | Δ thrpt | Verdict |
| --- | --- | --- | --- | --- | --- |
| ``top10/1000`` | 210.76 µs | 161.41 µs | **−23.7 %** | +31 % | improved (p < 0.05) |
| ``top10/5000`` | 1.093 ms | 943.34 µs | **−13.1 %** | +15 % | improved (p < 0.05) |
| ``top10/50000`` | 19.74 ms | 18.08 ms | **−8.4 %** | +9 % | improved (p < 0.05) |

All three are statistically significant. The 50 k case showed +10 % on the first run (noise — this case has higher per-iter variance) and converged to −8.4 % on a re-run; the table above uses the converged number.

The audit's optimistic ~2× estimate was based on halving the SIMD work alone. The bench measures end-to-end fallback search, which also includes ``get_vector``, ``String`` / ``Vector`` clones, push, and sort. The 8-24 % end-to-end win is consistent with halving the SIMD body when the rest of the path is also non-trivial.

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench vector_search_bench -- "HNSW Fallback Search" --save-baseline pre-404
git checkout perf/hnsw-fallback-double-distance
cargo bench -p laurus --bench vector_search_bench -- "HNSW Fallback Search" --baseline pre-404
```

## Test plan

- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass

`distance_to_similarity` is the same arithmetic the existing graph-search path uses, so similarity values are numerically equivalent — `cargo test` would catch any divergence.

Closes #404