### PR TITLE
perf(lexical/bm25): per-block max-impact + Block-Max early-break (#403 PR-C)

### DIFF
--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -1387,6 +1387,7 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
                 posting_offset: cached_info.posting_offset,
                 posting_size: cached_info.posting_length,
                 max_score_factor: cached_info.max_score_factor,
+                block_max: cached_info.block_max.clone(),
             }));
         }
 
@@ -1420,6 +1421,12 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
                 posting_offset: 0, // Aggregated value, not meaningful for multi-segment
                 posting_size: 0,   // Aggregated value, not meaningful for multi-segment
                 max_score_factor,
+                // Aggregated cross-segment view does not carry per-block
+                // metadata: each segment's blocks are anchored to its own
+                // local `avg_field_length`, and concatenating them across
+                // segments would require re-indexing. Scorers fall back
+                // to the term-level `max_score_factor`.
+                block_max: Vec::new(),
             };
 
             let term_info = TermInfo {
@@ -1428,6 +1435,12 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
                 doc_frequency: total_doc_freq,
                 total_frequency: total_term_freq,
                 max_score_factor,
+                // Aggregated cross-segment view does not carry per-block
+                // metadata: each segment's blocks are anchored to its own
+                // local `avg_field_length`, and concatenating them across
+                // segments would require re-indexing. Scorers fall back
+                // to the term-level `max_score_factor`.
+                block_max: Vec::new(),
             };
             self.cache_manager.cache_term_info(cache_key, term_info);
 

