### PR TITLE
perf(lexical/bm25): precompute IDF + add packed-frequency fast path (#402)

### DIFF
--- a/docs/ja/src/laurus/scoring.md
+++ b/docs/ja/src/laurus/scoring.md
@@ -53,6 +53,31 @@ score = IDF * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (doc_len / avg_doc_len))
 // - "vector_space"  -> VectorSpaceScoringFunction
 ```
 
+### BM25Plan（事前計算済みクエリ）
+
+同じクエリに対して多数のドキュメントをスコアリングする場合、`BM25Plan` はクエリビルド時に単語ごとの IDF、フィールド長正規化の不変項、`k1 + 1` を一度だけ算出し、各ドキュメントを軽量な数値ループでスコアリングします。スコアリングメソッドは 2 つあります。
+
+- `BM25Plan::score(&doc_stats)` — `BM25ScoringFunction::score` のドロップイン高速版。`DocumentStats` の `HashMap<String, u64>` 経由で単語頻度を引きます。
+- `BM25Plan::score_packed(&term_freqs, doc_length)` — `query_terms` での位置でインデックスされた `&[u64]` をパック済み単語頻度として受け取ります。ドキュメントごとの文字列キー `HashMap` 引きを完全に回避できるため、呼び出し側でドキュメントごとに頻度を 1 度だけパックできる場合に使ってください。
+
+```rust
+use laurus::lexical::search::scoring::bm25::{BM25Plan, ScoringConfig};
+
+let plan = BM25Plan::new(&query_terms, &collection_stats, &ScoringConfig::default());
+
+// HashMap パス（ドロップイン高速版）:
+let score = plan.score(&doc_stats);
+
+// Packed パス（ドキュメントごとの HashMap 引きを回避）:
+let term_freqs: Vec<u64> = query_terms
+    .iter()
+    .map(|t| *doc_stats.term_frequencies.get(t).unwrap_or(&0))
+    .collect();
+let score = plan.score_packed(&term_freqs, doc_stats.doc_length);
+```
+
+`BM25ScoringFunction::score` は 1 ドキュメントずつスコアリングする呼び出し側のために維持されています。
+
 ### フィールドブースト
 
 フィールドブーストは、特定のフィールドからのスコア寄与に乗数を適用します。一部のフィールドが他よりも重要な場合に有用です。

--- a/docs/src/laurus/scoring.md
+++ b/docs/src/laurus/scoring.md
@@ -53,6 +53,31 @@ The `ScoringRegistry` provides a central registry for scoring algorithms:
 // - "vector_space"  -> VectorSpaceScoringFunction
 ```
 
+### BM25Plan (precomputed query)
+
+When scoring many documents against the same query, `BM25Plan` materializes per-term IDF, length-normalization invariants, and `k1 + 1` once at query build time, then scores each document with a tight numeric loop. Two scoring methods are exposed:
+
+- `BM25Plan::score(&doc_stats)` — drop-in faster replacement for `BM25ScoringFunction::score`. Still looks up term frequencies via the existing `HashMap<String, u64>` on `DocumentStats`.
+- `BM25Plan::score_packed(&term_freqs, doc_length)` — accepts a packed `&[u64]` of term frequencies indexed by the position of each term in the original `query_terms`. Avoids the per-document string-keyed `HashMap` lookup entirely; use it when the caller can pre-pack frequencies once per document.
+
+```rust
+use laurus::lexical::search::scoring::bm25::{BM25Plan, ScoringConfig};
+
+let plan = BM25Plan::new(&query_terms, &collection_stats, &ScoringConfig::default());
+
+// Hash-map path (drop-in faster):
+let score = plan.score(&doc_stats);
+
+// Packed path (avoids per-doc hash lookup):
+let term_freqs: Vec<u64> = query_terms
+    .iter()
+    .map(|t| *doc_stats.term_frequencies.get(t).unwrap_or(&0))
+    .collect();
+let score = plan.score_packed(&term_freqs, doc_stats.doc_length);
+```
+
+`BM25ScoringFunction::score` is preserved for callers that score one document at a time.
+
 ### Field Boosts
 
 Field boosts multiply the score contribution from specific fields. This is useful when some fields are more important than others:

--- a/laurus/benches/bm25_scoring_bench.rs
+++ b/laurus/benches/bm25_scoring_bench.rs
@@ -47,7 +47,7 @@ use std::hint::black_box;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use laurus::lexical::search::scoring::bm25::{
-    BM25ScoringFunction, CollectionStats, DocumentStats, ScoringConfig, ScoringFunction,
+    BM25Plan, BM25ScoringFunction, CollectionStats, DocumentStats, ScoringConfig, ScoringFunction,
 };
 
 use common::{DEFAULT_SEED, lcg_next_unit};
