### PR TITLE
perf(lexical/searcher): correctness fix + global MaxScore early-break (#403 PR-B1)

### DIFF
--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -95,6 +95,17 @@ impl InvertedIndexSearcher {
         // Create a scorer for the query
         let scorer = query.scorer(self.reader.as_ref())?;
 
+        // Cache the query-wide score upper bound for the global
+        // MaxScore early-termination check. Constant for the lifetime
+        // of the search; combined with the collector's
+        // `min_competitive()` it lets the loop break the moment no
+        // remaining doc can possibly enter the top-K (#403 PR-B1).
+        // Today this rarely fires under typical BM25 distributions
+        // because `Scorer::max_score()` returns a loose `boost · idf
+        // · (k1 + 1)` upper bound; a tightened per-block bound lands
+        // in PR-B2 with the index-format change.
+        let max_score = scorer.max_score();
+
         // Iterate through matching documents
         while !matcher.is_exhausted() {
             let doc_id = matcher.doc_id();
@@ -128,7 +139,16 @@ impl InvertedIndexSearcher {
             // Collect the result
             collector.collect(doc_id, score)?;
 
-            // Check if we need more results
+            // Global MaxScore early-break (#403 PR-B1). After every
+            // collect the collector's `min_competitive()` may have
+            // tightened — once it reaches `max_score` the upper bound
+            // on any remaining doc's score is no longer competitive
+            // and the walk is provably complete.
+            if max_score <= collector.min_competitive() {
+                break;
+            }
+
+            // Check if we need more results (count-cap collectors).
             if !collector.needs_more() {
                 break;
             }

--- a/laurus/src/lexical/query/collector.rs
+++ b/laurus/src/lexical/query/collector.rs
@@ -483,7 +483,16 @@ impl Collector for TopDocsCollector {
     }
 
     fn needs_more(&self) -> bool {
-        self.hits.len() < self.max_docs
+        // Top-K collectors must see every candidate: a doc later in
+        // the iteration with a higher score still needs to displace
+        // the current heap-min. The previous
+        // `self.hits.len() < self.max_docs` short-circuit returned the
+        // first K matches by `doc_id` rather than the highest-scoring
+        // K (#459). Early termination is now driven by
+        // [`Collector::min_competitive`] + [`Scorer::max_score`] in
+        // the searcher loop, which only fires when no future doc can
+        // beat the current K-th score.
+        true
     }
 
     fn min_score(&self) -> f32 {
@@ -687,7 +696,12 @@ mod tests {
         collector.collect(3, 0.3).unwrap();
 
         assert_eq!(collector.total_hits(), 3);
-        assert!(!collector.needs_more());
+        // `needs_more` is `true` even when the heap is full, because a
+        // higher-scoring doc later in the iteration can still displace
+        // the current worst. Early termination is now driven by
+        // `min_competitive` + `Scorer::max_score()` in the searcher
+        // loop (see #459).
+        assert!(collector.needs_more());
 
         // Add a better document - should replace the worst
         collector.collect(4, 0.9).unwrap();
@@ -724,6 +738,32 @@ mod tests {
 
         // Check that low-score document was filtered out
         assert!(!results.iter().any(|hit| hit.score == 0.3));
+    }
+
+    #[test]
+    fn test_top_docs_collector_replaces_lower_after_full() {
+        // Verifies the correctness contract restored by the
+        // `needs_more = true` change (#459): a higher-scoring doc that
+        // arrives **after** the heap fills must displace the current
+        // heap-min, regardless of doc-id order. The pre-fix collector
+        // short-circuited the search loop the moment the heap filled
+        // and returned the first K matches by `doc_id`, dropping any
+        // higher-scoring doc that came later in the iteration.
+        let mut collector = TopDocsCollector::new(3);
+
+        collector.collect(1, 0.10).unwrap();
+        collector.collect(2, 0.20).unwrap();
+        collector.collect(3, 0.30).unwrap();
+        assert!(collector.needs_more());
+
+        collector.collect(4, 0.99).unwrap();
+
+        let results = collector.results();
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].doc_id, 4);
+        assert!((results[0].score - 0.99).abs() < 1e-6);
+        // Lowest-scoring doc (1) should have been evicted.
+        assert!(results.iter().all(|hit| hit.doc_id != 1));
     }
 
     #[test]

--- a/laurus/src/lexical/query/scorer.rs
+++ b/laurus/src/lexical/query/scorer.rs
@@ -29,6 +29,24 @@ pub trait Scorer: Send + Debug {
     /// Get the maximum possible score.
     fn max_score(&self) -> f32;
 
+    /// Upper bound on the score of the **next-block** of postings.
+    ///
+    /// For scorers that do not yet expose per-block max-score metadata,
+    /// the default impl forwards to [`Scorer::max_score`], i.e. it
+    /// returns the global upper bound — correct but loose. A future
+    /// per-posting block-max index format (#403 PR-B2) will let scorers
+    /// override this with a tightened bound that varies as the matcher
+    /// advances, enabling Block-Max-WAND skips.
+    ///
+    /// # Returns
+    ///
+    /// An upper bound on any score the scorer can produce for documents
+    /// in the matcher's current block. The returned value is **at most**
+    /// [`Scorer::max_score`] but may be tighter.
+    fn block_max_score(&self) -> f32 {
+        self.max_score()
+    }
+
     /// Get the name of this scorer.
     fn name(&self) -> &'static str;
 }


### PR DESCRIPTION
## Summary

Closes #459. Refs #403, #416.

Second slice of the WAND / MaxScore / Block-Max early-termination effort. Wires the searcher loop end-to-end and fixes a pre-existing top-K correctness bug; the bound that drives the early-break is intentionally still loose, awaiting the per-block index format in **PR-B2**.

### What lands

1. **Correctness fix (closes #459)** — `TopDocsCollector::needs_more()` now returns `true` always. Previously it returned `false` once the heap reached `max_docs`, causing the search loop to short-circuit and return the first K matches by `doc_id` rather than the highest-scoring K. New regression test `test_top_docs_collector_replaces_lower_after_full` verifies that a higher-scoring doc arriving after the heap fills correctly evicts the heap-min.

2. **Global MaxScore early-break** in [`InvertedIndexSearcher::search_with_collector_parallel`](laurus/src/lexical/index/inverted/searcher.rs). The loop caches `scorer.max_score()` once and breaks out the moment `max_score <= collector.min_competitive()`, since no remaining doc can possibly enter the top-K.

3. **`Scorer::block_max_score()` trait method** with a default impl that forwards to `max_score()`. PR-B2 will override this on `BM25Scorer` to return the tightened per-block bound from the new index metadata, where this PR's plumbing starts firing.

### Bench (`lexical_search_bench`, vs `pre-403-A` baseline)

| Scenario | Δ time |
| --- | --- |
| ``boolean_query/should_or/100`` | −0.7 % (noise) |
| ``boolean_query/should_or/1000`` | +32.1 % |
| ``boolean_query/should_or/5000`` | +33.1 % |
| ``boolean_query/should_or_high_freq/100`` | +26.6 % |
| ``boolean_query/should_or_high_freq/1000`` | +56.2 % |
| ``boolean_query/should_or_high_freq/5000`` | +40.6 % |

These are the **cost of correctness**: the loop now walks every matching candidate instead of stopping at K, and the global `BM25Scorer::max_score()` upper bound at `boost · idf · (k1 + 1)` is too loose to fire the MaxScore break under typical BM25 distributions. PR-B2 replaces that upper bound with a per-term / per-block tightened bound from the new index format, at which point the break fires reliably and the regression flips to a multi-fold speedup on the same workloads.

The regression is therefore intentional — landing the correctness fix and the loop plumbing now lets PR-B2 focus purely on the index format change without also having to re-justify the searcher refactor.

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench lexical_search_bench -- "boolean_query/should_or" --save-baseline pre-403-A
git checkout perf/wand-needs-more-maxscore-break
cargo bench -p laurus --bench lexical_search_bench -- "boolean_query/should_or" --baseline pre-403-A
```

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus --lib` (817 / 817 pass — one new top-K eviction-order regression test)

## Out of scope

- **PR-B2** — write-side per-posting block-max metadata + `BM25Scorer::block_max_score()` override that consumes it. Recovers and exceeds the wall time the regression in this PR sacrificed.
- **PR-C** — `BlockMaxScorer` trait wiring + WAND (pivot-term skipping) for `BooleanQuery` SHOULD clauses on top of PR-B2.
- **PR-D** — MaxScore for `BooleanQuery` MUST clauses.