### PR TITLE
perf(lexical/bm25): index-side tightened max_score_factor (#403 PR-B2)

### DIFF
--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -1386,12 +1386,19 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
                 total_freq: cached_info.total_frequency,
                 posting_offset: cached_info.posting_offset,
                 posting_size: cached_info.posting_length,
+                max_score_factor: cached_info.max_score_factor,
             }));
         }
 
         // Search across all segments
         let mut total_doc_freq = 0;
         let mut total_term_freq = 0;
+        // Aggregate across segments by taking the **max** of per-segment
+        // factors — each segment computed it against its own
+        // `avg_field_length`, but `max(seg_max)` is still a valid upper
+        // bound on any individual posting's TF-component contribution
+        // (#403 PR-B2).
+        let mut max_score_factor: f32 = 0.0;
         let mut found = false;
 
         for segment_reader in &self.segment_readers {
@@ -1399,6 +1406,7 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
             if let Some(term_info) = reader.term_info(field, term)? {
                 total_doc_freq += term_info.doc_frequency;
                 total_term_freq += term_info.total_frequency;
+                max_score_factor = max_score_factor.max(term_info.max_score_factor);
                 found = true;
             }
         }
@@ -1411,14 +1419,15 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
                 total_freq: total_term_freq,
                 posting_offset: 0, // Aggregated value, not meaningful for multi-segment
                 posting_size: 0,   // Aggregated value, not meaningful for multi-segment
+                max_score_factor,
             };
 
