### PR TITLE
perf(lexical/bm25): single-segment per-block bound passthrough (#403 PR-D, partial)

### DIFF
--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -1419,9 +1419,8 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
         let mut total_term_freq = 0;
         let mut max_score_factor: f32 = 0.0;
         let mut matched_count = 0_usize;
-        let mut combined_block_max: Vec<
-            crate::lexical::index::structures::dictionary::BlockMax,
-        > = Vec::new();
+        let mut combined_block_max: Vec<crate::lexical::index::structures::dictionary::BlockMax> =
+            Vec::new();
 
         for segment_reader in &self.segment_readers {
             let reader = segment_reader.read().unwrap();

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -1391,16 +1391,37 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
             }));
         }
 
-        // Search across all segments
+        // Search across all segments. Aggregate by taking the **max**
+        // of per-segment factors — each segment computed
+        // `max_score_factor` against its own `avg_field_length`, but
+        // `max(seg_max)` remains a valid upper bound on any
+        // individual posting's TF-component contribution (#403 PR-B2).
+        //
+        // Block-max metadata is concatenated across segments
+        // (#403 PR-D). The inverted writer assigns segments
+        // monotonically-increasing doc-id ranges, so segment-order
+        // concatenation preserves the `last_doc_id` ordering that
+        // [`BM25Scorer::block_max_score_at`]'s binary search relies
+        // on.
+        //
+        // Per-block `max_factor` was computed against each segment's
+        // local `avg_field_length`. The cross-segment BM25 scorer
+        // uses the global average; the per-block factor is therefore
+        // approximate. For corpora whose segments have similar
+        // average field lengths (the common case — segments are
+        // sized in docs, not field-length bytes) the divergence is
+        // small and the factor remains a usable bound. For corpora
+        // with widely-varying segment averages a future PR will need
+        // to either re-index or store enough per-block raw data
+        // (max-tf + min-field-length) to re-anchor the factor at
+        // query time.
         let mut total_doc_freq = 0;
         let mut total_term_freq = 0;
-        // Aggregate across segments by taking the **max** of per-segment
-        // factors — each segment computed it against its own
-        // `avg_field_length`, but `max(seg_max)` is still a valid upper
-        // bound on any individual posting's TF-component contribution
-        // (#403 PR-B2).
         let mut max_score_factor: f32 = 0.0;
-        let mut found = false;
+        let mut matched_count = 0_usize;
+        let mut combined_block_max: Vec<
+            crate::lexical::index::structures::dictionary::BlockMax,
+        > = Vec::new();
 
         for segment_reader in &self.segment_readers {
             let reader = segment_reader.read().unwrap();
@@ -1408,9 +1429,35 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
                 total_doc_freq += term_info.doc_frequency;
                 total_term_freq += term_info.total_frequency;
                 max_score_factor = max_score_factor.max(term_info.max_score_factor);
-                found = true;
+                matched_count += 1;
+                combined_block_max.extend(term_info.block_max.iter().copied());
             }
         }
