### PR TITLE
bench(infra): page-cache eviction helpers for cold-cache benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "hf-hub",
  "image",
  "lazy_static",
+ "libc",
  "lindera",
  "lindera-dictionary",
  "log",

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -215,3 +215,10 @@ lindera = { version = "3.0.7", features = [
     "embed-cc-cedict",
 ] }
 tokio-test = "0.4.5"
+
+# Used by the cold-cache bench harness in `laurus/benches/common.rs` to
+# call `posix_fadvise(POSIX_FADV_DONTNEED)` on Linux. Already a
+# transitive runtime dep through other crates, so listing it explicitly
+# here adds no compile cost.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+libc = "0.2"

--- a/laurus/benches/common.rs
+++ b/laurus/benches/common.rs
@@ -140,3 +140,108 @@ pub fn lcg_next_unit(state: &mut u64) -> f32 {
 pub fn lcg_vec_unit(state: &mut u64, dim: usize) -> Vec<f32> {
     (0..dim).map(|_| lcg_next_unit(state)).collect()
 }
+
+// ============================================================================
+// Cold-cache bench harness
+// ============================================================================
+//
+// Cold-cache benches simulate "first access from disk" by evicting the
+// OS page cache for an index file before each measured iteration.
+// Without eviction, the kernel keeps the file warm in the page cache
+// after construction (or after the previous sample), so any read into
+// the same byte range hits RAM and the measurement collapses to a
+// memcpy benchmark.
+//
+// On Linux, `posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED)` is the
+// canonical knob for this — it requests that the kernel drop the
+// file's clean pages from the page cache. It is non-destructive
+// (dirty pages stay), needs no root, and is precisely scoped to the
+// file being benchmarked.
+//
+// Other operating systems do not expose an equivalent at this level
+// (macOS' `F_NOCACHE` applies to a fd's future I/O rather than evicting
+// existing pages; Windows has no public API for it). On those hosts
+// the helpers below are best-effort no-ops and the cold-cache numbers
+// will silently conflate with warm-cache state — call this out
+// explicitly in any PR that posts numbers measured off Linux.
+
+/// Evict the OS page cache for a single file. Best-effort: real eviction
+/// on Linux via `posix_fadvise(POSIX_FADV_DONTNEED)`; no-op on other
+/// hosts.
+///
+/// # Arguments
+///
+/// * `path` - Absolute or relative path of the file to evict.
+///
+/// # Errors
+///
+/// Returns the underlying `std::io::Error` if the file cannot be
+/// opened or the syscall fails.
+pub fn evict_file_cache<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<()> {
+    evict_file_cache_impl(path.as_ref())
+}
+
+#[cfg(target_os = "linux")]
+fn evict_file_cache_impl(path: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    let file = std::fs::File::open(path)?;
+    // SAFETY: `posix_fadvise` is FFI-safe. The fd is alive for the
+    // duration of the call (held by `file`); offset 0 + len 0 is the
+    // documented "to end of file" form; `POSIX_FADV_DONTNEED` is a
+    // valid advice constant. The return value is the errno (0 on
+    // success), not a pointer, so there is nothing to dereference.
+    let r = unsafe { libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_DONTNEED) };
+    if r != 0 {
+        return Err(std::io::Error::from_raw_os_error(r));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn evict_file_cache_impl(_path: &std::path::Path) -> std::io::Result<()> {
+    // Best-effort no-op. See module-level note above.
+    Ok(())
+}
+
+/// Evict the OS page cache for every regular file under `dir`,
+/// recursively. Used by cold-cache benches that touch a whole
+/// segment directory (`*.dict`, `*.post`, `*.docs`, etc. are all
+/// flushed in one call).
+///
+/// # Arguments
+///
+/// * `dir` - Directory to walk recursively.
+///
+/// # Errors
+///
+/// Returns on the first error from either `read_dir` or
+/// [`evict_file_cache`]. Partial eviction may have already happened
+/// when the error is returned; for cold-cache bench correctness, treat
+/// any error from this helper as "unable to guarantee cold cache" and
+/// abort the bench.
+pub fn evict_directory_cache<P: AsRef<std::path::Path>>(dir: P) -> std::io::Result<()> {
+    fn walk(dir: &std::path::Path) -> std::io::Result<()> {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                walk(&path)?;
+            } else if file_type.is_file() {
+                evict_file_cache(&path)?;
+            }
+        }
+        Ok(())
+    }
+    walk(dir.as_ref())
+}
+
+/// Returns `true` if the host supports real page-cache eviction via
+/// the helpers above. Cold-cache benches should consult this and emit
+/// a one-line warning when running on a host where eviction is a
+/// no-op, so PR readers don't trust the resulting numbers as
+/// "cold-cache" silently.
+pub const fn cold_cache_eviction_supported() -> bool {
+    cfg!(target_os = "linux")
+}


### PR DESCRIPTION
## Summary

Adds two helpers to the shared bench harness (`laurus/benches/common.rs`):

- `evict_file_cache(path)` — drop the OS page cache for a single file.
- `evict_directory_cache(dir)` — same, recursively, for every regular
  file under `dir`.
- `cold_cache_eviction_supported()` — `const fn` returning `true` on hosts
  where eviction is real, so cold-cache benches can warn loudly when
  running on a host where the helpers are no-ops.

On Linux the helpers wrap `posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED)`,
which asks the kernel to drop the file's clean pages. No root, no
side-effects on other files. On macOS / Windows / other hosts the
helpers degrade to a best-effort no-op:

- macOS' `F_NOCACHE` only applies to a fd's *future* I/O rather than
  evicting already-cached pages.
- Windows has no public API for explicit page-cache eviction.

Adds `libc` as a Linux-only dev-dependency. It is already a transitive
runtime dep of the workspace, so this contributes no extra compile
time.

## Why it lands now

This is the prerequisite for the mmap-backed posting list access work
in the umbrella #463 Tier 2 list. The `FileStorage` already supports
`use_mmap = true`, but the existing bench paths read into a warm page
cache populated by index construction (or by the previous criterion
sample), so any read into the same byte range hits RAM. Without a way
to flush the page cache between samples, a "mmap zero-copy" bench
collapses into a memcpy bench and the optimisation cannot be evaluated.

This pattern matches PR #488 (`dict_lookup_bench`): land the
measurement infrastructure first as its own PR, then the optimisation
PR can use it cleanly. Avoids the failure mode hit by the reverted FST
attempt (#487 history) where the measurement story was bundled with
the optimisation and we couldn't tell signal from noise.

## What's intentionally out of scope

- A demonstration bench (`cold_cache_bench.rs`). On tmpfs (the typical
  CI `$TMPDIR` filesystem) the helpers succeed but evict nothing
  meaningful, which would make a demo bench produce ambiguous numbers.
  The future mmap PR will land its own end-to-end cold-cache bench
  against disk-backed `FileStorage` and exercise the helpers there.
- Storage-trait extension for zero-copy `&[u8]` slice access. That is
  the actual optimisation work; this PR is infrastructure-only.

## Test plan

- [x] `cargo build --benches` — clean, no new warnings.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo test -p laurus --lib` — 826 passed.
- [x] Visual review of `posix_fadvise` invocation: arguments
      (`offset = 0`, `len = 0` for "to end of file", advice
      `POSIX_FADV_DONTNEED`) match the documented form. Return value
      is the errno (0 on success), bridged through
      `std::io::Error::from_raw_os_error`.

Refs umbrella #463.