### PR TITLE
perf(lexical/store): per-field document fetch via document_fields trait method (#410)

### DIFF
--- a/laurus/benches/store_fetch_bench.rs
+++ b/laurus/benches/store_fetch_bench.rs
@@ -123,6 +123,28 @@ impl LexicalIndexReader for MockStoreReader {
         Ok(self.documents.get(doc_id as usize).cloned())
     }
 
+    /// Override the default trait impl so the bench measures the
+    /// real-reader behaviour: only the requested fields are cloned out
+    /// of the cached `Document`, not the whole map (#410). Without
+    /// this override the default falls through to `document()` and
+    /// post-filters, defeating the comparison.
+    fn document_fields(
+        &self,
+        doc_id: u64,
+        field_names: &[&str],
+    ) -> LaurusResult<Option<HashMap<String, DataValue>>> {
+        if let Some(doc) = self.documents.get(doc_id as usize) {
+            let mut out = HashMap::with_capacity(field_names.len());
+            for &name in field_names {
+                if let Some(value) = doc.fields.get(name) {
+                    out.insert(name.to_string(), value.clone());
+                }
+            }
+            return Ok(Some(out));
+        }
+        Ok(None)
+    }
+
     fn term_info(&self, _field: &str, _term: &str) -> LaurusResult<Option<ReaderTermInfo>> {
         Ok(None)
     }
@@ -171,6 +193,24 @@ fn fetch_and_filter(
             if selected.contains(name.as_str()) {
                 out.insert(name.clone(), data_value_to_string(value));
             }
+        }
+    }
+    out
+}
+
+/// `fetch_and_filter`'s subset-aware counterpart (#410). Calls
+/// [`LexicalIndexReader::document_fields`] so the reader clones only
+/// the requested field values out of the cached `Document`. Returns
+/// the same shape as `fetch_and_filter` for direct comparison.
+fn fetch_subset(
+    reader: &dyn LexicalIndexReader,
+    doc_id: u64,
+    selected: &[&str],
+) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    if let Ok(Some(fields)) = reader.document_fields(doc_id, selected) {
+        for (name, value) in fields {
+            out.insert(name, data_value_to_string(&value));
         }
     }
     out
@@ -339,9 +379,74 @@ fn bench_field_size_variance(c: &mut Criterion) {
     group.finish();
 }
 
