### PR TITLE
perf(hnsw): replace HashSet visited-set with bit-vec bitmap (#406)

### DIFF
--- a/laurus/src/vector/index/hnsw/graph.rs
+++ b/laurus/src/vector/index/hnsw/graph.rs
@@ -33,6 +33,12 @@ pub struct HnswGraph {
     pub m_max_0: usize, // Max neighbors for layer 0 (usually 2*M)
     pub ef_construction: usize,
     pub level_mult: f64,
+
+    /// Largest `doc_id` ever inserted into the graph. Cached so search-
+    /// time code can size a visited-set bitmap (`BitVec` of length
+    /// `max_doc_id + 1`) without rescanning the graph. Updated by
+    /// [`get_or_create_index`] when a new node is added.
+    max_doc_id: u64,
 }
 
 impl HnswGraph {
@@ -64,12 +70,16 @@ impl HnswGraph {
         let mut id_to_index = AHashMap::with_capacity(nodes_map.len());
         let mut index_to_id = Vec::with_capacity(nodes_map.len());
         let mut nodes = Vec::with_capacity(nodes_map.len());
+        let mut max_doc_id: u64 = 0;
 
         for (doc_id, layers) in nodes_map {
             let index = nodes.len();
             id_to_index.insert(doc_id, index);
             index_to_id.push(doc_id);
             nodes.push(layers);
+            if doc_id > max_doc_id {
+                max_doc_id = doc_id;
+            }
         }
 
         Self {
@@ -83,7 +93,17 @@ impl HnswGraph {
             m_max_0,
             ef_construction,
             level_mult,
+            max_doc_id,
         }
+    }
+
+    /// Largest `doc_id` currently stored in the graph.
+    ///
+    /// Returns `0` for an empty graph; callers should sanity-check
+    /// against [`node_count`](Self::node_count) before allocating.
+    /// Used by `HnswSearcher` to size the visited-set bitmap.
+    pub fn max_doc_id(&self) -> u64 {
+        self.max_doc_id
     }
 
     /// Get neighbors of a node at a specific level.
@@ -121,6 +141,9 @@ impl HnswGraph {
             self.id_to_index.insert(doc_id, index);
             self.index_to_id.push(doc_id);
             self.nodes.push(Vec::new());
+            if doc_id > self.max_doc_id {
+                self.max_doc_id = doc_id;
+            }
             index
         }
     }

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -11,8 +11,9 @@ use crate::vector::search::searcher::VectorIndexSearcher;
 use crate::vector::search::searcher::{
     VectorIndexQuery, VectorIndexQueryResult, VectorIndexQueryResults,
 };
+use bit_vec::BitVec;
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{BinaryHeap, HashMap};
 
 /// HNSW vector searcher that performs approximate nearest neighbor search.
 #[derive(Debug)]
@@ -249,8 +250,15 @@ impl HnswSearcher {
             distance: dist,
         });
 
-        let mut visited = HashSet::new();
-        visited.insert(curr_obj);
+        // Visited set as a dense bitmap. doc_ids in laurus are assigned
+        // sequentially from 0, so the bitmap is sized to fit every node
+        // currently in the graph (`max_doc_id + 1` bits ≈ N / 8 bytes for
+        // N nodes). `BitVec::get` / `BitVec::set` are a single array
+        // index + bit op, materially cheaper than `HashSet<u64>`'s hash
+        // + bucket lookup that the audit (#406) flagged for ef_search
+        // graph traversals which examine hundreds-to-thousands of nodes.
+        let mut visited = BitVec::from_elem(graph.max_doc_id() as usize + 1, false);
+        visited.set(curr_obj as usize, true);
 
         while let Some(curr) = candidates.pop() {
             if let Some(furthest) = found.peek()
@@ -265,7 +273,7 @@ impl HnswSearcher {
                 // O(1) per neighbor (u64 HashMap lookup, no allocation).
                 if let Some(idx) = field_prefetch {
                     for &neighbor_id in neighbors {
-                        if !visited.contains(&neighbor_id) {
+                        if !visited.get(neighbor_id as usize).unwrap_or(false) {
                             Self::prefetch_neighbor(idx, neighbor_id, prefetch_n_bytes);
                         }
                     }
@@ -274,10 +282,11 @@ impl HnswSearcher {
                 // Pass 2: compute distances for unvisited neighbors (data loading
                 // overlaps with the prefetch hints issued above).
                 for &neighbor_id in neighbors {
-                    if visited.contains(&neighbor_id) {
+                    let nbr_idx = neighbor_id as usize;
+                    if visited.get(nbr_idx).unwrap_or(false) {
                         continue;
                     }
-                    visited.insert(neighbor_id);
+                    visited.set(nbr_idx, true);
 
                     let d = self.calc_dist(reader, query, neighbor_id, field_name)?;
                     let furthest_dist = found.peek().map(|c| c.distance).unwrap_or(f32::MAX);


### PR DESCRIPTION
## Summary

`HnswSearcher::search_graph` maintained the visited set as `HashSet<u64>`. Each `ef_search` graph traversal examines hundreds-to-thousands of nodes; every neighbour check pays SipHash + bucket walk + cache miss. The audit (#406) flagged this as a clear win for a dense bitmap.

Replace with `bit-vec::BitVec` (already a workspace dep) sized to `graph.max_doc_id() + 1`:

- Per-check cost drops to one array index + one bit op.
- Memory footprint is `N / 8` bytes for an N-node graph (negligible vs. `HashSet`'s ~32+ bytes per entry).

To size the bitmap without rescanning the graph at every search, `HnswGraph` caches ``max_doc_id`` on construction and updates it from ``get_or_create_index`` when nodes are added at runtime.

## Diff

| File | Change |
| --- | --- |
| ``laurus/src/vector/index/hnsw/graph.rs`` | +23 — cached ``max_doc_id`` field + accessor |
| ``laurus/src/vector/index/hnsw/searcher.rs`` | +15 / -6 — HashSet → BitVec |

Total +38 / -6.

## Performance

Bench: ``vector_search_bench::HNSW ef_search``, baseline saved on `main`, comparison run on this branch. Memory storage, single threaded.

| Bench | Before | After | Δ time | Verdict |
| --- | --- | --- | --- | --- |
| ``ef_16/top10`` | ~121 µs | 74.7 µs | **−38.2 %** | improved (p < 0.05) |
| ``ef_64/top10`` | ~294 µs | 197 µs | **−33.1 %** | improved (p < 0.05) |
| ``ef_128/top10`` | ~551 µs | 377 µs | **−31.6 %** | improved (p < 0.05) |
| ``ef_256/top10`` | ~886 µs | 526 µs | **−40.6 %** | improved (p < 0.05) |
| ``ef_512/top10`` | ~1.47 ms | 650 µs | **−55.9 %** | improved (p < 0.05) |

All five are statistically significant. The audit's 1.2-1.5× estimate is exceeded across the board; the gain grows with `ef_search` because the visited-set access count scales with the number of nodes examined — at ef_512 each query checks several thousand nodes, so the per-check savings compound.

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench vector_search_bench -- "HNSW ef_search" --save-baseline pre-406
git checkout perf/hnsw-visited-bitmap
cargo bench -p laurus --bench vector_search_bench -- "HNSW ef_search" --baseline pre-406
```

## Test plan

- [x] ``cargo fmt --check`` — clean
- [x] ``cargo clippy -p laurus --benches -- -D warnings`` — clean
- [x] ``cargo test -p laurus --lib`` — 810 / 810 pass

The visited-set semantics are unchanged: each unique `doc_id` is recorded once and reads are idempotent. Behavior under concurrent graph modification is the same as before (search reads a fixed snapshot; bitmap is sized at search start).

Closes #406