### PR TITLE
perf(highlight): pre-compile regex patterns once per query in SimpleHighlighter (#407)

### DIFF
--- a/laurus/benches/highlight_bench.rs
+++ b/laurus/benches/highlight_bench.rs
@@ -153,6 +153,54 @@ fn bench_simple_highlight_terms(c: &mut Criterion) {
     group.finish();
 }
 
+/// Same workload shape as `bench_simple_highlight_terms`, but with the
+/// regex patterns **pre-compiled outside the timed loop** via
+/// `SimpleHighlighter::compile_patterns`. This is the case for callers
+/// that reuse the same term set across many highlight calls (e.g. one
+/// query × N search results); the per-call cost drops to
+/// `replace_all` only.
+///
+/// Compare against `bench_simple_highlight_terms` at matching ids
+/// (`1KB/n_terms_5` etc.) to see the regex-compile cost the
+/// pre-compiled API avoids — this is the workload #407 reduces.
+fn bench_simple_highlight_terms_precompiled(c: &mut Criterion) {
+    let mut group = c.benchmark_group("highlight/simple_highlight_precompiled");
+
+    let highlighter = SimpleHighlighter::new(HighlightConfig::default());
+
+    for &(label, target_bytes) in &[("1KB", 1024usize), ("100KB", 100 * 1024)] {
+        let text = build_text(target_bytes);
+
+        for &n_terms in &[1usize, 5, 20] {
+            let terms = pick_terms(n_terms);
+            // Compile patterns ONCE, outside the timed loop.
+            let patterns = SimpleHighlighter::compile_patterns(&terms);
+
+            // Sanity check: the precompiled path must produce the same
+            // <mark>-bearing output shape.
+            let probe = highlighter.highlight_terms_compiled(&text, &patterns);
+            assert!(
+                probe.contains("<mark>"),
+                "simple_highlight_precompiled probe must contain at least one <mark> tag (size={label}, n_terms={n_terms})"
+            );
+
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{label}/n_terms_{n_terms}")),
+                &(),
+                |b, _| {
+                    b.iter(|| {
+                        let out = highlighter
+                            .highlight_terms_compiled(black_box(&text), black_box(&patterns));
+                        black_box(out);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 fn bench_full_highlight_retokenize(c: &mut Criterion) {
     let mut group = c.benchmark_group("highlight/retokenize");
 
@@ -223,6 +271,7 @@ fn bench_full_highlight_top_k(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_simple_highlight_terms,
+    bench_simple_highlight_terms_precompiled,
     bench_full_highlight_retokenize,
     bench_full_highlight_top_k,
 );

--- a/laurus/src/lexical/search/features/highlight.rs
+++ b/laurus/src/lexical/search/features/highlight.rs
@@ -549,11 +549,68 @@ impl SimpleHighlighter {
         SimpleHighlighter { config }
     }
 
+    /// Pre-compile a slice of terms into reusable regex patterns.
+    ///
+    /// Each term becomes one case-insensitive word-boundary regex
+    /// (`(?i)\bTERM\b`). Compilation is the dominant per-call cost in
+    /// [`highlight_terms`](Self::highlight_terms): callers that highlight
+    /// the same term set against many texts (e.g. one query × N search
+    /// results) should compile once and feed the result to
+    /// [`highlight_terms_compiled`](Self::highlight_terms_compiled),
+    /// avoiding O(N × terms.len()) recompilations.
+    ///
+    /// Empty terms are skipped. Returned patterns preserve length-
+    /// descending order so replacement is "longest match first" — this
+    /// matches the implicit ordering of [`highlight_terms`].
+    pub fn compile_patterns(terms: &[&str]) -> Vec<Regex> {
+        let mut sorted_terms: Vec<&&str> = terms.iter().collect();
+        sorted_terms.sort_by_key(|term| std::cmp::Reverse(term.len()));
+
+        sorted_terms
+            .into_iter()
+            .filter(|term| !term.is_empty())
+            .filter_map(|term| {
+                let pattern = format!(r"(?i)\b{}\b", regex::escape(term));
+                Regex::new(&pattern).ok()
+            })
+            .collect()
+    }
+
+    /// Highlight `text` using a pre-compiled set of regex patterns.
+    ///
+    /// `patterns` should typically come from
+    /// [`compile_patterns`](Self::compile_patterns). The patterns are
+    /// applied in the order given; for length-descending input (the
+    /// `compile_patterns` default), the result matches
+    /// [`highlight_terms`].
+    pub fn highlight_terms_compiled(&self, text: &str, patterns: &[Regex]) -> String {
+        let mut result = text.to_string();
+        for regex in patterns {
+            result = regex
+                .replace_all(&result, |caps: &regex::Captures| {
+                    format!(
+                        "{}{}{}",
+                        self.config.opening_tag(),
+                        &caps[0],
+                        self.config.closing_tag()
+                    )
+                })
+                .to_string();
+        }
+        result
+    }
+
     /// Highlight specific terms in text.
+    ///
+    /// One-shot convenience entry point: compiles a regex per term inline
+    /// and replaces. When the same term set is reused across many
+    /// highlight calls (e.g. one query × N search results), prefer the
+    /// two-step [`compile_patterns`] / [`highlight_terms_compiled`] API
+    /// to avoid recompiling on every invocation.
     pub fn highlight_terms(&self, text: &str, terms: &[&str]) -> String {
         let mut result = text.to_string();
 
-        // Sort terms by length (longest first) to avoid partial replacements
+        // Sort terms by length (longest first) to avoid partial replacements.
         let mut sorted_terms: Vec<&str> = terms.to_vec();
         sorted_terms.sort_by_key(|term| std::cmp::Reverse(term.len()));
 


### PR DESCRIPTION
## Summary

`SimpleHighlighter::highlight_terms` compiles one regex per term on every call. For callers that highlight the same term set against many texts (the typical "one query × N search results" pattern), the regex compilation cost is paid ``N × terms.len()`` times instead of ``terms.len()``.

Add two new methods so callers can hoist compilation:

- ``SimpleHighlighter::compile_patterns(&[&str]) -> Vec<Regex>``
- ``SimpleHighlighter::highlight_terms_compiled(&self, text, &[Regex])``

The existing ``highlight_terms`` remains **unchanged** (inline compile + replace) to preserve its single-shot semantics and avoid any wrapper-induced overhead — callers opt in to the precompiled API when they reuse a term set.

## Performance

Bench: ``highlight_bench::simple_highlight_precompiled`` (new) compared with the existing ``simple_highlight`` at matching ids. Memory storage, single threaded.

| Bench | Existing API | Precompiled API | Δ |
| --- | --- | --- | --- |
| ``1KB/n_terms_1`` | 118 µs | 3.85 µs | **−96.7 % (~30×)** |
| ``1KB/n_terms_5`` | 537 µs | 18.01 µs | **−96.6 % (~30×)** |
| ``1KB/n_terms_20`` | 2.16 ms | 57.96 µs | **−97.3 % (~37×)** |
| ``100KB/n_terms_1`` | 503 µs | 362.6 µs | **−28.0 %** |
| ``100KB/n_terms_5`` | 2.08 ms | 1.452 ms | **−30.5 %** |
| ``100KB/n_terms_20`` | 7.06 ms | 5.55 ms | **−21.4 %** |

Short-text wins are dominated by avoided regex compile (compile dominates total cost). Long-text wins shrink because ``replace_all`` itself takes longer; compile is still avoided but is a smaller fraction.

### Existing path unchanged

``highlight_terms`` numbers vs the saved ``pre-407`` baseline are within bench noise:

| Bench | Δ vs baseline | Notes |
| --- | --- | --- |
| ``1KB/n_terms_5`` | +1.1 % | within noise |
| ``100KB/n_terms_1`` | −1.2 % | within noise |
| ``100KB/n_terms_5`` | −13.2 % | variance |
| ``100KB/n_terms_20`` | −7.0 % | variance |

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench highlight_bench -- "simple_highlight" --save-baseline pre-407
git checkout perf/highlight-regex-precompile
cargo bench -p laurus --bench highlight_bench -- "simple_highlight" --baseline pre-407
```

## Test plan

- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass

The precompiled API is a strict superset: ``highlight_terms_compiled`` does the same case-insensitive word-boundary regex replace as ``highlight_terms``, just with patterns supplied externally. ``compile_patterns`` produces the same length-descending order so longest-match-first behaviour is preserved.

Closes #407