### PR TITLE
perf(lexical/postings): SoA-native decode + iterator (#465 part 1)

### DIFF
--- a/docs/src/concepts/indexing/lexical_indexing.md
+++ b/docs/src/concepts/indexing/lexical_indexing.md
@@ -89,6 +89,12 @@ Per-segment doc IDs must fit in `u32`. Encoding a value beyond `u32::MAX`
 fails fast with a clear error to prevent silent corruption of the
 bit-packed segment.
 
+The decoder exposes a SoA-native fast path (`PostingList::decode_soa`) that
+produces parallel `Vec<u32>` slices for `doc_id` and `frequency` directly
+from disk without the intermediate `Vec<Posting>` reassembly. The query
+iterator stores those slices, so `next()` advances a single `u32` cursor
+over a dense slice instead of striding across a 40-byte `Posting` struct.
+
 ## Numeric and Date Fields
 
 Integer, float, and datetime fields are indexed using a **[BKD tree](../bkd_tree.md)** — a space-partitioning data structure optimized for range queries:

--- a/laurus/src/lexical/index/inverted/core/posting.rs
+++ b/laurus/src/lexical/index/inverted/core/posting.rs
@@ -233,6 +233,121 @@ pub struct PostingList {
     pub doc_frequency: u64,
 }
 
+/// SoA-native decoded posting data, produced directly by
+/// [`PostingList::decode_soa`] without an intermediate `Vec<Posting>`
+/// reassembly.
+///
+/// Designed for the query hot path: the iterator can be backed by parallel
+/// arrays and serve `doc_id` / `term_freq` / `weight` from sequential `u32` /
+/// `f32` slices instead of striding over a 40-byte `Posting` struct.
+///
+/// Doc IDs are kept as `u32` because per-segment doc-id space is bounded to
+/// `u32::MAX` (Lucene / Tantivy convention) — see [`PostingList::encode`] for
+/// the matching invariant on the writer side.
+#[derive(Debug, Clone)]
+pub struct DecodedPostingList {
+    /// The term this posting list represents.
+    pub term: String,
+    /// Doc IDs, sorted ascending. Parallel to `frequencies` / `weights`.
+    pub doc_ids: Vec<u32>,
+    /// Term frequencies. Parallel to `doc_ids` / `weights`.
+    pub frequencies: Vec<u32>,
+    /// Per-document weights. Parallel to `doc_ids` / `frequencies`.
+    pub weights: Vec<f32>,
+    /// Optional per-posting positions sidecar. `None` when **no** posting in
+    /// this list carries position data (the common case for boolean / BM25
+    /// queries that don't need phrases). When `Some(v)`, `v[i]` is the
+    /// positions for posting `i`: `Some(Vec<u32>)` if positions are present,
+    /// `None` otherwise.
+    pub positions: Option<Vec<Option<Vec<u32>>>>,
+    /// Total term frequency across all documents.
+    pub total_frequency: u64,
+    /// Document frequency (number of documents containing this term).
+    pub doc_frequency: u64,
+}
+
+impl DecodedPostingList {
+    /// Number of postings in this list.
+    pub fn len(&self) -> usize {
+        self.doc_ids.len()
+    }
+
+    /// Returns `true` if there are no postings.
+    pub fn is_empty(&self) -> bool {
+        self.doc_ids.is_empty()
+    }
+
+    /// Build a SoA decoded view from an AoS [`PostingList`]. Used by callers
+    /// that already hold an in-memory `Vec<Posting>` and want the SoA-native
+    /// iterator path.
+    ///
+    /// # Arguments
+    ///
+    /// * `list` - The AoS posting list to convert.
+    pub fn from_posting_list(list: &PostingList) -> Self {
+        let n = list.postings.len();
+        let mut doc_ids = Vec::with_capacity(n);
+        let mut frequencies = Vec::with_capacity(n);
+        let mut weights = Vec::with_capacity(n);
+        let any_positions = list.postings.iter().any(|p| p.positions.is_some());
+        let mut positions: Option<Vec<Option<Vec<u32>>>> = if any_positions {
+            Some(Vec::with_capacity(n))
+        } else {
+            None
+        };
+
+        for posting in &list.postings {
+            doc_ids.push(posting.doc_id as u32);
+            frequencies.push(posting.frequency);
+            weights.push(posting.weight);
+            if let Some(out) = positions.as_mut() {
+                out.push(posting.positions.clone());
+            }
+        }
+
+        DecodedPostingList {
+            term: list.term.clone(),
+            doc_ids,
+            frequencies,
+            weights,
+            positions,
+            total_frequency: list.total_frequency,
+            doc_frequency: list.doc_frequency,
+        }
+    }
+
+    /// Reassemble an AoS [`PostingList`] from this SoA view. Useful for tests
+    /// and back-compat code paths that still expect `Vec<Posting>`.
+    pub fn into_posting_list(self) -> PostingList {
+        let n = self.doc_ids.len();
+        let positions_iter: Box<dyn Iterator<Item = Option<Vec<u32>>>> = match self.positions {
+            Some(v) => Box::new(v.into_iter()),
+            None => Box::new(std::iter::repeat_with(|| None).take(n)),
+        };
+
+        let postings: Vec<Posting> = self
+            .doc_ids
+            .into_iter()
+            .zip(self.frequencies)
+            .zip(self.weights)
+            .zip(positions_iter)
+            .map(|(((did, freq), w), pos)| Posting {
+                doc_id: did as u64,
+                frequency: freq,
+                positions: pos,
+                weight: w,
+            })
+            .collect();
+
+        PostingList {
+            term: self.term,
+            postings,
+            total_frequency: self.total_frequency,
+            doc_frequency: self.doc_frequency,
+        }
+    }
+}
+
 impl PostingList {
     /// Create a new empty posting list.
     pub fn new(term: String) -> Self {
@@ -481,16 +596,21 @@ impl PostingList {
         Ok(())
     }
 
-    /// Decode a posting list previously written by [`Self::encode`].
+    /// Decode a posting list previously written by [`Self::encode`] in
+    /// SoA-native form, **without** an intermediate `Vec<Posting>`
+    /// reassembly.
     ///
-    /// Reads the SoA-laid sections (doc_ids, frequencies, weights, optional
-    /// positions) and rebuilds the AoS [`Vec<Posting>`].
+    /// This is the fast path for the query hot loop: callers can store the
+    /// returned [`DecodedPostingList`] in their iterator directly and serve
+    /// `doc_id` / `term_freq` / `weight` from the parallel `u32` / `f32`
+    /// slices, avoiding both the malloc and the AoS struct stride that the
+    /// `Vec<Posting>` form pays.
     ///
     /// # Arguments
     ///
     /// * `reader` - The structured input reader positioned at a posting-list
     ///   header.
-    pub fn decode<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
+    pub fn decode_soa<R: StorageInput>(reader: &mut StructReader<R>) -> Result<DecodedPostingList> {
         let term = reader.read_string()?;
         let total_frequency = reader.read_varint()?;
         let doc_frequency = reader.read_varint()?;
@@ -498,9 +618,16 @@ impl PostingList {
         let any_positions = reader.read_u8()? != 0;
 
         if n == 0 {
-            return Ok(PostingList {
+            return Ok(DecodedPostingList {
                 term,
-                postings: Vec::new(),
+                doc_ids: Vec::new(),
+                frequencies: Vec::new(),
+                weights: Vec::new(),
+                positions: if any_positions {
+                    Some(Vec::new())
+                } else {
+                    None
+                },
                 total_frequency,
                 doc_frequency,
             });
@@ -553,50 +680,55 @@ impl PostingList {
             weights.push(reader.read_f32()?);
         }
 
-        // Section 4: positions.
-        let positions_per_posting: Vec<Option<Vec<u32>>> = if any_positions {
-            let mut out = Vec::with_capacity(n);
+        // Section 4: positions (only materialised when at least one posting
+        // carries them; absent otherwise to keep the SoA path zero-allocation
+        // for the common BM25 / boolean case).
+        let positions = if any_positions {
+            let mut out: Vec<Option<Vec<u32>>> = Vec::with_capacity(n);
             for _ in 0..n {
                 let has = reader.read_u8()? != 0;
                 if has {
                     let count = reader.read_varint()? as usize;
-                    let mut positions = Vec::with_capacity(count);
+                    let mut p = Vec::with_capacity(count);
                     let mut prev_pos = 0u32;
                     for _ in 0..count {
                         let delta = reader.read_varint()? as u32;
                         let pos = prev_pos + delta;
-                        positions.push(pos);
+                        p.push(pos);
                         prev_pos = pos;
                     }
-                    out.push(Some(positions));
+                    out.push(Some(p));
                 } else {
                     out.push(None);
                 }
             }
-            out
+            Some(out)
         } else {
-            (0..n).map(|_| None).collect()
+            None
         };
 
-        let postings: Vec<Posting> = doc_ids
-            .into_iter()
-            .zip(frequencies)
-            .zip(weights)
-            .zip(positions_per_posting)
-            .map(|(((did, freq), w), pos)| Posting {
-                doc_id: did as u64,
-                frequency: freq,
-                positions: pos,
-                weight: w,
-            })
-            .collect();
-
-        Ok(PostingList {
+        Ok(DecodedPostingList {
             term,
-            postings,
+            doc_ids,
+            frequencies,
+            weights,
+            positions,
             total_frequency,
             doc_frequency,
         })
+    }
+
+    /// Decode a posting list previously written by [`Self::encode`] into the
+    /// AoS [`Vec<Posting>`] form. Thin wrapper over [`Self::decode_soa`] kept
+    /// for callers that need positions per `Posting` or want a back-compat
+    /// view.
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - The structured input reader positioned at a posting-list
+    ///   header.
+    pub fn decode<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
+        Ok(Self::decode_soa(reader)?.into_posting_list())
     }
 }
 
@@ -1316,6 +1448,102 @@ mod tests {
 
         assert_eq!(decoded.postings.len(), original.postings.len());
         for (orig, dec) in original.postings.iter().zip(decoded.postings.iter()) {
+            assert_eq!(orig, dec);
+        }
+    }
+
+    /// `decode_soa` must produce the same data as the AoS `decode` path
+    /// across full-block / tail / mixed-positions sizes. This protects the
+    /// fast SoA path against drift from the back-compat AoS path.
+    #[test]
+    fn test_decode_soa_matches_decode_aos() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        for &(n, with_pos) in &[
+            (0usize, false),
+            (1, false),
+            (1, true),
+            (127, false),
+            (128, true),
+            (129, false),
+            (256, true),
+            (1000, false),
+        ] {
+            let mut original = PostingList::new(format!("term_n{n}_p{with_pos}"));
+            for i in 0..n {
+                let did = (i as u64) * 3 + 1;
+                let freq = ((i % 7) + 1) as u32;
+                let weight = 0.25 + (i % 4) as f32 * 0.5;
+                let p = if with_pos {
+                    let mut positions = Vec::with_capacity(freq as usize);
+                    let mut p = (i % 11) as u32;
+                    for _ in 0..freq {
+                        positions.push(p);
+                        p += 2;
+                    }
+                    Posting::with_positions(did, positions).with_weight(weight)
+                } else {
+                    Posting::with_frequency(did, freq).with_weight(weight)
+                };
+                original.add_posting(p);
+            }
+
+            let path = format!("soa_match_n{n}_p{with_pos}.bin");
+            {
+                let output = storage.create_output(&path).unwrap();
+                let mut writer = StructWriter::new(output);
+                original.encode(&mut writer).unwrap();
+                writer.close().unwrap();
+            }
+
+            // Decode through both paths and compare.
+            let aos_decoded = {
+                let input = storage.open_input(&path).unwrap();
+                let mut reader = StructReader::new(input).unwrap();
+                PostingList::decode(&mut reader).unwrap()
+            };
+            let soa_decoded = {
+                let input = storage.open_input(&path).unwrap();
+                let mut reader = StructReader::new(input).unwrap();
+                PostingList::decode_soa(&mut reader).unwrap()
+            };
+
+            assert_eq!(aos_decoded.term, soa_decoded.term);
+            assert_eq!(aos_decoded.total_frequency, soa_decoded.total_frequency);
+            assert_eq!(aos_decoded.doc_frequency, soa_decoded.doc_frequency);
+            assert_eq!(aos_decoded.postings.len(), soa_decoded.len());
+            for (i, p) in aos_decoded.postings.iter().enumerate() {
+                assert_eq!(p.doc_id as u32, soa_decoded.doc_ids[i], "doc_id at {i}");
+                assert_eq!(p.frequency, soa_decoded.frequencies[i], "freq at {i}");
+                assert_eq!(p.weight, soa_decoded.weights[i], "weight at {i}");
+                let soa_pos = soa_decoded.positions.as_ref().and_then(|v| v[i].clone());
+                assert_eq!(p.positions, soa_pos, "positions at {i}");
+            }
+        }
+    }
+
+    /// `DecodedPostingList::from_posting_list` followed by
+    /// `into_posting_list` must round-trip every field on both
+    /// positions-present and positions-absent shapes.
+    #[test]
+    fn test_decoded_posting_list_aos_soa_roundtrip() {
+        let mut list = PostingList::new("term".to_string());
+        for i in 0..200u64 {
+            let mut p = Posting::with_frequency(i * 2 + 7, ((i % 5) + 1) as u32)
+                .with_weight(0.5 + (i % 3) as f32);
+            if i % 4 == 0 {
+                p.add_position((i % 13) as u32);
+                p.add_position(((i % 13) + 4) as u32);
+            }
+            list.add_posting(p);
+        }
+
+        let soa = DecodedPostingList::from_posting_list(&list);
+        assert_eq!(soa.len(), list.postings.len());
+        let rebuilt = soa.into_posting_list();
+        assert_eq!(rebuilt.term, list.term);
+        assert_eq!(rebuilt.total_frequency, list.total_frequency);
+        assert_eq!(rebuilt.doc_frequency, list.doc_frequency);
+        for (orig, dec) in list.postings.iter().zip(rebuilt.postings.iter()) {
             assert_eq!(orig, dec);
         }
     }

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -15,7 +15,7 @@ use crate::analysis::token::Token;
 use crate::error::{LaurusError, Result};
 use crate::lexical::core::document::Document;
 use crate::lexical::core::field::FieldValue;
-use crate::lexical::index::inverted::core::posting::{Posting, PostingList};
+use crate::lexical::index::inverted::core::posting::{DecodedPostingList, Posting, PostingList};
 use crate::lexical::index::inverted::core::terms::{
     InvertedIndexTerms, MergedInvertedIndexTerms, TermDictionaryAccess, Terms,
 };
@@ -88,6 +88,16 @@ impl Default for InvertedIndexReaderConfig {
 /// # Purpose
 /// Used when executing queries against the actual index.
 ///
+/// # Storage layout
+///
+/// Internally backed by **structure-of-arrays** parallel slices
+/// (`doc_ids: Vec<u32>`, `frequencies: Vec<u32>`, optional positions
+/// sidecar). This avoids the AoS `Vec<Posting>` reassembly that
+/// `PostingList::decode` previously paid: 4 bytes per doc-id instead of a
+/// 40-byte `Posting` struct, and `next()` advances a single integer cursor
+/// over a dense `&[u32]` slice. Per-segment doc-ids fit in `u32` by the same
+/// invariant the encoder enforces.
+///
 /// # Implemented Traits
 /// - `reader::PostingIterator` trait
 ///
@@ -108,21 +118,32 @@ impl Default for InvertedIndexReaderConfig {
 /// - `InvertedIndexPostingIterator`: Advanced iterator for index queries
 #[derive(Debug)]
 pub struct InvertedIndexPostingIterator {
-    /// The posting data.
-    postings: Vec<crate::lexical::index::inverted::core::posting::Posting>,
+    /// Doc IDs, sorted ascending. Parallel to `frequencies`.
+    doc_ids: Vec<u32>,
 
-    /// Current position in the posting list.
+    /// Term frequencies. Parallel to `doc_ids`.
+    frequencies: Vec<u32>,
+
+    /// Optional per-posting positions sidecar. `None` when no posting carries
+    /// positions; otherwise `vec[i]` holds the positions for doc `i`.
+    positions: Option<Vec<Option<Vec<u32>>>>,
+
+    /// Current position in the parallel arrays.
     position: usize,
 
-    /// Block cache for efficient access.
+    /// Block cache for efficient skip-to.
     block_cache: Option<Vec<PostingBlock>>,
 
     /// Current block being processed.
     current_block: usize,
 
-    /// Whether next() has been called at least once.
+    /// Whether `next()` has been called at least once.
     started: bool,
 }
+
+/// Parallel-array form returned by [`InvertedIndexPostingIterator::soa_from_aos`].
+/// Tuple is `(doc_ids, frequencies, optional positions sidecar)`.
+type SoaArrays = (Vec<u32>, Vec<u32>, Option<Vec<Option<Vec<u32>>>>);
 
 /// A block of postings for efficient processing.
 #[derive(Debug, Clone)]
@@ -141,10 +162,15 @@ pub struct PostingBlock {
 }
 
 impl InvertedIndexPostingIterator {
-    /// Create a new advanced posting iterator.
+    /// Create a new advanced posting iterator from an AoS [`Vec<Posting>`].
+    /// Performs an AoS→SoA conversion eagerly; prefer
+    /// [`Self::from_decoded_soa`] in the query hot path to skip this copy.
     pub fn new(postings: Vec<Posting>) -> Self {
+        let (doc_ids, frequencies, positions) = Self::soa_from_aos(&postings);
         InvertedIndexPostingIterator {
-            postings,
+            doc_ids,
+            frequencies,
+            positions,
             position: 0,
             block_cache: None,
             current_block: 0,
@@ -152,11 +178,16 @@ impl InvertedIndexPostingIterator {
         }
     }
 
-    /// Create posting iterator with block optimization.
+    /// Create a posting iterator from AoS postings with block optimization.
+    /// Performs an AoS→SoA conversion eagerly; prefer
+    /// [`Self::from_decoded_soa_with_blocks`] in the query hot path.
     pub fn with_blocks(postings: Vec<Posting>, block_size: usize) -> Self {
-        let blocks = Self::create_blocks(&postings, block_size);
+        let (doc_ids, frequencies, positions) = Self::soa_from_aos(&postings);
+        let blocks = Self::create_blocks(&doc_ids, block_size);
         InvertedIndexPostingIterator {
-            postings,
+            doc_ids,
+            frequencies,
+            positions,
             position: 0,
             block_cache: Some(blocks),
             current_block: 0,
@@ -164,31 +195,88 @@ impl InvertedIndexPostingIterator {
         }
     }
 
-    /// Create posting blocks for efficient skip-to operations.
-    fn create_blocks(postings: &[Posting], block_size: usize) -> Vec<PostingBlock> {
+    /// Construct an iterator directly from a SoA-decoded posting list,
+    /// without paying an AoS reassembly. This is the fast path used by
+    /// [`SegmentReader::postings`] / `term_postings` after
+    /// [`PostingList::decode_soa`].
+    ///
+    /// # Arguments
+    ///
+    /// * `decoded` - SoA-decoded posting data.
+    pub fn from_decoded_soa(decoded: DecodedPostingList) -> Self {
+        InvertedIndexPostingIterator {
+            doc_ids: decoded.doc_ids,
+            frequencies: decoded.frequencies,
+            positions: decoded.positions,
+            position: 0,
+            block_cache: None,
+            current_block: 0,
+            started: false,
+        }
+    }
+
+    /// Like [`Self::from_decoded_soa`], but also pre-builds the skip-block
+    /// cache used by [`Self::skip_to`].
+    ///
+    /// # Arguments
+    ///
+    /// * `decoded` - SoA-decoded posting data.
+    /// * `block_size` - Number of postings per skip block.
+    pub fn from_decoded_soa_with_blocks(decoded: DecodedPostingList, block_size: usize) -> Self {
+        let blocks = Self::create_blocks(&decoded.doc_ids, block_size);
+        InvertedIndexPostingIterator {
+            doc_ids: decoded.doc_ids,
+            frequencies: decoded.frequencies,
+            positions: decoded.positions,
+            position: 0,
+            block_cache: Some(blocks),
+            current_block: 0,
+            started: false,
+        }
+    }
+
+    /// Convert AoS postings to parallel SoA arrays; the positions sidecar is
+    /// allocated only when at least one posting carries position data.
+    fn soa_from_aos(postings: &[Posting]) -> SoaArrays {
+        let n = postings.len();
+        let mut doc_ids = Vec::with_capacity(n);
+        let mut frequencies = Vec::with_capacity(n);
+        let any_positions = postings.iter().any(|p| p.positions.is_some());
+        let mut positions: Option<Vec<Option<Vec<u32>>>> = if any_positions {
+            Some(Vec::with_capacity(n))
+        } else {
+            None
+        };
+        for p in postings {
+            doc_ids.push(p.doc_id as u32);
+            frequencies.push(p.frequency);
+            if let Some(out) = positions.as_mut() {
+                out.push(p.positions.clone());
+            }
+        }
+        (doc_ids, frequencies, positions)
+    }
+
+    /// Build skip-block index over the doc_id slice.
+    fn create_blocks(doc_ids: &[u32], block_size: usize) -> Vec<PostingBlock> {
         let mut blocks = Vec::new();
         let mut start = 0;
 
-        while start < postings.len() {
-            let end = (start + block_size).min(postings.len());
-            let block_postings = &postings[start..end];
-
-            if !block_postings.is_empty() {
-                blocks.push(PostingBlock {
-                    min_doc_id: block_postings[0].doc_id,
-                    max_doc_id: block_postings[block_postings.len() - 1].doc_id,
-                    start_position: start,
-                    count: end - start,
-                });
-            }
-
+        while start < doc_ids.len() {
+            let end = (start + block_size).min(doc_ids.len());
+            blocks.push(PostingBlock {
+                min_doc_id: doc_ids[start] as u64,
+                max_doc_id: doc_ids[end - 1] as u64,
+                start_position: start,
+                count: end - start,
+            });
             start = end;
         }
 
         blocks
     }
 
-    /// Find the block containing the target document ID.
+    /// Find the block containing (or first ahead of) the target document ID.
     fn find_block(&self, target: u64) -> Option<usize> {
         if let Some(blocks) = &self.block_cache {
             for (i, block) in blocks.iter().enumerate() {
@@ -216,37 +304,36 @@ impl InvertedIndexPostingIterator {
 
 impl crate::lexical::reader::PostingIterator for InvertedIndexPostingIterator {
     fn doc_id(&self) -> u64 {
-        if self.position < self.postings.len() {
-            self.postings[self.position].doc_id
+        if self.position < self.doc_ids.len() {
+            self.doc_ids[self.position] as u64
         } else {
             u64::MAX // Convention for exhausted iterator
         }
     }
 
     fn term_freq(&self) -> u64 {
-        if self.position < self.postings.len() {
-            self.postings[self.position].frequency as u64
+        if self.position < self.frequencies.len() {
+            self.frequencies[self.position] as u64
         } else {
             0
         }
     }
 
     fn positions(&self) -> Result<Vec<u64>> {
-        if self.position < self.postings.len() {
-            Ok(self.postings[self.position]
-                .positions
-                .as_ref()
-                .unwrap_or(&Vec::new())
-                .iter()
-                .map(|&p| p as u64)
-                .collect())
-        } else {
-            Ok(Vec::new())
+        if self.position >= self.doc_ids.len() {
+            return Ok(Vec::new());
+        }
+        match &self.positions {
+            Some(per_doc) => match &per_doc[self.position] {
+                Some(p) => Ok(p.iter().map(|&v| v as u64).collect()),
+                None => Ok(Vec::new()),
+            },
+            None => Ok(Vec::new()),
         }
     }
 
     fn next(&mut self) -> Result<bool> {
-        if self.postings.is_empty() {
+        if self.doc_ids.is_empty() {
             return Ok(false);
         }
 
@@ -257,7 +344,7 @@ impl crate::lexical::reader::PostingIterator for InvertedIndexPostingIterator {
         } else {
             // Move to next document
             self.position += 1;
-            Ok(self.position < self.postings.len())
+            Ok(self.position < self.doc_ids.len())
         }
     }
 
@@ -275,8 +362,8 @@ impl crate::lexical::reader::PostingIterator for InvertedIndexPostingIterator {
         }
 
         // Linear search within the current range
-        while self.position < self.postings.len() {
-            if self.postings[self.position].doc_id >= target_doc_id {
+        while self.position < self.doc_ids.len() {
+            if self.doc_ids[self.position] as u64 >= target_doc_id {
                 return Ok(true);
             }
             self.position += 1;
@@ -285,7 +372,7 @@ impl crate::lexical::reader::PostingIterator for InvertedIndexPostingIterator {
     }
 
     fn cost(&self) -> u64 {
-        self.postings.len() as u64
+        self.doc_ids.len() as u64
     }
 }
 
@@ -605,6 +692,55 @@ impl SegmentReader {
         }
     }
 
+    /// Drop deleted entries from a SoA-decoded posting list in lockstep
+    /// across the parallel arrays (`doc_ids`, `frequencies`, optional
+    /// positions). Returns the same list unchanged when the segment has no
+    /// deletions, avoiding any allocation in the common case.
+    fn filter_deleted_soa(&self, decoded: DecodedPostingList) -> Result<DecodedPostingList> {
+        // Fast path: nothing to filter.
+        if !self.info.has_deletions {
+            return Ok(decoded);
+        }
+        // Materialise the bitmap once (load on demand) so the inner loop is a
+        // pure index lookup.
+        if self.deletion_bitmap.read().unwrap().is_none() {
+            self.load_deletion_bitmap()?;
+        }
+        let bitmap_lock = self.deletion_bitmap.read().unwrap();
+        let bitmap = match bitmap_lock.as_ref() {
+            Some(b) => b,
+            None => return Ok(decoded),
+        };
+
+        let n = decoded.doc_ids.len();
+        let mut doc_ids = Vec::with_capacity(n);
+        let mut frequencies = Vec::with_capacity(n);
+        let mut positions: Option<Vec<Option<Vec<u32>>>> =
+            decoded.positions.as_ref().map(|_| Vec::with_capacity(n));
+
+        for i in 0..n {
+            let did = decoded.doc_ids[i] as u64;
+            if bitmap.is_deleted(did) {
+                continue;
+            }
+            doc_ids.push(decoded.doc_ids[i]);
+            frequencies.push(decoded.frequencies[i]);
+            if let (Some(out), Some(src)) = (positions.as_mut(), decoded.positions.as_ref()) {
+                out.push(src[i].clone());
+            }
+        }
+
+        Ok(DecodedPostingList {
+            term: decoded.term,
+            doc_ids,
+            frequencies,
+            weights: Vec::new(), // weights are not consumed by the iterator API
+            positions,
+            total_frequency: decoded.total_frequency,
+            doc_frequency: decoded.doc_frequency,
+        })
+    }
+
     /// Get a DocValues field value for a document.
     fn get_doc_value(&self, field: &str, doc_id: u64) -> Result<Option<FieldValue>> {
         // Ensure DocValues are loaded (lazy loading)
@@ -864,22 +1000,18 @@ impl SegmentReader {
                 reader.seek(std::io::SeekFrom::Start(term_info.posting_offset))?;
             }
 
-            // Decode the posting list
-            let posting_list = PostingList::decode(&mut reader)?;
-
-            let mut filtered = Vec::new();
-            for posting in posting_list.postings.into_iter() {
-                if !self.is_deleted(posting.doc_id)? {
-                    filtered.push(posting);
-                }
-            }
+            // Decode the posting list in SoA-native form to skip the
+            // intermediate `Vec<Posting>` reassembly and keep the iterator
+            // backed by parallel `Vec<u32>` slices.
+            let decoded = PostingList::decode_soa(&mut reader)?;
+            let filtered = self.filter_deleted_soa(decoded)?;
 
             if filtered.is_empty() {
                 Ok(None)
             } else {
-                Ok(Some(Box::new(InvertedIndexPostingIterator::with_blocks(
-                    filtered, 64,
-                ))))
+                Ok(Some(Box::new(
+                    InvertedIndexPostingIterator::from_decoded_soa_with_blocks(filtered, 64),
+                )))
             }
         } else {
             Ok(None)


### PR DESCRIPTION
## Summary

Foundation work for #465: replace the AoS `Vec<Posting>` reassembly in
`PostingList::decode` with a SoA-native fast path, and back the query iterator
with parallel `Vec<u32>` slices instead of a `Vec<Posting>`.

- New `PostingList::decode_soa` returns `DecodedPostingList` (parallel
  `doc_ids` / `frequencies` / `weights` arrays plus optional positions
  sidecar) directly from disk. The legacy `decode` is now a thin wrapper that
  calls `decode_soa` and zips into `Vec<Posting>` for back-compat.
- `InvertedIndexPostingIterator` now stores SoA arrays. The new
  `from_decoded_soa` / `from_decoded_soa_with_blocks` constructors are the
  fast path used by `SegmentReader::postings`; the legacy
  `new(Vec<Posting>)` / `with_blocks(Vec<Posting>)` constructors stay
  available and perform an AoS→SoA conversion eagerly for non-hot-path
  callers (test fixtures, the document-scan fallback).
- `SegmentReader::postings` switches to `decode_soa` +
  `from_decoded_soa_with_blocks`, with a SoA-aware deletion filter that drops
  entries from the parallel arrays in lockstep and short-circuits to a no-op
  when the segment has no deletions.

Per-posting memory drops from ~40 bytes (`Posting` struct) to 8 bytes
(parallel `u32` doc_id / `u32` frequency) plus an optional positions sidecar.
`doc_id()` / `next()` now advance a single integer cursor over a dense slice
instead of striding across a 40-byte struct.

## Bench

`lexical_search_bench::topk_or_skewed_tf/should_or_topk10`, baseline `pre-465`
(main HEAD before this branch):

| Size    | post-465 (this PR)              | Note |
|---------|---------------------------------|------|
| 1,000   | 608 µs (-16.6%)                 | improved |
| 10,000  | 4.10 ms (-72.8%)                | baseline run had unusually high variance (10.99-18.02 ms) |
| 100,000 | 17.5-23.5 ms (run 1 +9.6%, run 2 -19.0% vs 21.98 ms baseline) | bench noise floor at this size is ±15-20%; this PR is **in the noise band** |

This PR alone does **not** hit the issue's ≥ 1.5x acceptance at 100k — the
storage-layer change saves the AoS reassembly + cuts per-doc memory but the
BMW hot loop still pays per-doc trait dispatch via `LeafMatcher`. Closing the
remaining gap requires the block-batched iterator API
(`next_block_unpacked(&mut self, dst: &mut [u32; 128]) -> bool`) and rewiring
BM25 / WAND inner loops to consume unpacked buffers directly — left as a
follow-up on the same issue.

## Test plan

- [x] `cargo test -p laurus --lib` — 826 passed (existing 824 + 2 new SoA-path tests)
  - `test_decode_soa_matches_decode_aos`: SoA / AoS decode produce identical data across full-block, tail, and mixed-positions sizes
  - `test_decoded_posting_list_aos_soa_roundtrip`: `from_posting_list` + `into_posting_list` round-trip
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npx markdownlint-cli2 "docs/src/**/*.md"` — 0 errors

## Out of scope (follow-up on #465)

- `PostingIterator::next_block_unpacked` API (block-batched decode into a
  caller-provided `[u32; 128]` buffer)
- BMW / `BooleanScorer` hot loops consume the buffer directly (no per-doc
  trait dispatch)
- `BM25Scorer::batch_score` becomes the default scoring path for the BMW pivot

Refs #465.
Refs #463.