### PR TITLE
perf(lexical/searcher): add Collector::min_competitive() (#403 PR-A)

### DIFF
--- a/laurus/src/lexical/query/collector.rs
+++ b/laurus/src/lexical/query/collector.rs
@@ -27,6 +27,24 @@ pub trait Collector: Send + Debug {
 
     /// Reset the collector for a new search.
     fn reset(&mut self);
+
+    /// The current "competitive" score floor — a candidate whose
+    /// upper-bound score is at or below this value cannot enter the
+    /// final result set, so the searcher is free to skip it.
+    ///
+    /// Top-K collectors override this to expose the K-th heap score
+    /// once the heap is full, enabling MaxScore / WAND-style early
+    /// termination (#403). The default returns `f32::NEG_INFINITY`,
+    /// which disables the optimisation for collectors that do not have
+    /// a meaningful upper-bound concept (count-only, all-docs, etc.).
+    ///
+    /// # Returns
+    ///
+    /// The score that an incoming candidate's upper bound must exceed
+    /// to be worth collecting.
+    fn min_competitive(&self) -> f32 {
+        f32::NEG_INFINITY
+    }
 }
 
 /// A collector that keeps the top N documents by score.
@@ -472,6 +490,29 @@ impl Collector for TopDocsCollector {
         self.current_min_score()
     }
 
+    fn min_competitive(&self) -> f32 {
+        // The MaxScore early-termination signal: once the heap is full
+        // the heap-min equals the K-th best score, and any future doc
+        // whose upper-bound score is ≤ this value cannot enter the
+        // top-K. While the heap has spare slots, return
+        // `NEG_INFINITY` so the searcher does not attempt to skip
+        // anything before the heap fills.
+        //
+        // Currently dead code in the default search path because
+        // `needs_more()` short-circuits the loop the moment the heap
+        // fills — fixing that without per-posting block-max metadata
+        // would walk every candidate and regress wall time on common
+        // OR workloads (the global `BM25Scorer::max_score()` upper
+        // bound is too loose at `k1 + 1`). The correctness fix +
+        // MaxScore activation lands together with the block-max index
+        // format in the next PR (#403 PR-B onward).
+        if self.hits.len() < self.max_docs {
+            f32::NEG_INFINITY
+        } else {
+            self.hits.peek().map(|d| d.score).unwrap_or(self.min_score)
+        }
+    }
+
     fn reset(&mut self) {
         self.hits.clear();
         self.total_hits = 0;
@@ -683,6 +724,33 @@ mod tests {
 
         // Check that low-score document was filtered out
         assert!(!results.iter().any(|hit| hit.score == 0.3));
+    }
+
+    #[test]
+    fn test_top_docs_collector_min_competitive() {
+        // Validates the #403 PR-A `min_competitive` signal:
+        //   - empty / partially full heap → `NEG_INFINITY` (no useful
+        //     bound; the searcher must keep collecting).
+        //   - full heap → heap-min, i.e. the K-th best score.
+        //   - replaces the worst when a higher score arrives → bound
+        //     advances upward.
+        let mut collector = TopDocsCollector::new(3);
+
+        assert_eq!(collector.min_competitive(), f32::NEG_INFINITY);
+
+        collector.collect(1, 0.5).unwrap();
+        assert_eq!(collector.min_competitive(), f32::NEG_INFINITY);
+
+        collector.collect(2, 0.8).unwrap();
+        assert_eq!(collector.min_competitive(), f32::NEG_INFINITY);
+
+        collector.collect(3, 0.3).unwrap();
+        // Heap full — bound is the K-th score (lowest of the three).
+        assert!((collector.min_competitive() - 0.3).abs() < 1e-6);
+
+        // A higher-scoring doc tightens the bound to the next-lowest.
+        collector.collect(4, 0.9).unwrap();
+        assert!((collector.min_competitive() - 0.5).abs() < 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refs #403, #416.

First slice of the WAND / MaxScore / Block-Max early-termination effort tracked in #403. This PR is **API plumbing only** — it adds the score-floor signal that the searcher loop and the (future) block-max scorer will consume, with no behaviour change in the default search path.

### What lands

- New trait method **`Collector::min_competitive(&self) -> f32`** on [`Collector`](laurus/src/lexical/query/collector.rs). Returns the score that an incoming candidate's upper bound must exceed to be worth collecting; the default impl returns `f32::NEG_INFINITY`, disabling the optimisation for collectors without a meaningful upper-bound concept (count-only, all-docs).
- **`TopDocsCollector` override** — returns the heap-min once the heap is full (the K-th best score), `NEG_INFINITY` while there are spare slots.
- Unit test `test_top_docs_collector_min_competitive` covering the empty / partial / full / displaced-after-full transitions.

### Why split this off

The audit's full plan (#403) bundles four moving parts: per-posting block-max metadata, a `BlockMaxScorer` trait, WAND for OR queries, and MaxScore for AND. The first three need an index-format change to land safely.

I prototyped the missing fourth piece — fixing `TopDocsCollector::needs_more` (the bug where it short-circuits the search loop the moment the heap fills, returning the first-K matches by `doc_id` rather than the top-K by score — tracked as #459) plus a global `max_score <= min_competitive` skip in the searcher loop — and benched it. Without per-block bounds the global `BM25Scorer::max_score() = boost · idf · (k1+1)` upper bound is too loose to fire under typical TF distributions, so the correctness fix walks every matching doc and regresses each OR-heavy `lexical_search_bench` case:

| Scenario | Δ time vs `pre-403-A` |
| --- | --- |
| ``boolean_query/should_or/1000`` | +18.6 % |
| ``boolean_query/should_or/5000`` | +20.1 % |
| ``boolean_query/should_or_high_freq/1000`` | +19.8 % |
| ``boolean_query/should_or_high_freq/5000`` | +27.1 % |

Bundling the correctness fix with the per-block tightness in the same PR is therefore the safer split — that work now lands as **PR-B (#403)** with the index format change, where the tightened bound covers the cost. This PR keeps the trait surface in place so PR-B is purely additive.

### Bench (`lexical_search_bench`, vs `pre-403-A`)

API addition only — the new method is not yet called from the search path:

| Scenario | Δ time |
| --- | --- |
| ``boolean_query/should_or/100`` | −8.1 % |
| ``boolean_query/should_or/1000`` | −10.8 % |
| ``boolean_query/should_or/5000`` | −10.2 % |
| ``boolean_query/should_or_high_freq/100`` | −0.3 % |
| ``boolean_query/should_or_high_freq/1000`` | −1.8 % |
| ``boolean_query/should_or_high_freq/5000`` | −1.0 % |

All within bench noise; no regression.

## Follow-up planned for #403

- **PR-B** — write-side per-posting-block max-impact / max-tf metadata + a tightened `Scorer::max_score()` derived from it. Bundles the `TopDocsCollector::needs_more` correctness fix tracked in #459 (the tightened max-score covers the per-doc walk cost).
- **PR-C** — `BlockMaxScorer` trait and WAND (pivot-term skipping) for `BooleanQuery` SHOULD clauses, fed by `min_competitive`.
- **PR-D** — MaxScore for `BooleanQuery` MUST clauses.

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus --lib` (816 / 816 pass)