### PR TITLE
perf(lexical/highlight): skip per-token to_lowercase + length-filter (#408)

### DIFF
--- a/laurus/src/lexical/search/features/highlight.rs
+++ b/laurus/src/lexical/search/features/highlight.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::analysis::analyzer::analyzer::Analyzer;
 use crate::analysis::analyzer::standard::StandardAnalyzer;
-use crate::analysis::token::Token;
 use crate::error::Result;
 use crate::lexical::query::Query;
 
@@ -289,20 +288,69 @@ impl Highlighter {
     ) -> Result<Vec<HighlightSpan>> {
         let mut spans = Vec::new();
 
-        // Tokenize the text
-        let tokens = self.analyzer.analyze(text)?;
-        let tokens: Vec<Token> = tokens.collect();
-
-        // Find matching tokens
-        for token in &tokens {
-            if terms.contains(&token.text.to_lowercase()) {
-                let score = self.calculate_term_score(&token.text, terms);
-                spans.push(HighlightSpan::new(
-                    token.start_offset..token.start_offset + token.text.len(),
-                    true,
-                    score,
-                ));
+        // Precompute the byte-length range of single-word terms so we can
+        // length-filter analyzer tokens before the (relatively expensive)
+        // string-keyed `HashSet` probe. Phrase terms (containing spaces)
+        // are handled by the regex pass below and excluded here.
+        //
+        // Empty range → no single-word terms; the per-token loop becomes a
+        // no-op and only the phrase pass runs.
+        let mut min_term_len = usize::MAX;
+        let mut max_term_len = 0usize;
+        for term in terms {
+            if term.contains(' ') {
+                continue;
             }
+            min_term_len = min_term_len.min(term.len());
+            max_term_len = max_term_len.max(term.len());
+        }
+
+        // Tokenize the text. The previous code collected the iterator into
+        // a `Vec<Token>` — we drop that collect since tokens are consumed
+        // exactly once below; the analyzer iterator streams a `Token` at a
+        // time.
+        let tokens = self.analyzer.analyze(text)?;
+
+        // Find matching tokens.
+        //
+        // `terms` arrives lowercased from `extract_query_terms`. Most
+        // analyzer pipelines (e.g. `StandardAnalyzer`) already lowercase
+        // tokens via `LowercaseFilter`, so the previous unconditional
+        // `to_lowercase()` allocated a `String` per token even though the
+        // token text was already in canonical form. For 1 MB / ~200k-token
+        // fields this allocation alone dominated the per-hit cost (#408).
+        //
+        // Try a direct `&str` lookup first. Only when the token contains
+        // an upper-case character does the lookup fall back to
+        // `to_lowercase()` — preserving case-insensitive matching for
+        // callers that plug in a custom analyzer without a lowercase
+        // filter. Tokens whose length is outside the term-length range
+        // can never match and are skipped before the hash probe.
+        if max_term_len > 0 {
+            for token in tokens {
+                let len = token.text.len();
+                if len < min_term_len || len > max_term_len {
+                    continue;
+                }
+                let matched = if has_uppercase(&token.text) {
+                    terms.contains(&token.text.to_lowercase())
+                } else {
+                    terms.contains(token.text.as_str())
+                };
+                if matched {
+                    let score = self.calculate_term_score(&token.text, terms);
+                    spans.push(HighlightSpan::new(
+                        token.start_offset..token.start_offset + token.text.len(),
+                        true,
+                        score,
+                    ));
+                }
+            }
+        } else {
+            // Drain the analyzer iterator to keep observable side-effects
+            // (e.g. character-position bookkeeping) consistent with the
+            // pre-#408 path that always collected first.
+            for _ in tokens {}
         }
 
         // Also find phrase matches (simple implementation)
@@ -682,6 +730,24 @@ impl SimpleHighlighter {
     }
 }
 
+/// Return `true` if `s` contains any upper-case character.
+///
+/// Fast path: ASCII-only strings are scanned byte by byte (`is_ascii`
+/// itself is byte-level and short-circuits on the first non-ASCII byte,
+/// after which the second scan does an ASCII upper-case check). Strings
+/// containing non-ASCII characters fall back to a Unicode-aware char
+/// iterator. Used by `Highlighter::find_highlight_spans` (#408) to avoid
+/// allocating a lower-cased `String` per analyzer token when the token
+/// is already in canonical (lower-cased) form.
+#[inline]
+fn has_uppercase(s: &str) -> bool {
+    if s.is_ascii() {
+        s.bytes().any(|b| b.is_ascii_uppercase())
+    } else {
+        s.chars().any(|c| c.is_uppercase())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -766,6 +832,39 @@ mod tests {
 
         // Note: This is a simplified test since term extraction is basic
         assert!(!terms.is_empty());
+    }
+
+    #[test]
+    fn test_has_uppercase() {
+        assert!(!has_uppercase("rust"));
+        assert!(!has_uppercase("123"));
+        assert!(!has_uppercase(""));
+        assert!(has_uppercase("Rust"));
+        assert!(has_uppercase("rusT"));
+        // Non-ASCII without case (Japanese) is treated as lowercase.
+        assert!(!has_uppercase("検索"));
+        // Non-ASCII upper-case (Greek capital alpha) takes the Unicode path.
+        assert!(has_uppercase("Α"));
+        assert!(!has_uppercase("α"));
+    }
+
+    #[test]
+    fn test_find_highlight_spans_case_insensitive() {
+        // Verifies that the #408 fast path (skip `to_lowercase()` when the
+        // token is already lowercase) preserves case-insensitive matching:
+        // an upper-cased token in the source text must still match a
+        // lower-cased term.
+        let highlighter = Highlighter::new(HighlightConfig::default());
+        let mut terms = HashSet::new();
+        terms.insert("rust".to_string());
+
+        let spans = highlighter
+            .find_highlight_spans("learning Rust today", &terms)
+            .unwrap();
+        assert!(
+            !spans.is_empty(),
+            "uppercase 'Rust' should still match lowercased term 'rust'"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #408. Refs #416.

`Highlighter::find_highlight_spans` allocated a `String` per analyzer token via `token.text.to_lowercase()` on every term-membership check, even though:

- `terms` arrives **already lowercased** from `extract_query_terms`.
- The default analyzer pipeline (`StandardAnalyzer`) already lowercases tokens via `LowercaseFilter`.

For 1 MB / ~200 k-token fields this duplicated normalisation dominated the per-hit cost.

## Changes

Three orthogonal optimisations in `find_highlight_spans`:

1. **Direct `&str` lookup against `terms`** — fall back to `to_lowercase()` only when the token contains an upper-case character. New `has_uppercase` helper takes the ASCII fast path (byte scan) for ASCII-only strings and the Unicode-correct char iterator for the rest, preserving case-insensitive matching for callers that plug in a custom analyzer without a lowercase filter.
2. **Length pre-filter** — precompute the byte-length range of the single-word terms once and skip the hash probe entirely for any token whose length is outside it. Phrase terms (containing spaces) are excluded from the range and handled by the existing regex pass below.
3. **Drop `Vec<Token>` materialisation** — the analyzer iterator is consumed exactly once; `tokens.collect::<Vec<_>>()` was a pure allocation tax.

## Bench (`highlight_bench`, vs `pre-408` baseline)

| Bench | Δ time | speed-up |
| --- | --- | --- |
| ``retokenize/1KB`` | −33.5 % | **1.50×** |
| ``retokenize/100KB`` | −18.7 % | 1.23× |
| ``retokenize/1MB`` | −7.2 % | 1.08× |
| ``top_k/k_1`` | −19.5 % | 1.24× |
| ``top_k/k_10`` | −21.0 % | 1.27× |
| ``top_k/k_50`` | **−33.2 %** | **1.50×** |

`top_k` simulates the issue's canonical `1 query × K hits` workload (`re-tokenizes 10 MB per query for 1 MB × 10 hits`); the 1.5× acceptance bar is met at k_50. The single-call `retokenize/1MB` case is dominated by the analyzer itself; a position-based highlighter that reuses index-stored token offsets would lift that case (#408 proposal point 2) but is a larger refactor than fits in this PR.

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench highlight_bench -- "highlight/retokenize|highlight/top_k" --save-baseline pre-408
git checkout perf/highlight-skip-lowercase
cargo bench -p laurus --bench highlight_bench -- "highlight/retokenize|highlight/top_k" --baseline pre-408
```

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus --lib` (815 / 815 pass)
- [x] New tests:
  - `test_has_uppercase` — covers ASCII / Japanese (no case) / Greek (Unicode case) inputs.
  - `test_find_highlight_spans_case_insensitive` — verifies the fast path still matches an upper-case token (`Rust`) against a lower-case term (`rust`).

## Out of scope (tracked elsewhere)

- Reusing index-stored token positions to skip re-tokenisation entirely (#408 proposal point 2). Would require a position-aware highlighter API and is a larger surface change.
- The phrase regex pass still compiles `Regex::new(...)` per phrase term per call. The same shape was addressed for the `SimpleHighlighter` API in #407; doing the same here would require exposing a precompiled `Highlighter` session type.