--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -95,17 +95,6 @@ impl InvertedIndexSearcher {
         // Create a scorer for the query
         let scorer = query.scorer(self.reader.as_ref())?;
 
-        // Cache the query-wide score upper bound for the global
-        // MaxScore early-termination check. Constant for the lifetime
-        // of the search; combined with the collector's
-        // `min_competitive()` it lets the loop break the moment no
-        // remaining doc can possibly enter the top-K (#403 PR-B1).
-        // Today this rarely fires under typical BM25 distributions
-        // because `Scorer::max_score()` returns a loose `boost · idf
-        // · (k1 + 1)` upper bound; a tightened per-block bound lands
-        // in PR-B2 with the index-format change.
-        let max_score = scorer.max_score();
-
         // Iterate through matching documents
         while !matcher.is_exhausted() {
             let doc_id = matcher.doc_id();
@@ -139,12 +128,16 @@ impl InvertedIndexSearcher {
             // Collect the result
             collector.collect(doc_id, score)?;
 
-            // Global MaxScore early-break (#403 PR-B1). After every
-            // collect the collector's `min_competitive()` may have
-            // tightened — once it reaches `max_score` the upper bound
-            // on any remaining doc's score is no longer competitive
-            // and the walk is provably complete.
-            if max_score <= collector.min_competitive() {
+            // Block-Max early-break (#403 PR-C). After every collect
+            // the collector's `min_competitive()` may have tightened;
+            // ask the scorer for the **per-block** upper bound at the
+            // matcher's current position rather than the looser term-
+            // level `max_score()` we used in PR-B1. As soon as the
+            // block-level bound is no longer competitive, the rest of
+            // this block (and, since `block_max_score_at` returns
+            // `0.0` past the last block, the rest of the posting list)
+            // cannot enter the top-K and the walk is provably done.
+            if scorer.block_max_score_at(doc_id) <= collector.min_competitive() {
                 break;
             }
 

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -740,29 +740,40 @@ impl InvertedIndexWriter {
                 // the first `:` to recover the field name. Terms that
                 // somehow lack a field prefix get a `0.0` factor and
                 // the BM25 scorer will fall back to the loose bound.
-                let max_score_factor = match term.split_once(':') {
+                let (max_score_factor, block_max) = match term.split_once(':') {
                     Some((field_name, _)) => {
                         let avg_len = field_avg_lengths
                             .get(field_name)
                             .copied()
                             .unwrap_or(0.0_f32);
-                        Self::compute_term_max_score_factor(
+                        let term_factor = Self::compute_term_max_score_factor(
                             posting_list,
                             field_name,
                             avg_len,
                             &field_lengths_by_doc,
-                        )
+                        );
+                        // Compute per-block max-impact metadata for
+                        // Block-Max-WAND (#403 PR-C). A term with no
+                        // postings naturally produces no blocks.
+                        let blocks = Self::compute_term_block_max(
+                            posting_list,
+                            field_name,
+                            avg_len,
+                            &field_lengths_by_doc,
+                        );
+                        (term_factor, blocks)
                     }
-                    None => 0.0,
+                    None => (0.0_f32, Vec::new()),
                 };
 
                 // Add to term dictionary
-                let term_info = TermInfo::with_max_score_factor(
+                let term_info = TermInfo::with_block_max(
                     start_offset,
                     length,
                     posting_list.doc_frequency,
                     posting_list.total_frequency,
                     max_score_factor,
+                    block_max,
                 );
                 term_dict_builder.add_term(term.clone(), term_info);
             }
@@ -851,6 +862,68 @@ impl InvertedIndexWriter {
             }
         }
         max_factor
+    }
+
+    /// Compute the per-block max-impact metadata used by Block-Max-WAND
+    /// (#403 PR-C). Walks the posting list in
+    /// [`BLOCK_SIZE`](crate::lexical::index::structures::dictionary::BLOCK_SIZE)-wide
+    /// chunks and records `(last_doc_id, max_factor)` for each block.
+    ///
+    /// `max_factor` is computed with the same formula as
+    /// [`Self::compute_term_max_score_factor`] but restricted to the
+    /// block's postings; the per-term factor is the max over all per-
+    /// block factors.
+    fn compute_term_block_max(
+        posting_list: &crate::lexical::index::inverted::core::posting::PostingList,
+        field_name: &str,
+        avg_field_length: f32,
+        field_lengths_by_doc: &AHashMap<u64, &AHashMap<String, u32>>,
+    ) -> Vec<crate::lexical::index::structures::dictionary::BlockMax> {
+        use crate::lexical::index::structures::dictionary::{BLOCK_SIZE, BlockMax};
+
+        const K1: f32 = 1.2;
+        const B: f32 = 0.75;
+
+        if posting_list.postings.is_empty() {
+            return Vec::new();
+        }
+
+        let mut blocks = Vec::with_capacity(posting_list.postings.len().div_ceil(BLOCK_SIZE));
+        for chunk in posting_list.postings.chunks(BLOCK_SIZE) {
+            let mut block_max: f32 = 0.0;
+            for posting in chunk {
+                let tf = posting.frequency as f32;
+                if tf == 0.0 {
+                    continue;
+                }
+                let field_len = field_lengths_by_doc
+                    .get(&posting.doc_id)
+                    .and_then(|fls| fls.get(field_name))
+                    .copied()
+                    .unwrap_or(0) as f32;
+                let len_ratio = if avg_field_length > 0.0 {
+                    field_len / avg_field_length
+                } else {
+                    1.0
+                };
+                let denom = tf + K1 * (1.0 - B + B * len_ratio);
+                if denom == 0.0 {
+                    continue;
+                }
+                let factor = (tf * (K1 + 1.0)) / denom;
+                if factor > block_max {
+                    block_max = factor;
+                }
+            }
+            // `chunks` always yields at least one element (we early-
+            // returned on empty above), so unwrap is safe.
+            let last_doc_id = chunk.last().unwrap().doc_id;
+            blocks.push(BlockMax {
+                last_doc_id,
+                max_factor: block_max,
+            });
+        }
+        blocks
     }
 
     /// Write stored documents to storage with type information preserved.

--- a/laurus/src/lexical/index/structures/dictionary.rs
+++ b/laurus/src/lexical/index/structures/dictionary.rs
@@ -13,6 +13,30 @@ use crate::error::{LaurusError, Result};
 use crate::storage::structured::{StructReader, StructWriter};
 use crate::storage::{StorageInput, StorageOutput};
 
+/// One block's max-impact metadata for Block-Max-WAND (#403 PR-C).
+///
+/// Each block covers up to [`BLOCK_SIZE`] consecutive postings of a
+/// term. The pair records:
+///
+/// - `last_doc_id` — the doc id of the last posting in the block; used
+///   to locate the block containing a target doc id by binary search,
+///   and to seek to the next block during WAND skipping.
+/// - `max_factor` — the tightest possible BM25 TF-component value over
+///   the postings in this block, computed with default BM25 parameters
+///   (`k1 = 1.2`, `b = 0.75`) and the segment's average field length.
+///   `BM25Scorer::block_max_score_at` multiplies it by `boost · idf`
+///   to expose a per-block upper bound to the searcher loop.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BlockMax {
+    /// Last doc id covered by this block.
+    pub last_doc_id: u64,
+    /// Block-level TF-component upper bound (default BM25 parameters).
+    pub max_factor: f32,
+}
+
+/// Posting blocks are 128 entries wide, matching Lucene 9 / Tantivy.
+pub const BLOCK_SIZE: usize = 128;
+
 /// Information about a term in the dictionary.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TermInfo {
@@ -24,21 +48,17 @@ pub struct TermInfo {
     pub doc_frequency: u64,
     /// Total frequency across all documents.
     pub total_frequency: u64,
-    /// Tightest possible BM25 TF-component upper bound for this term,
-    /// precomputed at index time using the default BM25 parameters
-    /// (`k1 = 1.2`, `b = 0.75`) and the segment's average field length.
+    /// Term-level tightened BM25 TF-component upper bound (#403 PR-B2).
     ///
-    /// Concretely, this is the maximum of
-    /// `(tf · (k1 + 1)) / (tf + k1 · (1 - b + b · (L / avg_L)))` taken
-    /// over every posting `(tf, L)` in the list. It feeds
-    /// [`BM25Scorer::block_max_score`] so the searcher loop's MaxScore
-    /// early-break (#403 PR-B1) can fire on a tight bound rather than
-    /// the synthetic `k1 + 1` ceiling.
-    ///
-    /// `0.0` is treated as "unset" (legacy v1 segments and freshly
-    /// constructed `TermInfo` values default to this); scorers fall
-    /// back to the loose `k1 + 1` bound in that case.
+    /// Maximum of `(tf · (k1 + 1)) / (tf + k1 · (1 - b + b · (L / avg_L)))`
+    /// over every posting in the list. `0.0` means "unset"; scorers
+    /// fall back to the loose `k1 + 1` synthetic ceiling.
     pub max_score_factor: f32,
+    /// Per-block (`BLOCK_SIZE`-wide) max-impact metadata used by
+    /// Block-Max-WAND (#403 PR-C). Empty if not available
+    /// (legacy v2 dictionaries or aggregated cross-segment views) —
+    /// scorers then fall back to [`Self::max_score_factor`].
+    pub block_max: Vec<BlockMax>,
 }
 
 impl TermInfo {
@@ -60,6 +80,7 @@ impl TermInfo {
             doc_frequency,
             total_frequency,
             max_score_factor: 0.0,
+            block_max: Vec::new(),
         }
     }
 
@@ -79,6 +100,27 @@ impl TermInfo {
             doc_frequency,
             total_frequency,
             max_score_factor,
+            block_max: Vec::new(),
+        }
+    }
+
+    /// Create new term info with both the term-level factor and the
+    /// per-block max-impact metadata used by Block-Max-WAND (#403 PR-C).
+    pub fn with_block_max(
+        posting_offset: u64,
+        posting_length: u64,
+        doc_frequency: u64,
+        total_frequency: u64,
+        max_score_factor: f32,
+        block_max: Vec<BlockMax>,
+    ) -> Self {
+        TermInfo {
+            posting_offset,
+            posting_length,
+            doc_frequency,
+            total_frequency,
+            max_score_factor,
+            block_max,
         }
     }
 }
@@ -207,7 +249,7 @@ impl SortedTermDictionary {
         }
 
         let version = reader.read_u32()?;
-        if version != 1 && version != 2 {
+        if version != 1 && version != 2 && version != 3 {
             return Err(LaurusError::index(format!(
                 "Unsupported sorted dictionary version: {version}"
             )));
@@ -229,6 +271,25 @@ impl SortedTermDictionary {
             } else {
                 0.0
             };
+            // v3: per-block (last_doc_id, max_factor) array. v1/v2
+            // entries decode with an empty `block_max`, which scorers
+            // treat as "fall back to the term-level
+            // `max_score_factor`" (#403 PR-C).
+            let block_max = if version >= 3 {
+                let block_count = reader.read_varint()? as usize;
+                let mut blocks = Vec::with_capacity(block_count);
+                for _ in 0..block_count {
+                    let last_doc_id = reader.read_u64()?;
+                    let mf = reader.read_f32()?;
+                    blocks.push(BlockMax {
+                        last_doc_id,
+                        max_factor: mf,
+                    });
+                }
+                blocks
+            } else {
+                Vec::new()
+            };
 
             terms.push(term);
             term_infos.push(TermInfo {
@@ -237,6 +298,7 @@ impl SortedTermDictionary {
                 doc_frequency,
                 total_frequency,
                 max_score_factor,
+                block_max,
             });
         }
 
@@ -312,16 +374,17 @@ impl HashTermDictionary {
         SortedTermDictionary::from_map(map)
     }
 
-    /// Write to storage in **v2** layout (#403 PR-B2). Each entry
-    /// carries the precomputed `max_score_factor: f32` after the four
-    /// legacy `u64` fields. See [`SortedTermDictionary::write_to_storage`]
+    /// Write to storage in **v3** layout (#403 PR-C). Each entry now
+    /// carries the v2 `max_score_factor: f32` plus a length-prefixed
+    /// per-block `(last_doc_id: u64, max_factor: f32)` array used by
+    /// Block-Max-WAND. See [`SortedTermDictionary::write_to_storage`]
     /// for the matching format on the sorted side.
     pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
         // Write magic number for hash dictionary
         writer.write_u32(0x48544443)?; // "HTDC"
 
         // Write version
-        writer.write_u32(2)?;
+        writer.write_u32(3)?;
 
         // Write number of terms
         writer.write_varint(self.terms.len() as u64)?;
@@ -336,15 +399,21 @@ impl HashTermDictionary {
             writer.write_u64(info.doc_frequency)?;
             writer.write_u64(info.total_frequency)?;
             writer.write_f32(info.max_score_factor)?;
+            writer.write_varint(info.block_max.len() as u64)?;
+            for block in &info.block_max {
+                writer.write_u64(block.last_doc_id)?;
+                writer.write_f32(block.max_factor)?;
+            }
         }
 
         Ok(())
     }
 
-    /// Read from storage. Accepts both **v1** (legacy) and **v2**
-    /// (#403 PR-B2) layouts; v1 entries fill `max_score_factor` with
-    /// `0.0`, which the BM25 scorer treats as "fall back to the loose
-    /// `k1 + 1` upper bound" so older segments continue to load.
+    /// Read from storage. Accepts **v1** (legacy), **v2** (#403 PR-B2)
+    /// and **v3** (#403 PR-C) layouts. Older entries fill the missing
+    /// fields with their "unset" defaults — `max_score_factor = 0.0`
+    /// and an empty `block_max` — which scorers treat as "fall back
+    /// to the looser bound" so older segments continue to load.
     pub fn read_from_storage<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
         // Read magic number
         let magic = reader.read_u32()?;
@@ -355,7 +424,7 @@ impl HashTermDictionary {
 
         // Read version
         let version = reader.read_u32()?;
-        if version != 1 && version != 2 {
+        if version != 1 && version != 2 && version != 3 {
             return Err(LaurusError::index(format!(
                 "Unsupported hash dictionary version: {version}"
             )));
@@ -378,12 +447,28 @@ impl HashTermDictionary {
             } else {
                 0.0
             };
+            let block_max = if version >= 3 {
+                let block_count = reader.read_varint()? as usize;
+                let mut blocks = Vec::with_capacity(block_count);
+                for _ in 0..block_count {
+                    let last_doc_id = reader.read_u64()?;
+                    let mf = reader.read_f32()?;
+                    blocks.push(BlockMax {
+                        last_doc_id,
+                        max_factor: mf,
+                    });
+                }
+                blocks
+            } else {
+                Vec::new()
+            };
             let info = TermInfo {
                 posting_offset,
                 posting_length,
                 doc_frequency,
                 total_frequency,
                 max_score_factor,
+                block_max,
             };
 
             terms.insert(term, info);
@@ -540,18 +625,19 @@ pub struct DictionaryStats {
 }
 
 impl SortedTermDictionary {
-    /// Write to storage in **v2** layout (#403 PR-B2).
+    /// Write to storage in **v3** layout (#403 PR-C).
     ///
-    /// Each entry now carries an extra `f32 max_score_factor` after the
-    /// four legacy `u64` fields. v1 readers are no longer able to load
-    /// new segments — readers from this codebase accept both versions
-    /// (see [`SortedTermDictionary::read_from_storage`]).
+    /// Each entry carries the v2 `max_score_factor: f32` plus a
+    /// length-prefixed per-block `(last_doc_id: u64, max_factor: f32)`
+    /// array used by Block-Max-WAND. v1/v2 readers are no longer able
+    /// to load new segments; readers from this codebase accept v1, v2
+    /// and v3 (see [`SortedTermDictionary::read_from_storage`]).
     pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
         // Write magic number for sorted dictionary
         writer.write_u32(0x53544443)?; // "STDC"
 
         // Write version
-        writer.write_u32(2)?;
+        writer.write_u32(3)?;
 
         // Write number of terms
         writer.write_varint(self.terms.len() as u64)?;
@@ -566,6 +652,11 @@ impl SortedTermDictionary {
             writer.write_u64(info.doc_frequency)?;
             writer.write_u64(info.total_frequency)?;
             writer.write_f32(info.max_score_factor)?;
+            writer.write_varint(info.block_max.len() as u64)?;
+            for block in &info.block_max {
+                writer.write_u64(block.last_doc_id)?;
+                writer.write_f32(block.max_factor)?;
+            }
         }
 
         Ok(())

--- a/laurus/src/lexical/query/scorer.rs
+++ b/laurus/src/lexical/query/scorer.rs
@@ -1,8 +1,10 @@
 //! Scoring implementations for ranking search results.
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use crate::error::Result;
+use crate::lexical::index::structures::dictionary::BlockMax;
 use crate::lexical::query::Query;
 use crate::lexical::query::matcher::Matcher;
 use crate::util::simd;
@@ -33,17 +35,30 @@ pub trait Scorer: Send + Debug {
     ///
     /// For scorers that do not yet expose per-block max-score metadata,
     /// the default impl forwards to [`Scorer::max_score`], i.e. it
-    /// returns the global upper bound — correct but loose. A future
-    /// per-posting block-max index format (#403 PR-B2) will let scorers
-    /// override this with a tightened bound that varies as the matcher
-    /// advances, enabling Block-Max-WAND skips.
-    ///
-    /// # Returns
-    ///
-    /// An upper bound on any score the scorer can produce for documents
-    /// in the matcher's current block. The returned value is **at most**
-    /// [`Scorer::max_score`] but may be tighter.
+    /// returns the global upper bound — correct but loose.
     fn block_max_score(&self) -> f32 {
+        self.max_score()
+    }
+
+    /// Tightened per-block upper bound on the score for the block
+    /// containing `doc_id` (#403 PR-C, Block-Max-WAND).
+    ///
+    /// Scorers that carry per-block metadata override this to return
+    /// `boost · idf · block_max_factor` for the block whose
+    /// `last_doc_id ≥ doc_id`. The default implementation forwards to
+    /// [`Scorer::max_score`] — correct but loose, identical to what
+    /// PR-B2's term-level bound would return.
+    ///
+    /// Returns `0.0` when `doc_id` is past the last block in the
+    /// posting list (no further docs can match), letting the searcher
+    /// loop short-circuit.
+    ///
+    /// # Arguments
+    ///
+    /// * `doc_id` — current matcher position. The scorer locates the
+    ///   block containing this doc id (binary search over its
+    ///   per-block table) and returns that block's bound.
+    fn block_max_score_at(&self, _doc_id: u64) -> f32 {
         self.max_score()
     }
 
@@ -84,6 +99,21 @@ pub struct BM25Scorer {
     /// when the caller overrides `(k1, b)` via [`Self::with_params`],
     /// since the precomputed factor is only valid for the defaults.
     max_score_factor: f32,
+    /// Per-block (`BLOCK_SIZE = 128`) max-impact metadata used by
+    /// Block-Max-WAND (#403 PR-C). Each entry holds `(last_doc_id,
+    /// max_factor)`; entries are sorted by `last_doc_id`.
+    /// [`Self::block_max_score_at`] binary-searches this slice to
+    /// return a tighter bound than the term-level
+    /// [`Self::max_score_factor`]. Empty when not available — the
+    /// scorer then falls back to the term-level bound.
+    block_max: Arc<[BlockMax]>,
+    /// Right-cumulative max-factor: `right_max[i] = max(block_max[j].max_factor
+    /// for j in i..)`. Pre-computed once at scorer construction so
+    /// [`Self::block_max_score_at`] can return a valid upper bound on the
+    /// score of **every doc at or after** the block containing the query
+    /// doc id — required for the searcher loop's global early-break to
+    /// be correctness-preserving.
+    right_max: Arc<[f32]>,
 }
 
 impl BM25Scorer {
@@ -128,6 +158,8 @@ impl BM25Scorer {
             b: Self::DEFAULT_B,
             cached_idf,
             max_score_factor: 0.0,
+            block_max: Arc::from([] as [BlockMax; 0]),
+            right_max: Arc::from([] as [f32; 0]),
         }
     }
 
@@ -158,6 +190,63 @@ impl BM25Scorer {
             b: Self::DEFAULT_B,
             cached_idf,
             max_score_factor,
+            block_max: Arc::from([] as [BlockMax; 0]),
+            right_max: Arc::from([] as [f32; 0]),
+        }
+    }
+
+    /// Compute the right-cumulative max-factor table from a sorted
+    /// `block_max` slice. `out[i] = max(block_max[j].max_factor for j
+    /// in i..)`. The result is monotonically non-increasing, which is
+    /// what the searcher loop's global early-break requires
+    /// (#403 PR-C): `block_max_score_at(doc_id)` returns a valid
+    /// upper bound on the score of every doc at or after the block
+    /// containing `doc_id`, not just the immediate block.
+    fn compute_right_max(blocks: &[BlockMax]) -> Vec<f32> {
+        let n = blocks.len();
+        let mut out = vec![0.0_f32; n];
+        if n == 0 {
+            return out;
+        }
+        out[n - 1] = blocks[n - 1].max_factor;
+        for i in (0..n - 1).rev() {
+            out[i] = blocks[i].max_factor.max(out[i + 1]);
+        }
+        out
+    }
+
+    /// Create a new BM25 scorer with the per-block max-impact metadata
+    /// (#403 PR-C). `block_max` carries `(last_doc_id, max_factor)`
+    /// entries sorted by `last_doc_id`; pass an empty slice to fall
+    /// back to the term-level [`Self::max_score_factor`] (which itself
+    /// falls back to `k1 + 1` when zero).
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_block_max(
+        doc_freq: u64,
+        total_term_freq: u64,
+        field_doc_count: u64,
+        avg_field_length: f64,
+        total_docs: u64,
+        boost: f32,
+        max_score_factor: f32,
+        block_max: Arc<[BlockMax]>,
+    ) -> Self {
+        let cached_idf = Self::compute_idf(doc_freq, total_docs);
+        let right_max: Arc<[f32]> =
+            Arc::from(Self::compute_right_max(&block_max).into_boxed_slice());
+        BM25Scorer {
+            doc_freq,
+            total_term_freq,
+            field_doc_count,
+            avg_field_length,
+            total_docs,
+            boost,
+            k1: Self::DEFAULT_K1,
+            b: Self::DEFAULT_B,
+            cached_idf,
+            max_score_factor,
+            block_max,
+            right_max,
         }
     }
 
@@ -188,6 +277,8 @@ impl BM25Scorer {
             b,
             cached_idf,
             max_score_factor: 0.0,
+            block_max: Arc::from([] as [BlockMax; 0]),
+            right_max: Arc::from([] as [f32; 0]),
         }
     }
 
@@ -287,12 +378,44 @@ impl Scorer for BM25Scorer {
     }
 
     fn block_max_score(&self) -> f32 {
-        // Today we do not yet store per-block bounds — return the
-        // tightest term-level upper bound, which is the same value
-        // [`Self::max_score`] returns. A future per-posting block-max
-        // index format (#403 PR-C) will let this method override with
-        // a bound that varies as the matcher advances.
+        // Without a doc id we cannot pick a specific block; report the
+        // term-level bound (same as `max_score()`). Use
+        // [`Self::block_max_score_at`] for the per-block bound.
         self.max_score()
+    }
+
+    fn block_max_score_at(&self, doc_id: u64) -> f32 {
+        // No per-block metadata → fall back to the term-level bound.
+        if self.block_max.is_empty() {
+            return self.max_score();
+        }
+        if self.doc_freq == 0 || self.total_docs == 0 {
+            return 0.0;
+        }
+        // Skip the per-block bound when the caller is using non-default
+        // BM25 parameters — the precomputed factor is only valid for
+        // `(k1, b) = (1.2, 0.75)`.
+        if self.k1 != Self::DEFAULT_K1 || self.b != Self::DEFAULT_B {
+            return self.max_score();
+        }
+
+        // Binary search for the first block whose `last_doc_id >= doc_id`.
+        let idx = self
+            .block_max
+            .partition_point(|block| block.last_doc_id < doc_id);
+        if idx >= self.block_max.len() {
+            // Past the last block — no remaining doc in this term's
+            // posting list can contribute.
+            return 0.0;
+        }
+        // Use the right-cumulative max so the returned bound holds for
+        // every doc at or after the block containing `doc_id`. The
+        // searcher loop's `if bound <= min_competitive { break }`
+        // would be unsound with the per-block factor alone — a later
+        // block could carry a higher factor and yield a higher-scoring
+        // doc.
+        let factor = self.right_max[idx];
+        self.boost * self.idf() * factor
     }
 
     fn name(&self) -> &'static str {
@@ -499,6 +622,21 @@ impl Scorer for BooleanScorer {
             total_max += scorer.max_score();
         }
         total_max * self.boost
+    }
+
+    fn block_max_score_at(&self, doc_id: u64) -> f32 {
+        // For an OR-style boolean any sub-clause might contribute, so
+        // the upper bound at `doc_id` is the sum of each sub-scorer's
+        // per-block bound at the same doc id (#403 PR-C). Because
+        // each sub-scorer's bound is itself ≤ its own `max_score()`,
+        // the sum is also ≤ `BooleanScorer::max_score()` and therefore
+        // a tighter, valid upper bound.
+        let mut total = 0.0_f32;
+        let clauses = self.clauses.borrow();
+        for (scorer, _) in clauses.iter() {
+            total += scorer.block_max_score_at(doc_id);
+        }
+        total * self.boost
     }
 
     fn name(&self) -> &'static str {

--- a/laurus/src/lexical/query/term.rs
+++ b/laurus/src/lexical/query/term.rs
@@ -69,6 +69,8 @@ impl Query for TermQuery {
     }
 
     fn scorer(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Scorer>> {
+        use std::sync::Arc;
+
         // Get term information for BM25 scoring
         let term_info = reader.term_info(&self.field, &self.term)?;
         let field_stats = reader.field_stats(&self.field)?;
@@ -76,12 +78,13 @@ impl Query for TermQuery {
         match (term_info, field_stats) {
             (Some(term_info), Some(field_stats)) => {
                 // Wire the index-side tightened TF-component upper
-                // bound (#403 PR-B2). `max_score_factor == 0.0` is
-                // treated by the scorer as "fall back to the loose
-                // `k1 + 1` bound" — handles legacy v1 dictionaries
-                // and aggregated cross-segment views where the factor
-                // is not available.
-                let scorer = BM25Scorer::with_max_score_factor(
+                // bound (#403 PR-B2) and the per-block max-impact
+                // metadata (#403 PR-C). Empty `block_max` and
+                // `max_score_factor == 0.0` cause the scorer to fall
+                // back to looser bounds, so legacy v1/v2 dictionaries
+                // and aggregated cross-segment views remain valid.
+                let block_max: Arc<[_]> = Arc::from(term_info.block_max.into_boxed_slice());
+                let scorer = BM25Scorer::with_block_max(
                     term_info.doc_freq,
                     term_info.total_freq,
                     field_stats.doc_count,
@@ -89,6 +92,7 @@ impl Query for TermQuery {
                     reader.doc_count(),
                     self.boost,
                     term_info.max_score_factor,
+                    block_max,
                 );
                 Ok(Box::new(scorer))
             }

--- a/laurus/src/lexical/reader.rs
+++ b/laurus/src/lexical/reader.rs
@@ -4,6 +4,7 @@ use crate::error::Result;
 use crate::lexical::core::document::Document;
 use crate::lexical::core::field::FieldValue;
 use crate::lexical::index::structures::bkd_tree::BKDTree;
+use crate::lexical::index::structures::dictionary::BlockMax;
 use std::sync::Arc;
 
 /// Information about a term in the index.
@@ -41,6 +42,12 @@ pub struct ReaderTermInfo {
     /// cross-segment views): scorers fall back to the loose
     /// `k1 + 1` synthetic bound in that case.
     pub max_score_factor: f32,
+
+    /// Per-block (`BLOCK_SIZE = 128`-wide) max-impact metadata used by
+    /// Block-Max-WAND (#403 PR-C). Empty if not available (legacy v2
+    /// dictionaries or aggregated cross-segment views) — scorers
+    /// then fall back to the term-level [`Self::max_score_factor`].
+    pub block_max: Vec<BlockMax>,
 }
 
 /// Statistics about a field in the index.


### PR DESCRIPTION
## Summary

Refs #403, #416, #459. Phase 1 of the Block-Max-WAND effort.

Adds the per-posting block-max metadata that #403 PR-B1's searcher-loop early-break has been waiting on, plus the right-cumulative bound that lets the break stay correctness-preserving. Lucene 9 / Tantivy use the same 128-doc block boundary and the same per-block max-impact concept.

### What lands

1. **Index format bump: TermDictionary v2 → v3**. Each `TermInfo` gains a length-prefixed `Vec<BlockMax>`, where `BlockMax = { last_doc_id: u64, max_factor: f32 }`. v1/v2 segments still load — they decode with an empty `block_max` and degrade gracefully to the term-level bound.

2. **Indexer flush** walks each posting list in `BLOCK_SIZE = 128`-wide chunks and records `(last_doc_id, max_factor)` per block. The factor uses the default BM25 parameters (`k1 = 1.2`, `b = 0.75`) and the segment's average field length — same formula as PR-B2's term-level factor, scoped to the block.

3. **`Scorer::block_max_score_at(doc_id) -> f32`** trait method (default forwards to `max_score()`).
   - `BM25Scorer` overrides it using a precomputed **right-cumulative** max array (`right_max[i] = max(block_max[j].max_factor for j in i..)`) so the returned bound is valid for **every doc at or after** the block containing `doc_id`.
   - `BooleanScorer` overrides it as the sum of sub-scorer bounds at the same doc id.

4. **Searcher loop** reads `scorer.block_max_score_at(matcher.doc_id())` instead of the loose term-level `max_score()` it cached once outside the loop. The break stays correctness-preserving because the right-cumulative bound dominates every later block.

### The right-cumulative max is the key correctness fix

An earlier draft returned the per-block bound directly. That is **unsound** for a global `break` from the search loop: a later block carrying a higher factor could let a future doc score above `min_competitive`, and we would have prematurely terminated the walk. Right-cumulative max fixes this — the bound is monotonically non-increasing in `doc_id`, so once it falls below `min_competitive` it stays there for the rest of the iteration.

### Bench (`lexical_search_bench`, vs `pre-403-C` baseline)

Skewed-TF fixture from #462 (every 10th doc carries `COMMON_TERMS` 16×):

| Bench | pre-403-C | post | Δ |
| --- | --- | --- | --- |
| ``topk_or_skewed_tf/should_or_topk10/10000`` | 12.10 ms | 12.00 ms | **−0.7 %** (neutral) |
| ``topk_or_skewed_tf/should_or_topk10/100000`` | 132 ms | 116 ms | **−14.4 %** |

The 100k case clearly beats `pre-403-C` for the first time in the #403 series — the regression PR-B1 introduced (correctness fix without a tight bound) is now overcome by an algorithm-level gain. The 10k case is bench-noise neutral.

### Why not 5x yet

The audit's `5x@100k` target needs the matcher to **skip blocks**, not just check a bound per iteration. Today the searcher walks every doc; the bound check just terminates the walk early once the right-cumulative max falls below the K-th score. To reach 5x we need full Block-Max-WAND with pivot-term skipping driving `matcher.skip_to(next_non_pruned_block_start)`. That is PR-D's scope — it builds entirely on the data plumbing and trait surface this PR adds.

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench lexical_search_bench -- "topk_or_skewed_tf" --save-baseline pre-403-C
git checkout perf/wand-block-max-impl
cargo bench -p laurus --bench lexical_search_bench -- "topk_or_skewed_tf" --baseline pre-403-C
```

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus --lib` (820 / 820 pass)
- [x] Skewed-TF bench (1k / 10k / 100k) runs to completion at all three sizes

## Format compatibility

| Reader | v1 segments | v2 segments | v3 segments |
| --- | --- | --- | --- |
| pre-#458 (main before PR-A) | ✅ | ❌ | ❌ |
| #461 (PR-B2) | ✅ | ✅ | ❌ |
| **this PR** | ✅ | ✅ | ✅ |

Newly written segments use v3 unconditionally. Rolling back to a binary that predates this PR fails to load v3 with `Unsupported sorted/hash dictionary version: 3`.

## Out of scope

- **PR-D** — full Block-Max-WAND: pivot-term selection + `matcher.skip_to(next_block_start)` to skip pruned blocks instead of walking each doc. Closes the remaining gap to the audit's `5x@100k` acceptance target.
- **#463 / #464 / #465 / #466** — the constant-factor catch-up with Lucene/Tantivy (PFOR-delta, SIMD decode, concrete-type dispatch). Layered on top of the algorithm work in PR-D.