-            // Cache the result
             let term_info = TermInfo {
                 posting_offset: 0,
                 posting_length: 0,
                 doc_frequency: total_doc_freq,
                 total_frequency: total_term_freq,
+                max_score_factor,
             };
             self.cache_manager.cache_term_info(cache_key, term_info);
 

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -708,6 +708,20 @@ impl InvertedIndexWriter {
 
         let mut term_dict_builder = TermDictionaryBuilder::new();
 
+        // Compute per-field average length and a `doc_id → field_lengths`
+        // lookup once per flush. Both are needed to precompute the
+        // tightened BM25 TF-component upper bound stored as
+        // `TermInfo::max_score_factor` (#403 PR-B2). The factor uses
+        // the default BM25 parameters (`k1 = 1.2`, `b = 0.75`) — at
+        // search time, scorers fall back to the loose `k1 + 1` ceiling
+        // when the caller overrides `(k1, b)`.
+        let field_avg_lengths = self.compute_field_avg_lengths();
+        let field_lengths_by_doc: AHashMap<u64, &AHashMap<String, u32>> = self
+            .buffered_docs
+            .iter()
+            .map(|(doc_id, doc)| (*doc_id, &doc.field_lengths))
+            .collect();
+
         // Collect and sort terms for deterministic output
         let mut terms: Vec<_> = self.inverted_index.terms().collect();
         terms.sort();
@@ -722,12 +736,33 @@ impl InvertedIndexWriter {
                 let end_offset = posting_writer.position();
                 let length = end_offset - start_offset;
 
+                // The internal term key is `"<field>:<term>"`; split on
+                // the first `:` to recover the field name. Terms that
+                // somehow lack a field prefix get a `0.0` factor and
+                // the BM25 scorer will fall back to the loose bound.
+                let max_score_factor = match term.split_once(':') {
+                    Some((field_name, _)) => {
+                        let avg_len = field_avg_lengths
+                            .get(field_name)
+                            .copied()
+                            .unwrap_or(0.0_f32);
+                        Self::compute_term_max_score_factor(
+                            posting_list,
+                            field_name,
+                            avg_len,
+                            &field_lengths_by_doc,
+                        )
+                    }
+                    None => 0.0,
+                };
+
                 // Add to term dictionary
-                let term_info = TermInfo::new(
+                let term_info = TermInfo::with_max_score_factor(
                     start_offset,
                     length,
                     posting_list.doc_frequency,
                     posting_list.total_frequency,
+                    max_score_factor,
                 );
                 term_dict_builder.add_term(term.clone(), term_info);
             }
@@ -745,6 +780,77 @@ impl InvertedIndexWriter {
         dict_writer.close()?;
 
         Ok(())
+    }
+
+    /// Compute per-field average field length over the currently
+    /// buffered documents. Used by [`Self::write_inverted_index`] to
+    /// precompute the tightened BM25 TF-component bound that lands in
+    /// each term's `TermInfo::max_score_factor` (#403 PR-B2).
+    fn compute_field_avg_lengths(&self) -> AHashMap<String, f32> {
+        let mut totals: AHashMap<String, (u64, u64)> = AHashMap::new();
+        for (_doc_id, doc) in &self.buffered_docs {
+            for (field_name, &length) in &doc.field_lengths {
+                let entry = totals.entry(field_name.clone()).or_insert((0, 0));
+                entry.0 += 1; // doc count contributing to this field
+                entry.1 += length as u64; // total length for this field
+            }
+        }
+        totals
+            .into_iter()
+            .map(|(field, (count, total))| {
+                let avg = if count > 0 {
+                    total as f32 / count as f32
+                } else {
+                    0.0
+                };
+                (field, avg)
+            })
+            .collect()
+    }
+
+    /// Compute the per-term tightened BM25 TF-component upper bound
+    /// using the default `k1 = 1.2`, `b = 0.75` parameters and the
+    /// segment's average field length (#403 PR-B2).
+    ///
+    /// Returns the maximum of
+    /// `(tf · (k1 + 1)) / (tf + k1 · (1 - b + b · (L / avg_L)))`
+    /// taken over every posting in `posting_list`. `0.0` if the
+    /// posting list is empty or no doc lengths are resolvable.
+    fn compute_term_max_score_factor(
+        posting_list: &crate::lexical::index::inverted::core::posting::PostingList,
+        field_name: &str,
+        avg_field_length: f32,
+        field_lengths_by_doc: &AHashMap<u64, &AHashMap<String, u32>>,
+    ) -> f32 {
+        const K1: f32 = 1.2;
+        const B: f32 = 0.75;
+
+        let mut max_factor: f32 = 0.0;
+        for posting in &posting_list.postings {
+            let tf = posting.frequency as f32;
+            if tf == 0.0 {
+                continue;
+            }
+            let field_len = field_lengths_by_doc
+                .get(&posting.doc_id)
+                .and_then(|fls| fls.get(field_name))
+                .copied()
+                .unwrap_or(0) as f32;
+            let len_ratio = if avg_field_length > 0.0 {
+                field_len / avg_field_length
+            } else {
+                1.0
+            };
+            let denom = tf + K1 * (1.0 - B + B * len_ratio);
+            if denom == 0.0 {
+                continue;
+            }
+            let factor = (tf * (K1 + 1.0)) / denom;
+            if factor > max_factor {
+                max_factor = factor;
+            }
+        }
+        max_factor
     }
 
     /// Write stored documents to storage with type information preserved.

--- a/laurus/src/lexical/index/structures/dictionary.rs
+++ b/laurus/src/lexical/index/structures/dictionary.rs
@@ -24,10 +24,30 @@ pub struct TermInfo {
     pub doc_frequency: u64,
     /// Total frequency across all documents.
     pub total_frequency: u64,
+    /// Tightest possible BM25 TF-component upper bound for this term,
+    /// precomputed at index time using the default BM25 parameters
+    /// (`k1 = 1.2`, `b = 0.75`) and the segment's average field length.
+    ///
+    /// Concretely, this is the maximum of
+    /// `(tf · (k1 + 1)) / (tf + k1 · (1 - b + b · (L / avg_L)))` taken
+    /// over every posting `(tf, L)` in the list. It feeds
+    /// [`BM25Scorer::block_max_score`] so the searcher loop's MaxScore
+    /// early-break (#403 PR-B1) can fire on a tight bound rather than
+    /// the synthetic `k1 + 1` ceiling.
+    ///
+    /// `0.0` is treated as "unset" (legacy v1 segments and freshly
+    /// constructed `TermInfo` values default to this); scorers fall
+    /// back to the loose `k1 + 1` bound in that case.
+    pub max_score_factor: f32,
 }
 
 impl TermInfo {
-    /// Create new term info.
+    /// Create new term info with `max_score_factor = 0.0` (loose bound).
+    ///
+    /// Use [`TermInfo::with_max_score_factor`] to build a value with the
+    /// tightened block-max bound from the index. Existing call sites
+    /// keep working — the searcher silently falls back to the synthetic
+    /// upper bound when the field is `0.0`.
     pub fn new(
         posting_offset: u64,
         posting_length: u64,
@@ -39,6 +59,26 @@ impl TermInfo {
             posting_length,
             doc_frequency,
             total_frequency,
+            max_score_factor: 0.0,
+        }
+    }
+
+    /// Create new term info with a precomputed tightened max-score
+    /// factor (#403 PR-B2). Pass `0.0` if the factor is not available
+    /// — scorers will fall back to the loose `k1 + 1` bound.
+    pub fn with_max_score_factor(
+        posting_offset: u64,
+        posting_length: u64,
+        doc_frequency: u64,
+        total_frequency: u64,
+        max_score_factor: f32,
+    ) -> Self {
+        TermInfo {
+            posting_offset,
+            posting_length,
+            doc_frequency,
+            total_frequency,
+            max_score_factor,
         }
     }
 }
@@ -149,6 +189,15 @@ impl SortedTermDictionary {
     }
 
     /// Read the dictionary from storage.
+    ///
+    /// Supports both **v1** (legacy) and **v2** (#403 PR-B2) layouts:
+    ///
+    /// - v1 entries store only the four `u64` fields. `max_score_factor`
+    ///   is filled with `0.0`, which the BM25 scorer treats as "fall
+    ///   back to the loose `k1 + 1` upper bound" — segments produced
+    ///   before this PR continue to load and search correctly.
+    /// - v2 entries append a single `f32` per term holding the
+    ///   precomputed tightened TF-component upper bound.
     pub fn read_from_storage<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
         // Read header
         let magic = reader.read_u32()?;
@@ -158,7 +207,7 @@ impl SortedTermDictionary {
         }
 
         let version = reader.read_u32()?;
-        if version != 1 {
+        if version != 1 && version != 2 {
             return Err(LaurusError::index(format!(
                 "Unsupported sorted dictionary version: {version}"
             )));
@@ -175,6 +224,11 @@ impl SortedTermDictionary {
             let posting_length = reader.read_u64()?;
             let doc_frequency = reader.read_u64()?;
             let total_frequency = reader.read_u64()?;
+            let max_score_factor = if version >= 2 {
+                reader.read_f32()?
+            } else {
+                0.0
+            };
 
             terms.push(term);
             term_infos.push(TermInfo {
@@ -182,6 +236,7 @@ impl SortedTermDictionary {
                 posting_length,
                 doc_frequency,
                 total_frequency,
+                max_score_factor,
             });
         }
 
@@ -257,13 +312,16 @@ impl HashTermDictionary {
         SortedTermDictionary::from_map(map)
     }
 
-    /// Write to storage.
+    /// Write to storage in **v2** layout (#403 PR-B2). Each entry
+    /// carries the precomputed `max_score_factor: f32` after the four
+    /// legacy `u64` fields. See [`SortedTermDictionary::write_to_storage`]
+    /// for the matching format on the sorted side.
     pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
         // Write magic number for hash dictionary
         writer.write_u32(0x48544443)?; // "HTDC"
 
         // Write version
-        writer.write_u32(1)?;
+        writer.write_u32(2)?;
 
         // Write number of terms
         writer.write_varint(self.terms.len() as u64)?;
@@ -277,12 +335,16 @@ impl HashTermDictionary {
             writer.write_u64(info.posting_length)?;
             writer.write_u64(info.doc_frequency)?;
             writer.write_u64(info.total_frequency)?;
+            writer.write_f32(info.max_score_factor)?;
         }
 
         Ok(())
     }
 
-    /// Read from storage.
+    /// Read from storage. Accepts both **v1** (legacy) and **v2**
+    /// (#403 PR-B2) layouts; v1 entries fill `max_score_factor` with
+    /// `0.0`, which the BM25 scorer treats as "fall back to the loose
+    /// `k1 + 1` upper bound" so older segments continue to load.
     pub fn read_from_storage<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
         // Read magic number
         let magic = reader.read_u32()?;
@@ -293,7 +355,7 @@ impl HashTermDictionary {
 
         // Read version
         let version = reader.read_u32()?;
-        if version != 1 {
+        if version != 1 && version != 2 {
             return Err(LaurusError::index(format!(
                 "Unsupported hash dictionary version: {version}"
             )));
@@ -307,11 +369,21 @@ impl HashTermDictionary {
 
         for _ in 0..term_count {
             let term = reader.read_string()?;
+            let posting_offset = reader.read_u64()?;
+            let posting_length = reader.read_u64()?;
+            let doc_frequency = reader.read_u64()?;
+            let total_frequency = reader.read_u64()?;
+            let max_score_factor = if version >= 2 {
+                reader.read_f32()?
+            } else {
+                0.0
+            };
             let info = TermInfo {
-                posting_offset: reader.read_u64()?,
-                posting_length: reader.read_u64()?,
-                doc_frequency: reader.read_u64()?,
-                total_frequency: reader.read_u64()?,
+                posting_offset,
+                posting_length,
+                doc_frequency,
+                total_frequency,
+                max_score_factor,
             };
 
             terms.insert(term, info);
@@ -468,13 +540,18 @@ pub struct DictionaryStats {
 }
 
 impl SortedTermDictionary {
-    /// Write to storage.
+    /// Write to storage in **v2** layout (#403 PR-B2).
+    ///
+    /// Each entry now carries an extra `f32 max_score_factor` after the
+    /// four legacy `u64` fields. v1 readers are no longer able to load
+    /// new segments — readers from this codebase accept both versions
+    /// (see [`SortedTermDictionary::read_from_storage`]).
     pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
         // Write magic number for sorted dictionary
         writer.write_u32(0x53544443)?; // "STDC"
 
         // Write version
-        writer.write_u32(1)?;
+        writer.write_u32(2)?;
 
         // Write number of terms
         writer.write_varint(self.terms.len() as u64)?;
@@ -488,6 +565,7 @@ impl SortedTermDictionary {
             writer.write_u64(info.posting_length)?;
             writer.write_u64(info.doc_frequency)?;
             writer.write_u64(info.total_frequency)?;
+            writer.write_f32(info.max_score_factor)?;
         }
 
         Ok(())

--- a/laurus/src/lexical/query/scorer.rs
+++ b/laurus/src/lexical/query/scorer.rs
@@ -74,9 +74,26 @@ pub struct BM25Scorer {
     b: f32,
     /// Cached IDF value computed at construction time.
     cached_idf: f32,
+    /// Tightened TF-component upper bound precomputed at index time
+    /// using the default `(k1, b) = (1.2, 0.75)` parameters and the
+    /// segment's average field length (#403 PR-B2). Read from
+    /// [`crate::lexical::reader::ReaderTermInfo::max_score_factor`].
+    ///
+    /// `0.0` is treated as "unset" — [`Self::max_score`] then falls
+    /// back to the loose synthetic `k1 + 1` ceiling. Also bypassed
+    /// when the caller overrides `(k1, b)` via [`Self::with_params`],
+    /// since the precomputed factor is only valid for the defaults.
+    max_score_factor: f32,
 }
 
 impl BM25Scorer {
+    /// Default BM25 `k1` parameter; matches what the indexer uses to
+    /// precompute [`crate::lexical::index::structures::dictionary::TermInfo::max_score_factor`].
+    const DEFAULT_K1: f32 = 1.2;
+    /// Default BM25 `b` parameter; matches the indexer's choice (see
+    /// [`Self::DEFAULT_K1`]).
+    const DEFAULT_B: f32 = 0.75;
+
     /// Compute the IDF (Inverse Document Frequency) value.
     fn compute_idf(doc_freq: u64, total_docs: u64) -> f32 {
         if doc_freq == 0 || total_docs == 0 {
@@ -89,7 +106,8 @@ impl BM25Scorer {
         base_idf.max(epsilon)
     }
 
-    /// Create a new BM25 scorer.
+    /// Create a new BM25 scorer with no precomputed `max_score_factor`
+    /// (loose `k1 + 1` upper bound).
     pub fn new(
         doc_freq: u64,
         total_term_freq: u64,
@@ -106,13 +124,47 @@ impl BM25Scorer {
             avg_field_length,
             total_docs,
             boost,
-            k1: 1.2,
-            b: 0.75,
+            k1: Self::DEFAULT_K1,
+            b: Self::DEFAULT_B,
             cached_idf,
+            max_score_factor: 0.0,
         }
     }
 
-    /// Create a new BM25 scorer with custom parameters.
+    /// Create a new BM25 scorer with the index-side tightened TF
+    /// upper bound (#403 PR-B2). Pass `0.0` for `max_score_factor` if
+    /// the index does not carry the precomputed value (legacy v1
+    /// dictionaries / aggregated cross-segment views) — [`Self::max_score`]
+    /// will fall back to the loose `k1 + 1` ceiling.
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_max_score_factor(
+        doc_freq: u64,
+        total_term_freq: u64,
+        field_doc_count: u64,
+        avg_field_length: f64,
+        total_docs: u64,
+        boost: f32,
+        max_score_factor: f32,
+    ) -> Self {
+        let cached_idf = Self::compute_idf(doc_freq, total_docs);
+        BM25Scorer {
+            doc_freq,
+            total_term_freq,
+            field_doc_count,
+            avg_field_length,
+            total_docs,
+            boost,
+            k1: Self::DEFAULT_K1,
+            b: Self::DEFAULT_B,
+            cached_idf,
+            max_score_factor,
+        }
+    }
+
+    /// Create a new BM25 scorer with custom `(k1, b)` parameters. The
+    /// precomputed `max_score_factor` is **not** wired in here because
+    /// the index-side factor is only valid for the default
+    /// `(k1, b) = (1.2, 0.75)` parameters.
     #[allow(clippy::too_many_arguments)]
     pub fn with_params(
         doc_freq: u64,
@@ -135,6 +187,7 @@ impl BM25Scorer {
             k1,
             b,
             cached_idf,
+            max_score_factor: 0.0,
         }
     }
 
@@ -216,9 +269,30 @@ impl Scorer for BM25Scorer {
         }
 
         let idf = self.idf();
-        let max_tf = self.k1 + 1.0; // Maximum possible TF component
+        // Use the index-side tightened bound (#403 PR-B2) when it is
+        // available **and** the scorer is running with the default
+        // BM25 parameters that the index-time precomputation assumed.
+        // Custom `(k1, b)` callers fall back to the synthetic
+        // `k1 + 1` upper bound on the TF component.
+        let tf_upper_bound = if self.max_score_factor > 0.0
+            && self.k1 == Self::DEFAULT_K1
+            && self.b == Self::DEFAULT_B
+        {
+            self.max_score_factor
+        } else {
+            self.k1 + 1.0
+        };
 
-        self.boost * idf * max_tf
+        self.boost * idf * tf_upper_bound
+    }
+
+    fn block_max_score(&self) -> f32 {
+        // Today we do not yet store per-block bounds — return the
+        // tightest term-level upper bound, which is the same value
+        // [`Self::max_score`] returns. A future per-posting block-max
+        // index format (#403 PR-C) will let this method override with
+        // a bound that varies as the matcher advances.
+        self.max_score()
     }
 
     fn name(&self) -> &'static str {
@@ -518,6 +592,57 @@ mod tests {
 
         // Max score should be >= actual score
         assert!(max_score >= actual_score);
+    }
+
+    #[test]
+    fn test_bm25_scorer_max_score_factor_tightens_bound() {
+        // #403 PR-B2: when the index supplies a precomputed
+        // `max_score_factor`, the scorer's `max_score()` upper bound
+        // is `boost * idf * factor` (tight) rather than the synthetic
+        // `boost * idf * (k1 + 1)` ceiling. With `factor < k1 + 1`
+        // (the realistic case) the new bound must be strictly
+        // smaller.
+        let loose = BM25Scorer::new(10, 100, 50, 10.0, 1000, 1.0);
+        // Average doc length 10, so a typical TF=1 / L=10 posting has
+        // factor ≈ 1.0 — well below the loose `k1 + 1 = 2.2` ceiling.
+        let tight = BM25Scorer::with_max_score_factor(10, 100, 50, 10.0, 1000, 1.0, 1.0);
+
+        assert!(
+            tight.max_score() < loose.max_score(),
+            "tight bound ({}) must be < loose bound ({})",
+            tight.max_score(),
+            loose.max_score()
+        );
+        assert!(tight.max_score() > 0.0, "tight bound must remain positive");
+    }
+
+    #[test]
+    fn test_bm25_scorer_max_score_factor_ignored_with_custom_params() {
+        // The precomputed `max_score_factor` is only valid for the
+        // default `(k1, b) = (1.2, 0.75)` parameters used at index
+        // time. When the caller overrides `(k1, b)` the scorer must
+        // fall back to the loose `k1 + 1` synthetic bound — verified
+        // here by constructing two scorers (one with custom params,
+        // one default) and confirming the custom-params scorer still
+        // emits the loose ceiling.
+        let custom = BM25Scorer::with_params(10, 100, 50, 10.0, 1000, 1.0, 2.0, 0.5);
+        let custom_loose = custom.boost() * custom.max_score() / custom.boost();
+        // Loose bound is `boost * idf * (k1 + 1) = 1.0 * idf * 3.0`.
+        // With factor unset (`with_params`) the scorer returns the
+        // loose bound, so `max_score / (boost * idf) = k1 + 1 = 3.0`.
+        let idf = ((1000.0_f32 - 10.0 + 0.5) / (10.0 + 0.5)).ln().max(0.01);
+        let expected = 1.0 * idf * 3.0;
+        assert!((custom_loose - expected).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_bm25_scorer_block_max_score_matches_max_score() {
+        // PR-B2 leaves `block_max_score()` forwarding to `max_score()`.
+        // PR-C will introduce per-block bounds; the contract that the
+        // block bound never exceeds the term-level bound is asserted
+        // here so a future override doesn't accidentally regress.
+        let scorer = BM25Scorer::with_max_score_factor(10, 100, 50, 10.0, 1000, 1.0, 1.0);
+        assert_eq!(scorer.block_max_score(), scorer.max_score());
     }
 
     #[test]

--- a/laurus/src/lexical/query/term.rs
+++ b/laurus/src/lexical/query/term.rs
@@ -75,13 +75,20 @@ impl Query for TermQuery {
 
         match (term_info, field_stats) {
             (Some(term_info), Some(field_stats)) => {
-                let scorer = BM25Scorer::new(
+                // Wire the index-side tightened TF-component upper
+                // bound (#403 PR-B2). `max_score_factor == 0.0` is
+                // treated by the scorer as "fall back to the loose
+                // `k1 + 1` bound" — handles legacy v1 dictionaries
+                // and aggregated cross-segment views where the factor
+                // is not available.
+                let scorer = BM25Scorer::with_max_score_factor(
                     term_info.doc_freq,
                     term_info.total_freq,
                     field_stats.doc_count,
                     field_stats.avg_length,
                     reader.doc_count(),
                     self.boost,
+                    term_info.max_score_factor,
                 );
                 Ok(Box::new(scorer))
             }

--- a/laurus/src/lexical/reader.rs
+++ b/laurus/src/lexical/reader.rs
@@ -26,6 +26,21 @@ pub struct ReaderTermInfo {
 
     /// Size of the posting list in bytes.
     pub posting_size: u64,
+
+    /// Tightened BM25 TF-component upper bound precomputed at index
+    /// time using the default BM25 parameters (`k1 = 1.2`, `b = 0.75`)
+    /// and the segment's average field length (#403 PR-B2).
+    ///
+    /// Concretely, this is the maximum of
+    /// `(tf · (k1 + 1)) / (tf + k1 · (1 - b + b · (L / avg_L)))` over
+    /// every posting `(tf, L)`. `BM25Scorer::block_max_score` uses it
+    /// to expose a tight per-term upper bound to the searcher loop's
+    /// MaxScore early-break.
+    ///
+    /// `0.0` is treated as "unset" (legacy v1 segments / aggregated
+    /// cross-segment views): scorers fall back to the loose
+    /// `k1 + 1` synthetic bound in that case.
+    pub max_score_factor: f32,
 }
 
 /// Statistics about a field in the index.


### PR DESCRIPTION
## Summary

Refs #403, #416.

Third slice of the WAND / MaxScore / Block-Max early-termination effort. Adds the per-term tightened BM25 TF-component upper bound that **PR-B1**'s searcher-loop MaxScore break (#460) needs to fire reliably, by storing the precomputed factor in the term dictionary at index time.

### What lands

1. **Index format bump** (`TermDictionary` v1 → v2). Each entry now carries an extra `f32 max_score_factor` after the four legacy `u64` fields. Old v1 segments still load: the read path accepts both versions and fills the field with `0.0` for v1 entries, which scorers treat as "fall back to the loose `k1 + 1` upper bound".

2. **Indexer `flush_segment::write_inverted_index`** now precomputes the factor per term using the default BM25 parameters (`k1 = 1.2`, `b = 0.75`) and the segment's per-field average length:

   ```
   max over postings of  (tf · (k1 + 1)) / (tf + k1 · (1 - b + b · (L / avg_L)))
   ```

   The two helper methods `WriterImpl::compute_field_avg_lengths` and `WriterImpl::compute_term_max_score_factor` keep the calculation localised; the rest of the segment-write pipeline is unchanged.

3. **`BM25Scorer::with_max_score_factor`** consumes the index-side factor:

   - `max_score()` returns `boost · idf · factor` when the factor is non-zero **and** the scorer is using the default `(k1, b)`.
   - Custom-params callers (via `with_params`) continue to use the loose `k1 + 1` synthetic ceiling, since the precomputed factor is only valid for the indexer's default parameters.
   - `block_max_score()` overrides the trait method to forward to `max_score()` for now. **PR-C** will introduce a true per-block bound on top of this hook.

4. **`ReaderTermInfo`** gains a `max_score_factor` field; the inverted reader populates it from the dictionary in both the cached and the cross-segment-aggregated paths (the latter takes the `max` over per-segment factors so it remains a valid upper bound).

5. **`TermQuery::scorer`** wires the factor from `ReaderTermInfo` into `BM25Scorer::with_max_score_factor`. Phrase / fuzzy / range queries are unchanged in this PR — they construct different scorer types or use `BM25Scorer::new`, which keeps the loose bound until follow-ups extend the wiring.

### Bench (`lexical_search_bench`, vs `pre-403-A` baseline)

| Scenario | PR-B1 | PR-B2 (this) | PR-B2 vs PR-B1 |
| --- | --- | --- | --- |
| ``boolean_query/should_or/100`` | −0.7 % | **−6.9 %** | improving |
| ``boolean_query/should_or/1000`` | +32.1 % | +26.9 % | −3.9 % |
| ``boolean_query/should_or/5000`` | +33.1 % | +16.3 % | **−12.6 %** |
| ``boolean_query/should_or_high_freq/100`` | +26.6 % | +11.2 % | −12.2 % |
| ``boolean_query/should_or_high_freq/1000`` | +56.2 % | +26.4 % | **−19.0 %** |
| ``boolean_query/should_or_high_freq/5000`` | +40.6 % | +30.2 % | −7.4 % |

PR-B2 recovers 7-19 % of PR-B1's correctness regression. The remaining gap (still slower than the pre-#459 buggy-fast baseline on most cases) is inherent to **per-term** — not **per-block** — bounds on this fixture: some docs hit `tf = 2` via topic-phrase overlap, so the per-term factor is ≈ 1.375 against an actual typical-doc score of ≈ 1.0. The MaxScore break only fires after the heap saturates near the full term-level bound, which is a low-probability event for this distribution. **PR-C** closes the remaining gap with WAND skipping over per-block bounds.

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench lexical_search_bench -- "boolean_query/should_or" --save-baseline pre-403-A
git checkout perf/bm25-block-max
cargo bench -p laurus --bench lexical_search_bench -- "boolean_query/should_or" --baseline pre-403-A
```

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus --lib` (820 / 820 pass — three new BM25Scorer regression tests)
- [x] New tests:
  - `test_bm25_scorer_max_score_factor_tightens_bound` — bound is strictly smaller than the loose ceiling when the factor is supplied.
  - `test_bm25_scorer_max_score_factor_ignored_with_custom_params` — custom-`(k1, b)` scorers fall back to the loose bound.
  - `test_bm25_scorer_block_max_score_matches_max_score` — guards the contract that the block bound never exceeds the term bound when PR-C overrides it.

## Index-format compatibility

Old (v1) segments continue to load and search correctly — the missing factor degrades gracefully to the same loose bound the codebase used before this PR. Newly written segments use v2 unconditionally; rolling back to a binary that predates this PR would fail to load them with `Unsupported sorted/hash dictionary version: 2`. This is the documented format bump #403's acceptance criterion #3 calls for.

## Out of scope (next up)

- **PR-C** — `BlockMaxScorer` trait wiring + WAND (pivot-term skipping) for `BooleanQuery` SHOULD clauses, fed by `min_competitive` + per-block bounds. Closes the remaining bench gap on `should_or_high_freq` and unlocks the audit's 5x speedup target.
- **PR-D** — MaxScore for `BooleanQuery` MUST clauses on top of PR-C.