### PR TITLE
perf(lexical/scorer): concrete-type dispatch in BooleanScorer / BMW hot loop (#466)

### DIFF
--- a/laurus/src/lexical/index/inverted/bmw.rs
+++ b/laurus/src/lexical/index/inverted/bmw.rs
@@ -20,8 +20,6 @@ use crate::lexical::index::inverted::reader::InvertedIndexReader;
 use crate::lexical::query::Query;
 use crate::lexical::query::boolean::{BooleanQuery, Occur};
 use crate::lexical::query::collector::Collector;
-use crate::lexical::query::matcher::Matcher;
-use crate::lexical::query::scorer::Scorer;
 use crate::lexical::query::term::TermQuery;
 use crate::lexical::reader::LexicalIndexReader;
 
@@ -29,13 +27,19 @@ use crate::lexical::reader::LexicalIndexReader;
 /// and matcher. The scorer is constructed once at executor-start
 /// time so the pivot loop can pull per-block bounds without
 /// re-resolving the term.
+///
+/// The `scorer` / `matcher` fields are concrete-type enums (#466)
+/// so the per-doc inner loop dispatches to BM25 / PostingMatcher
+/// arms via `match` instead of paying a vtable lookup.
 struct BmwClause {
-    /// The per-clause BM25 (or other) scorer. Must expose a
-    /// finite-block bound — checked at construction time.
-    scorer: Box<dyn Scorer>,
-    /// The per-clause matcher. Walks its posting list independently
-    /// of the other clauses' matchers.
-    matcher: Box<dyn Matcher>,
+    /// The per-clause scorer (specialised for BM25 / Constant in the
+    /// production hot path). Must expose a finite-block bound —
+    /// checked at construction time.
+    scorer: crate::lexical::query::scorer::LeafScorer,
+    /// The per-clause matcher (specialised for PostingMatcher in the
+    /// production hot path). Walks its posting list independently of
+    /// the other clauses' matchers.
+    matcher: crate::lexical::query::matcher::LeafMatcher,
     /// Field name extracted from the clause's underlying
     /// [`TermQuery`], used to look up per-doc field length at
     /// scoring time. `None` when the clause is not a [`TermQuery`]
@@ -70,8 +74,8 @@ impl<'r> BlockMaxOrExecutor<'r> {
             let matcher = clause.query.matcher(reader)?;
             let field_name = field_name_of(clause.query.as_ref());
             clauses.push(BmwClause {
-                scorer,
-                matcher,
+                scorer: crate::lexical::query::scorer::LeafScorer::from_box(scorer),
+                matcher: crate::lexical::query::matcher::LeafMatcher::from_box(matcher),
                 field_name,
             });
         }

--- a/laurus/src/lexical/query/geo.rs
+++ b/laurus/src/lexical/query/geo.rs
@@ -866,6 +866,9 @@ impl Matcher for GeoMatcher {
     fn is_exhausted(&self) -> bool {
         self.current_index >= self.matches.len()
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// Scorer for geographical queries.
@@ -912,6 +915,10 @@ impl Scorer for GeoScorer {
 
     fn name(&self) -> &'static str {
         "GeoScorer"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/laurus/src/lexical/query/geo3d.rs
+++ b/laurus/src/lexical/query/geo3d.rs
@@ -307,6 +307,9 @@ impl Matcher for Geo3dMatcher {
     fn is_exhausted(&self) -> bool {
         self.cursor >= self.matches.len()
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// Scorer for [`Geo3dDistanceQuery`]. Looks up the precomputed score
@@ -348,6 +351,10 @@ impl Scorer for Geo3dScorer {
 
     fn name(&self) -> &'static str {
         "Geo3dScorer"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/laurus/src/lexical/query/matcher.rs
+++ b/laurus/src/lexical/query/matcher.rs
@@ -28,6 +28,15 @@ pub trait Matcher: Send + Debug {
     fn term_freq(&self) -> u64 {
         1 // Default implementation for matchers that don't track term frequency
     }
+
+    /// Erased self-reference for runtime downcasting (#466).
+    /// Used by [`super::scorer::LeafScorer::from_box`] / `LeafMatcher`
+    /// dispatch helpers to specialise production hot-path matcher
+    /// types (`PostingMatcher`, `AllMatcher`, `EmptyMatcher`) so
+    /// `BooleanScorer` / `BlockMaxOrExecutor` inner loops can match-
+    /// dispatch into the concrete matcher without the per-doc vtable
+    /// lookup.
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 /// A matcher that matches no documents.
@@ -68,6 +77,9 @@ impl Matcher for EmptyMatcher {
 
     fn is_exhausted(&self) -> bool {
         self.exhausted
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -122,6 +134,9 @@ impl Matcher for AllMatcher {
 
     fn is_exhausted(&self) -> bool {
         self.current_doc >= self.max_doc
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -210,6 +225,9 @@ impl Matcher for PostingMatcher {
         } else {
             self.posting_iter.term_freq()
         }
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -398,6 +416,9 @@ impl Matcher for DisjunctionMatcher {
     fn is_exhausted(&self) -> bool {
         self.exhausted
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// A matcher that implements conjunction (AND) of multiple matchers.
@@ -537,6 +558,9 @@ impl Matcher for ConjunctionMatcher {
 
     fn is_exhausted(&self) -> bool {
         self.exhausted
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -679,6 +703,9 @@ impl Matcher for ConjunctionNotMatcher {
     fn is_exhausted(&self) -> bool {
         self.exhausted
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// A matcher that matches all documents except those matched by the negative matcher.
@@ -782,6 +809,9 @@ impl Matcher for NotMatcher {
 
     fn is_exhausted(&self) -> bool {
         self.exhausted || self.current_doc >= self.max_doc
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -1280,5 +1310,106 @@ impl Matcher for PreComputedMatcher {
 
     fn is_exhausted(&self) -> bool {
         self.exhausted
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Concrete-type dispatch enum for the production matcher hot path
+/// (#466). Used by `BooleanScorer` and `BlockMaxOrExecutor` so that
+/// the per-doc `skip_to` / `next` / `term_freq` calls in the inner
+/// loop dispatch by `match` (BM25-friendly inlining) instead of
+/// through a vtable.
+#[derive(Debug)]
+pub enum LeafMatcher {
+    /// `PostingMatcher` — production hot-path leaf matcher. Boxed
+    /// so the enum stays narrow and `Vec<(LeafScorer, LeafMatcher)>`
+    /// remains cache-friendly inside the BMW pivot loop.
+    Posting(Box<PostingMatcher>),
+    /// `EmptyMatcher` — empty-result clause.
+    Empty(Box<EmptyMatcher>),
+    /// `AllMatcher` — match-all (filter) clause.
+    All(Box<AllMatcher>),
+    /// Trait-object fallback for compound matchers (`DisjunctionMatcher`,
+    /// `ConjunctionMatcher`, etc.) and any custom `Matcher` impl.
+    Other(Box<dyn Matcher>),
+}
+
+impl LeafMatcher {
+    /// Specialise a `Box<dyn Matcher>` into a concrete enum variant
+    /// when the matcher is one of the production hot-path types.
+    /// Falls back to [`LeafMatcher::Other`] otherwise.
+    pub fn from_box(b: Box<dyn Matcher>) -> Self {
+        use std::any::TypeId;
+        let tid = b.as_any().type_id();
+        if tid == TypeId::of::<PostingMatcher>() {
+            // SAFETY: TypeId equality guarantees the trait object's
+            // concrete type. Convert via raw pointer cast.
+            let raw: *mut dyn Matcher = Box::into_raw(b);
+            let m: Box<PostingMatcher> = unsafe { Box::from_raw(raw as *mut PostingMatcher) };
+            LeafMatcher::Posting(m)
+        } else if tid == TypeId::of::<EmptyMatcher>() {
+            let raw: *mut dyn Matcher = Box::into_raw(b);
+            let m: Box<EmptyMatcher> = unsafe { Box::from_raw(raw as *mut EmptyMatcher) };
+            LeafMatcher::Empty(m)
+        } else if tid == TypeId::of::<AllMatcher>() {
+            let raw: *mut dyn Matcher = Box::into_raw(b);
+            let m: Box<AllMatcher> = unsafe { Box::from_raw(raw as *mut AllMatcher) };
+            LeafMatcher::All(m)
+        } else {
+            LeafMatcher::Other(b)
+        }
+    }
+
+    #[inline(always)]
+    pub fn doc_id(&self) -> u64 {
+        match self {
+            LeafMatcher::Posting(m) => m.doc_id(),
+            LeafMatcher::Empty(m) => m.doc_id(),
+            LeafMatcher::All(m) => m.doc_id(),
+            LeafMatcher::Other(m) => m.doc_id(),
+        }
+    }
+
+    #[inline(always)]
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Result<bool> {
+        match self {
+            LeafMatcher::Posting(m) => m.next(),
+            LeafMatcher::Empty(m) => m.next(),
+            LeafMatcher::All(m) => m.next(),
+            LeafMatcher::Other(m) => m.next(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn skip_to(&mut self, target: u64) -> Result<bool> {
+        match self {
+            LeafMatcher::Posting(m) => m.skip_to(target),
+            LeafMatcher::Empty(m) => m.skip_to(target),
+            LeafMatcher::All(m) => m.skip_to(target),
+            LeafMatcher::Other(m) => m.skip_to(target),
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_exhausted(&self) -> bool {
+        match self {
+            LeafMatcher::Posting(m) => m.is_exhausted(),
+            LeafMatcher::Empty(m) => m.is_exhausted(),
+            LeafMatcher::All(m) => m.is_exhausted(),
+            LeafMatcher::Other(m) => m.is_exhausted(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn term_freq(&self) -> u64 {
+        match self {
+            LeafMatcher::Posting(m) => m.term_freq(),
+            LeafMatcher::Empty(m) => m.term_freq(),
+            LeafMatcher::All(m) => m.term_freq(),
+            LeafMatcher::Other(m) => m.term_freq(),
+        }
     }
 }

--- a/laurus/src/lexical/query/phrase.rs
+++ b/laurus/src/lexical/query/phrase.rs
@@ -230,6 +230,9 @@ impl Matcher for PhraseMatcher {
     fn cost(&self) -> u64 {
         self.matches.len() as u64
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// A scorer specialized for phrase queries.
@@ -371,6 +374,9 @@ impl Scorer for PhraseScorer {
 
     fn name(&self) -> &'static str {
         "PhraseScorer"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/laurus/src/lexical/query/range.rs
+++ b/laurus/src/lexical/query/range.rs
@@ -237,6 +237,9 @@ impl Matcher for RangeMatcher {
     fn is_exhausted(&self) -> bool {
         self.exhausted
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// Specialized numeric range query for optimal performance.
@@ -579,6 +582,10 @@ impl Scorer for RangeScorer {
     fn name(&self) -> &'static str {
         "RangeScorer"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl Query for NumericRangeQuery {
@@ -784,6 +791,9 @@ impl Matcher for NumericRangeMatcher {
     fn is_exhausted(&self) -> bool {
         self.exhausted
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// A specialized matcher for numeric range queries that filters documents.
@@ -888,6 +898,9 @@ impl Matcher for NumericRangeFilterMatcher {
 
     fn is_exhausted(&self) -> bool {
         self.all_matcher.is_exhausted()
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -1151,6 +1164,9 @@ impl Matcher for DateTimeRangeMatcher {
 
     fn is_exhausted(&self) -> bool {
         self.exhausted
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/laurus/src/lexical/query/scorer.rs
+++ b/laurus/src/lexical/query/scorer.rs
@@ -6,11 +6,104 @@ use std::sync::Arc;
 use crate::error::Result;
 use crate::lexical::index::structures::dictionary::BlockMax;
 use crate::lexical::query::Query;
-use crate::lexical::query::matcher::Matcher;
 use crate::util::simd;
 
 /// Type alias for boolean scorer clauses.
-type BooleanScorerClauses = std::cell::RefCell<Vec<(Box<dyn Scorer>, Box<dyn Matcher>)>>;
+type BooleanScorerClauses =
+    std::cell::RefCell<Vec<(LeafScorer, crate::lexical::query::matcher::LeafMatcher)>>;
+
+/// Concrete-type dispatch enum for the production scorer hot path
+/// (#466). The `BooleanScorer` and `BlockMaxOrExecutor` inner loops
+/// match on this enum so the `BM25Scorer` / `ConstantScorer` arms
+/// inline their scoring math instead of paying a per-doc vtable
+/// lookup. `Other` keeps a trait-object escape hatch for nested
+/// `BooleanScorer` and any future custom scorer.
+#[derive(Debug)]
+pub enum LeafScorer {
+    /// `BM25Scorer` — production hot-path leaf scorer. Boxed so the
+    /// enum stays narrow (16 bytes), keeping `BooleanScorer` /
+    /// `BlockMaxOrExecutor` clause vectors cache-friendly.
+    BM25(Box<BM25Scorer>),
+    /// `ConstantScorer` — filter / `MustNot` paths.
+    Constant(Box<ConstantScorer>),
+    /// Trait-object fallback for nested `BooleanScorer` and
+    /// any custom `Scorer` impl.
+    Other(Box<dyn Scorer>),
+}
+
+impl LeafScorer {
+    /// Specialise a `Box<dyn Scorer>` into a concrete enum variant
+    /// when the scorer is one of the production hot-path types.
+    /// Falls back to [`LeafScorer::Other`] otherwise — that arm is
+    /// still trait-object dispatched.
+    pub fn from_box(b: Box<dyn Scorer>) -> Self {
+        use std::any::TypeId;
+        let tid = b.as_any().type_id();
+        if tid == TypeId::of::<BM25Scorer>() {
+            // SAFETY: TypeId equality guarantees the trait object's
+            // concrete type. Convert via raw pointer cast — Box's
+            // representation is identical for a `dyn Scorer` made of
+            // a single concrete type and a `Box<BM25Scorer>`.
+            let raw: *mut dyn Scorer = Box::into_raw(b);
+            let s: Box<BM25Scorer> = unsafe { Box::from_raw(raw as *mut BM25Scorer) };
+            LeafScorer::BM25(s)
+        } else if tid == TypeId::of::<ConstantScorer>() {
+            let raw: *mut dyn Scorer = Box::into_raw(b);
+            let s: Box<ConstantScorer> = unsafe { Box::from_raw(raw as *mut ConstantScorer) };
+            LeafScorer::Constant(s)
+        } else {
+            LeafScorer::Other(b)
+        }
+    }
+
+    /// Per-doc score. Matches the [`Scorer::score`] signature.
+    /// Each arm dispatches to a concrete impl which the optimiser
+    /// can inline.
+    #[inline(always)]
+    pub fn score(&self, doc_id: u64, term_freq: f32, field_length: Option<f32>) -> f32 {
+        match self {
+            LeafScorer::BM25(s) => s.score(doc_id, term_freq, field_length),
+            LeafScorer::Constant(s) => s.score(doc_id, term_freq, field_length),
+            LeafScorer::Other(s) => s.score(doc_id, term_freq, field_length),
+        }
+    }
+
+    #[inline(always)]
+    pub fn max_score(&self) -> f32 {
+        match self {
+            LeafScorer::BM25(s) => s.max_score(),
+            LeafScorer::Constant(s) => s.max_score(),
+            LeafScorer::Other(s) => s.max_score(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn block_max_score_at(&self, doc_id: u64) -> f32 {
+        match self {
+            LeafScorer::BM25(s) => s.block_max_score_at(doc_id),
+            LeafScorer::Constant(s) => s.block_max_score_at(doc_id),
+            LeafScorer::Other(s) => s.block_max_score_at(doc_id),
+        }
+    }
+
+    #[inline(always)]
+    pub fn current_block_max_score(&self, doc_id: u64) -> f32 {
+        match self {
+            LeafScorer::BM25(s) => s.current_block_max_score(doc_id),
+            LeafScorer::Constant(s) => s.current_block_max_score(doc_id),
+            LeafScorer::Other(s) => s.current_block_max_score(doc_id),
+        }
+    }
+
+    #[inline(always)]
+    pub fn next_block_boundary(&self, doc_id: u64) -> Option<u64> {
+        match self {
+            LeafScorer::BM25(s) => s.next_block_boundary(doc_id),
+            LeafScorer::Constant(s) => s.next_block_boundary(doc_id),
+            LeafScorer::Other(s) => s.next_block_boundary(doc_id),
+        }
+    }
+}
 
 /// Trait for document scorers.
 pub trait Scorer: Send + Debug {
@@ -101,6 +194,14 @@ pub trait Scorer: Send + Debug {
 
     /// Get the name of this scorer.
     fn name(&self) -> &'static str;
+
+    /// Erased self-reference for runtime downcasting (#466).
+    /// Used by [`LeafScorer::from_box`] to specialise production
+    /// hot-path scorer types out of a `Box<dyn Scorer>` so the
+    /// boolean / BMW inner loops can match-dispatch into a
+    /// concrete `BM25Scorer` / `ConstantScorer` without the
+    /// per-doc vtable lookup.
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 /// BM25 scorer implementation.
@@ -506,6 +607,10 @@ impl Scorer for BM25Scorer {
     fn name(&self) -> &'static str {
         "BM25"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl BM25Scorer {
@@ -636,6 +741,10 @@ impl Scorer for ConstantScorer {
     fn name(&self) -> &'static str {
         "Constant"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// A scorer that combines multiple scorers by summing their scores.
@@ -653,16 +762,22 @@ pub struct BooleanScorer {
 unsafe impl Send for BooleanScorer {}
 
 impl BooleanScorer {
-    /// Create a new boolean scorer.
+    /// Create a new boolean scorer. The clauses are specialised into
+    /// [`LeafScorer`] / [`crate::lexical::query::matcher::LeafMatcher`]
+    /// variants so the per-doc inner loop can match-dispatch into
+    /// the production hot-path types (#466).
     pub fn new(
         reader: &dyn crate::lexical::reader::LexicalIndexReader,
         queries: Vec<Box<dyn Query>>,
     ) -> Result<Self> {
-        let mut clauses = Vec::new();
+        let mut clauses = Vec::with_capacity(queries.len());
         for query in queries {
             let matcher = query.matcher(reader)?;
             let scorer = query.scorer(reader)?;
-            clauses.push((scorer, matcher));
+            clauses.push((
+                LeafScorer::from_box(scorer),
+                crate::lexical::query::matcher::LeafMatcher::from_box(matcher),
+            ));
         }
         Ok(BooleanScorer {
             clauses: std::cell::RefCell::new(clauses),
@@ -762,6 +877,10 @@ impl Scorer for BooleanScorer {
 
     fn name(&self) -> &'static str {
         "Boolean"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -1028,6 +1147,9 @@ mod tests {
             fn name(&self) -> &'static str {
                 "PairTest"
             }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
         }
         let pair = PairScorer(scorer_a, scorer_b, 1.0);
 
@@ -1065,6 +1187,9 @@ mod tests {
             fn name(&self) -> &'static str {
                 "NoBlock"
             }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
         }
         let blocks: Arc<[BlockMax]> = Arc::from(vec![BlockMax {
             last_doc_id: 50,
@@ -1096,6 +1221,9 @@ mod tests {
             }
             fn name(&self) -> &'static str {
                 "PairWithLegacy"
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
             }
         }
         let pair = PairWithLegacy(NoBlockScorer, block_scorer);

--- a/laurus/src/lexical/query/span.rs
+++ b/laurus/src/lexical/query/span.rs
@@ -611,6 +611,9 @@ impl Matcher for SpanMatcher {
     fn cost(&self) -> u64 {
         self.matches.len() as u64
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 /// A scorer for span queries.
@@ -674,6 +677,10 @@ impl Scorer for SpanScorer {
 
     fn name(&self) -> &'static str {
         "SpanScorer"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

Add `LeafScorer` / `LeafMatcher` enums that concrete-type dispatch the production hot-path scorer/matcher combinations (BM25 / Constant / Posting / Empty / All) via `match` arms instead of `Box<dyn Scorer>` / `Box<dyn Matcher>` vtable lookups. `Other(Box<dyn ...>)` keeps a trait-object escape hatch for nested `BooleanScorer` and any custom impl.

Each enum variant boxes its concrete type so the enum stays narrow (16 bytes) — keeps the `Vec<(LeafScorer, LeafMatcher)>` clause arrays inside `BooleanScorer` and `BlockMaxOrExecutor` cache-friendly during the BMW pivot loop's `sort_by_key` / scan.

## Architecture

- `Scorer::as_any` / `Matcher::as_any` added so `LeafScorer::from_box` / `LeafMatcher::from_box` can specialise an incoming `Box<dyn ...>` via `TypeId` match. All 22 production `Scorer`/`Matcher` impls grow a one-line `as_any` → `self` body.
- `BooleanScorer.clauses` and `BmwClause` switched to the enums.
- `LeafScorer::{score, max_score, block_max_score_at, current_block_max_score, next_block_boundary}` and `LeafMatcher::{doc_id, next, skip_to, is_exhausted, term_freq}` are `#[inline(always)]` so each `match` arm inlines into the hot loop.

## Bench (`lexical_search_bench`, vs `pre-466` baseline on `main`)

| Fixture | Change | Speedup |
|---|---|---|
| `topk_or_skewed_tf/should_or_topk10/1000` | **−21.8 %** | 1.28× |
| `topk_or_skewed_tf/should_or_topk10/10000` | **−10.9 %** | 1.12× |
| `topk_or_skewed_tf/should_or_topk10/100000` | **−6.3 %** | 1.07× |
| `boolean_query/should_or_high_freq/100` | **−12.2 %** | 1.14× |
| `boolean_query/should_or_high_freq/1000` | −1.4 % | noise |
| `boolean_query/should_or_high_freq/5000` | −1.5 % | small |

## Iteration note (in case it helps reviewers)

The first attempt stored the concrete types **inline** (no Box) which inflated `LeafScorer` to ~80 bytes — `BM25Scorer` carries two `Arc` fields — and regressed `topk_or_skewed_tf/100000` by **+30 %** from the extra cache footprint inside the BMW pivot loop. Re-boxing the hot-path variants drops the enum back to a single fat-pointer slot and converts that regression into a −6.3 % improvement. The 1k / 10k / 100 cases were positive on both attempts but the Box-wrapped version is uniformly better.

## Test plan

- [x] `cargo test -p laurus --lib` — 815 passed, 0 failed.
- [x] `cargo fmt --check && cargo clippy -p laurus --lib --tests -- -D warnings`.
- [x] Bench numbers above (`pre-466` baseline saved on `main` before this branch).

Refs #463, #466.