+/// Side-by-side comparison of `fetch_and_filter` (full document clone +
+/// post-filter) and `fetch_subset` (per-field clone via
+/// [`LexicalIndexReader::document_fields`]) at the wide-schema +
+/// narrow-selection workload that #410 targets. Two bench cases per
+/// `n_selected` value so the criterion id makes the comparison
+/// obvious from the output.
+fn bench_wide_narrow_subset(c: &mut Criterion) {
+    let mut group = c.benchmark_group("store_fetch/wide_narrow_subset");
+
+    const N_FIELDS: usize = 50;
+    const VALUE_BYTES: usize = 50;
+
+    let reader = MockStoreReader::new(build_documents(N_DOCS, N_FIELDS, VALUE_BYTES));
+    let all_field_names: Vec<String> = (0..N_FIELDS).map(|f| format!("field_{f}")).collect();
+
+    for &n_selected in &[1usize, 5, 50] {
+        let selected_owned: Vec<&str> = all_field_names
+            .iter()
+            .take(n_selected)
+            .map(String::as_str)
+            .collect();
+        let selected_set: HashSet<&str> = selected_owned.iter().copied().collect();
+
+        // Full-doc-clone + filter (pre-#410 path).
+        group.throughput(Throughput::Elements(TOP_K));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("full_clone/selected_{n_selected}")),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    for doc_id in 0..TOP_K {
+                        let result = fetch_and_filter(
+                            black_box(&reader),
+                            black_box(doc_id),
+                            black_box(&selected_set),
+                        );
+                        black_box(result);
+                    }
+                });
+            },
+        );
+
+        // Per-field clone via `document_fields` (#410 path).
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("subset/selected_{n_selected}")),
+            &(),
+            |b, _| {
+                b.iter(|| {
+                    for doc_id in 0..TOP_K {
+                        let result = fetch_subset(
+                            black_box(&reader),
+                            black_box(doc_id),
+                            black_box(&selected_owned),
+                        );
+                        black_box(result);
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_wide_narrow,
+    bench_wide_narrow_subset,
     bench_narrow_baseline,
     bench_field_size_variance,
 );

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -793,6 +793,43 @@ impl SegmentReader {
         }
     }
 
+    /// Fetch a subset of a document's stored fields without cloning
+    /// the rest of the [`Document`] map (#410).
+    ///
+    /// Wide-schema search requests typically retrieve only a handful
+    /// of stored fields; the default
+    /// [`document()`](Self::document) path clones every field's
+    /// `DataValue` — including byte arrays / vector payloads — before
+    /// the caller filters them. This method clones only the requested
+    /// fields out of the cached in-memory map.
+    pub fn document_fields(
+        &self,
+        doc_id: u64,
+        field_names: &[&str],
+    ) -> Result<Option<std::collections::HashMap<String, crate::data::DataValue>>> {
+        if !self.loaded.load(Ordering::Acquire) {
+            self.load_stored_documents()?;
+        }
+
+        if self.is_deleted(doc_id)? {
+            return Ok(None);
+        }
+
+        let docs = self.stored_documents.read().unwrap();
+        if let Some(ref documents) = *docs
+            && let Some(doc) = documents.get(&doc_id)
+        {
+            let mut out = std::collections::HashMap::with_capacity(field_names.len());
+            for &name in field_names {
+                if let Some(value) = doc.fields.get(name) {
+                    out.insert(name.to_string(), value.clone());
+                }
+            }
+            return Ok(Some(out));
+        }
+        Ok(None)
+    }
+
     /// Get term information for a field and term.
     pub fn term_info(&self, field: &str, term: &str) -> Result<Option<TermInfo>> {
         // Lazy load term dictionary if not loaded
@@ -1351,6 +1388,27 @@ impl crate::lexical::reader::LexicalIndexReader for InvertedIndexReader {
             let reader = segment_reader.read().unwrap();
             if let Ok(Some(doc)) = reader.document(doc_id) {
                 return Ok(Some(doc));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn document_fields(
+        &self,
+        doc_id: u64,
+        field_names: &[&str],
+    ) -> Result<Option<std::collections::HashMap<String, crate::data::DataValue>>> {
+        self.check_closed()?;
+
+        // Search across all segments — first hit wins, matching
+        // `document()`'s behaviour. The per-segment override clones
+        // only the requested fields, so wide schemas avoid the
+        // whole-document clone (#410).
+        for segment_reader in &self.segment_readers {
+            let reader = segment_reader.read().unwrap();
+            if let Ok(Some(fields)) = reader.document_fields(doc_id, field_names) {
+                return Ok(Some(fields));
             }
         }
 

--- a/laurus/src/lexical/reader.rs
+++ b/laurus/src/lexical/reader.rs
@@ -119,6 +119,49 @@ pub trait LexicalIndexReader: Send + Sync + std::fmt::Debug {
     /// `Ok(None)` if the document ID is not found or has no stored fields.
     fn document(&self, doc_id: u64) -> Result<Option<Document>>;
 
+    /// Fetch a **subset** of a document's stored fields by name (#410).
+    ///
+    /// For wide schemas where a search request only retrieves a few of
+    /// many stored fields, the default `document()` path clones the
+    /// entire `HashMap<String, DataValue>` (including bytes / vector
+    /// payloads of every other field) before the result-processor
+    /// drops the unrequested ones. This method returns only the
+    /// requested fields, so callers avoid that wasted clone.
+    ///
+    /// The default implementation forwards to `document()` and filters
+    /// — concrete readers should override it with a path that clones
+    /// each requested field individually out of the on-disk / cached
+    /// document map.
+    ///
+    /// # Arguments
+    ///
+    /// * `doc_id` - Document id to fetch.
+    /// * `field_names` - Field names to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(None)` if the document does not exist; `Ok(Some(map))`
+    /// where `map` contains only the requested fields that actually
+    /// exist on the document.
+    fn document_fields(
+        &self,
+        doc_id: u64,
+        field_names: &[&str],
+    ) -> Result<Option<std::collections::HashMap<String, crate::data::DataValue>>> {
+        match self.document(doc_id)? {
+            Some(doc) => {
+                let mut out = std::collections::HashMap::with_capacity(field_names.len());
+                for name in field_names {
+                    if let Some(value) = doc.fields.get(*name) {
+                        out.insert((*name).to_string(), value.clone());
+                    }
+                }
+                Ok(Some(out))
+            }
+            None => Ok(None),
+        }
+    }
+
     /// Get term information for a specific field and term.
     ///
     /// Returns a [`ReaderTermInfo`] containing the document frequency, total

--- a/laurus/src/lexical/search/result_processor.rs
+++ b/laurus/src/lexical/search/result_processor.rs
@@ -381,12 +381,31 @@ impl ResultProcessor {
     fn retrieve_document_fields(&self, doc_id: u64) -> Result<HashMap<String, String>> {
         let mut fields = HashMap::new();
 
-        if let Some(document) = self.reader.document(doc_id)? {
-            for (field_name, data_value) in &document.fields {
-                // Check if field should be retrieved
-                if self.should_retrieve_field(field_name) {
-                    let value_str = self.field_value_to_string(data_value);
-                    fields.insert(field_name.clone(), value_str);
+        // Wildcard or empty selection still wants the whole document;
+        // narrow selections route through `document_fields` so the
+        // reader clones only the requested fields (#410).
+        let wildcard = self.config.fields_to_retrieve.iter().any(|f| f == "*");
+
+        if wildcard || self.config.fields_to_retrieve.is_empty() {
+            if let Some(document) = self.reader.document(doc_id)? {
+                for (field_name, data_value) in &document.fields {
+                    if self.should_retrieve_field(field_name) {
+                        let value_str = self.field_value_to_string(data_value);
+                        fields.insert(field_name.clone(), value_str);
+                    }
+                }
+            }
+        } else {
+            let names: Vec<&str> = self
+                .config
+                .fields_to_retrieve
+                .iter()
+                .map(String::as_str)
+                .collect();
+            if let Some(subset) = self.reader.document_fields(doc_id, &names)? {
+                for (field_name, data_value) in subset {
+                    let value_str = self.field_value_to_string(&data_value);
+                    fields.insert(field_name, value_str);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes #410. Refs #416.

`result_processor::retrieve_document_fields` calls `reader.document(doc_id)`, which clones the **entire** `Document` (every field's `DataValue`, including any bytes / vector payloads of unrequested fields), and then post-filters the field list down to whatever the search request actually asked for. On wide schemas with sparse field selection this is significant waste — a 50-field document with only 5 fields requested clones 45 fields' worth of `DataValue`s for nothing.

This PR adds a per-field fetch path that clones only the requested values.

### What lands

1. **`LexicalIndexReader::document_fields(doc_id, &[&str])`** trait method. Default impl forwards to `document()` and filters; concrete readers override it with a path that clones each requested value individually out of the cached doc map.
2. **`InvertedIndexReader`** (multi-segment view) and **per-segment reader** override the new method.
3. **`result_processor::retrieve_document_fields`** routes narrow selections through `document_fields`; wildcard (`*`) / empty selection still uses the full-document path so behaviour is preserved for callers that ask for everything.

### Bench (`store_fetch_bench`, 50-field docs, top-K=10 fetches per iter)

| Selected | Full-clone path | `document_fields` path | speed-up |
| --- | --- | --- | --- |
| 1 | 37.7 µs | **1.42 µs** | **26.5×** |
| 5 | 50.0 µs | **6.10 µs** | **8.2×** |
| 50 | 103 µs | 89.0 µs | 1.16× |

The audit's ≥ 1.5× acceptance bar is met by a wide margin at narrow selection. Even the `selected_50` (every field requested) case sees a mild improvement because the new path skips the post-filter loop and the field-name comparison.

The bench's `MockStoreReader` overrides `document_fields` directly so the comparison reflects the real `InvertedIndexReader` behaviour. Without that override the default trait impl falls through to `document()` and the comparison degenerates to noise — see the new `bench_wide_narrow_subset` for the side-by-side measurement.

Reproduce:

```sh
cargo bench -p laurus --bench store_fetch_bench -- "wide_narrow_subset"
```

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo clippy -p laurus --benches -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p laurus --lib` (823 / 823 pass)

## Out of scope

- True on-disk skip-decode (deserialise only the requested field bytes from `.docs`). Today `InvertedIndexReader` lazy-loads the whole stored-documents map at first hit; the `document_fields` override clones from the cached map. Pushing the field selection down to the on-disk decoder is tracked as a follow-up; the trait surface this PR adds is the right hand-off.