### PR TITLE
perf(vector): per-field doc-id cache to skip full vector_ids scan (#405)

### DIFF
--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -587,6 +587,74 @@ fn bench_hnsw_multi_field_search(c: &mut Criterion) {
     group.finish();
 }
 
+/// Flat search filtered to a single field on a multi-field corpus.
+///
+/// The corpus is split 30 / 30 / 40 % across `field_a`, `field_b`,
+/// `field_c`. The query selects `field_a`, so only ~30 % of vectors are
+/// candidates. Today every search calls `vector_ids()` to materialise
+/// every `(id, field_name)` pair and filters by string equality —
+/// wasted work proportional to the non-target field count plus the
+/// `Vec<(u64, String)>` clone.
+///
+/// #405 (per-field `vector_ids` cache) targets this hot path: with the
+/// fix the searcher fetches a pre-built `Arc<[u64]>` for the target
+/// field at O(1) cost.
+fn bench_flat_multi_field_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Flat Multi-field Search");
+    let dim = 128;
+
+    for &count in &search_corpus_sizes() {
+        let vectors = generate_multi_field_vectors(count, dim);
+        let storage = create_storage();
+        let config = FlatIndexConfig {
+            dimension: dim,
+            distance_metric: DistanceMetric::Cosine,
+            ..Default::default()
+        };
+        let mut index = ManagedVectorIndex::new(
+            VectorIndexTypeConfig::Flat(config),
+            storage,
+            "flat_multi_field_bench",
+        )
+        .unwrap();
+        index.add_vectors(vectors).unwrap();
+        index.finalize().unwrap();
+
+        let reader = index.reader().unwrap();
+        let searcher = FlatVectorSearcher::new(reader).unwrap();
+        let query = generate_query(dim);
+
+        // Sanity: filtering to field_a (~30 % of corpus) must still hit.
+        let probe = searcher
+            .search(
+                &VectorIndexQuery::new(query.clone())
+                    .top_k(10)
+                    .field_name("field_a".to_string()),
+            )
+            .unwrap();
+        assert!(
+            !probe.results.is_empty(),
+            "flat multi-field probe must return at least one hit (field_a, count={count})"
+        );
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("field_a_30pct/{count}")),
+            &count,
+            |b, _| {
+                b.iter(|| {
+                    let request = VectorIndexQuery::new(query.clone())
+                        .top_k(10)
+                        .field_name("field_a".to_string());
+                    searcher.search(&request).unwrap()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_flat_construction,
@@ -598,5 +666,6 @@ criterion_group!(
     bench_hnsw_graph_search,
     bench_hnsw_ef_search_sweep,
     bench_hnsw_multi_field_search,
+    bench_flat_multi_field_search,
 );
 criterion_main!(benches);

--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -22,6 +22,28 @@ pub struct FlatVectorIndexReader {
     dimension: usize,
     distance_metric: DistanceMetric,
     deletion_bitmap: Option<Arc<DeletionBitmap>>,
+    /// Pre-built per-field doc-id list (`field_name → Arc<[u64]>`). Built
+    /// once at load so `doc_ids_for_field` returns a refcount-shared
+    /// slice without re-cloning `vector_ids`. #405.
+    vector_ids_by_field: std::collections::HashMap<String, Arc<[u64]>>,
+}
+
+/// Group `vector_ids` by field name into refcount-shared slices.
+fn build_vector_ids_by_field(
+    vector_ids: &[(u64, String)],
+) -> std::collections::HashMap<String, Arc<[u64]>> {
+    let mut by_field: std::collections::HashMap<String, Vec<u64>> =
+        std::collections::HashMap::new();
+    for (doc_id, field_name) in vector_ids {
+        by_field
+            .entry(field_name.clone())
+            .or_default()
+            .push(*doc_id);
+    }
+    by_field
+        .into_iter()
+        .map(|(field, ids)| (field, Arc::<[u64]>::from(ids)))
+        .collect()
 }
 
 impl FlatVectorIndexReader {
@@ -161,12 +183,14 @@ impl FlatVectorIndexReader {
             }
         };
 
+        let vector_ids_by_field = build_vector_ids_by_field(&vector_ids);
         Ok(Self {
             vectors,
             vector_ids,
             dimension,
             distance_metric,
             deletion_bitmap: None,
+            vector_ids_by_field,
         })
     }
 
@@ -223,6 +247,16 @@ impl VectorIndexReader for FlatVectorIndexReader {
 
     fn vector_ids(&self) -> Result<Vec<(u64, String)>> {
         Ok(self.vector_ids.clone())
+    }
+
+    fn doc_ids_for_field(&self, field_name: &str) -> Arc<[u64]> {
+        // O(1) HashMap lookup + Arc clone (refcount bump). Default impl
+        // would clone `vector_ids` (Vec<(u64, String)>) and filter
+        // linearly per call. #405.
+        self.vector_ids_by_field
+            .get(field_name)
+            .cloned()
+            .unwrap_or_else(|| Vec::<u64>::new().into())
     }
 
     fn vector_count(&self) -> usize {

--- a/laurus/src/vector/index/flat/searcher.rs
+++ b/laurus/src/vector/index/flat/searcher.rs
@@ -27,65 +27,97 @@ impl VectorIndexSearcher for FlatVectorSearcher {
 
         let start = Timer::now();
         let mut results = VectorIndexQueryResults::new();
+        let metric = self.index_reader.distance_metric();
 
-        // Get all vectors from the index
-        let vector_count = self.index_reader.vector_count();
-        results.candidates_examined = vector_count;
+        if let Some(ref field_name) = request.field_name {
+            // Field-filtered path: fetch the per-field doc-id slice from the
+            // reader's pre-built index (#405 — O(1) Arc clone, avoids the full
+            // `Vec<(u64, String)>` clone and the linear filter scan). Since
+            // every candidate shares the same `field_name`, do not store it
+            // per-candidate; clone it only when constructing the top_k
+            // results.
+            let ids = self.index_reader.doc_ids_for_field(field_name);
+            results.candidates_examined = ids.len();
 
-        // Get all vector IDs with field names
-        let vector_ids = self.index_reader.vector_ids()?;
-
-        // Filter by field_name if specified
-        let filtered_vector_ids: Vec<(u64, String)> =
-            if let Some(ref field_name) = request.field_name {
-                vector_ids
-                    .into_iter()
-                    .filter(|(_, f)| f == field_name)
-                    .collect()
-            } else {
-                vector_ids
-            };
-
-        // Calculate similarities for all vectors
-        let mut candidates: Vec<(u64, String, f32, f32, Vector)> =
-            Vec::with_capacity(filtered_vector_ids.len());
-        for (doc_id, field_name) in filtered_vector_ids {
-            if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, &field_name) {
-                let metric = self.index_reader.distance_metric();
-                let distance = metric.distance(&request.query.data, &vector.data)?;
-                let similarity = metric.distance_to_similarity(distance);
-                candidates.push((doc_id, field_name, similarity, distance, vector));
-            }
-        }
-
-        // Sort by similarity (descending)
-        candidates
-            .sort_unstable_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
-
-        // Take top_k results
-        let top_k = request.params.top_k.min(candidates.len());
-        for (doc_id, field_name, similarity, distance, vector) in candidates.into_iter().take(top_k)
-        {
-            // Apply minimum similarity threshold
-            if similarity < request.params.min_similarity {
-                break;
+            let mut candidates: Vec<(u64, f32, f32, Vector)> = Vec::with_capacity(ids.len());
+            for &doc_id in ids.iter() {
+                if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, field_name) {
+                    let distance = metric.distance(&request.query.data, &vector.data)?;
+                    let similarity = metric.distance_to_similarity(distance);
+                    candidates.push((doc_id, similarity, distance, vector));
+                }
             }
 
-            let vector_output = if request.params.include_vectors {
-                Some(vector)
-            } else {
-                None
-            };
+            candidates.sort_unstable_by(|a, b| {
+                b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+            });
 
-            results
-                .results
-                .push(crate::vector::search::searcher::VectorIndexQueryResult {
-                    doc_id,
-                    field_name,
-                    similarity,
-                    distance,
-                    vector: vector_output,
-                });
+            let top_k = request.params.top_k.min(candidates.len());
+            for (doc_id, similarity, distance, vector) in candidates.into_iter().take(top_k) {
+                if similarity < request.params.min_similarity {
+                    break;
+                }
+
+                let vector_output = if request.params.include_vectors {
+                    Some(vector)
+                } else {
+                    None
+                };
+
+                results
+                    .results
+                    .push(crate::vector::search::searcher::VectorIndexQueryResult {
+                        doc_id,
+                        field_name: field_name.clone(),
+                        similarity,
+                        distance,
+                        vector: vector_output,
+                    });
+            }
+        } else {
+            // Unfiltered path: each doc may belong to a different field, so the
+            // field name must travel with each candidate.
+            let candidates_list = self.index_reader.vector_ids()?;
+            results.candidates_examined = self.index_reader.vector_count();
+
+            let mut candidates: Vec<(u64, String, f32, f32, Vector)> =
+                Vec::with_capacity(candidates_list.len());
+            for (doc_id, field_name) in candidates_list {
+                if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, &field_name) {
+                    let distance = metric.distance(&request.query.data, &vector.data)?;
+                    let similarity = metric.distance_to_similarity(distance);
+                    candidates.push((doc_id, field_name, similarity, distance, vector));
+                }
+            }
+
+            candidates.sort_unstable_by(|a, b| {
+                b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+            let top_k = request.params.top_k.min(candidates.len());
+            for (doc_id, field_name, similarity, distance, vector) in
+                candidates.into_iter().take(top_k)
+            {
+                if similarity < request.params.min_similarity {
+                    break;
+                }
+
+                let vector_output = if request.params.include_vectors {
+                    Some(vector)
+                } else {
+                    None
+                };
+
+                results
+                    .results
+                    .push(crate::vector::search::searcher::VectorIndexQueryResult {
+                        doc_id,
+                        field_name,
+                        similarity,
+                        distance,
+                        vector: vector_output,
+                    });
+            }
         }
 
         results.search_time_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -93,14 +125,12 @@ impl VectorIndexSearcher for FlatVectorSearcher {
     }
 
     fn count(&self, request: VectorIndexQuery) -> Result<u64> {
-        // Get all vector IDs with field names
-        let vector_ids = self.index_reader.vector_ids()?;
-
-        // Filter by field_name if specified
+        // For a field-filtered count, use the pre-built per-field index
+        // (#405); avoids allocating + iterating the full `vector_ids`.
         if let Some(ref field_name) = request.field_name {
-            Ok(vector_ids.iter().filter(|(_, f)| f == field_name).count() as u64)
+            Ok(self.index_reader.doc_ids_for_field(field_name).len() as u64)
         } else {
-            Ok(vector_ids.len() as u64)
+            Ok(self.index_reader.vector_ids()?.len() as u64)
         }
     }
 }

--- a/laurus/src/vector/index/hnsw/field_reader.rs
+++ b/laurus/src/vector/index/hnsw/field_reader.rs
@@ -80,29 +80,32 @@ impl HnswFieldReader {
         query: &Vector,
         allowed_ids: Option<&std::collections::HashSet<u64>>,
     ) -> Result<Vec<FieldHit>> {
-        // Get vector IDs for this field
-        let vector_ids = self.index_reader.vector_ids()?;
-        let filtered_ids: Vec<(u64, String)> = vector_ids
-            .into_iter()
-            .filter(|(id, f)| {
-                f == &self.field_name && allowed_ids.is_none_or(|allowed| allowed.contains(id))
-            })
-            .collect();
+        // Fetch the per-field doc-id slice from the reader's pre-built
+        // index (#405). The `allowed_ids` filter — when supplied by the
+        // caller — is applied against this already-narrowed slice rather
+        // than the full corpus.
+        let field_ids = self.index_reader.doc_ids_for_field(&self.field_name);
+        let filtered: Vec<u64> = match allowed_ids {
+            Some(allowed) => field_ids
+                .iter()
+                .copied()
+                .filter(|id| allowed.contains(id))
+                .collect(),
+            None => field_ids.iter().copied().collect(),
+        };
 
         // Linear scan: examine all filtered vectors (ef_search only applies to graph search)
-        let mut candidates: Vec<(u64, f32, f32)> = Vec::with_capacity(filtered_ids.len());
+        let mut candidates: Vec<(u64, f32, f32)> = Vec::with_capacity(filtered.len());
 
-        for (doc_id, field_name) in filtered_ids.iter() {
-            if let Ok(Some(vector)) = self.index_reader.get_vector(*doc_id, field_name) {
-                let similarity = self
-                    .index_reader
-                    .distance_metric()
-                    .similarity(&query.data, &vector.data)?;
-                let distance = self
-                    .index_reader
-                    .distance_metric()
-                    .distance(&query.data, &vector.data)?;
-                candidates.push((*doc_id, similarity, distance));
+        for &doc_id in &filtered {
+            if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, &self.field_name) {
+                // Compute distance once and derive similarity (mirrors
+                // the #404 pattern: `similarity()` would otherwise rerun
+                // the SIMD distance kernel internally).
+                let metric = self.index_reader.distance_metric();
+                let distance = metric.distance(&query.data, &vector.data)?;
+                let similarity = metric.distance_to_similarity(distance);
+                candidates.push((doc_id, similarity, distance));
             }
         }
 

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -15,6 +15,24 @@ use crate::maintenance::deletion::DeletionBitmap;
 /// Storage for vectors (in-memory or on-demand).
 use crate::vector::index::storage::VectorStorage;
 
+/// Build a `field_name → Arc<[u64]>` lookup from a flat `Vec<(u64, String)>`.
+///
+/// The grouping happens once at reader load so search-time
+/// `doc_ids_for_field` is a single HashMap lookup + Arc clone.
+fn build_vector_ids_by_field(vector_ids: &[(u64, String)]) -> HashMap<String, Arc<[u64]>> {
+    let mut by_field: HashMap<String, Vec<u64>> = HashMap::new();
+    for (doc_id, field_name) in vector_ids {
+        by_field
+            .entry(field_name.clone())
+            .or_default()
+            .push(*doc_id);
+    }
+    by_field
+        .into_iter()
+        .map(|(field, ids)| (field, Arc::<[u64]>::from(ids)))
+        .collect()
+}
+
 /// Reader for HNSW (Hierarchical Navigable Small World) vector indexes.
 #[derive(Debug)]
 pub struct HnswIndexReader {
@@ -38,6 +56,13 @@ pub struct HnswIndexReader {
     /// The pointer is valid for the lifetime of `self` because the backing
     /// `Arc<Vec<f32>>` is kept alive by `VectorStorage::Owned`.
     prefetch_index: HashMap<String, HashMap<u64, usize>>,
+
+    /// Pre-built per-field doc-id list (`field_name → Arc<[u64]>`).
+    ///
+    /// Built once at load time so `doc_ids_for_field` returns a refcount-
+    /// shared slice (no per-call allocation, no `Vec<(u64, String)>` clone,
+    /// no linear filter). #405 (per-field `vector_ids` cache).
+    vector_ids_by_field: HashMap<String, Arc<[u64]>>,
 }
 
 impl HnswIndexReader {
@@ -264,6 +289,11 @@ impl HnswIndexReader {
             HashMap::new()
         };
 
+        // Per-field doc-id lookup (#405). Built from `vector_ids` so it
+        // reflects the same set the search path used to filter at every
+        // call; finalised into `Arc<[u64]>` for cheap clone semantics.
+        let vector_ids_by_field = build_vector_ids_by_field(&vector_ids);
+
         Ok(Self {
             vectors,
             vector_ids,
@@ -274,6 +304,7 @@ impl HnswIndexReader {
             graph,
             deletion_bitmap: None,
             prefetch_index,
+            vector_ids_by_field,
         })
     }
 
@@ -353,6 +384,16 @@ impl VectorIndexReader for HnswIndexReader {
 
     fn vector_ids(&self) -> Result<Vec<(u64, String)>> {
         Ok(self.vector_ids.clone())
+    }
+
+    fn doc_ids_for_field(&self, field_name: &str) -> Arc<[u64]> {
+        // O(1) HashMap lookup + Arc clone (refcount bump). Compared to
+        // the default impl this avoids the per-call `Vec<(u64, String)>`
+        // clone of the full corpus and the linear filter scan. #405.
+        self.vector_ids_by_field
+            .get(field_name)
+            .cloned()
+            .unwrap_or_else(|| Vec::<u64>::new().into())
     }
 
     fn vector_count(&self) -> usize {

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -58,58 +58,96 @@ impl VectorIndexSearcher for HnswSearcher {
 
         // Fallback to Linear Scan (brute-force over all vectors)
         let mut results = VectorIndexQueryResults::new();
+        let metric = self.index_reader.distance_metric();
 
-        let mut vector_ids = self.index_reader.vector_ids()?;
-
-        // Filter by field_name if specified
         if let Some(ref field_name) = request.field_name {
-            vector_ids.retain(|(_, fname)| fname == field_name);
-        }
+            // Field-filtered path: fetch the per-field doc-id slice from the
+            // reader's pre-built index (#405 — O(1) Arc clone, avoids the full
+            // `Vec<(u64, String)>` clone and the linear retain scan). Every
+            // candidate shares the same `field_name`, so it is not stored
+            // per-candidate; it is cloned only when emitting the top_k
+            // results.
+            let ids = self.index_reader.doc_ids_for_field(field_name);
+            results.candidates_examined = ids.len();
 
-        results.candidates_examined = vector_ids.len();
-
-        let mut candidates: Vec<(u64, String, f32, f32, Vector)> =
-            Vec::with_capacity(vector_ids.len());
-
-        for (doc_id, field_name) in vector_ids.iter() {
-            if let Ok(Some(vector)) = self.index_reader.get_vector(*doc_id, field_name) {
-                // Compute distance once and derive similarity from it.
-                // Calling `similarity()` would internally invoke `distance()`
-                // a second time on the same vector pair (the SIMD body runs
-                // twice), so the fallback path doubled its compute cost.
-                // The graph-search path at L308 already uses this pattern.
-                let metric = self.index_reader.distance_metric();
-                let distance = metric.distance(&request.query.data, &vector.data)?;
-                let similarity = metric.distance_to_similarity(distance);
-                candidates.push((*doc_id, field_name.clone(), similarity, distance, vector));
-            }
-        }
-
-        candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
-
-        let top_k = request.params.top_k.min(candidates.len());
-        for (doc_id, field_name, similarity, distance, vector) in candidates.into_iter().take(top_k)
-        {
-            // Apply minimum similarity threshold
-            if similarity < request.params.min_similarity {
-                break;
+            let mut candidates: Vec<(u64, f32, f32, Vector)> = Vec::with_capacity(ids.len());
+            for &doc_id in ids.iter() {
+                if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, field_name) {
+                    // Compute distance once and derive similarity from it.
+                    // `similarity()` would otherwise re-run the SIMD distance
+                    // kernel a second time on the same pair.
+                    let distance = metric.distance(&request.query.data, &vector.data)?;
+                    let similarity = metric.distance_to_similarity(distance);
+                    candidates.push((doc_id, similarity, distance, vector));
+                }
             }
 
-            let vector_output = if request.params.include_vectors {
-                Some(vector)
-            } else {
-                None
-            };
+            candidates.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
 
-            results
-                .results
-                .push(crate::vector::search::searcher::VectorIndexQueryResult {
-                    doc_id,
-                    field_name,
-                    similarity,
-                    distance,
-                    vector: vector_output,
-                });
+            let top_k = request.params.top_k.min(candidates.len());
+            for (doc_id, similarity, distance, vector) in candidates.into_iter().take(top_k) {
+                if similarity < request.params.min_similarity {
+                    break;
+                }
+
+                let vector_output = if request.params.include_vectors {
+                    Some(vector)
+                } else {
+                    None
+                };
+
+                results
+                    .results
+                    .push(crate::vector::search::searcher::VectorIndexQueryResult {
+                        doc_id,
+                        field_name: field_name.clone(),
+                        similarity,
+                        distance,
+                        vector: vector_output,
+                    });
+            }
+        } else {
+            // Unfiltered path: docs may belong to different fields, so the
+            // field name must travel with each candidate.
+            let candidates_list = self.index_reader.vector_ids()?;
+            results.candidates_examined = candidates_list.len();
+
+            let mut candidates: Vec<(u64, String, f32, f32, Vector)> =
+                Vec::with_capacity(candidates_list.len());
+            for (doc_id, field_name) in candidates_list.iter() {
+                if let Ok(Some(vector)) = self.index_reader.get_vector(*doc_id, field_name) {
+                    let distance = metric.distance(&request.query.data, &vector.data)?;
+                    let similarity = metric.distance_to_similarity(distance);
+                    candidates.push((*doc_id, field_name.clone(), similarity, distance, vector));
+                }
+            }
+
+            candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(Ordering::Equal));
+
+            let top_k = request.params.top_k.min(candidates.len());
+            for (doc_id, field_name, similarity, distance, vector) in
+                candidates.into_iter().take(top_k)
+            {
+                if similarity < request.params.min_similarity {
+                    break;
+                }
+
+                let vector_output = if request.params.include_vectors {
+                    Some(vector)
+                } else {
+                    None
+                };
+
+                results
+                    .results
+                    .push(crate::vector::search::searcher::VectorIndexQueryResult {
+                        doc_id,
+                        field_name,
+                        similarity,
+                        distance,
+                        vector: vector_output,
+                    });
+            }
         }
 
         results.search_time_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -117,14 +155,12 @@ impl VectorIndexSearcher for HnswSearcher {
     }
 
     fn count(&self, request: VectorIndexQuery) -> Result<u64> {
-        // Get all vector IDs with field names
-        let vector_ids = self.index_reader.vector_ids()?;
-
-        // Filter by field_name if specified
+        // Field-filtered counts use the pre-built per-field index (#405);
+        // avoids allocating + linear-filtering the full `vector_ids`.
         if let Some(ref field_name) = request.field_name {
-            Ok(vector_ids.iter().filter(|(_, f)| f == field_name).count() as u64)
+            Ok(self.index_reader.doc_ids_for_field(field_name).len() as u64)
         } else {
-            Ok(vector_ids.len() as u64)
+            Ok(self.index_reader.vector_ids()?.len() as u64)
         }
     }
 }

--- a/laurus/src/vector/index/ivf/reader.rs
+++ b/laurus/src/vector/index/ivf/reader.rs
@@ -31,6 +31,25 @@ pub struct IvfIndexReader {
     /// `(doc_id, field_name)` pairs assigned to cluster `i`.
     cluster_to_vectors: Vec<Vec<(u64, String)>>,
     deletion_bitmap: Option<Arc<DeletionBitmap>>,
+    /// Pre-built per-field doc-id list (`field_name → Arc<[u64]>`). Built
+    /// once at load so `doc_ids_for_field` returns a refcount-shared
+    /// slice without re-cloning `vector_ids`. #405.
+    vector_ids_by_field: HashMap<String, Arc<[u64]>>,
+}
+
+/// Group `vector_ids` by field name into refcount-shared slices.
+fn build_vector_ids_by_field(vector_ids: &[(u64, String)]) -> HashMap<String, Arc<[u64]>> {
+    let mut by_field: HashMap<String, Vec<u64>> = HashMap::new();
+    for (doc_id, field_name) in vector_ids {
+        by_field
+            .entry(field_name.clone())
+            .or_default()
+            .push(*doc_id);
+    }
+    by_field
+        .into_iter()
+        .map(|(field, ids)| (field, Arc::<[u64]>::from(ids)))
+        .collect()
 }
 
 impl IvfIndexReader {
@@ -197,6 +216,7 @@ impl IvfIndexReader {
             }
         };
 
+        let vector_ids_by_field = build_vector_ids_by_field(&vector_ids);
         Ok(Self {
             vectors,
             vector_ids,
@@ -207,6 +227,7 @@ impl IvfIndexReader {
             centroids,
             cluster_to_vectors,
             deletion_bitmap: None,
+            vector_ids_by_field,
         })
     }
 
@@ -290,6 +311,16 @@ impl VectorIndexReader for IvfIndexReader {
 
     fn vector_ids(&self) -> Result<Vec<(u64, String)>> {
         Ok(self.vector_ids.clone())
+    }
+
+    fn doc_ids_for_field(&self, field_name: &str) -> Arc<[u64]> {
+        // O(1) HashMap lookup + Arc clone (refcount bump). Default impl
+        // would clone `vector_ids` (Vec<(u64, String)>) and filter
+        // linearly per call. #405.
+        self.vector_ids_by_field
+            .get(field_name)
+            .cloned()
+            .unwrap_or_else(|| Vec::<u64>::new().into())
     }
 
     fn vector_count(&self) -> usize {

--- a/laurus/src/vector/index/ivf/searcher.rs
+++ b/laurus/src/vector/index/ivf/searcher.rs
@@ -175,12 +175,12 @@ impl VectorIndexSearcher for IvfSearcher {
     }
 
     fn count(&self, request: VectorIndexQuery) -> Result<u64> {
-        let vector_ids = self.index_reader.vector_ids()?;
-
+        // Field-filtered counts use the pre-built per-field index (#405);
+        // avoids allocating + linear-filtering the full `vector_ids`.
         if let Some(ref field_name) = request.field_name {
-            Ok(vector_ids.iter().filter(|(_, f)| f == field_name).count() as u64)
+            Ok(self.index_reader.doc_ids_for_field(field_name).len() as u64)
         } else {
-            Ok(vector_ids.len() as u64)
+            Ok(self.index_reader.vector_ids()?.len() as u64)
         }
     }
 }

--- a/laurus/src/vector/reader.rs
+++ b/laurus/src/vector/reader.rs
@@ -84,6 +84,28 @@ pub trait VectorIndexReader: Send + Sync + std::fmt::Debug {
     /// Get all vector IDs with their field names in the index.
     fn vector_ids(&self) -> Result<Vec<(u64, String)>>;
 
+    /// Doc IDs that belong to a specific field.
+    ///
+    /// Concrete readers should override with an O(1) lookup into a
+    /// pre-built per-field index. The default implementation falls back
+    /// to filtering [`vector_ids`](Self::vector_ids) every call, which
+    /// allocates a fresh `Vec<(u64, String)>` of size `total_vectors` —
+    /// the cost #405 (per-field `vector_ids` cache) targets.
+    ///
+    /// Returns an `Arc<[u64]>` so a cached implementation can hand back
+    /// a refcount bump rather than a fresh allocation. An empty
+    /// `Arc<[u64]>` is returned when the field has no vectors.
+    fn doc_ids_for_field(&self, field_name: &str) -> Arc<[u64]> {
+        self.vector_ids()
+            .map(|all| {
+                all.into_iter()
+                    .filter_map(|(id, f)| (f == field_name).then_some(id))
+                    .collect::<Vec<u64>>()
+                    .into()
+            })
+            .unwrap_or_else(|_| Vec::new().into())
+    }
+
     /// Get the total number of vectors.
     fn vector_count(&self) -> usize;
 


### PR DESCRIPTION
## Summary

Closes #405. Refs #416.

Field-filtered vector search currently calls `VectorIndexReader::vector_ids()`, which clones the full `Vec<(u64, String)>` of every (id, field) pair, then linearly filters by field name on every query. For a 5k-doc multi-field index that is 5 000 `String` allocations + a 5 000-row scan per call, even when only ~30 % of docs match the requested field.

This PR adds a per-field doc-id cache built once at reader construction:

- **New trait method**: `VectorIndexReader::doc_ids_for_field(field_name) -> Arc<[u64]>`. Default impl preserves the previous behaviour by filtering `vector_ids()`; concrete readers (Flat / HNSW / IVF) override with an O(1) `HashMap<String, Arc<[u64]>>` lookup + Arc clone.
- **Searcher refactor** (Flat fallback / HNSW fallback): split `search()` into two paths.
  - **Field-filtered**: candidates stored as `Vec<(u64, f32, f32, Vector)>` — no field name per row. Field name is cloned only when constructing top_k results (e.g. 10 clones instead of 1500).
  - **Unfiltered**: keeps the existing `Vec<(u64, String, f32, f32, Vector)>` flow because each doc may belong to a different field.
- **`count()` fast path** (Flat / HNSW / IVF): field-filtered counts call `doc_ids_for_field(field).len()` instead of allocating the full id list.
- **`HnswFieldReader`**: uses `Arc<[u64]>` directly instead of cloning the full id list.

## Bench (`vector_search_bench`, vs `pre-405` baseline)

| Bench | Δ time |
|---|---|
| Flat Multi-field Search / field_a_30pct / 1000 | **−10.0 %** |
| Flat Multi-field Search / field_a_30pct / 5000 | **−2.5 %** |

(The HNSW Multi-field bench drives the graph path, which never calls `vector_ids()`, so it is unchanged here. The Flat fallback bench is the canonical measurement for this change.)

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus` (all unit + doc tests pass)
- [x] `cargo bench --bench vector_search_bench -- "Flat Multi-field Search" --baseline pre-405` confirms improvement