+
+        let found = matched_count > 0;
+        // Pass per-block metadata through for the single-segment case
+        // only. With more than one matching segment, two costs offset
+        // the bound's tightness:
+        //
+        // 1. The binary search inside `BM25Scorer::block_max_score_at`
+        //    walks `O(log Σ blocks)` instead of `O(log blocks_in_one_segment)`,
+        //    and on uniform corpora the per-block factor degenerates
+        //    to the term-level `max_score_factor` anyway — leaving
+        //    only the search overhead.
+        // 2. Per-block factors were computed against per-segment
+        //    `avg_field_length`. For corpora whose segments diverge
+        //    in average length, the segment-local factor can drop
+        //    below the cross-segment-anchored BM25 contribution and
+        //    the searcher's break would fire too early.
+        //
+        // Falling back to the term-level `max_score_factor` in the
+        // multi-segment case sidesteps both issues. Cross-segment
+        // block-max passthrough is tracked as a follow-up.
+        let aggregated_block_max = if matched_count == 1 {
+            combined_block_max
+        } else {
+            Vec::new()
+        };
 
         if found {
             let reader_info = crate::lexical::reader::ReaderTermInfo {
@@ -1421,12 +1468,7 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
                 posting_offset: 0, // Aggregated value, not meaningful for multi-segment
                 posting_size: 0,   // Aggregated value, not meaningful for multi-segment
                 max_score_factor,
-                // Aggregated cross-segment view does not carry per-block
-                // metadata: each segment's blocks are anchored to its own
-                // local `avg_field_length`, and concatenating them across
-                // segments would require re-indexing. Scorers fall back
-                // to the term-level `max_score_factor`.
-                block_max: Vec::new(),
+                block_max: aggregated_block_max.clone(),
             };
 
             let term_info = TermInfo {
@@ -1435,12 +1477,7 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
                 doc_frequency: total_doc_freq,
                 total_frequency: total_term_freq,
                 max_score_factor,
-                // Aggregated cross-segment view does not carry per-block
-                // metadata: each segment's blocks are anchored to its own
-                // local `avg_field_length`, and concatenating them across
-                // segments would require re-indexing. Scorers fall back
-                // to the term-level `max_score_factor`.
-                block_max: Vec::new(),
+                block_max: aggregated_block_max,
             };
             self.cache_manager.cache_term_info(cache_key, term_info);
 


### PR DESCRIPTION
## Summary

Refs #403, #416. Phase 2 of the Block-Max-WAND effort, **partial**.

This PR plumbs the per-block max-impact metadata that PR-C added to the index through to the single-segment query path. PR-C unconditionally returned an empty `block_max` from the cross-segment aggregation in the inverted reader, so even segments that carried the full v3 metadata never exercised `BM25Scorer::block_max_score_at`'s tight bound.

### What lands

- `InvertedIndexReader::term_info` now passes the segment's `block_max` through unchanged when **exactly one** segment matches the term.
- The cross-segment branch continues to return empty (term-level fallback) — see the design notes below for why.

### Why multi-segment is left at term-level fallback

1. **Bound anchoring**. Per-block factors were computed at index time against each segment's local `avg_field_length`. Cross-segment scoring uses the global average; if a segment's local average is below the global average the segment-local factor under-bounds the true BM25 contribution, and the searcher loop's break would fire prematurely.
2. **Overhead vs payoff**. On uniform-TF block layouts (every block is 'mixed' between heavy hitters and normals) the per-block factor degenerates to the term-level bound. The binary-search inside `block_max_score_at` is then pure overhead. Falling back to the term-level bound on multi-segment views avoids paying that cost.

A follow-up issue tracks the proper fix: store `(max_tf, min_field_length)` per block so the BM25 scorer can re-anchor the factor at query time using the global average. That would make multi-segment passthrough sound.

### Bench (`lexical_search_bench`, vs `pre-403-C` baseline)

| Bench | Δ time |
| --- | --- |
| ``topk_or_skewed_tf/should_or_topk10/1000`` | **−5.8 %** |
| ``topk_or_skewed_tf/should_or_topk10/10000`` | +4.2 %  (per-iter overhead on uniform blocks) |
| ``topk_or_skewed_tf/should_or_topk10/100000`` | **−12.6 %**  (term-level fallback for multi-segment) |

### What's missing relative to the audit's `5x` acceptance

The audit's `5x@100k` target requires the matcher to **skip past entire blocks** whose bound is already non-competitive instead of walking each doc with a per-iter check. That needs:

- A `Matcher::skip_to_block(...)` API extension so the searcher can advance past `last_doc_id + 1` of the current block in O(log N) rather than O(block-size) `next()` calls.
- A Block-Max-WAND **pivot loop** in `BooleanScorer` that picks the cheapest matcher to advance and drives the others via `skip_to`.
- Multi-segment block-max safe aggregation (per the bound-anchoring discussion above).

These are substantial — Block-Max-WAND in Lucene/Tantivy is roughly a multi-week effort by itself. They are tracked as follow-up items in the #403 umbrella.

Reproduce:

```sh
git checkout main
cargo bench -p laurus --bench lexical_search_bench -- "topk_or_skewed_tf" --save-baseline pre-403-C
git checkout perf/wand-pivot-skipping
cargo bench -p laurus --bench lexical_search_bench -- "topk_or_skewed_tf" --baseline pre-403-C
```

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus --lib` (820 / 820 pass)

## Out of scope (next up)

- **Matcher block-skip API + BMW pivot loop** in `BooleanScorer` — closes the remaining gap to the `5x@100k` audit target.
- **Multi-segment block-max safe aggregation** — store `(max_tf, min_field_length)` per block, re-anchor the factor at query time.
- **Constant-factor catch-up with Lucene/Tantivy** (#463, #464, #465, #466) — PFOR-delta posting compression, SIMD batch decode, concrete-type dispatch in BooleanScorer.