### PR TITLE
perf(lexical/searcher): per-segment fanout for multi-segment top-K (#476 Phase 1)

### DIFF
--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -35,6 +35,7 @@ use crate::storage::file::{FileStorage, FileStorageConfig};
 pub(crate) mod bmw;
 pub mod core;
 pub mod maintenance;
+pub(crate) mod per_segment_view;
 pub mod reader;
 pub mod searcher;
 pub mod segment;

--- a/laurus/src/lexical/index/inverted/per_segment_view.rs
+++ b/laurus/src/lexical/index/inverted/per_segment_view.rs
@@ -1,0 +1,197 @@
+//! Per-segment view of an [`InvertedIndexReader`] for the per-segment
+//! fanout search path (#476 Phase 1).
+//!
+//! [`PerSegmentReaderView`] adapts a [`SegmentReader`] reference into
+//! a [`LexicalIndexReader`] implementation. It forwards posting / field
+//! / document access to the underlying segment, but **injects
+//! cross-segment-aggregated** `doc_count`, `max_doc`, and `term_info`
+//! `doc_freq` / `total_freq` so the BM25 scorer's IDF reflects the
+//! global term rarity rather than the segment-local one.
+//!
+//! ## Cross-segment scoring semantics
+//!
+//! | Field | Source | Reason |
+//! | ----- | ------ | ------ |
+//! | `doc_freq`, `total_freq` (IDF) | global cross-segment aggregate | consistent term-rarity ranking across segments |
+//! | `total_docs` (IDF) | global | same |
+//! | `avg_field_length` (BM25 TF normaliser) | per-segment | matches the avg the segment's `block_max` factors were anchored against |
+//! | `block_max` table | per-segment | computed at write time against the segment's avg, valid as a per-segment scoring bound |
+//!
+//! Per-segment scoring with cross-segment IDF mirrors how Lucene /
+//! Elasticsearch score across shards. Same-doc-id micro-score
+//! divergence between segments is accepted: top-K ranking from each
+//! segment, then merge.
+//!
+//! ## Why this matters for #476
+//!
+//! `InvertedIndexReader::term_info`'s cross-segment aggregation
+//! returns an empty `block_max` `Vec` when more than one segment
+//! matches (PR-D's safety fallback against under-bounded
+//! `block_max_score_at`). With this view the per-segment block_max
+//! flows through unchanged because the BM25 scorer is built with
+//! per-segment avg, restoring PR-F's BMW pivot loop on each segment.
+
+use std::any::Any;
+use std::sync::{Arc, RwLock};
+
+use crate::error::Result;
+use crate::lexical::core::document::Document;
+use crate::lexical::index::inverted::reader::SegmentReader;
+use crate::lexical::reader::{FieldStats, LexicalIndexReader, PostingIterator, ReaderTermInfo};
+
+/// Cross-segment term-info lookup function. Returns the **global**
+/// `doc_freq` and `total_freq` for a `(field, term)` pair so per-segment
+/// BM25 scorers see the same IDF every segment uses. Returning `None`
+/// signals that no segment has the term — the per-segment view will
+/// then also report `None` from its `term_info`.
+type GlobalTermInfoFn = dyn Fn(&str, &str) -> Result<Option<ReaderTermInfo>> + Send + Sync;
+
+/// Adapter that exposes a single [`SegmentReader`] as a
+/// [`LexicalIndexReader`] backed by per-segment posting / field data
+/// and cross-segment-global IDF inputs.
+///
+/// Owns the segment via `Arc<RwLock<SegmentReader>>` and acquires a
+/// read lock per method call. This keeps the type `'static` so it
+/// can satisfy `LexicalIndexReader`'s `as_any` requirement, and the
+/// per-method lock acquisition is not a measurable cost in the
+/// fanout path because each rayon worker owns a distinct segment.
+pub(crate) struct PerSegmentReaderView {
+    segment: Arc<RwLock<SegmentReader>>,
+    global_doc_count: u64,
+    global_max_doc: u64,
+    global_term_info_fn: Arc<GlobalTermInfoFn>,
+}
+
+impl PerSegmentReaderView {
+    /// Create a view over `segment` that reports the supplied global
+    /// `doc_count` / `max_doc` and looks up cross-segment term-info via
+    /// `global_term_info_fn`.
+    pub fn new(
+        segment: Arc<RwLock<SegmentReader>>,
+        global_doc_count: u64,
+        global_max_doc: u64,
+        global_term_info_fn: Arc<GlobalTermInfoFn>,
+    ) -> Self {
+        PerSegmentReaderView {
+            segment,
+            global_doc_count,
+            global_max_doc,
+            global_term_info_fn,
+        }
+    }
+
+    /// Per-segment field length for `(doc_id, field)`. Mirrors
+    /// `InvertedIndexReader::field_length` so the searcher can pull
+    /// accurate per-doc lengths through the view (otherwise BM25 would
+    /// fall back to the segment's avg field length and lose precision
+    /// on long / short docs).
+    pub fn field_length(&self, doc_id: u64, field: &str) -> Result<Option<u32>> {
+        let seg = self.segment.read().unwrap();
+        seg.field_length(doc_id, field)
+    }
+}
+
+impl std::fmt::Debug for PerSegmentReaderView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PerSegmentReaderView")
+            .field("global_doc_count", &self.global_doc_count)
+            .field("global_max_doc", &self.global_max_doc)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LexicalIndexReader for PerSegmentReaderView {
+    fn doc_count(&self) -> u64 {
+        // Global cross-segment count so IDF sees the right
+        // `total_docs`.
+        self.global_doc_count
+    }
+
+    fn max_doc(&self) -> u64 {
+        self.global_max_doc
+    }
+
+    fn is_deleted(&self, doc_id: u64) -> bool {
+        // SegmentReader::is_deleted returns Result<bool>; on error or
+        // when the bitmap is not loadable we conservatively report
+        // `false` (the doc proceeds through scoring) — matching the
+        // top-level reader's tolerance for transient I/O issues.
+        let seg = self.segment.read().unwrap();
+        seg.is_deleted(doc_id).unwrap_or(false)
+    }
+
+    fn document(&self, doc_id: u64) -> Result<Option<Document>> {
+        let seg = self.segment.read().unwrap();
+        seg.document(doc_id)
+    }
+
+    fn term_info(&self, field: &str, term: &str) -> Result<Option<ReaderTermInfo>> {
+        // Combine: global doc_freq / total_freq + per-segment posting
+        // offset, max_score_factor, and (critically) the per-segment
+        // `block_max` slice so PR-F's BMW pivot loop fires on the
+        // per-segment view.
+        let local_opt = {
+            let seg = self.segment.read().unwrap();
+            seg.term_info(field, term)?
+        };
+        let local = match local_opt {
+            Some(li) => li,
+            None => return Ok(None),
+        };
+        let global = (self.global_term_info_fn)(field, term)?;
+        let global = match global {
+            Some(gi) => gi,
+            None => {
+                // The segment claims the term but the cross-segment
+                // aggregate does not — defensive: fall back to local
+                // counts so scoring still produces a result.
+                return Ok(Some(ReaderTermInfo {
+                    field: field.to_string(),
+                    term: term.to_string(),
+                    doc_freq: local.doc_frequency,
+                    total_freq: local.total_frequency,
+                    posting_offset: local.posting_offset,
+                    posting_size: local.posting_length,
+                    max_score_factor: local.max_score_factor,
+                    block_max: local.block_max,
+                }));
+            }
+        };
+        Ok(Some(ReaderTermInfo {
+            field: field.to_string(),
+            term: term.to_string(),
+            doc_freq: global.doc_freq,
+            total_freq: global.total_freq,
+            posting_offset: local.posting_offset,
+            posting_size: local.posting_length,
+            max_score_factor: local.max_score_factor,
+            block_max: local.block_max,
+        }))
+    }
+
+    fn postings(&self, field: &str, term: &str) -> Result<Option<Box<dyn PostingIterator>>> {
+        let seg = self.segment.read().unwrap();
+        seg.postings(field, term)
+    }
+
+    fn field_stats(&self, field: &str) -> Result<Option<FieldStats>> {
+        // Per-segment avg so the BM25 normaliser matches the avg
+        // each block_max factor was anchored against (#403 PR-D
+        // would otherwise under-bound).
+        let seg = self.segment.read().unwrap();
+        seg.field_stats(field)
+    }
+
+    fn close(&mut self) -> Result<()> {
+        // The view does not own the segment — closing is a no-op.
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        false
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -1308,6 +1308,19 @@ impl InvertedIndexReader {
         &self.config.analyzer
     }
 
+    /// Number of segments backing this reader (#476 Phase 1).
+    pub fn segment_count(&self) -> usize {
+        self.segment_readers.len()
+    }
+
+    /// Borrow the per-segment readers (#476 Phase 1). Used by the
+    /// inverted searcher's per-segment fanout path to run a query
+    /// against each segment independently so PR-F's BMW pivot loop
+    /// can fire on each segment's local `block_max` table.
+    pub fn segment_readers(&self) -> &[Arc<RwLock<SegmentReader>>] {
+        &self.segment_readers
+    }
+
     /// Check if the reader is closed.
     fn check_closed(&self) -> Result<()> {
         if self.closed.load(Ordering::Acquire) {

--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -18,6 +18,7 @@ use crate::error::{LaurusError, Result};
 // Note: Geo and DateTime were removed from FieldValue definition implicitly by switching to DataValue.
 // Only standard types remain. Logic using Geo/DateTime needs update.
 use crate::lexical::index::inverted::bmw::{BlockMaxOrExecutor, is_bmw_eligible};
+use crate::lexical::index::inverted::per_segment_view::PerSegmentReaderView;
 use crate::lexical::index::inverted::reader::InvertedIndexReader;
 use crate::lexical::query::Query;
 use crate::lexical::query::boolean::{BooleanQuery, Occur};
@@ -89,6 +90,21 @@ impl InvertedIndexSearcher {
             return self.search_boolean_query_parallel(boolean_query, collector);
         }
 
+        // Per-segment fanout fast path (#476 Phase 1). For multi-
+        // segment top-K queries, each segment's `block_max` table is
+        // valid as a per-segment scoring bound; running the query
+        // independently on each segment via [`PerSegmentReaderView`]
+        // re-activates PR-F's BMW pivot loop on each one. Cross-
+        // segment merge collects the per-segment top-K into the
+        // caller's collector.
+        if collector.bmw_capable()
+            && let Some(inverted_reader) =
+                self.reader.as_any().downcast_ref::<InvertedIndexReader>()
+            && inverted_reader.segment_count() >= 2
+        {
+            return self.search_per_segment_fanout(query, collector);
+        }
+
         // Block-Max-WAND fast path (#475 PR-F). Eligible for Should-only
         // BooleanQuery against a top-K-style collector. Construction
         // re-checks each clause's per-block metadata at runtime; on
@@ -156,6 +172,16 @@ impl InvertedIndexSearcher {
                         .ok()
                         .flatten()
                         .map(|len| len as f32)
+                } else if let Some(view) =
+                    self.reader.as_any().downcast_ref::<PerSegmentReaderView>()
+                {
+                    // #476 Phase 1: per-segment fanout reads field
+                    // lengths through the view so BM25 normalisation
+                    // matches each segment's local avg.
+                    view.field_length(doc_id, field_name)
+                        .ok()
+                        .flatten()
+                        .map(|len| len as f32)
                 } else {
                     None
                 }
@@ -189,6 +215,84 @@ impl InvertedIndexSearcher {
             }
         }
 
+        Ok(collector)
+    }
+
+    /// Execute a top-K query against a multi-segment reader by
+    /// fanning out to per-segment searches (#476 Phase 1). Each
+    /// segment runs the query through a [`PerSegmentReaderView`],
+    /// which lets PR-F's BMW pivot loop fire on the segment's local
+    /// `block_max` table. Results are merged into the caller's
+    /// collector.
+    fn search_per_segment_fanout<C: Collector>(
+        &self,
+        query: Box<dyn Query>,
+        mut collector: C,
+    ) -> Result<C> {
+        // Downcast ensured by the caller, but re-resolve here to
+        // borrow the segment list.
+        let inverted_reader = self
+            .reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .expect("search_per_segment_fanout requires InvertedIndexReader");
+
+        let global_doc_count = inverted_reader.doc_count();
+        let global_max_doc = inverted_reader.max_doc();
+        // Build a global term-info closure that captures an Arc
+        // pointing back at the cross-segment reader so each
+        // PerSegmentReaderView can resolve IDF lookups.
+        let global_term_info_fn = {
+            let reader_arc = self.reader.clone();
+            std::sync::Arc::new(
+                move |field: &str,
+                      term: &str|
+                      -> Result<Option<crate::lexical::reader::ReaderTermInfo>> {
+                    reader_arc.term_info(field, term)
+                },
+            )
+        };
+
+        // Per-segment K. The collector wants `top_k` hits globally;
+        // each segment returns up to `top_k` so the merge has the
+        // headroom to pick any combination of per-segment hits.
+        let per_segment_k = collector.requested_top_k().unwrap_or(10);
+
+        let segments = inverted_reader.segment_readers().to_vec();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let segment_iter = segments.par_iter();
+        #[cfg(target_arch = "wasm32")]
+        let segment_iter = segments.iter();
+
+        let per_segment_results: Vec<Result<Vec<SearchHit>>> = segment_iter
+            .map(|seg_arc| -> Result<Vec<SearchHit>> {
+                let view = PerSegmentReaderView::new(
+                    seg_arc.clone(),
+                    global_doc_count,
+                    global_max_doc,
+                    global_term_info_fn.clone(),
+                );
+                let view_reader: Arc<dyn LexicalIndexReader> = Arc::new(view);
+                let temp_searcher = InvertedIndexSearcher::from_arc(view_reader);
+                let temp_collector = TopDocsCollector::new(per_segment_k);
+                let collected =
+                    temp_searcher.search_with_collector(query.clone_box(), temp_collector)?;
+                Ok(collected.results())
+            })
+            .collect();
+
+        // Merge per-segment top-K into the caller's collector. Errors
+        // from any one segment short-circuit the whole search.
+        for hits in per_segment_results {
+            let hits = hits?;
+            for hit in hits {
+                collector.collect(hit.doc_id, hit.score)?;
+                if !collector.needs_more() {
+                    return Ok(collector);
+                }
+            }
+        }
         Ok(collector)
     }
 
@@ -1008,5 +1112,177 @@ mod tests {
         // the round-trip technique. The wrapper is kept for future
         // tests that want to invoke the legacy path explicitly.
         let _suppress_dead_code = NonBmwTopDocs(TopDocsCollector::new(0));
+    }
+
+    /// Helper for #476 Phase 1 tests: build a `LexicalStore` with
+    /// the same skewed-TF corpus as the equivalence test, but split
+    /// the writes across `segment_count` commits so the underlying
+    /// reader has multiple segments.
+    fn build_skewed_store_with_segments(
+        segment_count: usize,
+    ) -> crate::lexical::store::LexicalStore {
+        use crate::Document;
+        use crate::lexical::store::LexicalStore;
+        use crate::lexical::store::config::LexicalIndexConfig;
+
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let store = LexicalStore::new(storage, LexicalIndexConfig::default()).unwrap();
+
+        let n: u64 = 512;
+        let chunk = n.div_ceil(segment_count as u64);
+        let mut next_commit = chunk;
+        for id in 0..n {
+            let mut body = String::new();
+            if id < 60 {
+                body.push_str("alpha alpha alpha ");
+            } else if id < 200 {
+                body.push_str("alpha ");
+            }
+            if (100..400).contains(&id) {
+                body.push_str("beta ");
+            }
+            if id >= 350 && id % 3 == 0 {
+                body.push_str("gamma ");
+            }
+            body.push_str("filler text content body");
+            let doc = Document::builder()
+                .add_text("title", format!("doc-{id}"))
+                .add_text("body", &body)
+                .build();
+            store.upsert_document(id, doc).unwrap();
+
+            if id + 1 == next_commit && id + 1 < n {
+                store.commit().unwrap();
+                next_commit += chunk;
+            }
+        }
+        store.commit().unwrap();
+        store
+    }
+
+    /// PR-F follow-up #476 Phase 1: the per-segment fanout path
+    /// must return the **same top-K** as the legacy cross-segment
+    /// path on the same multi-segment store. We can't compare to
+    /// a single-segment build because per-segment scoring uses each
+    /// segment's local `avg_field_length` (Lucene-style), which
+    /// produces ranking-equivalent but numerically-different scores
+    /// from global-avg single-segment scoring. Comparing fanout to
+    /// the **legacy path on the same multi-segment store** isolates
+    /// the fanout's correctness from that scoring choice.
+    #[test]
+    fn per_segment_fanout_topk_matches_legacy_multi_segment_path() {
+        use crate::lexical::query::SearchHit;
+        use crate::lexical::query::boolean::BooleanQueryBuilder;
+
+        let store = build_skewed_store_with_segments(4);
+        let make_query = || -> Box<dyn Query> {
+            Box::new(
+                BooleanQueryBuilder::new()
+                    .should(Box::new(TermQuery::new("body", "alpha")))
+                    .should(Box::new(TermQuery::new("body", "beta")))
+                    .should(Box::new(TermQuery::new("body", "gamma")))
+                    .build(),
+            )
+        };
+
+        // Fanout path: TopDocsCollector reports `bmw_capable = true`
+        // and segment_count == 4 → dispatches to fanout.
+        let fanout_hits = store
+            .search(LexicalSearchRequest::new(make_query()).limit(10))
+            .unwrap()
+            .hits;
+
+        // Legacy path: drive the searcher directly with our
+        // `NonBmwTopDocs` wrapper so `bmw_capable = false` and
+        // dispatch falls through to the existing matcher-driven
+        // loop on the cross-segment-aggregated reader.
+        let legacy_hits: Vec<SearchHit> = {
+            let reader = store.reader_for_tests().unwrap();
+            let searcher = InvertedIndexSearcher::from_arc(reader);
+            let collector = NonBmwTopDocs(TopDocsCollector::new(10));
+            let collected = searcher
+                .search_with_collector(make_query(), collector)
+                .unwrap();
+            collected.0.results()
+        };
+
+        assert_eq!(
+            fanout_hits.len(),
+            legacy_hits.len(),
+            "fanout vs legacy hit count differs"
+        );
+
+        let fanout_ids: std::collections::BTreeSet<u64> =
+            fanout_hits.iter().map(|h| h.doc_id).collect();
+        let legacy_ids: std::collections::BTreeSet<u64> =
+            legacy_hits.iter().map(|h| h.doc_id).collect();
+        assert_eq!(
+            fanout_ids, legacy_ids,
+            "fanout vs legacy top-K doc id sets differ"
+        );
+
+        // Both paths run on the same multi-segment store with the
+        // same per-segment avg semantics, so scores must agree
+        // within float tolerance.
+        for hit in &fanout_hits {
+            let legacy_score = legacy_hits
+                .iter()
+                .find(|h| h.doc_id == hit.doc_id)
+                .expect("doc must be in legacy top-K too")
+                .score;
+            let tol = 1e-4_f32.max(0.01_f32 * legacy_score.abs());
+            assert!(
+                (hit.score - legacy_score).abs() < tol,
+                "doc {}: fanout={} legacy={} (tol {})",
+                hit.doc_id,
+                hit.score,
+                legacy_score,
+                tol,
+            );
+        }
+    }
+
+    /// PR-F follow-up #476 Phase 1: the per-segment fanout must
+    /// fall through to the legacy path when the store has only one
+    /// segment (the existing PR-F BMW path is already optimal).
+    #[test]
+    fn per_segment_fanout_falls_back_when_single_segment() {
+        use crate::lexical::query::boolean::BooleanQueryBuilder;
+
+        let store = build_skewed_store_with_segments(1);
+        let query: Box<dyn Query> = Box::new(
+            BooleanQueryBuilder::new()
+                .should(Box::new(TermQuery::new("body", "alpha")))
+                .should(Box::new(TermQuery::new("body", "beta")))
+                .build(),
+        );
+        // The fact that this returns at all (without panicking on the
+        // `expect("requires InvertedIndexReader")` in fanout) is the
+        // proof: the dispatch saw `segment_count() == 1` and skipped
+        // the fanout branch.
+        let hits = store
+            .search(LexicalSearchRequest::new(query).limit(10))
+            .unwrap()
+            .hits;
+        assert!(!hits.is_empty(), "single-seg query should return hits");
+    }
+
+    /// PR-F follow-up #476 Phase 1: a non-`bmw_capable` collector
+    /// (here: `CountCollector`) must skip both the BMW fast path and
+    /// the per-segment fanout, so multi-segment count queries still
+    /// hit the legacy aggregation path.
+    #[test]
+    fn per_segment_fanout_falls_back_for_count_collector() {
+        use crate::lexical::query::boolean::BooleanQueryBuilder;
+
+        let store = build_skewed_store_with_segments(4);
+        let query: Box<dyn Query> = Box::new(
+            BooleanQueryBuilder::new()
+                .should(Box::new(TermQuery::new("body", "alpha")))
+                .should(Box::new(TermQuery::new("body", "beta")))
+                .build(),
+        );
+        let count = store.count(LexicalSearchRequest::new(query)).unwrap();
+        assert!(count > 0, "count query on multi-seg corpus must hit");
     }
 }

--- a/laurus/src/lexical/query/collector.rs
+++ b/laurus/src/lexical/query/collector.rs
@@ -59,6 +59,15 @@ pub trait Collector: Send + Debug {
     fn bmw_capable(&self) -> bool {
         false
     }
+
+    /// Hint: the number of top hits the collector wants (#476 Phase 1).
+    /// The per-segment fanout uses this to size each segment's local
+    /// [`TopDocsCollector`] so cross-segment merge has enough headroom
+    /// without wasting work. Returns `None` for collectors without a
+    /// meaningful top-K (e.g. [`CountCollector`]).
+    fn requested_top_k(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// A collector that keeps the top N documents by score.
@@ -538,6 +547,10 @@ impl Collector for TopDocsCollector {
 
     fn bmw_capable(&self) -> bool {
         true
+    }
+
+    fn requested_top_k(&self) -> Option<usize> {
+        Some(self.max_docs)
     }
 
     fn reset(&mut self) {

--- a/laurus/src/lexical/store.rs
+++ b/laurus/src/lexical/store.rs
@@ -13,6 +13,8 @@ use crate::lexical::index::LexicalIndex;
 use crate::lexical::index::factory::LexicalIndexFactory;
 use crate::lexical::index::inverted::InvertedIndexStats;
 use crate::lexical::query::LexicalSearchResults;
+#[cfg(test)]
+use crate::lexical::reader::LexicalIndexReader;
 use crate::lexical::search::searcher::{LexicalSearchRequest, LexicalSearcher};
 use crate::lexical::store::config::LexicalIndexConfig;
 use crate::lexical::writer::LexicalIndexWriter;
@@ -322,6 +324,18 @@ impl LexicalStore {
     pub fn refresh(&self) -> Result<()> {
         *self.searcher_cache.write() = None;
         Ok(())
+    }
+
+    /// Borrow the underlying [`LexicalIndexReader`] (#476 Phase 1).
+    ///
+    /// Exposed for crate-internal tests that need to drive the
+    /// inverted searcher directly with a custom collector — e.g. to
+    /// bypass the per-segment fanout and exercise the legacy
+    /// matcher-driven path against the same multi-segment store.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn reader_for_tests(&self) -> Result<Arc<dyn LexicalIndexReader>> {
+        self.index.reader()
     }
 
     /// Get index statistics.


### PR DESCRIPTION
## Summary

Closes the long-standing gap where multi-segment indexes lost PR-F's BMW pivot loop because `InvertedIndexReader::term_info`'s cross-segment aggregation drops the per-segment `block_max` table (PR-D under-bound safety).

This PR routes multi-segment top-K queries through a per-segment fanout: each segment is wrapped in a new `PerSegmentReaderView`, the query runs independently against each, and PR-F's BMW path fires on each segment's local `block_max`. Cross-segment results merge into the caller's collector.

## Cross-segment scoring semantics (Lucene-style)

| Field | Source | Reason |
|---|---|---|
| `doc_freq`, `total_freq` (IDF) | global cross-segment aggregate | consistent term-rarity ranking across segments |
| `total_docs` (IDF) | global | same |
| `avg_field_length` (BM25 TF) | per-segment | matches the avg each segment's `block_max` factors were anchored against |
| `block_max` table | per-segment | computed at write time against the segment's avg, valid as a per-segment scoring bound |

## Bench (`lexical_search_bench`, vs `pre-403-Phase1-v2` baseline on `main`)

| Fixture | Time | Change |
|---|---|---|
| `topk_or_multi_segment/10000/segments=1` | 5.68 ms | no change (true single-seg, BMW path unchanged) |
| `topk_or_multi_segment/10000/segments=4` | 3.17 ms | **−74.8 %** (≈4.0×) |
| `topk_or_multi_segment/10000/segments=8` | 2.14 ms | **−82.4 %** (≈5.6×) |
| `topk_or_multi_segment/100000/segments=1` | 24.14 ms | **−81.5 %** (≈5.3×) |
| `topk_or_multi_segment/100000/segments=4` | 24.25 ms | **−79.5 %** (≈4.9×) |
| `topk_or_multi_segment/100000/segments=8` | 23.48 ms | **−80.5 %** (≈5.1×) |

The 100k/segments=1 speedup is genuine: the writer auto-flushes during a 100k-doc commit stream, so the resulting index has multiple internal segments and benefits from the fanout. The 10k case stays small enough to fit one segment, hence its no-change baseline.

**This meets `#416`'s audit-target 5× speedup at 100k**, which `#403` PR-A through PR-F left unmet on multi-segment workloads.

## Architecture

| Component | File | Notes |
|---|---|---|
| New `PerSegmentReaderView` | `laurus/src/lexical/index/inverted/per_segment_view.rs` | Adapter from `Arc<RwLock<SegmentReader>>` to `LexicalIndexReader`. Owns the segment so the type is `'static` (works as `Arc<dyn LexicalIndexReader>`). Forwards posting / field access; injects global IDF inputs. |
| `InvertedIndexReader::segment_count` / `segment_readers` | `inverted/reader.rs` | Public accessors so the searcher can fan out. |
| `Collector::requested_top_k` | `query/collector.rs` | Hint used by fanout to size each per-segment `TopDocsCollector` so the cross-segment merge has enough headroom. |
| `search_per_segment_fanout` | `inverted/searcher.rs` | rayon `par_iter` over segments → per-segment search via the view → merge results into the caller's collector. |
| `bmw_capable && segment_count >= 2` dispatch | `inverted/searcher.rs::search_with_collector_parallel` | Falls through to the existing PR-F BMW path for single-segment cases or non-top-K collectors. |
| `LexicalStore::reader_for_tests` | `lexical/store.rs` (`#[cfg(test)]`) | Lets the equivalence test bypass the public `search()` API and drive `NonBmwTopDocs` through the legacy matcher loop. |

## Tests

- `per_segment_fanout_topk_matches_legacy_multi_segment_path` — the new fanout path's top-10 must equal a `NonBmwTopDocs`-driven legacy matcher loop on the same 4-segment store (doc id sets equal, scores within tolerance).
- `per_segment_fanout_falls_back_when_single_segment` — single-segment store goes through the BMW path, not fanout.
- `per_segment_fanout_falls_back_for_count_collector` — non-`bmw_capable` collector skips fanout.
- All 359 existing `lexical::*` lib tests still pass.

## Test plan

- [x] `cargo test -p laurus --lib lexical::` — 359 + 3 new tests pass
- [x] `cargo fmt --check && cargo clippy -p laurus --lib --tests -- -D warnings`
- [x] Bench numbers above (pre-403-Phase1-v2 baseline)

Refs #403, #416, #476.