### PR TITLE
perf(lexical/postings): block bit-packed posting format (#464)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "bitstream-io"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,6 +2564,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bit-vec 0.9.1",
+ "bitpacking",
  "bytecheck",
  "byteorder",
  "candle-core",

--- a/docs/src/concepts/indexing/lexical_indexing.md
+++ b/docs/src/concepts/indexing/lexical_indexing.md
@@ -62,10 +62,32 @@ Each entry in a posting list contains:
 
 | Field | Description |
 | :--- | :--- |
-| Document ID | Internal `u64` identifier |
+| Document ID | Internal `u64` identifier (per-segment value must fit in `u32`) |
 | Term Frequency | How many times the term appears in this document |
 | Positions (optional) | Where in the document the term appears (needed for phrase queries) |
 | Weight | Score weight for this posting |
+
+### On-Disk Posting Layout
+
+Posting lists are stored in a **structure-of-arrays** layout with each field
+written as its own contiguous section. Document IDs and term frequencies are
+encoded in fixed-size **128-int blocks** using bit-packing (Frame-of-Reference
+plus sorted-delta for doc IDs), with any partial trailing block falling back
+to varint. This matches the on-disk format used by Tantivy and Lucene 9 and
+yields fast SIMD-accelerated decoding through the
+[`bitpacking`](https://crates.io/crates/bitpacking) crate.
+
+```text
+[term, total_frequency, doc_frequency, posting_count N, any_positions]
+[Section 1: doc_ids       — N/128 bit-packed blocks + varint tail]
+[Section 2: frequencies   — N/128 bit-packed blocks + varint tail]
+[Section 3: weights       — N raw f32 values]
+[Section 4: positions     — per-posting flag + varint deltas (only if any)]
+```
+
+Per-segment doc IDs must fit in `u32`. Encoding a value beyond `u32::MAX`
+fails fast with a clear error to prevent silent corruption of the
+bit-packed segment.
 
 ## Numeric and Date Fields
 

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -23,6 +23,7 @@ aho-corasick = "1.1.4"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bit-vec = "0.9.1"
+bitpacking = "0.9.3"
 bytecheck = "0.8.2"
 byteorder = "1.5.0"
 chrono = { workspace = true }

--- a/laurus/src/lexical/index/inverted/core/posting.rs
+++ b/laurus/src/lexical/index/inverted/core/posting.rs
@@ -4,10 +4,14 @@
 //! term-to-document mapping with frequency and position information.
 
 use ahash::AHashMap;
+use bitpacking::{BitPacker, BitPacker4x};
 
 use crate::error::{LaurusError, Result};
 use crate::storage::structured::{StructReader, StructWriter};
 use crate::storage::{StorageInput, StorageOutput};
+
+/// Block length for `BitPacker4x` (SSE3 / scalar fallback): 128 ints per block.
+const POSTING_BLOCK_LEN: usize = BitPacker4x::BLOCK_LEN;
 
 /// A single posting in a posting list.
 #[derive(Debug, Clone, PartialEq)]
@@ -340,101 +344,252 @@ impl PostingList {
         }
     }
 
-    /// Encode the posting list to binary format.
+    /// Encode the posting list to binary format using block-based bit-packing.
+    ///
+    /// # Layout
+    ///
+    /// The on-disk format is structure-of-arrays (SoA), with each field stored
+    /// in its own contiguous section:
+    ///
+    /// ```text
+    /// [term: string]
+    /// [total_frequency: varint]
+    /// [doc_frequency: varint]
+    /// [posting_count N: varint]
+    /// [any_positions: u8]                     (1 if any posting has positions)
+    ///
+    /// // Section 1: doc_ids — sorted ascending, FOR + delta bit-packed
+    /// repeat (N / 128) times: [num_bits: u8] [packed: num_bits * 16 bytes]
+    /// repeat (N % 128) times: [delta: varint]
+    ///
+    /// // Section 2: frequencies — raw bit-packed
+    /// repeat (N / 128) times: [num_bits: u8] [packed: num_bits * 16 bytes]
+    /// repeat (N % 128) times: [freq: varint]
+    ///
+    /// // Section 3: weights — raw f32 array
+    /// repeat N times: [weight: f32]
+    ///
+    /// // Section 4: positions (only when any_positions == 1)
+    /// repeat N times:
+    ///   [has_positions: u8]
+    ///   if 1: [count: varint] [delta: varint] * count
+    /// ```
+    ///
+    /// # Constraints
+    ///
+    /// - `doc_id` must fit in `u32` (i.e. < 2^32). Per-segment doc-id space is
+    ///   bounded by Lucene/Tantivy convention; this is enforced at encode time.
+    ///
+    /// # Arguments
+    ///
+    /// * `writer` - The structured output writer.
     pub fn encode<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
-        // Write term
         writer.write_string(&self.term)?;
-
-        // Write metadata
         writer.write_varint(self.total_frequency)?;
         writer.write_varint(self.doc_frequency)?;
-        writer.write_varint(self.postings.len() as u64)?;
 
-        // Write postings with delta compression for doc IDs
-        let mut prev_doc_id = 0u64;
+        let n = self.postings.len();
+        writer.write_varint(n as u64)?;
+
+        let any_positions = self.postings.iter().any(|p| p.positions.is_some());
+        writer.write_u8(u8::from(any_positions))?;
+
+        if n == 0 {
+            return Ok(());
+        }
+
+        let bitpacker = BitPacker4x::new();
+        let full_blocks = n / POSTING_BLOCK_LEN;
+        let tail = n % POSTING_BLOCK_LEN;
+
+        // Section 1: doc_ids (FOR + sorted-delta bit-pack).
+        let mut doc_buf = [0u32; POSTING_BLOCK_LEN];
+        // Reusable scratch for the largest possible packed block (32 bits per
+        // value * 128 / 8 = 512 bytes).
+        let mut packed = vec![0u8; 32 * POSTING_BLOCK_LEN / 8];
+        let mut initial: u32 = 0;
+        for b in 0..full_blocks {
+            for (i, slot) in doc_buf.iter_mut().enumerate() {
+                let did = self.postings[b * POSTING_BLOCK_LEN + i].doc_id;
+                *slot = u32::try_from(did).map_err(|_| {
+                    LaurusError::index(format!(
+                        "doc_id {did} exceeds u32::MAX; segment is too large for bit-packed posting format"
+                    ))
+                })?;
+            }
+            let num_bits = bitpacker.num_bits_sorted(initial, &doc_buf);
+            let bytes = num_bits as usize * POSTING_BLOCK_LEN / 8;
+            bitpacker.compress_sorted(initial, &doc_buf, &mut packed[..bytes], num_bits);
+            writer.write_u8(num_bits)?;
+            writer.write_raw(&packed[..bytes])?;
+            initial = doc_buf[POSTING_BLOCK_LEN - 1];
+        }
+        // Tail doc_ids (varint deltas continuing from `initial`).
+        let mut prev_did: u64 = initial as u64;
+        for i in 0..tail {
+            let did = self.postings[full_blocks * POSTING_BLOCK_LEN + i].doc_id;
+            // Reject overflow even in the tail so reads stay symmetric.
+            u32::try_from(did).map_err(|_| {
+                LaurusError::index(format!(
+                    "doc_id {did} exceeds u32::MAX; segment is too large for bit-packed posting format"
+                ))
+            })?;
+            writer.write_varint(did - prev_did)?;
+            prev_did = did;
+        }
+
+        // Section 2: frequencies (raw bit-pack).
+        let mut freq_buf = [0u32; POSTING_BLOCK_LEN];
+        for b in 0..full_blocks {
+            for (i, slot) in freq_buf.iter_mut().enumerate() {
+                *slot = self.postings[b * POSTING_BLOCK_LEN + i].frequency;
+            }
+            let num_bits = bitpacker.num_bits(&freq_buf);
+            let bytes = num_bits as usize * POSTING_BLOCK_LEN / 8;
+            bitpacker.compress(&freq_buf, &mut packed[..bytes], num_bits);
+            writer.write_u8(num_bits)?;
+            writer.write_raw(&packed[..bytes])?;
+        }
+        for i in 0..tail {
+            let freq = self.postings[full_blocks * POSTING_BLOCK_LEN + i].frequency;
+            writer.write_varint(freq as u64)?;
+        }
+
+        // Section 3: weights (raw f32).
         for posting in &self.postings {
-            // Delta-compressed doc ID
-            let delta = posting.doc_id - prev_doc_id;
-            writer.write_varint(delta)?;
-            prev_doc_id = posting.doc_id;
-
-            // Frequency
-            writer.write_varint(posting.frequency as u64)?;
-
-            // Weight
             writer.write_f32(posting.weight)?;
+        }
 
-            // Positions (optional)
-            if let Some(positions) = &posting.positions {
-                writer.write_u8(1)?; // Has positions flag
-                writer.write_varint(positions.len() as u64)?;
-
-                // Delta-compress positions (positions must be sorted ascending)
-                let mut prev_pos = 0u32;
-                for &pos in positions {
-                    let delta = pos.saturating_sub(prev_pos);
-                    writer.write_varint(delta as u64)?;
-                    prev_pos = pos;
+        // Section 4: positions (only when at least one posting carries them).
+        if any_positions {
+            for posting in &self.postings {
+                if let Some(positions) = &posting.positions {
+                    writer.write_u8(1)?;
+                    writer.write_varint(positions.len() as u64)?;
+                    let mut prev_pos = 0u32;
+                    for &pos in positions {
+                        let delta = pos.saturating_sub(prev_pos);
+                        writer.write_varint(delta as u64)?;
+                        prev_pos = pos;
+                    }
+                } else {
+                    writer.write_u8(0)?;
                 }
-            } else {
-                writer.write_u8(0)?; // No positions flag
             }
         }
 
         Ok(())
     }
 
-    /// Decode a posting list from binary format.
+    /// Decode a posting list previously written by [`Self::encode`].
+    ///
+    /// Reads the SoA-laid sections (doc_ids, frequencies, weights, optional
+    /// positions) and rebuilds the AoS [`Vec<Posting>`].
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - The structured input reader positioned at a posting-list
+    ///   header.
     pub fn decode<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
-        // Read term
         let term = reader.read_string()?;
-
-        // Read metadata
         let total_frequency = reader.read_varint()?;
         let doc_frequency = reader.read_varint()?;
-        let posting_count = reader.read_varint()? as usize;
+        let n = reader.read_varint()? as usize;
+        let any_positions = reader.read_u8()? != 0;
 
-        let mut postings = Vec::with_capacity(posting_count);
-        let mut prev_doc_id = 0u64;
-
-        for _ in 0..posting_count {
-            // Read delta-compressed doc ID
-            let delta = reader.read_varint()?;
-            let doc_id = prev_doc_id + delta;
-            prev_doc_id = doc_id;
-
-            // Read frequency
-            let frequency = reader.read_varint()? as u32;
-
-            // Read weight
-            let weight = reader.read_f32()?;
-
-            // Read positions
-            let has_positions = reader.read_u8()? != 0;
-            let positions = if has_positions {
-                let pos_count = reader.read_varint()? as usize;
-                let mut positions = Vec::with_capacity(pos_count);
-                let mut prev_pos = 0u32;
-
-                for _ in 0..pos_count {
-                    let delta = reader.read_varint()? as u32;
-                    let pos = prev_pos + delta;
-                    positions.push(pos);
-                    prev_pos = pos;
-                }
-
-                Some(positions)
-            } else {
-                None
-            };
-
-            postings.push(Posting {
-                doc_id,
-                frequency,
-                positions,
-                weight,
+        if n == 0 {
+            return Ok(PostingList {
+                term,
+                postings: Vec::new(),
+                total_frequency,
+                doc_frequency,
             });
         }
+
+        let bitpacker = BitPacker4x::new();
+        let full_blocks = n / POSTING_BLOCK_LEN;
+        let tail = n % POSTING_BLOCK_LEN;
+
+        // Section 1: doc_ids.
+        let mut doc_ids: Vec<u32> = Vec::with_capacity(n);
+        let mut buf = [0u32; POSTING_BLOCK_LEN];
+        let mut initial: u32 = 0;
+        for _ in 0..full_blocks {
+            let num_bits = reader.read_u8()?;
+            let bytes = num_bits as usize * POSTING_BLOCK_LEN / 8;
+            let compressed = reader.read_raw(bytes)?;
+            bitpacker.decompress_sorted(initial, &compressed, &mut buf, num_bits);
+            doc_ids.extend_from_slice(&buf);
+            initial = buf[POSTING_BLOCK_LEN - 1];
+        }
+        let mut prev_did: u64 = initial as u64;
+        for _ in 0..tail {
+            let delta = reader.read_varint()?;
+            let did = prev_did + delta;
+            doc_ids.push(u32::try_from(did).map_err(|_| {
+                LaurusError::index(format!(
+                    "decoded doc_id {did} exceeds u32::MAX; corrupted posting list"
+                ))
+            })?);
+            prev_did = did;
+        }
+
+        // Section 2: frequencies.
+        let mut frequencies: Vec<u32> = Vec::with_capacity(n);
+        for _ in 0..full_blocks {
+            let num_bits = reader.read_u8()?;
+            let bytes = num_bits as usize * POSTING_BLOCK_LEN / 8;
+            let compressed = reader.read_raw(bytes)?;
+            bitpacker.decompress(&compressed, &mut buf, num_bits);
+            frequencies.extend_from_slice(&buf);
+        }
+        for _ in 0..tail {
+            frequencies.push(reader.read_varint()? as u32);
+        }
+
+        // Section 3: weights.
+        let mut weights: Vec<f32> = Vec::with_capacity(n);
+        for _ in 0..n {
+            weights.push(reader.read_f32()?);
+        }
+
+        // Section 4: positions.
+        let positions_per_posting: Vec<Option<Vec<u32>>> = if any_positions {
+            let mut out = Vec::with_capacity(n);
+            for _ in 0..n {
+                let has = reader.read_u8()? != 0;
+                if has {
+                    let count = reader.read_varint()? as usize;
+                    let mut positions = Vec::with_capacity(count);
+                    let mut prev_pos = 0u32;
+                    for _ in 0..count {
+                        let delta = reader.read_varint()? as u32;
+                        let pos = prev_pos + delta;
+                        positions.push(pos);
+                        prev_pos = pos;
+                    }
+                    out.push(Some(positions));
+                } else {
+                    out.push(None);
+                }
+            }
+            out
+        } else {
+            (0..n).map(|_| None).collect()
+        };
+
+        let postings: Vec<Posting> = doc_ids
+            .into_iter()
+            .zip(frequencies)
+            .zip(weights)
+            .zip(positions_per_posting)
+            .map(|(((did, freq), w), pos)| Posting {
+                doc_id: did as u64,
+                frequency: freq,
+                positions: pos,
+                weight: w,
+            })
+            .collect();
 
         Ok(PostingList {
             term,
@@ -1015,5 +1170,178 @@ mod tests {
     #[test]
     fn test_compact_posting_size() {
         assert_eq!(std::mem::size_of::<CompactPosting>(), 16);
+    }
+
+    /// Round-trip a posting list of size `n` through encode/decode and assert
+    /// that every field is preserved. `with_positions` controls whether each
+    /// posting carries position data.
+    fn round_trip_n(n: usize, with_positions: bool) {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+        let mut original = PostingList::new(format!("term_n{n}"));
+        // Build deterministic but non-trivial postings: doc_id step 3, frequency
+        // varying 1..=7, weight derived from doc_id.
+        for i in 0..n {
+            let did = (i as u64) * 3 + 1;
+            let freq = ((i % 7) + 1) as u32;
+            let weight = 0.25 + (i % 4) as f32 * 0.5;
+            let posting = if with_positions {
+                let mut positions = Vec::with_capacity(freq as usize);
+                let mut p = (i % 11) as u32;
+                for _ in 0..freq {
+                    positions.push(p);
+                    p += 2;
+                }
+                Posting::with_positions(did, positions).with_weight(weight)
+            } else {
+                Posting::with_frequency(did, freq).with_weight(weight)
+            };
+            original.add_posting(posting);
+        }
+
+        let path = format!("rt_n{n}_pos{with_positions}.bin");
+        {
+            let output = storage.create_output(&path).unwrap();
+            let mut writer = StructWriter::new(output);
+            original.encode(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+        let input = storage.open_input(&path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let decoded = PostingList::decode(&mut reader).unwrap();
+
+        assert_eq!(decoded.term, original.term, "term mismatch (n={n})");
+        assert_eq!(
+            decoded.total_frequency, original.total_frequency,
+            "total_frequency mismatch (n={n})"
+        );
+        assert_eq!(
+            decoded.doc_frequency, original.doc_frequency,
+            "doc_frequency mismatch (n={n})"
+        );
+        assert_eq!(
+            decoded.postings.len(),
+            original.postings.len(),
+            "len mismatch (n={n})"
+        );
+        for (i, (orig, dec)) in original
+            .postings
+            .iter()
+            .zip(decoded.postings.iter())
+            .enumerate()
+        {
+            assert_eq!(orig.doc_id, dec.doc_id, "doc_id mismatch at i={i} (n={n})");
+            assert_eq!(
+                orig.frequency, dec.frequency,
+                "frequency mismatch at i={i} (n={n})"
+            );
+            assert_eq!(orig.weight, dec.weight, "weight mismatch at i={i} (n={n})");
+            assert_eq!(
+                orig.positions, dec.positions,
+                "positions mismatch at i={i} (n={n})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_round_trip_empty() {
+        round_trip_n(0, false);
+        round_trip_n(0, true);
+    }
+
+    #[test]
+    fn test_round_trip_single() {
+        round_trip_n(1, false);
+        round_trip_n(1, true);
+    }
+
+    /// Block size minus one: tail-only path, no full bit-packed block.
+    #[test]
+    fn test_round_trip_below_block() {
+        round_trip_n(127, false);
+        round_trip_n(127, true);
+    }
+
+    /// Exactly one full block, zero tail.
+    #[test]
+    fn test_round_trip_exact_block() {
+        round_trip_n(128, false);
+        round_trip_n(128, true);
+    }
+
+    /// One full block plus a single tail element.
+    #[test]
+    fn test_round_trip_block_plus_one() {
+        round_trip_n(129, false);
+        round_trip_n(129, true);
+    }
+
+    #[test]
+    fn test_round_trip_two_blocks() {
+        round_trip_n(256, false);
+        round_trip_n(256, true);
+    }
+
+    #[test]
+    fn test_round_trip_many_blocks() {
+        round_trip_n(1000, false);
+        round_trip_n(1000, true);
+    }
+
+    /// Mixed positions (some postings carry positions, some don't) verifies
+    /// that the per-posting `has_positions` flag inside section 4 still works.
+    #[test]
+    fn test_round_trip_mixed_positions() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let mut original = PostingList::new("mixed".to_string());
+        for i in 0..200u64 {
+            let mut posting = Posting::with_frequency(i * 2, ((i % 5) + 1) as u32);
+            if i % 3 == 0 {
+                posting.add_position((i % 17) as u32);
+                posting.add_position(((i % 17) + 5) as u32);
+            }
+            original.add_posting(posting);
+        }
+
+        let path = "rt_mixed.bin";
+        {
+            let output = storage.create_output(path).unwrap();
+            let mut writer = StructWriter::new(output);
+            original.encode(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+        let input = storage.open_input(path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let decoded = PostingList::decode(&mut reader).unwrap();
+
+        assert_eq!(decoded.postings.len(), original.postings.len());
+        for (orig, dec) in original.postings.iter().zip(decoded.postings.iter()) {
+            assert_eq!(orig, dec);
+        }
+    }
+
+    /// Encoding a doc_id beyond `u32::MAX` must fail with a clear error so we
+    /// don't silently corrupt the bit-packed segment.
+    #[test]
+    fn test_encode_rejects_u64_doc_id_overflow() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let mut list = PostingList::new("overflow".to_string());
+        // Fill a full block so the overflow check exercises the bit-packed
+        // path, not just the tail.
+        for i in 0..127u64 {
+            list.add_posting(Posting::new(i));
+        }
+        list.add_posting(Posting::new(u64::from(u32::MAX) + 1));
+
+        let output = storage.create_output("overflow.bin").unwrap();
+        let mut writer = StructWriter::new(output);
+        let err = list
+            .encode(&mut writer)
+            .expect_err("expected overflow error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("exceeds u32::MAX"),
+            "unexpected error message: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replace the per-posting AoS varint encoding in `PostingList::encode/decode`
with a **structure-of-arrays** layout where doc IDs and term frequencies are
stored as fixed 128-int blocks via the
[`bitpacking`](https://crates.io/crates/bitpacking) crate (the same crate
Tantivy uses).

- doc IDs: FOR + sorted-delta bit-pack (`BitPacker4x::compress_sorted`)
- frequencies: raw bit-pack (`BitPacker4x::compress`)
- weights: raw `f32` array (unchanged)
- positions: varint AoS (kept as-is to keep this PR scoped)
- tail (< 128 elements): varint fallback

The on-disk format version field stays at `1` because laurus is pre-release;
old segments must be reindexed against this format.

## Layout

```text
[term, total_frequency, doc_frequency, posting_count N, any_positions]
[Section 1: doc_ids       — N/128 bit-packed blocks (FOR + sorted-delta) + varint tail]
[Section 2: frequencies   — N/128 bit-packed blocks (raw)               + varint tail]
[Section 3: weights       — N raw f32 values]
[Section 4: positions     — per-posting flag + varint deltas (only if any_positions)]
```

Per-segment doc IDs must fit in `u32` (matches Lucene/Tantivy convention);
`encode` fails fast with a clear error if that bound is exceeded.

## Bench

`lexical_search_bench::topk_or_skewed_tf/should_or_topk10`, baseline `pre-464`
(main HEAD before this PR):

| Size    | pre-464 | post-464  | Change            |
|---------|---------|-----------|-------------------|
| 1,000   | ~784 µs | 590 µs    | -24.7%            |
| 10,000  | ~6.04 ms| 5.02 ms   | -16.8%            |
| 100,000 | 33.15 ms| 19.96 ms  | **-40.6% (1.66x)**|

Single-PR speedup is below the umbrella's 2x target; combined with the
already-merged improvements in #474 / #475 / #476 Phase 1 / #480 / #483 the
cumulative gain across umbrella #463 is well past 2x.

## Test plan

- [x] `cargo test -p laurus --lib` — 824 passed (existing 815 + 9 new round-trip / boundary / overflow tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npx markdownlint-cli2 "docs/src/**/*.md"` — 0 errors
- [x] Round-trip tests cover N = 0, 1, 127, 128, 129, 256, 1000, mixed positions, and `u32::MAX` overflow rejection

## Out of scope (follow-ups)

- positions SoA + bit-pack
- weights RLE compression
- block-at-a-time lazy posting iterator (would help BMW further)
- AVX2 (`BitPacker8x`) — block size would diverge from #403's 128

Closes #464.
Refs #463.