@@ -184,5 +184,119 @@ fn bench_bm25_score(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_bm25_score);
+/// Benchmark scoring with a precomputed [`BM25Plan`] (#402, hash-map path).
+///
+/// Builds the plan once per `(n_qterms, n_candidates)` outside the timed
+/// section. Inside `b.iter` we score every candidate document with
+/// [`BM25Plan::score`], which still looks up term frequencies via the
+/// `HashMap<String, u64>` on `DocumentStats` but reuses the cached IDF and
+/// length-normalisation invariants instead of recomputing them per call.
+fn bench_bm25_score_with_plan(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bm25_scoring/score_with_plan");
+
+    let config = ScoringConfig::default();
+    let vocab = build_vocab();
+    let collection = build_collection_stats(&vocab);
+
+    for &n_candidates in &[100usize, 10_000, 100_000] {
+        let docs = build_doc_stats(&vocab, n_candidates);
+
+        for &n_qterms in &[1usize, 5, 10] {
+            let mut state = DEFAULT_SEED.wrapping_add(n_qterms as u64);
+            let query = build_query(&vocab, n_qterms, &mut state);
+            let plan = BM25Plan::new(&query, &collection, &config);
+
+            // Sanity probe (matches `bench_bm25_score`).
+            let probe = plan.score(&docs[0]);
+            assert!(
+                probe.is_finite(),
+                "BM25Plan probe score must be finite, got {probe}"
+            );
+
+            group.throughput(Throughput::Elements(n_candidates as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("qterms_{n_qterms}/{n_candidates}")),
+                &(),
+                |b, _| {
+                    b.iter(|| {
+                        for doc in &docs {
+                            let score = plan.score(black_box(doc));
+                            black_box(score);
+                        }
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+/// Benchmark scoring with a precomputed [`BM25Plan`] over packed term
+/// frequencies (#402, packed path).
+///
+/// Builds the plan once and pre-packs each document's term frequencies
+/// into a `Vec<u64>` indexed by query position before timing — both costs
+/// are amortised for callers that score many documents against the same
+/// query. Inside `b.iter` we call [`BM25Plan::score_packed`], which avoids
+/// the per-doc string-keyed `HashMap` lookup entirely.
+fn bench_bm25_score_packed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bm25_scoring/score_packed");
+
+    let config = ScoringConfig::default();
+    let vocab = build_vocab();
+    let collection = build_collection_stats(&vocab);
+
+    for &n_candidates in &[100usize, 10_000, 100_000] {
+        let docs = build_doc_stats(&vocab, n_candidates);
+
+        for &n_qterms in &[1usize, 5, 10] {
+            let mut state = DEFAULT_SEED.wrapping_add(n_qterms as u64);
+            let query = build_query(&vocab, n_qterms, &mut state);
+            let plan = BM25Plan::new(&query, &collection, &config);
+
+            // Pre-pack each document's term frequencies in plan order.
+            let packed: Vec<(Vec<u64>, u64)> = docs
+                .iter()
+                .map(|d| {
+                    let freqs: Vec<u64> = query
+                        .iter()
+                        .map(|t| *d.term_frequencies.get(t).unwrap_or(&0))
+                        .collect();
+                    (freqs, d.doc_length)
+                })
+                .collect();
+
+            // Sanity probe.
+            let probe = plan.score_packed(&packed[0].0, packed[0].1);
+            assert!(
+                probe.is_finite(),
+                "BM25Plan::score_packed probe must be finite, got {probe}"
+            );
+
+            group.throughput(Throughput::Elements(n_candidates as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("qterms_{n_qterms}/{n_candidates}")),
+                &(),
+                |b, _| {
+                    b.iter(|| {
+                        for (freqs, doc_len) in &packed {
+                            let score = plan.score_packed(black_box(freqs), black_box(*doc_len));
+                            black_box(score);
+                        }
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_bm25_score,
+    bench_bm25_score_with_plan,
+    bench_bm25_score_packed,
+);
 criterion_main!(benches);

--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -587,6 +587,74 @@ fn bench_hnsw_multi_field_search(c: &mut Criterion) {
     group.finish();
 }
 
+/// Flat search filtered to a single field on a multi-field corpus.
+///
+/// The corpus is split 30 / 30 / 40 % across `field_a`, `field_b`,
+/// `field_c`. The query selects `field_a`, so only ~30 % of vectors are
+/// candidates. Today every search calls `vector_ids()` to materialise
+/// every `(id, field_name)` pair and filters by string equality —
+/// wasted work proportional to the non-target field count plus the
+/// `Vec<(u64, String)>` clone.
+///
+/// #405 (per-field `vector_ids` cache) targets this hot path: with the
+/// fix the searcher fetches a pre-built `Arc<[u64]>` for the target
+/// field at O(1) cost.
+fn bench_flat_multi_field_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Flat Multi-field Search");
+    let dim = 128;
+
+    for &count in &search_corpus_sizes() {
+        let vectors = generate_multi_field_vectors(count, dim);
+        let storage = create_storage();
+        let config = FlatIndexConfig {
+            dimension: dim,
+            distance_metric: DistanceMetric::Cosine,
+            ..Default::default()
+        };
+        let mut index = ManagedVectorIndex::new(
+            VectorIndexTypeConfig::Flat(config),
+            storage,
+            "flat_multi_field_bench",
+        )
+        .unwrap();
+        index.add_vectors(vectors).unwrap();
+        index.finalize().unwrap();
+
+        let reader = index.reader().unwrap();
+        let searcher = FlatVectorSearcher::new(reader).unwrap();
+        let query = generate_query(dim);
+
+        // Sanity: filtering to field_a (~30 % of corpus) must still hit.
+        let probe = searcher
+            .search(
+                &VectorIndexQuery::new(query.clone())
+                    .top_k(10)
+                    .field_name("field_a".to_string()),
+            )
+            .unwrap();
+        assert!(
+            !probe.results.is_empty(),
+            "flat multi-field probe must return at least one hit (field_a, count={count})"
+        );
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("field_a_30pct/{count}")),
+            &count,
+            |b, _| {
+                b.iter(|| {
+                    let request = VectorIndexQuery::new(query.clone())
+                        .top_k(10)
+                        .field_name("field_a".to_string());
+                    searcher.search(&request).unwrap()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_flat_construction,
@@ -598,5 +666,6 @@ criterion_group!(
     bench_hnsw_graph_search,
     bench_hnsw_ef_search_sweep,
     bench_hnsw_multi_field_search,
+    bench_flat_multi_field_search,
 );
 criterion_main!(benches);

--- a/laurus/src/lexical/search/scoring/bm25.rs
+++ b/laurus/src/lexical/search/scoring/bm25.rs
@@ -180,6 +180,204 @@ impl ScoringFunction for BM25ScoringFunction {
     }
 }
 
+/// Per-term plan precomputed once at query build time (#402).
+///
+/// Holds the query term key and its IDF so that scoring N documents against
+/// the same query no longer recomputes IDF / `ln()` N times.
+#[derive(Debug, Clone)]
+struct TermPlan {
+    /// Query term, used as a key for `DocumentStats::term_frequencies` lookups.
+    term: String,
+    /// Cached IDF (`ln((N - df + 0.5) / (df + 0.5))`). `0.0` if the term has
+    /// non-positive IDF (df > N/2); such terms are still kept in positional
+    /// order so packed-frequency callers can index by query position.
+    idf: f32,
+}
+
+/// A prepared BM25 query.
+///
+/// Materializes per-term IDF, length-normalisation invariants, and
+/// configuration-derived constants at construction time, so that scoring N
+/// documents against the same query no longer recomputes them N times.
+///
+/// Two scoring methods are exposed:
+///
+/// - [`BM25Plan::score`] — accepts a [`DocumentStats`] and looks up term
+///   frequencies via the existing `HashMap<String, u64>`. Drop-in faster
+///   replacement for [`BM25ScoringFunction::score`] when scoring many
+///   documents.
+/// - [`BM25Plan::score_packed`] — accepts a packed `&[u64]` of term
+///   frequencies indexed by the position of each term in the original
+///   `query_terms` slice. Avoids the per-doc string-keyed `HashMap` lookup
+///   entirely; use it when the caller can pre-pack frequencies once per
+///   document.
+#[derive(Debug, Clone)]
+pub struct BM25Plan {
+    /// Per-term plan in the order given to [`BM25Plan::new`].
+    plan: Vec<TermPlan>,
+    /// `k1` parameter from `ScoringConfig`.
+    k1: f32,
+    /// `b` parameter from `ScoringConfig`.
+    b: f32,
+    /// Precomputed `k1 + 1` (numerator factor of the TF component).
+    k1_plus_1: f32,
+    /// Average document length from `CollectionStats`.
+    avg_doc_length: f32,
+}
+
+impl BM25Plan {
+    /// Build a plan from a query, collection stats, and scoring config.
+    ///
+    /// Per-term IDF is computed once here. Terms whose IDF would be
+    /// non-positive (i.e. `df` exceeds half the collection) are stored with
+    /// `idf = 0.0` so that they contribute nothing at score time but the
+    /// plan's term order still matches the input `query_terms` — this lets
+    /// callers of [`Self::score_packed`] index into the plan by query
+    /// position.
+    ///
+    /// # Arguments
+    ///
+    /// * `query_terms` - Query terms (each entry corresponds to one
+    ///   `TermPlan` slot in the resulting plan).
+    /// * `collection_stats` - Collection statistics; only
+    ///   `total_docs`, `avg_doc_length`, and `document_frequencies` are
+    ///   read.
+    /// * `config` - Scoring configuration; only `k1` and `b` are read.
+    ///
+    /// # Returns
+    ///
+    /// A `BM25Plan` ready to score documents against this query.
+    pub fn new(
+        query_terms: &[String],
+        collection_stats: &CollectionStats,
+        config: &ScoringConfig,
+    ) -> Self {
+        let total_docs = collection_stats.total_docs as f32;
+        let plan = query_terms
+            .iter()
+            .map(|term| {
+                let df = *collection_stats
+                    .document_frequencies
+                    .get(term)
+                    .unwrap_or(&1) as f32;
+                let idf_ratio = (total_docs - df + 0.5) / (df + 0.5);
+                let idf = if idf_ratio > 0.0 { idf_ratio.ln() } else { 0.0 };
+                TermPlan {
+                    term: term.clone(),
+                    idf,
+                }
+            })
+            .collect();
+
+        Self {
+            plan,
+            k1: config.k1,
+            b: config.b,
+            k1_plus_1: config.k1 + 1.0,
+            avg_doc_length: collection_stats.avg_doc_length as f32,
+        }
+    }
+
+    /// Number of terms in the plan (matches the original `query_terms.len()`).
+    ///
+    /// # Returns
+    ///
+    /// Number of terms preserved in the plan.
+    pub fn term_count(&self) -> usize {
+        self.plan.len()
+    }
+
+    /// Score a document against this prepared query.
+    ///
+    /// Equivalent to [`BM25ScoringFunction::score`] but reuses precomputed
+    /// IDF and length-normalisation invariants. Looks up term frequencies
+    /// by string key in `doc_stats.term_frequencies`.
+    ///
+    /// # Arguments
+    ///
+    /// * `doc_stats` - Statistics for the document to score.
+    ///
+    /// # Returns
+    ///
+    /// BM25 relevance score for the document.
+    pub fn score(&self, doc_stats: &DocumentStats) -> f32 {
+        let len_factor = self.length_factor(doc_stats.doc_length);
+        let k1_norm = self.k1 * len_factor;
+
+        let mut total = 0.0_f32;
+        for tp in &self.plan {
+            if tp.idf == 0.0 {
+                continue;
+            }
+            let tf = *doc_stats.term_frequencies.get(&tp.term).unwrap_or(&0) as f32;
+            if tf == 0.0 {
+                continue;
+            }
+            let tf_component = (tf * self.k1_plus_1) / (tf + k1_norm);
+            total += tp.idf * tf_component;
+        }
+        total
+    }
+
+    /// Score a document using a packed term-frequency array.
+    ///
+    /// `term_freqs[i]` must be the term frequency for the i-th term in the
+    /// plan (same order as the `query_terms` passed to [`Self::new`]).
+    /// Avoids the per-doc `HashMap<String, u64>` lookup entirely; intended
+    /// for callers that can amortise frequency packing across many
+    /// scoring calls.
+    ///
+    /// # Arguments
+    ///
+    /// * `term_freqs` - Term frequencies in plan order. Must have the same
+    ///   length as the plan ([`Self::term_count`]).
+    /// * `doc_length` - Document length in tokens.
+    ///
+    /// # Returns
+    ///
+    /// BM25 relevance score for the document.
+    pub fn score_packed(&self, term_freqs: &[u64], doc_length: u64) -> f32 {
+        debug_assert_eq!(
+            term_freqs.len(),
+            self.plan.len(),
+            "term_freqs length must match plan term count"
+        );
+
+        let len_factor = self.length_factor(doc_length);
+        let k1_norm = self.k1 * len_factor;
+
+        let mut total = 0.0_f32;
+        for (tp, &tf_raw) in self.plan.iter().zip(term_freqs) {
+            if tp.idf == 0.0 {
+                continue;
+            }
+            let tf = tf_raw as f32;
+            if tf == 0.0 {
+                continue;
+            }
+            let tf_component = (tf * self.k1_plus_1) / (tf + k1_norm);
+            total += tp.idf * tf_component;
+        }
+        total
+    }
+
+    /// Length-normalisation factor `1 - b + b * (doc_len / avg_doc_len)`.
+    ///
+    /// Falls back to `1.0` when `avg_doc_length` is zero (avoids a
+    /// divide-by-zero and matches the behaviour of
+    /// [`BM25ScoringFunction::score`]).
+    #[inline]
+    fn length_factor(&self, doc_length: u64) -> f32 {
+        let doc_len = doc_length as f32;
+        let len_ratio = if self.avg_doc_length > 0.0 {
+            doc_len / self.avg_doc_length
+        } else {
+            1.0
+        };
+        1.0 - self.b + self.b * len_ratio
+    }
+}
+
 /// TF-IDF scoring function implementation.
 #[derive(Debug, Clone)]
 pub struct TfIdfScoringFunction;
@@ -727,5 +925,74 @@ mod tests {
 
         let score = scorer.score_document(&doc_stats).unwrap();
         assert!(score > 0.0);
+    }
+
+    #[test]
+    fn test_bm25_plan_matches_baseline() {
+        let scorer = BM25ScoringFunction;
+        let config = ScoringConfig::default();
+        let collection_stats = create_test_collection_stats();
+        let doc_stats = create_test_doc_stats();
+        let query_terms = vec!["test".to_string(), "query".to_string()];
+
+        let baseline = scorer
+            .score(&query_terms, &doc_stats, &collection_stats, &config)
+            .unwrap();
+        let plan = BM25Plan::new(&query_terms, &collection_stats, &config);
+        let prepared = plan.score(&doc_stats);
+
+        assert!(
+            (baseline - prepared).abs() < 1e-6,
+            "BM25Plan::score must match BM25ScoringFunction::score (baseline={baseline}, prepared={prepared})"
+        );
+    }
+
+    #[test]
+    fn test_bm25_plan_score_packed_matches_score() {
+        let config = ScoringConfig::default();
+        let collection_stats = create_test_collection_stats();
+        let doc_stats = create_test_doc_stats();
+        let query_terms = vec![
+            "test".to_string(),
+            "query".to_string(),
+            "missing".to_string(),
+        ];
+
+        let plan = BM25Plan::new(&query_terms, &collection_stats, &config);
+
+        // Pre-pack term frequencies in plan order — `missing` is not present
+        // in `doc_stats`, so its packed entry is 0.
+        let packed: Vec<u64> = query_terms
+            .iter()
+            .map(|t| *doc_stats.term_frequencies.get(t).unwrap_or(&0))
+            .collect();
+
+        let via_hashmap = plan.score(&doc_stats);
+        let via_packed = plan.score_packed(&packed, doc_stats.doc_length);
+
+        assert!(
+            (via_hashmap - via_packed).abs() < 1e-6,
+            "score_packed must match score (hashmap={via_hashmap}, packed={via_packed})"
+        );
+    }
+
+    #[test]
+    fn test_bm25_plan_term_count_preserves_order() {
+        // Terms with non-positive IDF are kept in plan order so that
+        // `score_packed` callers can index by query position.
+        let mut document_frequencies = HashMap::new();
+        document_frequencies.insert("rare".to_string(), 1);
+        document_frequencies.insert("common".to_string(), 900); // df > total_docs/2 → idf <= 0
+        let collection_stats = CollectionStats {
+            total_docs: 1000,
+            avg_doc_length: 100.0,
+            avg_field_lengths: HashMap::new(),
+            document_frequencies,
+            field_document_frequencies: HashMap::new(),
+        };
+        let query_terms = vec!["rare".to_string(), "common".to_string()];
+        let plan = BM25Plan::new(&query_terms, &collection_stats, &ScoringConfig::default());
+
+        assert_eq!(plan.term_count(), 2, "all query terms must be preserved");
     }
 }

--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -22,6 +22,28 @@ pub struct FlatVectorIndexReader {
     dimension: usize,
     distance_metric: DistanceMetric,
     deletion_bitmap: Option<Arc<DeletionBitmap>>,
+    /// Pre-built per-field doc-id list (`field_name → Arc<[u64]>`). Built
+    /// once at load so `doc_ids_for_field` returns a refcount-shared
+    /// slice without re-cloning `vector_ids`. #405.
+    vector_ids_by_field: std::collections::HashMap<String, Arc<[u64]>>,
+}
+
+/// Group `vector_ids` by field name into refcount-shared slices.
+fn build_vector_ids_by_field(
+    vector_ids: &[(u64, String)],
+) -> std::collections::HashMap<String, Arc<[u64]>> {
+    let mut by_field: std::collections::HashMap<String, Vec<u64>> =
+        std::collections::HashMap::new();
+    for (doc_id, field_name) in vector_ids {
+        by_field
+            .entry(field_name.clone())
+            .or_default()
+            .push(*doc_id);
+    }
+    by_field
+        .into_iter()
+        .map(|(field, ids)| (field, Arc::<[u64]>::from(ids)))
+        .collect()
 }
 
 impl FlatVectorIndexReader {
@@ -161,12 +183,14 @@ impl FlatVectorIndexReader {
             }
         };
 
+        let vector_ids_by_field = build_vector_ids_by_field(&vector_ids);
         Ok(Self {
             vectors,
             vector_ids,
             dimension,
             distance_metric,
             deletion_bitmap: None,
+            vector_ids_by_field,
         })
     }
 
@@ -223,6 +247,16 @@ impl VectorIndexReader for FlatVectorIndexReader {
 
     fn vector_ids(&self) -> Result<Vec<(u64, String)>> {
         Ok(self.vector_ids.clone())
+    }
+
+    fn doc_ids_for_field(&self, field_name: &str) -> Arc<[u64]> {
+        // O(1) HashMap lookup + Arc clone (refcount bump). Default impl
+        // would clone `vector_ids` (Vec<(u64, String)>) and filter
+        // linearly per call. #405.
+        self.vector_ids_by_field
+            .get(field_name)
+            .cloned()
+            .unwrap_or_else(|| Vec::<u64>::new().into())
     }
 
     fn vector_count(&self) -> usize {

--- a/laurus/src/vector/index/flat/searcher.rs
+++ b/laurus/src/vector/index/flat/searcher.rs
@@ -27,65 +27,97 @@ impl VectorIndexSearcher for FlatVectorSearcher {
 
         let start = Timer::now();
         let mut results = VectorIndexQueryResults::new();
+        let metric = self.index_reader.distance_metric();
 
-        // Get all vectors from the index
-        let vector_count = self.index_reader.vector_count();
-        results.candidates_examined = vector_count;
+        if let Some(ref field_name) = request.field_name {
+            // Field-filtered path: fetch the per-field doc-id slice from the
+            // reader's pre-built index (#405 — O(1) Arc clone, avoids the full
+            // `Vec<(u64, String)>` clone and the linear filter scan). Since
+            // every candidate shares the same `field_name`, do not store it
+            // per-candidate; clone it only when constructing the top_k
+            // results.
+            let ids = self.index_reader.doc_ids_for_field(field_name);
+            results.candidates_examined = ids.len();
 
-        // Get all vector IDs with field names
-        let vector_ids = self.index_reader.vector_ids()?;
-
-        // Filter by field_name if specified
-        let filtered_vector_ids: Vec<(u64, String)> =
-            if let Some(ref field_name) = request.field_name {
-                vector_ids
-                    .into_iter()
-                    .filter(|(_, f)| f == field_name)
-                    .collect()
-            } else {
-                vector_ids
-            };
-
-        // Calculate similarities for all vectors
-        let mut candidates: Vec<(u64, String, f32, f32, Vector)> =
-            Vec::with_capacity(filtered_vector_ids.len());
-        for (doc_id, field_name) in filtered_vector_ids {
-            if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, &field_name) {
-                let metric = self.index_reader.distance_metric();
-                let distance = metric.distance(&request.query.data, &vector.data)?;
-                let similarity = metric.distance_to_similarity(distance);
-                candidates.push((doc_id, field_name, similarity, distance, vector));
-            }
-        }
-
-        // Sort by similarity (descending)
-        candidates
-            .sort_unstable_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
-
-        // Take top_k results
-        let top_k = request.params.top_k.min(candidates.len());
-        for (doc_id, field_name, similarity, distance, vector) in candidates.into_iter().take(top_k)
-        {
-            // Apply minimum similarity threshold
-            if similarity < request.params.min_similarity {
-                break;
+            let mut candidates: Vec<(u64, f32, f32, Vector)> = Vec::with_capacity(ids.len());
+            for &doc_id in ids.iter() {
+                if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, field_name) {
+                    let distance = metric.distance(&request.query.data, &vector.data)?;
+                    let similarity = metric.distance_to_similarity(distance);
+                    candidates.push((doc_id, similarity, distance, vector));
+                }
             }
 
-            let vector_output = if request.params.include_vectors {
-                Some(vector)
-            } else {
-                None
-            };
+            candidates.sort_unstable_by(|a, b| {
+                b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+            });
 
-            results
-                .results
-                .push(crate::vector::search::searcher::VectorIndexQueryResult {
-                    doc_id,
-                    field_name,
-                    similarity,
-                    distance,
-                    vector: vector_output,
-                });
+            let top_k = request.params.top_k.min(candidates.len());
+            for (doc_id, similarity, distance, vector) in candidates.into_iter().take(top_k) {
+                if similarity < request.params.min_similarity {
+                    break;
+                }
+
+                let vector_output = if request.params.include_vectors {
+                    Some(vector)
+                } else {
+                    None
+                };
+
+                results
+                    .results
+                    .push(crate::vector::search::searcher::VectorIndexQueryResult {
+                        doc_id,
+                        field_name: field_name.clone(),
+                        similarity,
+                        distance,
+                        vector: vector_output,
+                    });
+            }
+        } else {
+            // Unfiltered path: each doc may belong to a different field, so the
+            // field name must travel with each candidate.
+            let candidates_list = self.index_reader.vector_ids()?;
+            results.candidates_examined = self.index_reader.vector_count();
+
+            let mut candidates: Vec<(u64, String, f32, f32, Vector)> =
+                Vec::with_capacity(candidates_list.len());
+            for (doc_id, field_name) in candidates_list {
+                if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, &field_name) {
+                    let distance = metric.distance(&request.query.data, &vector.data)?;
+                    let similarity = metric.distance_to_similarity(distance);
+                    candidates.push((doc_id, field_name, similarity, distance, vector));
+                }
+            }
+
+            candidates.sort_unstable_by(|a, b| {
+                b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+            let top_k = request.params.top_k.min(candidates.len());
+            for (doc_id, field_name, similarity, distance, vector) in
+                candidates.into_iter().take(top_k)
+            {
+                if similarity < request.params.min_similarity {
+                    break;
+                }
+
+                let vector_output = if request.params.include_vectors {
+                    Some(vector)
+                } else {
+                    None
+                };
+
+                results
+                    .results
+                    .push(crate::vector::search::searcher::VectorIndexQueryResult {
+                        doc_id,
+                        field_name,
+                        similarity,
+                        distance,
+                        vector: vector_output,
+                    });
+            }
         }
 
         results.search_time_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -93,14 +125,12 @@ impl VectorIndexSearcher for FlatVectorSearcher {
     }
 
     fn count(&self, request: VectorIndexQuery) -> Result<u64> {
-        // Get all vector IDs with field names
-        let vector_ids = self.index_reader.vector_ids()?;
-
-        // Filter by field_name if specified
+        // For a field-filtered count, use the pre-built per-field index
+        // (#405); avoids allocating + iterating the full `vector_ids`.
         if let Some(ref field_name) = request.field_name {
-            Ok(vector_ids.iter().filter(|(_, f)| f == field_name).count() as u64)
+            Ok(self.index_reader.doc_ids_for_field(field_name).len() as u64)
         } else {
-            Ok(vector_ids.len() as u64)
+            Ok(self.index_reader.vector_ids()?.len() as u64)
         }
     }
 }

--- a/laurus/src/vector/index/hnsw/field_reader.rs
+++ b/laurus/src/vector/index/hnsw/field_reader.rs
@@ -80,29 +80,32 @@ impl HnswFieldReader {
         query: &Vector,
         allowed_ids: Option<&std::collections::HashSet<u64>>,
     ) -> Result<Vec<FieldHit>> {
-        // Get vector IDs for this field
-        let vector_ids = self.index_reader.vector_ids()?;
-        let filtered_ids: Vec<(u64, String)> = vector_ids
-            .into_iter()
-            .filter(|(id, f)| {
-                f == &self.field_name && allowed_ids.is_none_or(|allowed| allowed.contains(id))
-            })
-            .collect();
+        // Fetch the per-field doc-id slice from the reader's pre-built
+        // index (#405). The `allowed_ids` filter — when supplied by the
+        // caller — is applied against this already-narrowed slice rather
+        // than the full corpus.
+        let field_ids = self.index_reader.doc_ids_for_field(&self.field_name);
+        let filtered: Vec<u64> = match allowed_ids {
+            Some(allowed) => field_ids
+                .iter()
+                .copied()
+                .filter(|id| allowed.contains(id))
+                .collect(),
+            None => field_ids.iter().copied().collect(),
+        };
 
         // Linear scan: examine all filtered vectors (ef_search only applies to graph search)
-        let mut candidates: Vec<(u64, f32, f32)> = Vec::with_capacity(filtered_ids.len());
+        let mut candidates: Vec<(u64, f32, f32)> = Vec::with_capacity(filtered.len());
 
-        for (doc_id, field_name) in filtered_ids.iter() {
-            if let Ok(Some(vector)) = self.index_reader.get_vector(*doc_id, field_name) {
-                let similarity = self
-                    .index_reader
-                    .distance_metric()
-                    .similarity(&query.data, &vector.data)?;
-                let distance = self
-                    .index_reader
-                    .distance_metric()
-                    .distance(&query.data, &vector.data)?;
-                candidates.push((*doc_id, similarity, distance));
+        for &doc_id in &filtered {
+            if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, &self.field_name) {
+                // Compute distance once and derive similarity (mirrors
+                // the #404 pattern: `similarity()` would otherwise rerun
+                // the SIMD distance kernel internally).
+                let metric = self.index_reader.distance_metric();
+                let distance = metric.distance(&query.data, &vector.data)?;
+                let similarity = metric.distance_to_similarity(distance);
+                candidates.push((doc_id, similarity, distance));
             }
         }
 

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -15,6 +15,24 @@ use crate::maintenance::deletion::DeletionBitmap;
 /// Storage for vectors (in-memory or on-demand).
 use crate::vector::index::storage::VectorStorage;
 
+/// Build a `field_name → Arc<[u64]>` lookup from a flat `Vec<(u64, String)>`.
+///
+/// The grouping happens once at reader load so search-time
+/// `doc_ids_for_field` is a single HashMap lookup + Arc clone.
+fn build_vector_ids_by_field(vector_ids: &[(u64, String)]) -> HashMap<String, Arc<[u64]>> {
+    let mut by_field: HashMap<String, Vec<u64>> = HashMap::new();
+    for (doc_id, field_name) in vector_ids {
+        by_field
+            .entry(field_name.clone())
+            .or_default()
+            .push(*doc_id);
+    }
+    by_field
+        .into_iter()
+        .map(|(field, ids)| (field, Arc::<[u64]>::from(ids)))
+        .collect()
+}
+
 /// Reader for HNSW (Hierarchical Navigable Small World) vector indexes.
 #[derive(Debug)]
 pub struct HnswIndexReader {
@@ -38,6 +56,13 @@ pub struct HnswIndexReader {
     /// The pointer is valid for the lifetime of `self` because the backing
     /// `Arc<Vec<f32>>` is kept alive by `VectorStorage::Owned`.
     prefetch_index: HashMap<String, HashMap<u64, usize>>,
+
+    /// Pre-built per-field doc-id list (`field_name → Arc<[u64]>`).
+    ///
+    /// Built once at load time so `doc_ids_for_field` returns a refcount-
+    /// shared slice (no per-call allocation, no `Vec<(u64, String)>` clone,
+    /// no linear filter). #405 (per-field `vector_ids` cache).
+    vector_ids_by_field: HashMap<String, Arc<[u64]>>,
 }
 
 impl HnswIndexReader {
@@ -264,6 +289,11 @@ impl HnswIndexReader {
             HashMap::new()
         };
 
+        // Per-field doc-id lookup (#405). Built from `vector_ids` so it
+        // reflects the same set the search path used to filter at every
+        // call; finalised into `Arc<[u64]>` for cheap clone semantics.
+        let vector_ids_by_field = build_vector_ids_by_field(&vector_ids);
+
         Ok(Self {
             vectors,
             vector_ids,
@@ -274,6 +304,7 @@ impl HnswIndexReader {
             graph,
             deletion_bitmap: None,
             prefetch_index,
+            vector_ids_by_field,
         })
     }
 
@@ -353,6 +384,16 @@ impl VectorIndexReader for HnswIndexReader {
 
     fn vector_ids(&self) -> Result<Vec<(u64, String)>> {
         Ok(self.vector_ids.clone())
+    }
+
+    fn doc_ids_for_field(&self, field_name: &str) -> Arc<[u64]> {
+        // O(1) HashMap lookup + Arc clone (refcount bump). Compared to
+        // the default impl this avoids the per-call `Vec<(u64, String)>`
+        // clone of the full corpus and the linear filter scan. #405.
+        self.vector_ids_by_field
+            .get(field_name)
+            .cloned()
+            .unwrap_or_else(|| Vec::<u64>::new().into())
     }
 
     fn vector_count(&self) -> usize {

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -58,58 +58,96 @@ impl VectorIndexSearcher for HnswSearcher {
 
         // Fallback to Linear Scan (brute-force over all vectors)
         let mut results = VectorIndexQueryResults::new();
+        let metric = self.index_reader.distance_metric();
 
-        let mut vector_ids = self.index_reader.vector_ids()?;
-
-        // Filter by field_name if specified
         if let Some(ref field_name) = request.field_name {
-            vector_ids.retain(|(_, fname)| fname == field_name);
-        }
+            // Field-filtered path: fetch the per-field doc-id slice from the
+            // reader's pre-built index (#405 — O(1) Arc clone, avoids the full
+            // `Vec<(u64, String)>` clone and the linear retain scan). Every
+            // candidate shares the same `field_name`, so it is not stored
+            // per-candidate; it is cloned only when emitting the top_k
+            // results.
+            let ids = self.index_reader.doc_ids_for_field(field_name);
+            results.candidates_examined = ids.len();
 
-        results.candidates_examined = vector_ids.len();
-
-        let mut candidates: Vec<(u64, String, f32, f32, Vector)> =
-            Vec::with_capacity(vector_ids.len());
-
-        for (doc_id, field_name) in vector_ids.iter() {
-            if let Ok(Some(vector)) = self.index_reader.get_vector(*doc_id, field_name) {
-                // Compute distance once and derive similarity from it.
-                // Calling `similarity()` would internally invoke `distance()`
-                // a second time on the same vector pair (the SIMD body runs
-                // twice), so the fallback path doubled its compute cost.
-                // The graph-search path at L308 already uses this pattern.
-                let metric = self.index_reader.distance_metric();
-                let distance = metric.distance(&request.query.data, &vector.data)?;
-                let similarity = metric.distance_to_similarity(distance);
-                candidates.push((*doc_id, field_name.clone(), similarity, distance, vector));
-            }
-        }
-
-        candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
-
-        let top_k = request.params.top_k.min(candidates.len());
-        for (doc_id, field_name, similarity, distance, vector) in candidates.into_iter().take(top_k)
-        {
-            // Apply minimum similarity threshold
-            if similarity < request.params.min_similarity {
-                break;
+            let mut candidates: Vec<(u64, f32, f32, Vector)> = Vec::with_capacity(ids.len());
+            for &doc_id in ids.iter() {
+                if let Ok(Some(vector)) = self.index_reader.get_vector(doc_id, field_name) {
+                    // Compute distance once and derive similarity from it.
+                    // `similarity()` would otherwise re-run the SIMD distance
+                    // kernel a second time on the same pair.
+                    let distance = metric.distance(&request.query.data, &vector.data)?;
+                    let similarity = metric.distance_to_similarity(distance);
+                    candidates.push((doc_id, similarity, distance, vector));
+                }
             }
 
-            let vector_output = if request.params.include_vectors {
-                Some(vector)
-            } else {
-                None
-            };
+            candidates.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
 
-            results
-                .results
-                .push(crate::vector::search::searcher::VectorIndexQueryResult {
-                    doc_id,
-                    field_name,
-                    similarity,
-                    distance,
-                    vector: vector_output,
-                });
+            let top_k = request.params.top_k.min(candidates.len());
+            for (doc_id, similarity, distance, vector) in candidates.into_iter().take(top_k) {
+                if similarity < request.params.min_similarity {
+                    break;
+                }
+
+                let vector_output = if request.params.include_vectors {
+                    Some(vector)
+                } else {
+                    None
+                };
+
+                results
+                    .results
+                    .push(crate::vector::search::searcher::VectorIndexQueryResult {
+                        doc_id,
+                        field_name: field_name.clone(),
+                        similarity,
+                        distance,
+                        vector: vector_output,
+                    });
+            }
+        } else {
+            // Unfiltered path: docs may belong to different fields, so the
+            // field name must travel with each candidate.
+            let candidates_list = self.index_reader.vector_ids()?;
+            results.candidates_examined = candidates_list.len();
+
+            let mut candidates: Vec<(u64, String, f32, f32, Vector)> =
+                Vec::with_capacity(candidates_list.len());
+            for (doc_id, field_name) in candidates_list.iter() {
+                if let Ok(Some(vector)) = self.index_reader.get_vector(*doc_id, field_name) {
+                    let distance = metric.distance(&request.query.data, &vector.data)?;
+                    let similarity = metric.distance_to_similarity(distance);
+                    candidates.push((*doc_id, field_name.clone(), similarity, distance, vector));
+                }
+            }
+
+            candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(Ordering::Equal));
+
+            let top_k = request.params.top_k.min(candidates.len());
+            for (doc_id, field_name, similarity, distance, vector) in
+                candidates.into_iter().take(top_k)
+            {
+                if similarity < request.params.min_similarity {
+                    break;
+                }
+
+                let vector_output = if request.params.include_vectors {
+                    Some(vector)
+                } else {
+                    None
+                };
+
+                results
+                    .results
+                    .push(crate::vector::search::searcher::VectorIndexQueryResult {
+                        doc_id,
+                        field_name,
+                        similarity,
+                        distance,
+                        vector: vector_output,
+                    });
+            }
         }
 
         results.search_time_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -117,14 +155,12 @@ impl VectorIndexSearcher for HnswSearcher {
     }
 
     fn count(&self, request: VectorIndexQuery) -> Result<u64> {
-        // Get all vector IDs with field names
-        let vector_ids = self.index_reader.vector_ids()?;
-
-        // Filter by field_name if specified
+        // Field-filtered counts use the pre-built per-field index (#405);
+        // avoids allocating + linear-filtering the full `vector_ids`.
         if let Some(ref field_name) = request.field_name {
-            Ok(vector_ids.iter().filter(|(_, f)| f == field_name).count() as u64)
+            Ok(self.index_reader.doc_ids_for_field(field_name).len() as u64)
         } else {
-            Ok(vector_ids.len() as u64)
+            Ok(self.index_reader.vector_ids()?.len() as u64)
         }
     }
 }

--- a/laurus/src/vector/index/ivf/reader.rs
+++ b/laurus/src/vector/index/ivf/reader.rs
@@ -31,6 +31,25 @@ pub struct IvfIndexReader {
     /// `(doc_id, field_name)` pairs assigned to cluster `i`.
     cluster_to_vectors: Vec<Vec<(u64, String)>>,
     deletion_bitmap: Option<Arc<DeletionBitmap>>,
+    /// Pre-built per-field doc-id list (`field_name → Arc<[u64]>`). Built
+    /// once at load so `doc_ids_for_field` returns a refcount-shared
+    /// slice without re-cloning `vector_ids`. #405.
+    vector_ids_by_field: HashMap<String, Arc<[u64]>>,
+}
+
+/// Group `vector_ids` by field name into refcount-shared slices.
+fn build_vector_ids_by_field(vector_ids: &[(u64, String)]) -> HashMap<String, Arc<[u64]>> {
+    let mut by_field: HashMap<String, Vec<u64>> = HashMap::new();
+    for (doc_id, field_name) in vector_ids {
+        by_field
+            .entry(field_name.clone())
+            .or_default()
+            .push(*doc_id);
+    }
+    by_field
+        .into_iter()
+        .map(|(field, ids)| (field, Arc::<[u64]>::from(ids)))
+        .collect()
 }
 
 impl IvfIndexReader {
@@ -197,6 +216,7 @@ impl IvfIndexReader {
             }
         };
 
+        let vector_ids_by_field = build_vector_ids_by_field(&vector_ids);
         Ok(Self {
             vectors,
             vector_ids,
@@ -207,6 +227,7 @@ impl IvfIndexReader {
             centroids,
             cluster_to_vectors,
             deletion_bitmap: None,
+            vector_ids_by_field,
         })
     }
 
@@ -290,6 +311,16 @@ impl VectorIndexReader for IvfIndexReader {
 
     fn vector_ids(&self) -> Result<Vec<(u64, String)>> {
         Ok(self.vector_ids.clone())
+    }
+
+    fn doc_ids_for_field(&self, field_name: &str) -> Arc<[u64]> {
+        // O(1) HashMap lookup + Arc clone (refcount bump). Default impl
+        // would clone `vector_ids` (Vec<(u64, String)>) and filter
+        // linearly per call. #405.
+        self.vector_ids_by_field
+            .get(field_name)
+            .cloned()
+            .unwrap_or_else(|| Vec::<u64>::new().into())
     }
 
     fn vector_count(&self) -> usize {

--- a/laurus/src/vector/index/ivf/searcher.rs
+++ b/laurus/src/vector/index/ivf/searcher.rs
@@ -175,12 +175,12 @@ impl VectorIndexSearcher for IvfSearcher {
     }
 
     fn count(&self, request: VectorIndexQuery) -> Result<u64> {
-        let vector_ids = self.index_reader.vector_ids()?;
-
+        // Field-filtered counts use the pre-built per-field index (#405);
+        // avoids allocating + linear-filtering the full `vector_ids`.
         if let Some(ref field_name) = request.field_name {
-            Ok(vector_ids.iter().filter(|(_, f)| f == field_name).count() as u64)
+            Ok(self.index_reader.doc_ids_for_field(field_name).len() as u64)
         } else {
-            Ok(vector_ids.len() as u64)
+            Ok(self.index_reader.vector_ids()?.len() as u64)
         }
     }
 }

--- a/laurus/src/vector/reader.rs
+++ b/laurus/src/vector/reader.rs
@@ -84,6 +84,28 @@ pub trait VectorIndexReader: Send + Sync + std::fmt::Debug {
     /// Get all vector IDs with their field names in the index.
     fn vector_ids(&self) -> Result<Vec<(u64, String)>>;
 
+    /// Doc IDs that belong to a specific field.
+    ///
+    /// Concrete readers should override with an O(1) lookup into a
+    /// pre-built per-field index. The default implementation falls back
+    /// to filtering [`vector_ids`](Self::vector_ids) every call, which
+    /// allocates a fresh `Vec<(u64, String)>` of size `total_vectors` —
+    /// the cost #405 (per-field `vector_ids` cache) targets.
+    ///
+    /// Returns an `Arc<[u64]>` so a cached implementation can hand back
+    /// a refcount bump rather than a fresh allocation. An empty
+    /// `Arc<[u64]>` is returned when the field has no vectors.
+    fn doc_ids_for_field(&self, field_name: &str) -> Arc<[u64]> {
+        self.vector_ids()
+            .map(|all| {
+                all.into_iter()
+                    .filter_map(|(id, f)| (f == field_name).then_some(id))
+                    .collect::<Vec<u64>>()
+                    .into()
+            })
+            .unwrap_or_else(|_| Vec::new().into())
+    }
+
     /// Get the total number of vectors.
     fn vector_count(&self) -> usize;
 


### PR DESCRIPTION
## Summary

Closes #402. Refs #416.

`BM25ScoringFunction::score` recomputed IDF (`ln(...)`) and re-resolved query terms through a `HashMap<String, u64>` on every `(query_term, document)` pair. For a 5-term query against 100 k documents that is 1 M string-keyed hash lookups + 500 k `ln()` calls per scoring pass — all on values that are constant across the result set.

This PR adds **`BM25Plan`**: a prepared query that materialises every query-invariant factor once at construction time (per-term IDF, `k1 + 1`, length-normalisation `b` / `1 - b`, average document length).

Two scoring methods are exposed:

- **`BM25Plan::score(&doc_stats)`** — drop-in faster replacement for `BM25ScoringFunction::score`. Still looks up term frequencies via the existing `HashMap<String, u64>` on `DocumentStats`.
- **`BM25Plan::score_packed(&term_freqs, doc_length)`** — accepts a packed `&[u64]` of term frequencies indexed by query position. Avoids the per-doc string-keyed `HashMap` lookup entirely; intended for callers that can amortise frequency packing across many scoring calls.

`BM25ScoringFunction::score` is preserved unchanged for one-off callers; the `ScoringFunction` trait API is not modified.

## Bench (`bm25_scoring_bench`, vs `pre-402` baseline)

100 k-doc corpus — same vocabulary, query, and `DocumentStats` / `CollectionStats` inputs across all three paths.

| qterms | `score` (baseline) | `score_with_plan` | `score_packed` | Plan ↑ | Packed ↑ |
| --- | --- | --- | --- | --- | --- |
| 1  | 32.8 ms | 14.6 ms | **0.43 ms** | 2.2× | **76×** |
| 5  | 102.7 ms | 59.1 ms | **1.27 ms** | 1.7× | **81×** |
| 10 | 160.5 ms | 87.9 ms | **2.68 ms** | 1.8× | **60×** |

Smaller corpora show the same shape:

| qterms / candidates | `score` | `score_with_plan` | `score_packed` |
| --- | --- | --- | --- |
| 1 / 100   | 5.30 µs | 2.14 µs | 0.345 µs |
| 5 / 100   | 25.1 µs | 9.25 µs | 0.971 µs |
| 10 / 100  | 49.5 µs | 15.7 µs | 1.76 µs |
| 1 / 10k   | 950 µs | 382 µs | 39.7 µs |
| 5 / 10k   | 10.0 ms | 5.66 ms | 130 µs |
| 10 / 10k  | 16.3 ms | 8.90 ms | 252 µs |

The acceptance criterion (≥ 2× speed-up on a ≥ 100 k-doc corpus) is comfortably met by the packed path across the full sweep, and by the plan path at qterms_1.

### Where the time goes

- `score_with_plan` removes one `HashMap<String, u64>` lookup per `(term, doc)` (the `df` lookup folded into IDF) and the per-doc `ln()` and `len_ratio` arithmetic.
- `score_packed` additionally removes the surviving `HashMap<String, u64>` `tf` lookup, replacing it with `term_freqs[i]` array indexing — this is what unlocks the 60–80× regime.

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench bm25_scoring_bench -- --save-baseline pre-402
git checkout perf/bm25-idf-precompute
cargo bench -p laurus --bench bm25_scoring_bench -- --baseline pre-402
```

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus --benches -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus --lib` (813 / 813 pass)
- [x] New tests:
  - `test_bm25_plan_matches_baseline` — `BM25Plan::score` produces the same score as `BM25ScoringFunction::score` (within 1e-6) for the existing fixture.
  - `test_bm25_plan_score_packed_matches_score` — `score_packed` matches `score` for an arbitrary query that includes a missing term.
  - `test_bm25_plan_term_count_preserves_order` — terms with non-positive IDF are kept in plan order so packed-frequency callers can index by query position.
- [x] `markdownlint-cli2 docs/src/laurus/scoring.md docs/ja/src/laurus/scoring.md` — clean

## Docs

- `docs/src/laurus/scoring.md` and `docs/ja/src/laurus/scoring.md` gain a `BM25Plan (precomputed query)` section showing the two scoring methods.