### PR TITLE
perf(lexical/dict): hybrid BTT disk + AHashMap in-memory layer

### DIFF
--- a/docs/ja/src/concepts/indexing/lexical_indexing.md
+++ b/docs/ja/src/concepts/indexing/lexical_indexing.md
@@ -52,7 +52,7 @@ graph LR
 
 | コンポーネント | 説明 |
 | :--- | :--- |
-| **Term Dictionary** | インデックス内のすべてのユニークなタームのソート済みリスト。高速なプレフィックス検索をサポート |
+| **Term Dictionary** | インデックス内のユニークなタームのソート済み辞書。**ディスク形式**は Lucene `BlockTreeTermsWriter` 互換のブロックツリー（FST + 128 ターム単位の front-coded ブロック + bit-packed `TermInfo`）でファイルサイズを最小化。**メモリ形式**は load 時に構築する `AHashMap` インデックス + parallel-array 形式のクエリ層で、`get` / `iter` / `find_prefix` を parallel-array 同等のレイテンシで提供。完全一致検索、順序イテレーション、プレフィックススキャンに対応 |
 | **Posting Lists** | 各タームに対する、ドキュメント ID とメタデータ（ターム頻度、位置情報）のリスト |
 | **Doc Values** | 数値フィールドや日付フィールドでのソート/フィルター操作のためのカラム指向ストレージ |
 
@@ -66,6 +66,49 @@ Posting List の各エントリには以下の情報が含まれます。
 | Term Frequency | そのドキュメント内でタームが出現する回数 |
 | Positions（オプション） | ドキュメント内でタームが出現する位置（フレーズクエリに必要） |
 | Weight | このポスティングのスコアウェイト |
+
+### Term Dictionary の 2 層構造
+
+ディクショナリは **ディスク** と **メモリ** で別の表現を持ち、
+それぞれの最適化目標を分離しています。
+
+- **ディスク層** — `.dict` ファイルは Lucene `BlockTreeTermsWriter`
+  風のブロックツリーレイアウト（マジック `LTDD`、スキーマ v1）。
+  100k ユニーク 5-10 バイトタームのコーパスで `.dict` は ~12.5
+  バイト/ターム と、旧 parallel-array 形式比 **約 70% 削減**
+- **メモリ層** — build / load 時に `AHashMap<term, ordinal>` 索引、
+  ordinal indexed の `Vec<String>`、単一コピーの `Arc<[TermInfo]>`
+  を構築。`get` / `iter` / `find_prefix` / `find_range` はすべて
+  この in-memory 構造のみを参照するので、per-query レイテンシは
+  旧 parallel-array 実装と同等（ FST traversal や block 内線形
+  スキャンのコストを払わない）
+
+ディスク形式のスクラッチ (FST + BlockSection bytes) は
+[`BlockTermDictionary::write_to_storage`] でセグメントマージ時に
+再エンコードせず再シリアライズするためにのみ保持しています。
+
+```text
+[Header                ]  マジック "LTDD" + バージョン
+[FstSection            ]  各ブロック末尾タームを key、ブロックの開始
+                          バイトオフセットを value とする fst::Map<u64>
+[BlockSection          ]  128 ターム単位のブロックを連結。各ブロックは
+                          front-coded タームバイト列、bit-packed の
+                          固定長 TermInfo ブロック、可変長の per-term
+                          Block-Max-WAND メタデータ配列を含む
+[Footer                ]  全タームカウント + ブロックカウント
+```
+
+- 検索: FST を 1 回辿って (`O(|term|)`) target を含むブロックを特定
+  し、そのブロック内（≤ 128 件）を front-coded で線形スキャン
+- イテレーション: FST を経由せず BlockSection を順次走査。各ブロック
+  の front-coding バッファを再利用するため、per-step コストは
+  front-coding decode（≈ 5–10 ns）のみ
+- プレフィックススキャン: FST で先頭ブロックを特定し、prefix が一致
+  しなくなるまで順次ブロックを走査
+
+flat per-term FST と比較して block-head FST は 1〜2 桁小さく、
+front-coded タームバイト列と bit-packed `TermInfo` の組み合わせで
+production 規模ではディスクサイズが 50〜80 % 削減されます。
 
 ## 数値フィールドと日付フィールド
 
@@ -121,7 +164,7 @@ graph TB
 
 | ファイル拡張子 | 内容 |
 | :--- | :--- |
-| `.dict` | Term Dictionary（ソート済みターム + メタデータオフセット） |
+| `.dict` | Term Dictionary。v1 `LTDD` ブロックツリーレイアウト（FST + 128 ターム単位の front-coded ブロック + bit-packed `TermInfo`）。セグメント open 時に `AHashMap` バックの in-memory クエリ層へ展開 |
 | `.post` | Posting Lists（ドキュメント ID、ターム頻度、位置情報） |
 | `.bkd` | 数値・日付・`Geo`（2D）・`Geo3d`（3D ECEF）フィールドの [BKD ツリー](../bkd_tree.md) データ |
 | `.docs` | 格納されたフィールド値（元のドキュメント内容） |

--- a/docs/src/concepts/indexing/lexical_indexing.md
+++ b/docs/src/concepts/indexing/lexical_indexing.md
@@ -52,7 +52,7 @@ graph LR
 
 | Component | Description |
 | :--- | :--- |
-| **Term Dictionary** | Sorted list of all unique terms in the index; supports fast prefix lookup |
+| **Term Dictionary** | Sorted dictionary of unique terms in the index. Disk format is a Lucene `BlockTreeTermsWriter`-style block-tree (FST over per-block representative terms + front-coded term bytes inside each 128-term block + bit-packed `TermInfo`); in-memory is an `AHashMap`-indexed parallel-array query layer populated at load time. Disk format minimises file size, in-memory layer keeps `get` / `iter` / prefix-scan at parallel-array speed. Supports exact lookup, ordered iteration, and prefix scans. |
 | **Posting Lists** | For each term, a list of document IDs and metadata (term frequency, positions) |
 | **Doc Values** | Column-oriented storage for sort/filter operations on numeric and date fields |
 
@@ -94,6 +94,53 @@ produces parallel `Vec<u32>` slices for `doc_id` and `frequency` directly
 from disk without the intermediate `Vec<Posting>` reassembly. The query
 iterator stores those slices, so `next()` advances a single `u32` cursor
 over a dense slice instead of striding across a 40-byte `Posting` struct.
+
+### Term Dictionary Storage Layers
+
+The dictionary uses a **two-layer** representation that decouples
+on-disk compactness from in-memory query speed:
+
+- **Disk layer** — the `.dict` file uses a Lucene
+  `BlockTreeTermsWriter`-style block-tree layout (magic `LTDD`,
+  schema v1). This produces a compact file: at 100k unique 5-10 byte
+  terms a `.dict` is ~12.5 bytes / term, roughly **70 % smaller** than
+  the prior parallel-array on-disk format.
+- **In-memory query layer** — at build / load time the dictionary
+  populates an `AHashMap<term, ordinal>` index, an
+  ordinal-indexed sorted `Vec<String>`, and a single-copy
+  `Arc<[TermInfo]>`. `get` / `iter` / `find_prefix` / `find_range`
+  operate exclusively on these structures, so per-query cost matches
+  the prior parallel-array implementation (no per-call FST traversal
+  or in-block linear scan).
+
+The disk-format scratch (FST + BlockSection bytes) is retained only so
+[`BlockTermDictionary::write_to_storage`] can re-serialise the
+dictionary on segment merge without re-encoding from scratch.
+
+```text
+[Header                ]  magic "LTDD" + version
+[FstSection            ]  fst::Map<u64> keyed by each block's last term,
+                          valued by that block's start byte offset
+[BlockSection          ]  concatenated 128-term blocks, each containing
+                          front-coded term bytes, a bit-packed
+                          fixed-size TermInfo block, and a
+                          variable-length per-term Block-Max-WAND
+                          metadata array
+[Footer                ]  total term count + block count
+```
+
+Lookup walks the FST once (`O(|term|)`) to identify the block whose
+last term is `≥ target`, then performs a linear front-coded scan
+inside the block (≤ 128 entries). Iteration walks the BlockSection
+sequentially without consulting the FST, decoding each block's
+front-coded prefix once and reusing the buffer across terms. Prefix
+scans combine the two: FST seek to the first matching block, then
+sequential block walk until the prefix no longer matches.
+
+Compared to a flat per-term FST the block-head FST is one to two
+orders of magnitude smaller, and the front-coded block bytes plus
+bit-packed `TermInfo` typically cut the on-disk size by 50-80 % at
+production scale.
 
 ## Numeric and Date Fields
 
@@ -150,7 +197,7 @@ graph TB
 
 | File Extension | Contents |
 | :--- | :--- |
-| `.dict` | Term dictionary (sorted terms + metadata offsets) |
+| `.dict` | Term dictionary in the v1 `LTDD` block-tree layout (FST over per-block representative terms + 128-term blocks of front-coded term bytes + bit-packed `TermInfo`). Loaded into an `AHashMap`-backed in-memory query layer at segment open. |
 | `.post` | Posting lists (document IDs, term frequencies, positions) |
 | `.bkd` | [BKD tree](../bkd_tree.md) data for numeric, date, `Geo` (2D), and `Geo3d` (3D ECEF) fields |
 | `.docs` | Stored field values (the original document content) |

--- a/laurus/benches/dict_lookup_bench.rs
+++ b/laurus/benches/dict_lookup_bench.rs
@@ -1,14 +1,17 @@
 //! Criterion benchmarks for the lexical term dictionary.
 //!
-//! Exercises [`HybridTermDictionary`] at scales (10k / 100k / 1M unique
-//! terms) that the rest of the bench suite does not reach. Required as
-//! the prerequisite for evaluating the Lucene `BlockTreeTermsWriter`-style
-//! port tracked in #487 (and, more broadly, the Tier 2 dict item in
-//! umbrella #463): the existing `lexical/fuzzy_query` fixture caps at
-//! 5000 terms, which is well below the corpus size where any
-//! BlockTreeTerms-style indirection (FST over per-block heads + flat
-//! front-coded term bytes inside each block) starts to win against the
-//! current parallel-array `(Vec<String>, Vec<TermInfo>)` representation.
+//! Exercises the active term dictionary implementation at scales
+//! (10k / 100k / 1M unique terms) that the rest of the bench suite
+//! does not reach.
+//!
+//! Issue #487 ports the dictionary from a parallel-array
+//! `(Vec<String>, Vec<TermInfo>)` representation
+//! (`HybridTermDictionary`, removed in Phase 9) to a Lucene
+//! `BlockTreeTermsWriter`-style block + FST structure
+//! ([`BlockTermDictionary`]). This bench is the
+//! before-and-after measurement: same probes, same term corpus,
+//! comparing the new dictionary against the `pre-fst-port`
+//! criterion baseline saved on `main`.
 //!
 //! # Scope
 //!
@@ -67,7 +70,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use common::{DEFAULT_SEED, SAMPLE_SIZE_SLOW};
 
 use laurus::lexical::index::structures::dictionary::{
-    HybridTermDictionary, TermDictionaryBuilder, TermInfo,
+    BlockTermDictionary, TermDictionaryBuilder, TermInfo,
 };
 
 /// Corpus sizes the dict bench sweeps. Chosen to bracket the crossover
@@ -77,7 +80,9 @@ use laurus::lexical::index::structures::dictionary::{
 /// - `10_000` — small corpus, baseline win for a flat sorted Vec.
 /// - `100_000` — typical mid-sized index; expected crossover region.
 /// - `1_000_000` — Lucene's documented sweet spot for FST + block-tree.
-const CORPUS_SIZES: &[usize] = &[10_000, 100_000, 1_000_000];
+/// - `10_000_000` — production-target scale (10M+ terms / segment) for
+///   #487 evaluation. Adds ~1 minute per group to the run time.
+const CORPUS_SIZES: &[usize] = &[10_000, 100_000, 1_000_000, 10_000_000];
 
 /// Number of probe terms drawn for the `get_*` and prefix microbenches.
 /// Picked at 100 so each `b.iter` body amortises the criterion harness
@@ -115,7 +120,7 @@ fn lcg_term(state: &mut u64, min_len: usize, max_len: usize) -> String {
 /// terms (each guaranteed to be present in the dictionary). Probes are
 /// spaced at roughly even ordinals so the lookup pattern doesn't
 /// concentrate on a single hash bucket / FST branch.
-fn build_dict_with_hit_probes(n: usize, probe_count: usize) -> (HybridTermDictionary, Vec<String>) {
+fn build_dict_with_hit_probes(n: usize, probe_count: usize) -> (BlockTermDictionary, Vec<String>) {
     assert!(n >= probe_count, "n must be at least probe_count");
 
     // Generate `n` unique terms via BTreeSet (dedupes the LCG output).
@@ -134,7 +139,7 @@ fn build_dict_with_hit_probes(n: usize, probe_count: usize) -> (HybridTermDictio
     for (i, term) in terms.iter().enumerate() {
         builder.add_term(term.clone(), TermInfo::new(i as u64 * 16, 64, 1, 1));
     }
-    let dict = builder.build_hybrid();
+    let dict = builder.build().expect("build BlockTermDictionary");
 
     // Probe sampling: spread evenly across the dictionary by ordinal so
     // every probe lands at a different position in the sorted layout.

--- a/laurus/src/lexical/index/inverted/core/terms.rs
+++ b/laurus/src/lexical/index/inverted/core/terms.rs
@@ -197,7 +197,7 @@ impl TermsEnum for Box<dyn TermsEnum> {
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use crate::lexical::index::structures::dictionary::{HybridTermDictionary, TermInfo};
+use crate::lexical::index::structures::dictionary::{BlockTermDictionary, TermInfo};
 
 /// Iterator over terms in a term dictionary.
 pub struct InvertedIndexTermsEnum {
@@ -214,7 +214,7 @@ impl InvertedIndexTermsEnum {
     ///
     /// This extracts all terms for the specified field from the term dictionary.
     /// Terms are stored in the format "field:term", so we filter by prefix.
-    pub fn new(field: &str, dict: &Arc<HybridTermDictionary>) -> Self {
+    pub fn new(field: &str, dict: &Arc<BlockTermDictionary>) -> Self {
         let field_prefix = format!("{}:", field);
         let mut terms = Vec::new();
 
@@ -226,7 +226,7 @@ impl InvertedIndexTermsEnum {
             }
         }
 
-        // Terms are already sorted since HybridTermDictionary.iter() uses SortedTermDictionary
+        // Terms are already sorted since BlockTermDictionary.iter() uses SortedTermDictionary
         InvertedIndexTermsEnum {
             terms,
             position: 0,
@@ -322,7 +322,7 @@ impl TermsEnum for InvertedIndexTermsEnum {
 /// Implementation of Terms trait for a specific field.
 pub struct InvertedIndexTerms {
     field: String,
-    dict: Arc<HybridTermDictionary>,
+    dict: Arc<BlockTermDictionary>,
     // Cached statistics
     size: Option<u64>,
     sum_doc_freq: Option<u64>,
@@ -331,7 +331,7 @@ pub struct InvertedIndexTerms {
 
 impl InvertedIndexTerms {
     /// Create a new Terms instance for a field.
-    pub fn new(field: &str, dict: Arc<HybridTermDictionary>) -> Self {
+    pub fn new(field: &str, dict: Arc<BlockTermDictionary>) -> Self {
         let field_prefix = format!("{}:", field);
 
         // Calculate statistics by iterating through matching terms
@@ -397,7 +397,7 @@ pub struct MergedInvertedIndexTerms {
 
 impl MergedInvertedIndexTerms {
     /// Create merged terms for `field` from multiple dictionaries.
-    pub fn new(field: &str, dicts: &[Arc<HybridTermDictionary>]) -> Self {
+    pub fn new(field: &str, dicts: &[Arc<BlockTermDictionary>]) -> Self {
         let field_prefix = format!("{}:", field);
         let mut map: BTreeMap<String, (u64, u64)> = BTreeMap::new();
 

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -21,7 +21,7 @@ use crate::lexical::index::inverted::core::terms::{
 };
 use crate::lexical::index::inverted::segment::SegmentInfo;
 use crate::lexical::index::structures::bkd_tree::{BKDReader, BKDTree};
-use crate::lexical::index::structures::dictionary::HybridTermDictionary;
+use crate::lexical::index::structures::dictionary::BlockTermDictionary;
 use crate::lexical::index::structures::dictionary::TermInfo;
 use crate::lexical::index::structures::doc_values::DocValuesReader;
 use crate::lexical::reader::FieldStats;
@@ -386,7 +386,7 @@ pub struct SegmentReader {
     storage: Arc<dyn Storage>,
 
     /// Term dictionary for efficient term lookup.
-    term_dictionary: RwLock<Option<Arc<HybridTermDictionary>>>,
+    term_dictionary: RwLock<Option<Arc<BlockTermDictionary>>>,
 
     /// Cached stored documents.
     stored_documents: RwLock<Option<BTreeMap<u64, Document>>>,
@@ -491,7 +491,7 @@ impl SegmentReader {
 
         if let Ok(input) = self.storage.open_input(&dict_file) {
             let mut reader = StructReader::new(input)?;
-            let dictionary = HybridTermDictionary::read_from_storage(&mut reader).map_err(|e| {
+            let dictionary = BlockTermDictionary::read_from_storage(&mut reader).map_err(|e| {
                 LaurusError::index(format!(
                     "Failed to read term dictionary from {dict_file}: {e}"
                 ))

--- a/laurus/src/lexical/index/inverted/segment/merge_engine.rs
+++ b/laurus/src/lexical/index/inverted/segment/merge_engine.rs
@@ -459,7 +459,7 @@ impl MergeEngine {
                 builder.add_term(term.clone(), term_info);
             }
 
-            let dictionary = builder.build_sorted();
+            let dictionary = builder.build()?;
             dictionary.write_to_storage(&mut writer)?;
             writer.close()?;
             file_paths.push(dict_file);

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -786,7 +786,7 @@ impl InvertedIndexWriter {
         let dict_output = self.storage.create_output(&dict_file)?;
         let mut dict_writer = StructWriter::new(dict_output);
 
-        let term_dict = term_dict_builder.build_hybrid();
+        let term_dict = term_dict_builder.build()?;
         term_dict.write_to_storage(&mut dict_writer)?;
         dict_writer.close()?;
 

--- a/laurus/src/lexical/index/structures/dictionary.rs
+++ b/laurus/src/lexical/index/structures/dictionary.rs
@@ -1,17 +1,46 @@
 //! Term dictionary data structures for mapping terms to posting list metadata.
 //!
-//! This module provides multiple term dictionary implementations—sorted, hash-based,
-//! and hybrid—for efficiently mapping terms to their [`TermInfo`] (posting list
-//! offset, length, document frequency, and total frequency). A [`TermDictionaryBuilder`]
-//! is also provided for constructing any of the dictionary variants.
+//! This module provides [`BlockTermDictionary`] — a Lucene
+//! `BlockTreeTermsWriter`-style dictionary that maps each term to its
+//! [`TermInfo`] (posting list offset, length, document frequency, total
+//! frequency, and Block-Max-WAND metadata). The dictionary is built
+//! through [`TermDictionaryBuilder`] from an in-memory `BTreeMap`.
+//!
+//! See Issue [#487](https://github.com/mosuka/laurus/issues/487) for
+//! the design rationale and the migration path away from the legacy
+//! parallel-array / `AHashMap` representation that this module replaced.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use ahash::AHashMap;
+use fst::Map as FstMap;
 
 use crate::error::{LaurusError, Result};
 use crate::storage::structured::{StructReader, StructWriter};
 use crate::storage::{StorageInput, StorageOutput};
+
+// Sub-modules backing the new Lucene BlockTreeTerms-style
+// implementation (Issue #487). These will gradually take over as the
+// legacy `Hybrid` / `Sorted` / `Hash` dictionaries are decommissioned
+// in Phase 9.
+mod block_max_data;
+mod block_reader;
+mod builder;
+mod front_coding;
+mod term_info_block;
+
+/// Magic number for the v1 BlockTermDictionary on-disk format ("LTDD"
+/// = Laurus Term Dictionary, block-tree). Issue #487.
+const MAGIC_LTDD: u32 = 0x4C544444;
+/// Legacy magic for the removed sorted-array dictionary ("STDC").
+/// Reading a file with this magic now yields an explicit "rebuild
+/// required" error.
+const LEGACY_MAGIC_STDC: u32 = 0x53544443;
+/// Legacy magic for the removed hash-table dictionary ("HTDC").
+/// Reading a file with this magic now yields an explicit "rebuild
+/// required" error.
+const LEGACY_MAGIC_HTDC: u32 = 0x48544443;
 
 /// One block's max-impact metadata for Block-Max-WAND (#403 PR-C).
 ///
@@ -125,432 +154,297 @@ impl TermInfo {
     }
 }
 
-/// A sorted array-based term dictionary for prefix queries and ordered iteration.
-#[derive(Debug, Clone)]
-pub struct SortedTermDictionary {
-    /// Sorted terms.
-    terms: Vec<String>,
-    /// Term info for each term (parallel array).
-    term_infos: Vec<TermInfo>,
+/// Lucene `BlockTreeTermsWriter`-style block term dictionary
+/// (Issue [#487](https://github.com/mosuka/laurus/issues/487)).
+///
+/// Replaces the legacy parallel-array / `AHashMap`-backed dictionary
+/// triad (removed in #487 Phase 9) with a two-layer structure designed
+/// for production scale (10M-100M+ terms / segment):
+///
+/// - an [`fst::Map`] keyed by each block's **last** term, valued by the
+///   block's start offset within the BlockSection — typically 1-2
+///   orders of magnitude smaller than a flat per-term FST
+/// - a flat BlockSection holding 128-term blocks, each with
+///   front-coded term bytes, a bit-packed
+///   [`term_info_block::FixedTermInfoBlock`], and a
+///   [`block_max_data::BlockMaxData`] for variable-length per-term
+///   block_max arrays
+///
+/// Lookup: `fst.range().ge(target).into_stream().next()` identifies the
+/// block containing `target`; an in-block linear scan over the
+/// front-coded term bytes finds the exact match.
+///
+/// `iter()` walks the BlockSection sequentially without consulting the
+/// FST, so per-step cost is the front-coding decode (≈ 5–10 ns) rather
+/// than FST DFA traversal.
+///
+/// # Two-layer storage
+///
+/// The dictionary keeps **two equivalent representations** of the same
+/// data, optimised for different access patterns:
+///
+/// 1. **Disk-format scratch** (`fst` + `block_section`) — the compact
+///    FST + 128-term BlockSection layout written to `.dict`. Kept in
+///    memory so [`Self::write_to_storage`] can re-emit the segment
+///    without re-encoding from scratch.
+/// 2. **In-memory query layer** (`map` + `sorted_terms` + `term_infos`)
+///    — populated at build / load time so that `get` / `iter` /
+///    `find_prefix` operate at parallel-array / `AHashMap` speed
+///    rather than paying the in-block linear scan that the
+///    disk-format alone would require.
+///
+/// Both representations share a single source of truth: the
+/// `term_infos` array is `Arc<[TermInfo]>` (single copy across `map`'s
+/// ordinal index and any reader), and `sorted_terms` parallels it in
+/// ascending term order.
+#[derive(Clone, Debug)]
+pub struct BlockTermDictionary {
+    // ----- Disk-format scratch -----
+    /// FST: each block's last term bytes → block start offset within
+    /// `block_section`.
+    fst: Arc<FstMap<Vec<u8>>>,
+    /// Concatenated block bytes (one entry per block). Shared via
+    /// `Arc` so that cloning a `BlockTermDictionary` does not copy
+    /// the term data.
+    block_section: Arc<[u8]>,
+
+    // ----- In-memory query layer -----
+    /// `term -> ordinal (0..total_term_count)` index for `O(1)` `get`.
+    map: AHashMap<String, u32>,
+    /// `ordinal -> term`, in ascending term order. Used by `iter`,
+    /// `find_prefix`, and `find_range`.
+    sorted_terms: Vec<String>,
+    /// `ordinal -> TermInfo`. Single copy shared via `Arc`.
+    term_infos: Arc<[TermInfo]>,
+
+    /// Total number of terms across all blocks.
+    total_term_count: u64,
+    /// Number of blocks in `block_section`.
+    block_count: u32,
 }
 
-impl SortedTermDictionary {
-    /// Create a new empty sorted term dictionary.
-    pub fn new() -> Self {
-        SortedTermDictionary {
-            terms: Vec::new(),
-            term_infos: Vec::new(),
-        }
-    }
-
-    /// Create from a map of terms to term info.
-    pub fn from_map(map: BTreeMap<String, TermInfo>) -> Self {
-        let mut terms = Vec::with_capacity(map.len());
-        let mut term_infos = Vec::with_capacity(map.len());
-
-        for (term, info) in map.into_iter() {
-            terms.push(term);
-            term_infos.push(info);
-        }
-
-        SortedTermDictionary { terms, term_infos }
-    }
-
-    /// Look up a term and return its info.
+impl BlockTermDictionary {
+    /// Look up a term and return a borrowed [`TermInfo`] reference.
+    ///
+    /// Uses the in-memory `AHashMap` index for `O(1)` lookup. The
+    /// disk-format fields (`fst`, `block_section`) are not consulted —
+    /// they exist only so the dictionary can be re-serialised via
+    /// [`Self::write_to_storage`].
+    ///
+    /// Returns `None` if `term` is not present in the dictionary.
+    /// Callers that need an owned `TermInfo` should call `.cloned()`.
     pub fn get(&self, term: &str) -> Option<&TermInfo> {
-        match self
-            .terms
-            .binary_search_by(|probe| probe.as_str().cmp(term))
-        {
-            Ok(index) => Some(&self.term_infos[index]),
-            Err(_) => None,
-        }
+        let ordinal = *self.map.get(term)? as usize;
+        Some(&self.term_infos[ordinal])
     }
 
-    /// Find terms with the given prefix.
-    pub fn find_prefix(&self, prefix: &str) -> Vec<(&str, &TermInfo)> {
-        let start_pos = match self
-            .terms
-            .binary_search_by(|probe| probe.as_str().cmp(prefix))
-        {
-            Ok(pos) => pos,
-            Err(pos) => pos,
-        };
-
-        let mut results = Vec::new();
-        for i in start_pos..self.terms.len() {
-            if self.terms[i].starts_with(prefix) {
-                results.push((self.terms[i].as_str(), &self.term_infos[i]));
-            } else {
-                break;
-            }
-        }
-
-        results
-    }
-
-    /// Find terms in a range.
-    pub fn find_range(&self, start: &str, end: &str) -> Vec<(&str, &TermInfo)> {
-        let start_pos = match self
-            .terms
-            .binary_search_by(|probe| probe.as_str().cmp(start))
-        {
-            Ok(pos) => pos,
-            Err(pos) => pos,
-        };
-
-        let end_pos = match self.terms.binary_search_by(|probe| probe.as_str().cmp(end)) {
-            Ok(pos) => pos, // end is exclusive, so don't include it
-            Err(pos) => pos,
-        };
-
-        let mut results = Vec::new();
-        for i in start_pos..end_pos.min(self.terms.len()) {
-            results.push((self.terms[i].as_str(), &self.term_infos[i]));
-        }
-
-        results
-    }
-
-    /// Get the number of terms.
-    pub fn len(&self) -> usize {
-        self.terms.len()
-    }
-
-    /// Check if empty.
-    pub fn is_empty(&self) -> bool {
-        self.terms.is_empty()
-    }
-
-    /// Get an iterator over all terms.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &TermInfo)> {
-        self.terms
+    /// Iterate `(term, term_info)` borrowed pairs in ascending term
+    /// order. Yields references — no per-term `String` / `TermInfo`
+    /// clones — so iteration cost matches the legacy parallel-array
+    /// representation.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &TermInfo)> + '_ {
+        self.sorted_terms
             .iter()
             .zip(self.term_infos.iter())
             .map(|(term, info)| (term.as_str(), info))
     }
 
+    /// Collect borrowed `(term, term_info)` pairs whose term begins
+    /// with `prefix`, in ascending term order.
+    ///
+    /// Implemented eagerly via binary search over `sorted_terms`. The
+    /// FST is not consulted on this path.
+    pub fn find_prefix(&self, prefix: &str) -> Vec<(&str, &TermInfo)> {
+        // Binary-search for the first ordinal whose term ≥ prefix.
+        let start = self
+            .sorted_terms
+            .binary_search_by(|probe| probe.as_str().cmp(prefix))
+            .unwrap_or_else(|insert_at| insert_at);
+
+        let mut result = Vec::new();
+        for i in start..self.sorted_terms.len() {
+            let term = &self.sorted_terms[i];
+            if term.starts_with(prefix) {
+                result.push((term.as_str(), &self.term_infos[i]));
+            } else {
+                break;
+            }
+        }
+        result
+    }
+
+    /// Collect borrowed `(term, term_info)` pairs in the half-open
+    /// range `[start, end)`, in ascending term order.
+    ///
+    /// Implemented eagerly via binary search over `sorted_terms`.
+    pub fn find_range(&self, start: &str, end: &str) -> Vec<(&str, &TermInfo)> {
+        if start >= end {
+            return Vec::new();
+        }
+
+        let start_idx = self
+            .sorted_terms
+            .binary_search_by(|probe| probe.as_str().cmp(start))
+            .unwrap_or_else(|insert_at| insert_at);
+        let end_idx = self
+            .sorted_terms
+            .binary_search_by(|probe| probe.as_str().cmp(end))
+            .unwrap_or_else(|insert_at| insert_at);
+
+        let mut result = Vec::with_capacity(end_idx.saturating_sub(start_idx));
+        for i in start_idx..end_idx.min(self.sorted_terms.len()) {
+            result.push((self.sorted_terms[i].as_str(), &self.term_infos[i]));
+        }
+        result
+    }
+
+    /// Total number of terms in the dictionary.
+    pub fn len(&self) -> u64 {
+        self.total_term_count
+    }
+
+    /// Returns `true` if the dictionary contains no terms.
+    pub fn is_empty(&self) -> bool {
+        self.total_term_count == 0
+    }
+
+    /// Number of blocks in the dictionary's BlockSection.
+    pub fn block_count(&self) -> u32 {
+        self.block_count
+    }
+
     /// Read the dictionary from storage.
     ///
-    /// Supports both **v1** (legacy) and **v2** (#403 PR-B2) layouts:
+    /// Format (v1 `LTDD` layout):
     ///
-    /// - v1 entries store only the four `u64` fields. `max_score_factor`
-    ///   is filled with `0.0`, which the BM25 scorer treats as "fall
-    ///   back to the loose `k1 + 1` upper bound" — segments produced
-    ///   before this PR continue to load and search correctly.
-    /// - v2 entries append a single `f32` per term holding the
-    ///   precomputed tightened TF-component upper bound.
+    /// ```text
+    /// [magic:              u32 = 0x4C544444 "LTDD"]
+    /// [version:            u32 = 1]
+    /// [fst_bytes_len:      u32]
+    /// [fst_bytes:          u8 × fst_bytes_len]
+    /// [block_section_len:  u32]
+    /// [block_section:      u8 × block_section_len]
+    /// [total_term_count:   u64]
+    /// [block_count:        u32]
+    /// [reserved:           u32 = 0]
+    /// ```
+    ///
+    /// Rejects legacy `STDC` (sorted) / `HTDC` (hash) magic numbers
+    /// with an explicit error — pre-release semantics apply.
     pub fn read_from_storage<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
-        // Read header
         let magic = reader.read_u32()?;
-        if magic != 0x53544443 {
-            // "STDC"
-            return Err(LaurusError::index("Invalid sorted dictionary magic number"));
+        match magic {
+            MAGIC_LTDD => {} // proceed
+            LEGACY_MAGIC_STDC | LEGACY_MAGIC_HTDC => {
+                return Err(LaurusError::index(
+                    "Unsupported legacy term dictionary format. Rebuild required.",
+                ));
+            }
+            _ => {
+                return Err(LaurusError::index(format!(
+                    "Invalid term dictionary magic: 0x{magic:08X}"
+                )));
+            }
         }
 
         let version = reader.read_u32()?;
-        if version != 1 && version != 2 && version != 3 {
+        if version != 1 {
             return Err(LaurusError::index(format!(
-                "Unsupported sorted dictionary version: {version}"
+                "Unsupported BlockTermDictionary version: {version}"
             )));
         }
 
-        let term_count = reader.read_varint()? as usize;
-        let mut terms = Vec::with_capacity(term_count);
-        let mut term_infos = Vec::with_capacity(term_count);
+        let fst_bytes_len = reader.read_u32()? as usize;
+        let fst_bytes = reader.read_raw(fst_bytes_len)?;
+        let fst = FstMap::new(fst_bytes)
+            .map_err(|e| LaurusError::index(format!("FST parse error: {e}")))?;
 
-        // Read terms and term infos
-        for _ in 0..term_count {
-            let term = reader.read_string()?;
-            let posting_offset = reader.read_u64()?;
-            let posting_length = reader.read_u64()?;
-            let doc_frequency = reader.read_u64()?;
-            let total_frequency = reader.read_u64()?;
-            let max_score_factor = if version >= 2 {
-                reader.read_f32()?
-            } else {
-                0.0
-            };
-            // v3: per-block (last_doc_id, max_factor) array. v1/v2
-            // entries decode with an empty `block_max`, which scorers
-            // treat as "fall back to the term-level
-            // `max_score_factor`" (#403 PR-C).
-            let block_max = if version >= 3 {
-                let block_count = reader.read_varint()? as usize;
-                let mut blocks = Vec::with_capacity(block_count);
-                for _ in 0..block_count {
-                    let last_doc_id = reader.read_u64()?;
-                    let mf = reader.read_f32()?;
-                    blocks.push(BlockMax {
-                        last_doc_id,
-                        max_factor: mf,
-                    });
-                }
-                blocks
-            } else {
-                Vec::new()
-            };
+        let block_section_len = reader.read_u32()? as usize;
+        let block_section_vec = reader.read_raw(block_section_len)?;
 
-            terms.push(term);
-            term_infos.push(TermInfo {
-                posting_offset,
-                posting_length,
-                doc_frequency,
-                total_frequency,
-                max_score_factor,
-                block_max,
-            });
-        }
+        let total_term_count = reader.read_u64()?;
+        let block_count = reader.read_u32()?;
+        let _reserved = reader.read_u32()?;
 
-        Ok(SortedTermDictionary { terms, term_infos })
-    }
-}
+        let block_section: Arc<[u8]> = Arc::from(block_section_vec.into_boxed_slice());
 
-impl Default for SortedTermDictionary {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+        // Populate the in-memory query layer by streaming the
+        // BlockSection once. After this point, all hot-path queries go
+        // through the in-memory structures; the FST + block_section
+        // remain only for `write_to_storage`.
+        let (map, sorted_terms, term_infos) =
+            populate_in_memory_layer(&block_section, block_count, total_term_count);
 
-/// A hash-based term dictionary for fast random access.
-#[derive(Debug, Clone)]
-pub struct HashTermDictionary {
-    /// Hash map from terms to term info.
-    terms: AHashMap<String, TermInfo>,
-}
-
-impl HashTermDictionary {
-    /// Create a new empty hash term dictionary.
-    pub fn new() -> Self {
-        HashTermDictionary {
-            terms: AHashMap::new(),
-        }
+        Ok(BlockTermDictionary {
+            fst: Arc::new(fst),
+            block_section,
+            map,
+            sorted_terms,
+            term_infos,
+            total_term_count,
+            block_count,
+        })
     }
 
-    /// Create with initial capacity.
-    pub fn with_capacity(capacity: usize) -> Self {
-        HashTermDictionary {
-            terms: AHashMap::with_capacity(capacity),
-        }
-    }
-
-    /// Insert a term with its info.
-    pub fn insert(&mut self, term: String, info: TermInfo) {
-        self.terms.insert(term, info);
-    }
-
-    /// Look up a term and return its info.
-    pub fn get(&self, term: &str) -> Option<&TermInfo> {
-        self.terms.get(term)
-    }
-
-    /// Check if a term exists.
-    pub fn contains(&self, term: &str) -> bool {
-        self.terms.contains_key(term)
-    }
-
-    /// Get the number of terms.
-    pub fn len(&self) -> usize {
-        self.terms.len()
-    }
-
-    /// Check if empty.
-    pub fn is_empty(&self) -> bool {
-        self.terms.is_empty()
-    }
-
-    /// Get an iterator over all terms.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &TermInfo)> {
-        self.terms.iter().map(|(term, info)| (term.as_str(), info))
-    }
-
-    /// Convert to a sorted dictionary.
-    pub fn to_sorted(&self) -> SortedTermDictionary {
-        let map: BTreeMap<String, TermInfo> = self
-            .terms
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        SortedTermDictionary::from_map(map)
-    }
-
-    /// Write to storage in **v3** layout (#403 PR-C). Each entry now
-    /// carries the v2 `max_score_factor: f32` plus a length-prefixed
-    /// per-block `(last_doc_id: u64, max_factor: f32)` array used by
-    /// Block-Max-WAND. See [`SortedTermDictionary::write_to_storage`]
-    /// for the matching format on the sorted side.
+    /// Write the dictionary to storage in the v1 `LTDD` layout.
+    /// See [`Self::read_from_storage`] for the byte layout.
     pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
-        // Write magic number for hash dictionary
-        writer.write_u32(0x48544443)?; // "HTDC"
+        writer.write_u32(MAGIC_LTDD)?;
+        writer.write_u32(1)?; // version
 
-        // Write version
-        writer.write_u32(3)?;
+        let fst_bytes = self.fst.as_fst().as_inner();
+        writer.write_u32(
+            u32::try_from(fst_bytes.len())
+                .map_err(|_| LaurusError::index("FST bytes length exceeds u32::MAX"))?,
+        )?;
+        writer.write_raw(fst_bytes)?;
 
-        // Write number of terms
-        writer.write_varint(self.terms.len() as u64)?;
+        writer.write_u32(
+            u32::try_from(self.block_section.len())
+                .map_err(|_| LaurusError::index("BlockSection length exceeds u32::MAX"))?,
+        )?;
+        writer.write_raw(&self.block_section)?;
 
-        // Write terms and their info
-        for (term, info) in &self.terms {
-            writer.write_string(term)?;
-
-            // Write TermInfo
-            writer.write_u64(info.posting_offset)?;
-            writer.write_u64(info.posting_length)?;
-            writer.write_u64(info.doc_frequency)?;
-            writer.write_u64(info.total_frequency)?;
-            writer.write_f32(info.max_score_factor)?;
-            writer.write_varint(info.block_max.len() as u64)?;
-            for block in &info.block_max {
-                writer.write_u64(block.last_doc_id)?;
-                writer.write_f32(block.max_factor)?;
-            }
-        }
+        writer.write_u64(self.total_term_count)?;
+        writer.write_u32(self.block_count)?;
+        writer.write_u32(0)?; // reserved
 
         Ok(())
     }
 
-    /// Read from storage. Accepts **v1** (legacy), **v2** (#403 PR-B2)
-    /// and **v3** (#403 PR-C) layouts. Older entries fill the missing
-    /// fields with their "unset" defaults — `max_score_factor = 0.0`
-    /// and an empty `block_max` — which scorers treat as "fall back
-    /// to the looser bound" so older segments continue to load.
-    pub fn read_from_storage<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
-        // Read magic number
-        let magic = reader.read_u32()?;
-        if magic != 0x48544443 {
-            // "HTDC"
-            return Err(LaurusError::index("Invalid hash dictionary magic number"));
+    /// Get aggregate statistics about the dictionary.
+    ///
+    /// Walks the dictionary once to compute term-length statistics and
+    /// frequency totals. `memory_size` reports the encoded size of the
+    /// FST plus the BlockSection in bytes.
+    pub fn stats(&self) -> DictionaryStats {
+        let term_count = self.total_term_count as usize;
+
+        let mut total_term_length = 0usize;
+        let mut total_doc_frequency = 0u64;
+        let mut total_term_frequency = 0u64;
+
+        for (term, info) in self.iter() {
+            total_term_length += term.len();
+            total_doc_frequency += info.doc_frequency;
+            total_term_frequency += info.total_frequency;
         }
 
-        // Read version
-        let version = reader.read_u32()?;
-        if version != 1 && version != 2 && version != 3 {
-            return Err(LaurusError::index(format!(
-                "Unsupported hash dictionary version: {version}"
-            )));
+        let avg_term_length = if term_count > 0 {
+            total_term_length as f64 / term_count as f64
+        } else {
+            0.0
+        };
+
+        let memory_size = self.fst.as_fst().as_inner().len() + self.block_section.len();
+
+        DictionaryStats {
+            term_count,
+            memory_size,
+            avg_term_length,
+            total_doc_frequency,
+            total_term_frequency,
         }
-
-        // Read number of terms
-        let term_count = reader.read_varint()? as usize;
-
-        // Read terms and their info
-        let mut terms = AHashMap::with_capacity(term_count);
-
-        for _ in 0..term_count {
-            let term = reader.read_string()?;
-            let posting_offset = reader.read_u64()?;
-            let posting_length = reader.read_u64()?;
-            let doc_frequency = reader.read_u64()?;
-            let total_frequency = reader.read_u64()?;
-            let max_score_factor = if version >= 2 {
-                reader.read_f32()?
-            } else {
-                0.0
-            };
-            let block_max = if version >= 3 {
-                let block_count = reader.read_varint()? as usize;
-                let mut blocks = Vec::with_capacity(block_count);
-                for _ in 0..block_count {
-                    let last_doc_id = reader.read_u64()?;
-                    let mf = reader.read_f32()?;
-                    blocks.push(BlockMax {
-                        last_doc_id,
-                        max_factor: mf,
-                    });
-                }
-                blocks
-            } else {
-                Vec::new()
-            };
-            let info = TermInfo {
-                posting_offset,
-                posting_length,
-                doc_frequency,
-                total_frequency,
-                max_score_factor,
-                block_max,
-            };
-
-            terms.insert(term, info);
-        }
-
-        Ok(HashTermDictionary { terms })
-    }
-}
-
-impl Default for HashTermDictionary {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// A hybrid term dictionary that provides both fast access and prefix queries.
-#[derive(Debug, Clone)]
-pub struct HybridTermDictionary {
-    /// Hash dictionary for fast random access.
-    hash_dict: HashTermDictionary,
-    /// Sorted dictionary for prefix and range queries.
-    sorted_dict: SortedTermDictionary,
-}
-
-impl HybridTermDictionary {
-    /// Create a new hybrid dictionary from a hash dictionary.
-    pub fn from_hash(hash_dict: HashTermDictionary) -> Self {
-        let sorted_dict = hash_dict.to_sorted();
-        HybridTermDictionary {
-            hash_dict,
-            sorted_dict,
-        }
-    }
-
-    /// Read hybrid term dictionary from storage.
-    pub fn read_from_storage<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
-        let sorted_dict = SortedTermDictionary::read_from_storage(reader)?;
-        let mut hash_dict = HashTermDictionary::with_capacity(sorted_dict.len());
-
-        for (term, info) in sorted_dict.iter() {
-            hash_dict.insert(term.to_string(), info.clone());
-        }
-
-        Ok(HybridTermDictionary {
-            hash_dict,
-            sorted_dict,
-        })
-    }
-
-    /// Look up a term (uses hash dictionary for speed).
-    pub fn get(&self, term: &str) -> Option<&TermInfo> {
-        self.hash_dict.get(term)
-    }
-
-    /// Find terms with the given prefix (uses sorted dictionary).
-    pub fn find_prefix(&self, prefix: &str) -> Vec<(&str, &TermInfo)> {
-        self.sorted_dict.find_prefix(prefix)
-    }
-
-    /// Find terms in a range (uses sorted dictionary).
-    pub fn find_range(&self, start: &str, end: &str) -> Vec<(&str, &TermInfo)> {
-        self.sorted_dict.find_range(start, end)
-    }
-
-    /// Get the number of terms.
-    pub fn len(&self) -> usize {
-        self.hash_dict.len()
-    }
-
-    /// Check if empty.
-    pub fn is_empty(&self) -> bool {
-        self.hash_dict.is_empty()
-    }
-
-    /// Get an iterator over all terms (ordered).
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &TermInfo)> {
-        self.sorted_dict.iter()
-    }
-
-    /// Write the dictionary to storage.
-    pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
-        self.sorted_dict.write_to_storage(writer)
     }
 }
 
@@ -572,24 +466,110 @@ impl TermDictionaryBuilder {
         self.terms.insert(term, info);
     }
 
-    /// Build a sorted term dictionary.
-    pub fn build_sorted(self) -> SortedTermDictionary {
-        SortedTermDictionary::from_map(self.terms)
-    }
+    /// Build a [`BlockTermDictionary`] (Lucene BlockTreeTerms-style,
+    /// Issue [#487](https://github.com/mosuka/laurus/issues/487)).
+    ///
+    /// Splits the sorted term map into 128-term blocks, encodes each
+    /// block via [`builder::encode_block_into`], and indexes the
+    /// blocks' last terms in an FST keyed by block byte offset.
+    ///
+    /// Returns an empty dictionary (no FST keys, empty BlockSection)
+    /// for an empty builder.
+    pub fn build(self) -> Result<BlockTermDictionary> {
+        let total_term_count = self.terms.len() as u64;
 
-    /// Build a hash term dictionary.
-    pub fn build_hash(self) -> HashTermDictionary {
-        let mut hash_dict = HashTermDictionary::with_capacity(self.terms.len());
-        for (term, info) in self.terms {
-            hash_dict.insert(term, info);
+        if self.terms.is_empty() {
+            // Build an empty FST so callers can still call `get` /
+            // `iter` without special-casing.
+            let fst_builder = fst::MapBuilder::memory();
+            let bytes = fst_builder
+                .into_inner()
+                .map_err(|e| LaurusError::index(format!("FST finish error: {e}")))?;
+            let fst = FstMap::new(bytes)
+                .map_err(|e| LaurusError::index(format!("FST construct error: {e}")))?;
+            return Ok(BlockTermDictionary {
+                fst: Arc::new(fst),
+                block_section: Arc::from(Vec::<u8>::new().into_boxed_slice()),
+                map: AHashMap::new(),
+                sorted_terms: Vec::new(),
+                term_infos: Arc::from(Vec::<TermInfo>::new().into_boxed_slice()),
+                total_term_count: 0,
+                block_count: 0,
+            });
         }
-        hash_dict
-    }
 
-    /// Build a hybrid term dictionary.
-    pub fn build_hybrid(self) -> HybridTermDictionary {
-        let hash_dict = self.build_hash();
-        HybridTermDictionary::from_hash(hash_dict)
+        // BTreeMap iteration is already ascending key order.
+        let entries: Vec<(String, TermInfo)> = self.terms.into_iter().collect();
+
+        let mut block_section: Vec<u8> = Vec::new();
+        let mut fst_builder = fst::MapBuilder::memory();
+        let mut block_count: u32 = 0;
+
+        // While we encode the disk-format scratch we also populate the
+        // in-memory query layer in lock-step. This avoids walking the
+        // BlockSection again post-build to materialise the AHashMap +
+        // sorted_terms + term_infos arrays.
+        let mut map = AHashMap::with_capacity(entries.len());
+        let mut sorted_terms: Vec<String> = Vec::with_capacity(entries.len());
+        let mut term_infos: Vec<TermInfo> = Vec::with_capacity(entries.len());
+        let mut next_ordinal: u32 = 0;
+
+        for chunk in entries.chunks(term_info_block::BLOCK_TERM_COUNT) {
+            let block_offset = block_section.len() as u64;
+
+            let term_byte_refs: Vec<&[u8]> = chunk.iter().map(|(t, _)| t.as_bytes()).collect();
+            let fixed_infos: Vec<term_info_block::FixedTermInfo> = chunk
+                .iter()
+                .map(|(_, info)| term_info_block::FixedTermInfo {
+                    posting_offset: info.posting_offset,
+                    posting_length: info.posting_length,
+                    doc_frequency: info.doc_frequency,
+                    total_frequency: info.total_frequency,
+                    max_score_factor: info.max_score_factor,
+                })
+                .collect();
+            let block_max_per_term: Vec<Vec<BlockMax>> = chunk
+                .iter()
+                .map(|(_, info)| info.block_max.clone())
+                .collect();
+
+            builder::encode_block_into(
+                &mut block_section,
+                &term_byte_refs,
+                &fixed_infos,
+                &block_max_per_term,
+            );
+
+            // Mirror the chunk into the in-memory layer.
+            for (term, info) in chunk {
+                map.insert(term.clone(), next_ordinal);
+                sorted_terms.push(term.clone());
+                term_infos.push(info.clone());
+                next_ordinal += 1;
+            }
+
+            let last_term = chunk.last().expect("chunk non-empty").0.as_bytes();
+            fst_builder
+                .insert(last_term, block_offset)
+                .map_err(|e| LaurusError::index(format!("FST insert error: {e}")))?;
+            block_count += 1;
+        }
+
+        let fst_bytes = fst_builder
+            .into_inner()
+            .map_err(|e| LaurusError::index(format!("FST finish error: {e}")))?;
+        let fst = FstMap::new(fst_bytes)
+            .map_err(|e| LaurusError::index(format!("FST construct error: {e}")))?;
+
+        Ok(BlockTermDictionary {
+            fst: Arc::new(fst),
+            block_section: Arc::from(block_section.into_boxed_slice()),
+            map,
+            sorted_terms,
+            term_infos: Arc::from(term_infos.into_boxed_slice()),
+            total_term_count,
+            block_count,
+        })
     }
 
     /// Get the current number of terms.
@@ -609,6 +589,33 @@ impl Default for TermDictionaryBuilder {
     }
 }
 
+/// Stream the BlockSection bytes once, building the in-memory query
+/// layer (`map`, `sorted_terms`, `term_infos`) for a freshly-loaded
+/// [`BlockTermDictionary`].
+///
+/// Used by [`BlockTermDictionary::read_from_storage`] only. Build-time
+/// population happens inline in [`TermDictionaryBuilder::build`] to
+/// avoid a redundant BlockSection walk.
+fn populate_in_memory_layer(
+    block_section: &[u8],
+    block_count: u32,
+    total_term_count: u64,
+) -> (AHashMap<String, u32>, Vec<String>, Arc<[TermInfo]>) {
+    let cap = total_term_count as usize;
+    let mut map = AHashMap::with_capacity(cap);
+    let mut sorted_terms: Vec<String> = Vec::with_capacity(cap);
+    let mut term_infos: Vec<TermInfo> = Vec::with_capacity(cap);
+
+    let iter = block_reader::BlockSectionIter::new(block_section, block_count);
+    for (ordinal, (term, info)) in iter.enumerate() {
+        map.insert(term.clone(), ordinal as u32);
+        sorted_terms.push(term);
+        term_infos.push(info);
+    }
+
+    (map, sorted_terms, Arc::from(term_infos.into_boxed_slice()))
+}
+
 /// Dictionary statistics.
 #[derive(Debug, Clone)]
 pub struct DictionaryStats {
@@ -622,103 +629,6 @@ pub struct DictionaryStats {
     pub total_doc_frequency: u64,
     /// Total term frequency.
     pub total_term_frequency: u64,
-}
-
-impl SortedTermDictionary {
-    /// Write to storage in **v3** layout (#403 PR-C).
-    ///
-    /// Each entry carries the v2 `max_score_factor: f32` plus a
-    /// length-prefixed per-block `(last_doc_id: u64, max_factor: f32)`
-    /// array used by Block-Max-WAND. v1/v2 readers are no longer able
-    /// to load new segments; readers from this codebase accept v1, v2
-    /// and v3 (see [`SortedTermDictionary::read_from_storage`]).
-    pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
-        // Write magic number for sorted dictionary
-        writer.write_u32(0x53544443)?; // "STDC"
-
-        // Write version
-        writer.write_u32(3)?;
-
-        // Write number of terms
-        writer.write_varint(self.terms.len() as u64)?;
-
-        // Write terms and their info
-        for (term, info) in self.terms.iter().zip(self.term_infos.iter()) {
-            writer.write_string(term)?;
-
-            // Write TermInfo
-            writer.write_u64(info.posting_offset)?;
-            writer.write_u64(info.posting_length)?;
-            writer.write_u64(info.doc_frequency)?;
-            writer.write_u64(info.total_frequency)?;
-            writer.write_f32(info.max_score_factor)?;
-            writer.write_varint(info.block_max.len() as u64)?;
-            for block in &info.block_max {
-                writer.write_u64(block.last_doc_id)?;
-                writer.write_f32(block.max_factor)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Get statistics about the dictionary.
-    pub fn stats(&self) -> DictionaryStats {
-        let term_count = self.terms.len();
-        let total_term_length: usize = self.terms.iter().map(|t| t.len()).sum();
-        let avg_term_length = if term_count > 0 {
-            total_term_length as f64 / term_count as f64
-        } else {
-            0.0
-        };
-
-        let total_doc_frequency = self.term_infos.iter().map(|info| info.doc_frequency).sum();
-        let total_term_frequency = self
-            .term_infos
-            .iter()
-            .map(|info| info.total_frequency)
-            .sum();
-
-        // Estimate memory size
-        let memory_size =
-            total_term_length + (self.term_infos.len() * std::mem::size_of::<TermInfo>());
-
-        DictionaryStats {
-            term_count,
-            memory_size,
-            avg_term_length,
-            total_doc_frequency,
-            total_term_frequency,
-        }
-    }
-}
-
-impl HashTermDictionary {
-    /// Get statistics about the dictionary.
-    pub fn stats(&self) -> DictionaryStats {
-        let term_count = self.terms.len();
-        let total_term_length: usize = self.terms.keys().map(|t| t.len()).sum();
-        let avg_term_length = if term_count > 0 {
-            total_term_length as f64 / term_count as f64
-        } else {
-            0.0
-        };
-
-        let total_doc_frequency = self.terms.values().map(|info| info.doc_frequency).sum();
-        let total_term_frequency = self.terms.values().map(|info| info.total_frequency).sum();
-
-        // Estimate memory size (includes hash map overhead)
-        let memory_size =
-            total_term_length + (self.terms.len() * (std::mem::size_of::<TermInfo>() + 64));
-
-        DictionaryStats {
-            term_count,
-            memory_size,
-            avg_term_length,
-            total_doc_frequency,
-            total_term_frequency,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -735,104 +645,224 @@ mod tests {
     }
 
     #[test]
-    fn test_sorted_term_dictionary() {
+    fn test_dictionary_builder_basic() {
         let mut builder = TermDictionaryBuilder::new();
-        builder.add_term("apple".to_string(), create_test_term_info(0));
-        builder.add_term("banana".to_string(), create_test_term_info(100));
-        builder.add_term("cherry".to_string(), create_test_term_info(200));
-        builder.add_term("apricot".to_string(), create_test_term_info(300));
+        assert!(builder.is_empty());
 
-        let dict = builder.build_sorted();
+        builder.add_term("test".to_string(), create_test_term_info(0));
+        assert_eq!(builder.len(), 1);
 
-        // Test exact lookup
-        assert!(dict.get("apple").is_some());
-        assert!(dict.get("banana").is_some());
-        assert!(dict.get("nonexistent").is_none());
-
-        // Test prefix search
-        let ap_results = dict.find_prefix("ap");
-        assert_eq!(ap_results.len(), 2);
-        assert!(ap_results.iter().any(|(term, _)| *term == "apple"));
-        assert!(ap_results.iter().any(|(term, _)| *term == "apricot"));
-
-        // Test range search
-        let range_results = dict.find_range("apple", "cherry");
-        assert_eq!(range_results.len(), 3); // apple, apricot, banana
+        let dict = builder.build().unwrap();
+        assert_eq!(dict.len(), 1);
+        assert!(dict.get("test").is_some());
     }
 
-    #[test]
-    fn test_hash_term_dictionary() {
-        let mut dict = HashTermDictionary::new();
-        dict.insert("apple".to_string(), create_test_term_info(0));
-        dict.insert("banana".to_string(), create_test_term_info(100));
-        dict.insert("cherry".to_string(), create_test_term_info(200));
+    // ----- BlockTermDictionary tests (#487 PR1) -----
 
-        assert!(dict.contains("apple"));
-        assert!(dict.contains("banana"));
-        assert!(!dict.contains("nonexistent"));
-
-        assert_eq!(dict.len(), 3);
-        assert!(!dict.is_empty());
-
-        let info = dict.get("apple").unwrap();
-        assert_eq!(info.posting_offset, 0);
-    }
-
-    #[test]
-    fn test_hybrid_term_dictionary() {
-        let mut hash_dict = HashTermDictionary::new();
-        hash_dict.insert("apple".to_string(), create_test_term_info(0));
-        hash_dict.insert("banana".to_string(), create_test_term_info(100));
-        hash_dict.insert("apricot".to_string(), create_test_term_info(200));
-
-        let hybrid_dict = HybridTermDictionary::from_hash(hash_dict);
-
-        // Test hash-based lookup
-        assert!(hybrid_dict.get("apple").is_some());
-        assert!(hybrid_dict.get("nonexistent").is_none());
-
-        // Test prefix search
-        let ap_results = hybrid_dict.find_prefix("ap");
-        assert_eq!(ap_results.len(), 2);
-    }
-
-    #[test]
-    fn test_dictionary_serialization() {
-        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
-
-        let mut builder = TermDictionaryBuilder::new();
-        builder.add_term("apple".to_string(), create_test_term_info(0));
-        builder.add_term("banana".to_string(), create_test_term_info(100));
-        builder.add_term("cherry".to_string(), create_test_term_info(200));
-
-        let original_dict = builder.build_sorted();
-
-        // Write to storage
-        {
-            let output = storage.create_output("test_dict.bin").unwrap();
-            let mut writer = StructWriter::new(output);
-            original_dict.write_to_storage(&mut writer).unwrap();
-            writer.close().unwrap();
-        }
-
-        // Read from storage
-        {
-            let input = storage.open_input("test_dict.bin").unwrap();
-            let mut reader = StructReader::new(input).unwrap();
-            let loaded_dict = SortedTermDictionary::read_from_storage(&mut reader).unwrap();
-
-            assert_eq!(loaded_dict.len(), original_dict.len());
-
-            for term in ["apple", "banana", "cherry"] {
-                let orig_info = original_dict.get(term).unwrap();
-                let loaded_info = loaded_dict.get(term).unwrap();
-                assert_eq!(orig_info, loaded_info);
-            }
+    fn make_test_term_info_with_block_max(offset: u64, block_max: Vec<BlockMax>) -> TermInfo {
+        TermInfo {
+            posting_offset: offset,
+            posting_length: 100,
+            doc_frequency: 5,
+            total_frequency: 20,
+            max_score_factor: 1.0,
+            block_max,
         }
     }
 
     #[test]
-    fn test_dictionary_stats() {
+    fn block_dict_empty_builder_yields_empty_dict() {
+        let builder = TermDictionaryBuilder::new();
+        let dict = builder.build().unwrap();
+        assert!(dict.is_empty());
+        assert_eq!(dict.len(), 0);
+        assert_eq!(dict.block_count(), 0);
+        assert!(dict.get("anything").is_none());
+        assert_eq!(dict.iter().count(), 0);
+    }
+
+    #[test]
+    fn block_dict_single_term_round_trip() {
+        let mut builder = TermDictionaryBuilder::new();
+        builder.add_term("hello".to_string(), create_test_term_info(42));
+        let dict = builder.build().unwrap();
+        assert_eq!(dict.len(), 1);
+        assert_eq!(dict.block_count(), 1);
+
+        let info = dict.get("hello").unwrap();
+        assert_eq!(info.posting_offset, 42);
+        assert!(dict.get("missing").is_none());
+    }
+
+    #[test]
+    fn block_dict_get_within_single_block() {
+        let mut builder = TermDictionaryBuilder::new();
+        for (i, term) in ["apple", "banana", "cherry", "date"].iter().enumerate() {
+            builder.add_term(term.to_string(), create_test_term_info(i as u64 * 100));
+        }
+        let dict = builder.build().unwrap();
+        assert_eq!(dict.len(), 4);
+        assert_eq!(dict.block_count(), 1);
+
+        for (i, term) in ["apple", "banana", "cherry", "date"].iter().enumerate() {
+            assert_eq!(dict.get(term).unwrap().posting_offset, i as u64 * 100);
+        }
+        assert!(dict.get("aardvark").is_none());
+        assert!(dict.get("blueberry").is_none());
+        assert!(dict.get("zulu").is_none());
+    }
+
+    #[test]
+    fn block_dict_iter_yields_in_sorted_order() {
+        let mut builder = TermDictionaryBuilder::new();
+        for term in ["zulu", "alpha", "mike", "bravo"] {
+            builder.add_term(term.to_string(), create_test_term_info(0));
+        }
+        let dict = builder.build().unwrap();
+        let collected: Vec<String> = dict.iter().map(|(t, _)| t.to_string()).collect();
+        assert_eq!(collected, vec!["alpha", "bravo", "mike", "zulu"]);
+    }
+
+    #[test]
+    fn block_dict_multi_block_get_hit_and_miss() {
+        // 300 terms → 3 blocks of 128/128/44 (BLOCK_TERM_COUNT = 128).
+        let mut builder = TermDictionaryBuilder::new();
+        for i in 0..300 {
+            builder.add_term(format!("term{i:04}"), create_test_term_info(i as u64));
+        }
+        let dict = builder.build().unwrap();
+        assert_eq!(dict.len(), 300);
+        assert_eq!(dict.block_count(), 3);
+
+        // Hits across all blocks.
+        for i in [0, 1, 100, 127, 128, 129, 200, 299] {
+            let key = format!("term{i:04}");
+            assert_eq!(
+                dict.get(&key).unwrap().posting_offset,
+                i as u64,
+                "miss on hit probe {key}"
+            );
+        }
+
+        // Misses (after, between, before existing keys).
+        assert!(dict.get("term0300").is_none());
+        assert!(dict.get("term9999").is_none());
+        assert!(dict.get("aaa").is_none());
+        assert!(dict.get("zzz").is_none());
+    }
+
+    #[test]
+    fn block_dict_iter_walks_multi_block() {
+        let mut builder = TermDictionaryBuilder::new();
+        for i in 0..200 {
+            builder.add_term(format!("term{i:04}"), create_test_term_info(i as u64));
+        }
+        let dict = builder.build().unwrap();
+        let collected: Vec<(String, u64)> = dict
+            .iter()
+            .map(|(t, info)| (t.to_string(), info.posting_offset))
+            .collect();
+        assert_eq!(collected.len(), 200);
+        for (i, (term, offset)) in collected.iter().enumerate() {
+            assert_eq!(term, &format!("term{i:04}"));
+            assert_eq!(*offset, i as u64);
+        }
+    }
+
+    #[test]
+    fn block_dict_find_prefix_within_block() {
+        let mut builder = TermDictionaryBuilder::new();
+        for term in ["alpha", "apple", "apricot", "axis", "banana"] {
+            builder.add_term(term.to_string(), create_test_term_info(0));
+        }
+        let dict = builder.build().unwrap();
+
+        let ap = dict.find_prefix("ap");
+        let ap_terms: Vec<&str> = ap.iter().map(|(t, _)| *t).collect();
+        assert_eq!(ap_terms, vec!["apple", "apricot"]);
+
+        // Empty prefix → all terms.
+        let all = dict.find_prefix("");
+        assert_eq!(all.len(), 5);
+
+        // No matches.
+        let zzz = dict.find_prefix("zzz");
+        assert!(zzz.is_empty());
+    }
+
+    #[test]
+    fn block_dict_find_prefix_across_block_boundary() {
+        // Force a prefix to span the block boundary at 128.
+        let mut builder = TermDictionaryBuilder::new();
+        for i in 0..200 {
+            builder.add_term(format!("term{i:04}"), create_test_term_info(i as u64));
+        }
+        let dict = builder.build().unwrap();
+        // "term01" matches term0100..term0199 → 100 entries spanning
+        // both blocks (128-term boundary at "term0127"/"term0128").
+        let matches = dict.find_prefix("term01");
+        assert_eq!(matches.len(), 100);
+        assert_eq!(matches[0].0, "term0100");
+        assert_eq!(matches[99].0, "term0199");
+    }
+
+    #[test]
+    fn block_dict_find_range_basic() {
+        let mut builder = TermDictionaryBuilder::new();
+        for term in ["apple", "banana", "cherry", "date", "fig"] {
+            builder.add_term(term.to_string(), create_test_term_info(0));
+        }
+        let dict = builder.build().unwrap();
+        let r = dict.find_range("banana", "fig");
+        let r_terms: Vec<&str> = r.iter().map(|(t, _)| *t).collect();
+        assert_eq!(r_terms, vec!["banana", "cherry", "date"]);
+
+        // Empty range when start >= end.
+        assert!(dict.find_range("date", "banana").is_empty());
+        assert!(dict.find_range("date", "date").is_empty());
+    }
+
+    #[test]
+    fn block_dict_term_info_with_block_max_round_trip() {
+        let mut builder = TermDictionaryBuilder::new();
+        let bm = vec![
+            BlockMax {
+                last_doc_id: 5,
+                max_factor: 0.5,
+            },
+            BlockMax {
+                last_doc_id: 10,
+                max_factor: 1.5,
+            },
+        ];
+        builder.add_term(
+            "hello".to_string(),
+            make_test_term_info_with_block_max(99, bm.clone()),
+        );
+        let dict = builder.build().unwrap();
+        let info = dict.get("hello").unwrap();
+        assert_eq!(info.posting_offset, 99);
+        assert_eq!(info.block_max.len(), 2);
+        assert_eq!(info.block_max[0].last_doc_id, 5);
+        assert_eq!(info.block_max[1].last_doc_id, 10);
+    }
+
+    #[test]
+    fn block_dict_clone_shares_storage() {
+        let mut builder = TermDictionaryBuilder::new();
+        for i in 0..50 {
+            builder.add_term(format!("term{i:03}"), create_test_term_info(i as u64));
+        }
+        let dict = builder.build().unwrap();
+        let dict2 = dict.clone();
+        assert_eq!(dict.len(), dict2.len());
+        assert_eq!(dict.get("term025").unwrap(), dict2.get("term025").unwrap());
+        // Arc strong count should be > 1 because of clone.
+        assert!(Arc::strong_count(&dict.fst) >= 2);
+    }
+
+    #[test]
+    fn block_dict_stats() {
         let mut builder = TermDictionaryBuilder::new();
         builder.add_term("short".to_string(), TermInfo::new(0, 50, 1, 1));
         builder.add_term("longer_term".to_string(), TermInfo::new(50, 100, 5, 10));
@@ -841,7 +871,7 @@ mod tests {
             TermInfo::new(150, 200, 3, 8),
         );
 
-        let dict = builder.build_sorted();
+        let dict = builder.build().unwrap();
         let stats = dict.stats();
 
         assert_eq!(stats.term_count, 3);
@@ -852,24 +882,162 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_dictionary() {
-        let dict = SortedTermDictionary::new();
-        assert!(dict.is_empty());
-        assert_eq!(dict.len(), 0);
-        assert!(dict.get("anything").is_none());
-        assert!(dict.find_prefix("any").is_empty());
+    fn block_dict_round_trip_via_storage() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+        let mut builder = TermDictionaryBuilder::new();
+        for i in 0..200u64 {
+            // 200 terms exercises 2 blocks (BLOCK_TERM_COUNT = 128 +
+            // partial second block).
+            let mut info = create_test_term_info(i * 16);
+            // Sprinkle non-trivial block_max on every 5th term to
+            // exercise the variable-length BlockMaxData encoding.
+            if i.is_multiple_of(5) {
+                info.block_max = vec![BlockMax {
+                    last_doc_id: i,
+                    max_factor: 1.0 + (i as f32) * 0.01,
+                }];
+            }
+            builder.add_term(format!("term{i:04}"), info);
+        }
+        let original_dict = builder.build().unwrap();
+
+        // Write
+        {
+            let output = storage.create_output("test_block_dict.bin").unwrap();
+            let mut writer = StructWriter::new(output);
+            original_dict.write_to_storage(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+
+        // Read
+        let loaded_dict = {
+            let input = storage.open_input("test_block_dict.bin").unwrap();
+            let mut reader = StructReader::new(input).unwrap();
+            BlockTermDictionary::read_from_storage(&mut reader).unwrap()
+        };
+
+        assert_eq!(loaded_dict.len(), original_dict.len());
+        assert_eq!(loaded_dict.block_count(), original_dict.block_count());
+
+        // All-term spot check.
+        for i in 0..200 {
+            let key = format!("term{i:04}");
+            let orig = original_dict.get(&key).unwrap();
+            let loaded = loaded_dict.get(&key).unwrap();
+            assert_eq!(orig, loaded, "mismatch for {key}");
+        }
+        // iter order
+        let orig_iter: Vec<_> = original_dict.iter().collect();
+        let loaded_iter: Vec<_> = loaded_dict.iter().collect();
+        assert_eq!(orig_iter.len(), loaded_iter.len());
+        for (a, b) in orig_iter.iter().zip(loaded_iter.iter()) {
+            assert_eq!(a, b);
+        }
     }
 
     #[test]
-    fn test_dictionary_builder() {
+    fn block_dict_read_rejects_legacy_stdc_magic() {
+        // Synthesise a file starting with the legacy `STDC` magic.
+        // Real legacy writers no longer exist (#487 Phase 9); we emit
+        // just the magic so `read_from_storage` short-circuits before
+        // trying to decode any payload.
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        {
+            let output = storage.create_output("legacy_stdc.bin").unwrap();
+            let mut writer = StructWriter::new(output);
+            writer.write_u32(LEGACY_MAGIC_STDC).unwrap();
+            writer.write_u32(3).unwrap(); // dummy version
+            writer.close().unwrap();
+        }
+
+        let input = storage.open_input("legacy_stdc.bin").unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let err = BlockTermDictionary::read_from_storage(&mut reader);
+        assert!(err.is_err());
+        let msg = format!("{}", err.unwrap_err());
+        assert!(
+            msg.contains("Unsupported legacy term dictionary format"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn block_dict_read_rejects_legacy_htdc_magic() {
+        // Same idea as `..._stdc_magic`: emit only the legacy magic.
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        {
+            let output = storage.create_output("legacy_htdc.bin").unwrap();
+            let mut writer = StructWriter::new(output);
+            writer.write_u32(LEGACY_MAGIC_HTDC).unwrap();
+            writer.write_u32(3).unwrap();
+            writer.close().unwrap();
+        }
+
+        let input = storage.open_input("legacy_htdc.bin").unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let err = BlockTermDictionary::read_from_storage(&mut reader);
+        assert!(err.is_err());
+        let msg = format!("{}", err.unwrap_err());
+        assert!(
+            msg.contains("Unsupported legacy term dictionary format"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn block_dict_read_rejects_unknown_magic() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        {
+            let output = storage.create_output("garbage.bin").unwrap();
+            let mut writer = StructWriter::new(output);
+            writer.write_u32(0xDEADBEEF).unwrap(); // bogus magic
+            writer.write_u32(0).unwrap();
+            writer.close().unwrap();
+        }
+        let input = storage.open_input("garbage.bin").unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let err = BlockTermDictionary::read_from_storage(&mut reader);
+        let msg = format!("{}", err.unwrap_err());
+        assert!(msg.contains("Invalid term dictionary magic"));
+    }
+
+    #[test]
+    fn block_dict_round_trip_empty() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let original_dict = TermDictionaryBuilder::new().build().unwrap();
+        {
+            let output = storage.create_output("empty.bin").unwrap();
+            let mut writer = StructWriter::new(output);
+            original_dict.write_to_storage(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+        let input = storage.open_input("empty.bin").unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let loaded = BlockTermDictionary::read_from_storage(&mut reader).unwrap();
+        assert!(loaded.is_empty());
+        assert_eq!(loaded.block_count(), 0);
+    }
+
+    #[test]
+    fn block_dict_exact_block_boundary_term_count() {
+        // Exactly 128 terms → 1 block, fully filled.
         let mut builder = TermDictionaryBuilder::new();
-        assert!(builder.is_empty());
+        for i in 0..128 {
+            builder.add_term(format!("term{i:03}"), create_test_term_info(i as u64));
+        }
+        let dict = builder.build().unwrap();
+        assert_eq!(dict.len(), 128);
+        assert_eq!(dict.block_count(), 1);
 
-        builder.add_term("test".to_string(), create_test_term_info(0));
-        assert_eq!(builder.len(), 1);
-
-        let sorted = builder.build_sorted();
-        assert_eq!(sorted.len(), 1);
-        assert!(sorted.get("test").is_some());
+        // 129 terms → 2 blocks (128 + 1).
+        let mut builder2 = TermDictionaryBuilder::new();
+        for i in 0..129 {
+            builder2.add_term(format!("term{i:03}"), create_test_term_info(i as u64));
+        }
+        let dict2 = builder2.build().unwrap();
+        assert_eq!(dict2.len(), 129);
+        assert_eq!(dict2.block_count(), 2);
+        assert_eq!(dict2.get("term128").unwrap().posting_offset, 128);
     }
 }

--- a/laurus/src/lexical/index/structures/dictionary/block_max_data.rs
+++ b/laurus/src/lexical/index/structures/dictionary/block_max_data.rs
@@ -1,0 +1,252 @@
+//! Per-block storage of variable-length [`crate::lexical::index::structures::dictionary::BlockMax`] arrays.
+//!
+//! Each term in a dictionary block has its own `Vec<BlockMax>` (used by
+//! Block-Max-WAND, #403 PR-C). Lengths vary widely (proportional to
+//! `doc_frequency`), so this layer stores the data as:
+//!
+//! - a parallel `offsets: Vec<u32>` of length `term_count + 1`, where
+//!   `data[offsets[i]..offsets[i + 1]]` is the `BlockMax` byte stream
+//!   for the i-th term in the block
+//! - a flat `data: Vec<u8>` of all `BlockMax` entries concatenated
+//!   (12 bytes each: `u64 last_doc_id` little-endian followed by
+//!   `f32 max_factor` little-endian)
+//!
+//! Random access to ordinal `i` is `O(1)`: read `offsets[i..=i+1]`,
+//! slice `data`, decode 12 bytes per `BlockMax`.
+
+// Skeleton wiring: these `pub(super)` items are consumed by
+// `block_reader` (Phase 5) and `builder` (Phase 6). Until then,
+// `cargo check` flags them as dead code. Remove this allow once the
+// integration is complete.
+#![allow(dead_code)]
+
+use crate::lexical::index::structures::dictionary::BlockMax;
+
+/// Bytes per [`BlockMax`] entry on the wire (`u64 last_doc_id` +
+/// `f32 max_factor`).
+const BLOCK_MAX_BYTES: usize = 12;
+
+/// Variable-length per-term `BlockMax` data for a single dictionary
+/// block.
+///
+/// On disk layout (within the BlockSection of `.dict`):
+///
+/// ```text
+/// [bm_offsets_len: u32]       (= term_count + 1)
+/// [bm_offsets:     u32 × bm_offsets_len]
+/// [bm_data_len:    u32]
+/// [bm_data:        u8 × bm_data_len]
+/// ```
+pub(super) struct BlockMaxData {
+    /// Byte offsets into `data`, length `term_count + 1`. The i-th
+    /// term's `BlockMax` byte slice is
+    /// `data[offsets[i] as usize..offsets[i + 1] as usize]`.
+    pub(super) offsets: Vec<u32>,
+    /// Flat byte stream of all `BlockMax` entries concatenated.
+    pub(super) data: Vec<u8>,
+}
+
+impl BlockMaxData {
+    /// Encode `per_term[i]` as the i-th term's `BlockMax` array. The
+    /// resulting `offsets` has length `per_term.len() + 1`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the total encoded size would exceed `u32::MAX` (4 GB
+    /// per block, far beyond any realistic block).
+    pub(super) fn encode(per_term: &[Vec<BlockMax>]) -> Self {
+        let mut offsets = Vec::with_capacity(per_term.len() + 1);
+        offsets.push(0u32);
+
+        let total_block_max_count: usize = per_term.iter().map(|blocks| blocks.len()).sum();
+        let mut data = Vec::with_capacity(total_block_max_count * BLOCK_MAX_BYTES);
+
+        for blocks in per_term {
+            for bm in blocks {
+                data.extend_from_slice(&bm.last_doc_id.to_le_bytes());
+                data.extend_from_slice(&bm.max_factor.to_le_bytes());
+            }
+            assert!(
+                data.len() <= u32::MAX as usize,
+                "BlockMaxData: encoded size exceeds u32::MAX"
+            );
+            offsets.push(data.len() as u32);
+        }
+
+        BlockMaxData { offsets, data }
+    }
+
+    /// Decode the `BlockMax` array for the i-th term in the block.
+    /// Returns an empty `Vec` if the term has no block_max.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `inner_offset >= self.term_count()`.
+    pub(super) fn get(&self, inner_offset: usize) -> Vec<BlockMax> {
+        assert!(
+            inner_offset < self.term_count(),
+            "BlockMaxData::get: inner_offset {} >= term_count {}",
+            inner_offset,
+            self.term_count()
+        );
+
+        let start = self.offsets[inner_offset] as usize;
+        let end = self.offsets[inner_offset + 1] as usize;
+        debug_assert!(
+            (end - start).is_multiple_of(BLOCK_MAX_BYTES),
+            "BlockMaxData: byte range not a multiple of {BLOCK_MAX_BYTES}"
+        );
+
+        let count = (end - start) / BLOCK_MAX_BYTES;
+        let mut result = Vec::with_capacity(count);
+        for i in 0..count {
+            let off = start + i * BLOCK_MAX_BYTES;
+            let last_doc_id = u64::from_le_bytes(
+                self.data[off..off + 8]
+                    .try_into()
+                    .expect("8-byte slice for u64"),
+            );
+            let max_factor = f32::from_le_bytes(
+                self.data[off + 8..off + 12]
+                    .try_into()
+                    .expect("4-byte slice for f32"),
+            );
+            result.push(BlockMax {
+                last_doc_id,
+                max_factor,
+            });
+        }
+        result
+    }
+
+    /// Number of terms covered by this block_max data (= `offsets.len() - 1`).
+    pub(super) fn term_count(&self) -> usize {
+        self.offsets.len().saturating_sub(1)
+    }
+
+    /// Total encoded data size in bytes.
+    pub(super) fn data_len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bm(doc: u64, factor: f32) -> BlockMax {
+        BlockMax {
+            last_doc_id: doc,
+            max_factor: factor,
+        }
+    }
+
+    #[test]
+    fn empty_block() {
+        let data = BlockMaxData::encode(&[]);
+        assert_eq!(data.term_count(), 0);
+        assert_eq!(data.data_len(), 0);
+        assert_eq!(data.offsets, vec![0u32]);
+    }
+
+    #[test]
+    fn all_terms_empty() {
+        let per_term: Vec<Vec<BlockMax>> = vec![Vec::new(); 5];
+        let data = BlockMaxData::encode(&per_term);
+        assert_eq!(data.term_count(), 5);
+        assert_eq!(data.data_len(), 0);
+        // offsets all zero
+        for &off in &data.offsets {
+            assert_eq!(off, 0);
+        }
+        for i in 0..5 {
+            assert!(data.get(i).is_empty());
+        }
+    }
+
+    #[test]
+    fn single_term_with_blocks() {
+        let per_term = vec![vec![bm(10, 1.5), bm(20, 2.5), bm(30, 3.5)]];
+        let data = BlockMaxData::encode(&per_term);
+        assert_eq!(data.term_count(), 1);
+        assert_eq!(data.data_len(), 3 * BLOCK_MAX_BYTES);
+        assert_eq!(data.offsets, vec![0, 36]);
+
+        let got = data.get(0);
+        assert_eq!(got.len(), 3);
+        assert_eq!(got[0].last_doc_id, 10);
+        assert!((got[0].max_factor - 1.5).abs() < 1e-6);
+        assert_eq!(got[2].last_doc_id, 30);
+    }
+
+    #[test]
+    fn mixed_lengths() {
+        let per_term = vec![
+            Vec::new(),
+            vec![bm(100, 0.5)],
+            (0..10).map(|i| bm(i, i as f32 * 0.1)).collect(),
+            vec![bm(1, 9.9), bm(2, 8.8)],
+        ];
+        let data = BlockMaxData::encode(&per_term);
+        assert_eq!(data.term_count(), 4);
+
+        // term 0: empty
+        assert!(data.get(0).is_empty());
+
+        // term 1: 1 entry
+        let t1 = data.get(1);
+        assert_eq!(t1.len(), 1);
+        assert_eq!(t1[0].last_doc_id, 100);
+        assert!((t1[0].max_factor - 0.5).abs() < 1e-6);
+
+        // term 2: 10 entries
+        let t2 = data.get(2);
+        assert_eq!(t2.len(), 10);
+        for (i, b) in t2.iter().enumerate() {
+            assert_eq!(b.last_doc_id, i as u64);
+            assert!((b.max_factor - i as f32 * 0.1).abs() < 1e-6);
+        }
+
+        // term 3: 2 entries
+        let t3 = data.get(3);
+        assert_eq!(t3.len(), 2);
+        assert_eq!(t3[0].last_doc_id, 1);
+        assert_eq!(t3[1].last_doc_id, 2);
+    }
+
+    #[test]
+    fn round_trip_128_terms_random() {
+        let mut state: u64 = 0xBADC0FFE_E0DDF00D;
+        let mut next_u64 = || -> u64 {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            state
+        };
+
+        let per_term: Vec<Vec<BlockMax>> = (0..128)
+            .map(|i| {
+                let count = (i as u64 % 6) as usize; // 0..5 entries per term
+                (0..count)
+                    .map(|j| bm(next_u64() % 1_000_000, j as f32 * 1.5))
+                    .collect()
+            })
+            .collect();
+        let data = BlockMaxData::encode(&per_term);
+        for (i, expected) in per_term.iter().enumerate() {
+            let got = data.get(i);
+            assert_eq!(got.len(), expected.len(), "length mismatch at i={i}");
+            for (g, e) in got.iter().zip(expected.iter()) {
+                assert_eq!(g.last_doc_id, e.last_doc_id);
+                assert_eq!(g.max_factor.to_bits(), e.max_factor.to_bits());
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "inner_offset 5 >= term_count 3")]
+    fn get_panics_on_out_of_range() {
+        let data = BlockMaxData::encode(&[Vec::new(), Vec::new(), Vec::new()]);
+        let _ = data.get(5);
+    }
+}

--- a/laurus/src/lexical/index/structures/dictionary/block_reader.rs
+++ b/laurus/src/lexical/index/structures/dictionary/block_reader.rs
@@ -1,0 +1,686 @@
+//! In-memory reader and iterator over the BlockSection of a `.dict` file.
+//!
+//! A [`BlockReader`] points to the bytes of a single block within the
+//! BlockSection. It can perform an in-block lookup (linear front-coded
+//! scan) or yield each `(term_bytes, TermInfo)` pair sequentially.
+//!
+//! [`BlockSectionIter`] walks the entire BlockSection, lazily decoding
+//! one block at a time so that `iter()` does not need to materialise
+//! the whole dictionary into memory.
+//!
+//! # Block layout (within `BlockSection`)
+//!
+//! ```text
+//! [term_count:                varint (u16 bounded)]
+//! [front_coded_terms_len:     varint]
+//! [front_coded_terms_bytes:   u8 × front_coded_terms_len]
+//! [FixedTermInfoBlock serialized]
+//!   block_min_posting_offset:    u64 LE  (8 bytes)
+//!   block_min_posting_length:    u64 LE  (8 bytes)
+//!   block_min_doc_frequency:     u64 LE  (8 bytes)
+//!   block_min_total_frequency:   u64 LE  (8 bytes)
+//!   ref_max_score_factor:        f32 LE  (4 bytes)
+//!   posting_offset_nbits:        u8
+//!   posting_length_nbits:        u8
+//!   doc_frequency_nbits:         u8
+//!   total_frequency_nbits:       u8
+//!   max_score_factor_size:       u8
+//!   payload_len:                 u32 LE  (4 bytes)
+//!   payload:                     u8 × payload_len
+//! [BlockMaxData serialized]
+//!   bm_offsets:                  u32 LE × (term_count + 1)
+//!   bm_data_len:                 u32 LE  (4 bytes)
+//!   bm_data:                     u8 × bm_data_len
+//! ```
+
+// Skeleton wiring: these `pub(super)` items are consumed by
+// `builder` (Phase 6). Until then, `cargo check` flags some of them
+// as dead code. Remove this allow once the integration is complete.
+#![allow(dead_code)]
+
+use crate::error::{LaurusError, Result};
+use crate::lexical::index::structures::dictionary::TermInfo;
+
+use super::block_max_data::BlockMaxData;
+use super::front_coding::FrontCodingDecoder;
+use super::term_info_block::FixedTermInfoBlock;
+
+/// Reader for a single block parsed out of the BlockSection.
+pub(super) struct BlockReader<'a> {
+    /// Number of terms in this block (`1..=BLOCK_TERM_COUNT`).
+    pub(super) block_term_count: u16,
+    /// Front-coded term bytes section of the block (sub-slice of the
+    /// BlockSection).
+    pub(super) term_bytes: &'a [u8],
+    /// Bit-packed fixed-size `TermInfo` portion (payload bytes copied
+    /// from the BlockSection — see module-level note about
+    /// zero-copy).
+    pub(super) term_info_block: FixedTermInfoBlock,
+    /// Variable-length `block_max` storage (offsets + bytes copied
+    /// from the BlockSection).
+    pub(super) block_max_data: BlockMaxData,
+}
+
+impl<'a> BlockReader<'a> {
+    /// Parse a block starting at `cursor` within the BlockSection
+    /// `bytes`. Returns the parsed reader and the cursor advanced past
+    /// the block.
+    pub(super) fn parse(bytes: &'a [u8], cursor: usize) -> Result<(Self, usize)> {
+        let mut c = cursor;
+
+        let term_count_u64 = read_varint(bytes, &mut c)?;
+        let term_count = u16::try_from(term_count_u64).map_err(|_| {
+            LaurusError::index(format!(
+                "BlockReader: term_count {term_count_u64} exceeds u16::MAX"
+            ))
+        })?;
+        if term_count == 0 {
+            return Err(LaurusError::index("BlockReader: empty block"));
+        }
+
+        let fc_len = read_varint(bytes, &mut c)? as usize;
+        if c + fc_len > bytes.len() {
+            return Err(LaurusError::index(
+                "BlockReader: front-coded section overruns BlockSection",
+            ));
+        }
+        let term_bytes = &bytes[c..c + fc_len];
+        c += fc_len;
+
+        // FixedTermInfoBlock fixed header (36 bytes block_min + ref f32,
+        // 5 bytes nbits + size, 4 bytes payload_len = 45 bytes).
+        const FTIB_FIXED_HEADER_BYTES: usize = 8 + 8 + 8 + 8 + 4 + 5 + 4;
+        if c + FTIB_FIXED_HEADER_BYTES > bytes.len() {
+            return Err(LaurusError::index(
+                "BlockReader: FixedTermInfoBlock header overruns BlockSection",
+            ));
+        }
+
+        let block_min_posting_offset = read_u64_le(bytes, &mut c);
+        let block_min_posting_length = read_u64_le(bytes, &mut c);
+        let block_min_doc_frequency = read_u64_le(bytes, &mut c);
+        let block_min_total_frequency = read_u64_le(bytes, &mut c);
+        let ref_max_score_factor = read_f32_le(bytes, &mut c);
+        let posting_offset_nbits = read_u8(bytes, &mut c);
+        let posting_length_nbits = read_u8(bytes, &mut c);
+        let doc_frequency_nbits = read_u8(bytes, &mut c);
+        let total_frequency_nbits = read_u8(bytes, &mut c);
+        let max_score_factor_size = read_u8(bytes, &mut c);
+        let payload_len = read_u32_le(bytes, &mut c) as usize;
+
+        if c + payload_len > bytes.len() {
+            return Err(LaurusError::index(
+                "BlockReader: FixedTermInfoBlock payload overruns BlockSection",
+            ));
+        }
+        let payload = bytes[c..c + payload_len].to_vec();
+        c += payload_len;
+
+        let term_info_block = FixedTermInfoBlock {
+            term_count,
+            block_min_posting_offset,
+            block_min_posting_length,
+            block_min_doc_frequency,
+            block_min_total_frequency,
+            ref_max_score_factor,
+            posting_offset_nbits,
+            posting_length_nbits,
+            doc_frequency_nbits,
+            total_frequency_nbits,
+            max_score_factor_size,
+            payload,
+        };
+
+        // BlockMaxData: (term_count + 1) u32 offsets, then bm_data_len + bytes.
+        let offsets_count = term_count as usize + 1;
+        let offsets_bytes = offsets_count * 4;
+        if c + offsets_bytes + 4 > bytes.len() {
+            return Err(LaurusError::index(
+                "BlockReader: BlockMaxData header overruns BlockSection",
+            ));
+        }
+        let mut offsets = Vec::with_capacity(offsets_count);
+        for _ in 0..offsets_count {
+            offsets.push(read_u32_le(bytes, &mut c));
+        }
+        let bm_data_len = read_u32_le(bytes, &mut c) as usize;
+        if c + bm_data_len > bytes.len() {
+            return Err(LaurusError::index(
+                "BlockReader: BlockMaxData data overruns BlockSection",
+            ));
+        }
+        let bm_data = bytes[c..c + bm_data_len].to_vec();
+        c += bm_data_len;
+
+        let block_max_data = BlockMaxData {
+            offsets,
+            data: bm_data,
+        };
+
+        Ok((
+            BlockReader {
+                block_term_count: term_count,
+                term_bytes,
+                term_info_block,
+                block_max_data,
+            },
+            c,
+        ))
+    }
+
+    /// Look up `target` within this block. Returns `Some(TermInfo)` on
+    /// hit, `None` if not present.
+    ///
+    /// Performs a linear scan over front-coded term bytes, comparing
+    /// each decoded term to `target`. Stops early if a decoded term
+    /// is greater than `target` (terms are sorted within a block).
+    pub(super) fn lookup(&self, target: &[u8]) -> Option<TermInfo> {
+        let mut decoder = FrontCodingDecoder::new(self.term_bytes, self.block_term_count as u32);
+        let mut inner: usize = 0;
+        while let Some(term) = decoder.next() {
+            match term.cmp(target) {
+                std::cmp::Ordering::Equal => {
+                    return Some(self.materialise_term_info(inner));
+                }
+                std::cmp::Ordering::Greater => return None,
+                std::cmp::Ordering::Less => {
+                    inner += 1;
+                }
+            }
+        }
+        None
+    }
+
+    /// Iterate `(term_bytes_owned, TermInfo)` pairs in sorted order.
+    pub(super) fn iter(&self) -> BlockReaderIter<'_, 'a> {
+        BlockReaderIter {
+            decoder: FrontCodingDecoder::new(self.term_bytes, self.block_term_count as u32),
+            term_info_block: &self.term_info_block,
+            block_max_data: &self.block_max_data,
+            inner: 0,
+        }
+    }
+
+    /// Build a [`TermInfo`] for the entry at `inner_offset` by
+    /// combining the bit-packed fixed fields with the variable-length
+    /// `block_max` array.
+    fn materialise_term_info(&self, inner_offset: usize) -> TermInfo {
+        let fti = self.term_info_block.decode_at(inner_offset);
+        let block_max = self.block_max_data.get(inner_offset);
+        TermInfo {
+            posting_offset: fti.posting_offset,
+            posting_length: fti.posting_length,
+            doc_frequency: fti.doc_frequency,
+            total_frequency: fti.total_frequency,
+            max_score_factor: fti.max_score_factor,
+            block_max,
+        }
+    }
+}
+
+/// Iterator yielded by [`BlockReader::iter`]. Yields fresh `Vec<u8>`
+/// term bytes (copy of the decoder's reusable buffer) so the caller
+/// can move the term independently of the iterator.
+pub(super) struct BlockReaderIter<'r, 'a: 'r> {
+    decoder: FrontCodingDecoder<'a>,
+    term_info_block: &'r FixedTermInfoBlock,
+    block_max_data: &'r BlockMaxData,
+    inner: usize,
+}
+
+impl<'r, 'a: 'r> Iterator for BlockReaderIter<'r, 'a> {
+    type Item = (Vec<u8>, TermInfo);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let term = self.decoder.next()?;
+        let term_owned = term.to_vec();
+        let fti = self.term_info_block.decode_at(self.inner);
+        let block_max = self.block_max_data.get(self.inner);
+        let info = TermInfo {
+            posting_offset: fti.posting_offset,
+            posting_length: fti.posting_length,
+            doc_frequency: fti.doc_frequency,
+            total_frequency: fti.total_frequency,
+            max_score_factor: fti.max_score_factor,
+            block_max,
+        };
+        self.inner += 1;
+        Some((term_owned, info))
+    }
+}
+
+/// Streaming iterator over the entire BlockSection, yielding
+/// `(term_string, TermInfo)` pairs in sorted order.
+///
+/// Internally walks block-by-block using [`BlockReader`], decoding
+/// front-coded term bytes lazily so memory usage stays at one block
+/// + one decode buffer regardless of dictionary size.
+pub(super) struct BlockSectionIter<'a> {
+    /// BlockSection bytes (full).
+    bytes: &'a [u8],
+    /// Cursor into `bytes` for the next block to parse.
+    cursor: usize,
+    /// Number of blocks remaining to be parsed (excluding the current
+    /// in-flight one).
+    blocks_remaining: u32,
+    /// Currently-active block reader (or `None` if exhausted / not yet
+    /// loaded).
+    current: Option<CurrentBlock<'a>>,
+}
+
+/// Owned per-block state held by [`BlockSectionIter`].
+///
+/// Holds a stateful [`FrontCodingDecoder`] alongside the parsed block
+/// metadata so consecutive `next()` calls advance through the block in
+/// `O(1)` per term instead of re-decoding the front-coded prefix from
+/// the start of the block each time. Both `decoder` and the
+/// `term_info_block` / `block_max_data` borrows live for `'a`, the
+/// lifetime of the underlying BlockSection bytes — there is no
+/// self-reference between fields.
+struct CurrentBlock<'a> {
+    block_term_count: u16,
+    decoder: FrontCodingDecoder<'a>,
+    term_info_block: FixedTermInfoBlock,
+    block_max_data: BlockMaxData,
+    inner: usize,
+}
+
+impl<'a> BlockSectionIter<'a> {
+    /// Create a new iterator over `bytes` covering exactly `block_count`
+    /// blocks.
+    pub(super) fn new(bytes: &'a [u8], block_count: u32) -> Self {
+        BlockSectionIter {
+            bytes,
+            cursor: 0,
+            blocks_remaining: block_count,
+            current: None,
+        }
+    }
+
+    /// Advance into the next block, populating `self.current`. Returns
+    /// `Ok(false)` when no further blocks remain.
+    fn advance_block(&mut self) -> Result<bool> {
+        if self.blocks_remaining == 0 {
+            self.current = None;
+            return Ok(false);
+        }
+        let (reader, next_cursor) = BlockReader::parse(self.bytes, self.cursor)?;
+        self.cursor = next_cursor;
+        self.blocks_remaining -= 1;
+
+        let decoder = FrontCodingDecoder::new(reader.term_bytes, reader.block_term_count as u32);
+        self.current = Some(CurrentBlock {
+            block_term_count: reader.block_term_count,
+            decoder,
+            term_info_block: reader.term_info_block,
+            block_max_data: reader.block_max_data,
+            inner: 0,
+        });
+        Ok(true)
+    }
+}
+
+impl<'a> Iterator for BlockSectionIter<'a> {
+    type Item = (String, TermInfo);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.current.is_none() {
+                match self.advance_block() {
+                    Ok(true) => {}
+                    Ok(false) => return None,
+                    Err(_) => return None, // corruption: end iteration silently
+                }
+            }
+            // SAFETY of unwrap: just set in advance_block.
+            let cb = self.current.as_mut().unwrap();
+            if cb.inner >= cb.block_term_count as usize {
+                self.current = None;
+                continue;
+            }
+
+            // Single decoder advance per call. Buffer is reused across
+            // calls, so per-step cost is the front-coding decode
+            // (≈ 5–10 ns) rather than a `O(N²)` full-block re-walk.
+            let term_bytes = match cb.decoder.next() {
+                Some(b) => b,
+                None => {
+                    // Decoder exhausted unexpectedly — treat as
+                    // corruption and end iteration silently.
+                    self.current = None;
+                    return None;
+                }
+            };
+            let term_string = String::from_utf8_lossy(term_bytes).into_owned();
+            let fti = cb.term_info_block.decode_at(cb.inner);
+            let block_max = cb.block_max_data.get(cb.inner);
+            let info = TermInfo {
+                posting_offset: fti.posting_offset,
+                posting_length: fti.posting_length,
+                doc_frequency: fti.doc_frequency,
+                total_frequency: fti.total_frequency,
+                max_score_factor: fti.max_score_factor,
+                block_max,
+            };
+            cb.inner += 1;
+            return Some((term_string, info));
+        }
+    }
+}
+
+// ---------- byte-level helpers ----------
+
+/// Read an unsigned LEB128 varint at `*cursor`, advancing the cursor.
+fn read_varint(bytes: &[u8], cursor: &mut usize) -> Result<u64> {
+    let mut result: u64 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        if *cursor >= bytes.len() {
+            return Err(LaurusError::index("BlockReader: truncated varint"));
+        }
+        let byte = bytes[*cursor];
+        *cursor += 1;
+        result |= u64::from(byte & 0x7F) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(result);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(LaurusError::index("BlockReader: varint overflow"));
+        }
+    }
+}
+
+fn read_u64_le(bytes: &[u8], cursor: &mut usize) -> u64 {
+    let v = u64::from_le_bytes(
+        bytes[*cursor..*cursor + 8]
+            .try_into()
+            .expect("8-byte slice"),
+    );
+    *cursor += 8;
+    v
+}
+
+fn read_u32_le(bytes: &[u8], cursor: &mut usize) -> u32 {
+    let v = u32::from_le_bytes(
+        bytes[*cursor..*cursor + 4]
+            .try_into()
+            .expect("4-byte slice"),
+    );
+    *cursor += 4;
+    v
+}
+
+fn read_f32_le(bytes: &[u8], cursor: &mut usize) -> f32 {
+    let v = f32::from_le_bytes(
+        bytes[*cursor..*cursor + 4]
+            .try_into()
+            .expect("4-byte slice"),
+    );
+    *cursor += 4;
+    v
+}
+
+fn read_u8(bytes: &[u8], cursor: &mut usize) -> u8 {
+    let v = bytes[*cursor];
+    *cursor += 1;
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexical::index::structures::dictionary::BlockMax;
+
+    use super::super::front_coding::encode_block_terms;
+    use super::super::term_info_block::FixedTermInfo;
+
+    fn fti(po: u64, pl: u64, df: u64, tf: u64, msf: f32) -> FixedTermInfo {
+        FixedTermInfo {
+            posting_offset: po,
+            posting_length: pl,
+            doc_frequency: df,
+            total_frequency: tf,
+            max_score_factor: msf,
+        }
+    }
+
+    fn sample_block_max(doc: u64, factor: f32) -> BlockMax {
+        BlockMax {
+            last_doc_id: doc,
+            max_factor: factor,
+        }
+    }
+
+    /// Encode one block's bytes (BlockHeader + TermBytes +
+    /// FixedTermInfoBlock + BlockMaxData) into `out`. Used by tests
+    /// to build a synthetic BlockSection without depending on the
+    /// (Phase 6) builder.
+    fn encode_block_into(
+        out: &mut Vec<u8>,
+        terms: &[&[u8]],
+        infos: &[(FixedTermInfo, Vec<BlockMax>)],
+    ) {
+        assert_eq!(terms.len(), infos.len());
+        let term_count = terms.len();
+        // Term count varint.
+        write_varint_into(out, term_count as u64);
+        // Front-coded term bytes.
+        let fc = encode_block_terms(terms);
+        write_varint_into(out, fc.len() as u64);
+        out.extend_from_slice(&fc);
+        // FixedTermInfoBlock.
+        let fixed: Vec<FixedTermInfo> = infos.iter().map(|(f, _)| *f).collect();
+        let ftib = FixedTermInfoBlock::encode(&fixed);
+        out.extend_from_slice(&ftib.block_min_posting_offset.to_le_bytes());
+        out.extend_from_slice(&ftib.block_min_posting_length.to_le_bytes());
+        out.extend_from_slice(&ftib.block_min_doc_frequency.to_le_bytes());
+        out.extend_from_slice(&ftib.block_min_total_frequency.to_le_bytes());
+        out.extend_from_slice(&ftib.ref_max_score_factor.to_le_bytes());
+        out.push(ftib.posting_offset_nbits);
+        out.push(ftib.posting_length_nbits);
+        out.push(ftib.doc_frequency_nbits);
+        out.push(ftib.total_frequency_nbits);
+        out.push(ftib.max_score_factor_size);
+        out.extend_from_slice(&(ftib.payload.len() as u32).to_le_bytes());
+        out.extend_from_slice(&ftib.payload);
+        // BlockMaxData.
+        let per_term: Vec<Vec<BlockMax>> = infos.iter().map(|(_, bm)| bm.clone()).collect();
+        let bmd = BlockMaxData::encode(&per_term);
+        for off in &bmd.offsets {
+            out.extend_from_slice(&off.to_le_bytes());
+        }
+        out.extend_from_slice(&(bmd.data.len() as u32).to_le_bytes());
+        out.extend_from_slice(&bmd.data);
+    }
+
+    fn write_varint_into(buf: &mut Vec<u8>, mut value: u64) {
+        while value >= 0x80 {
+            buf.push(((value as u8) & 0x7F) | 0x80);
+            value >>= 7;
+        }
+        buf.push(value as u8);
+    }
+
+    /// Build an in-memory BlockSection containing two blocks for the
+    /// integration tests below. Returns the bytes plus the test
+    /// fixtures so tests can verify lookups.
+    fn build_two_block_section() -> (Vec<u8>, Vec<(Vec<u8>, TermInfo)>) {
+        // Block 0: "alpha", "beta", "gamma" (sorted).
+        // Block 1: "delta", "epsilon", "zeta" — note "delta" < "gamma"
+        //          would violate the global sort order, so we use
+        //          "kappa", "lambda", "mu" instead.
+        let block0_terms: Vec<&[u8]> = vec![b"alpha", b"beta", b"gamma"];
+        let block0_infos = vec![
+            (
+                fti(0, 100, 5, 50, 1.5),
+                vec![sample_block_max(10, 1.5), sample_block_max(20, 2.5)],
+            ),
+            (fti(100, 80, 3, 40, 1.5), Vec::new()),
+            (fti(180, 200, 8, 100, 2.0), vec![sample_block_max(30, 3.5)]),
+        ];
+
+        let block1_terms: Vec<&[u8]> = vec![b"kappa", b"lambda", b"mu"];
+        let block1_infos = vec![
+            (fti(380, 50, 1, 1, 0.5), Vec::new()),
+            (fti(430, 70, 2, 5, 0.5), Vec::new()),
+            (fti(500, 90, 4, 8, 0.5), vec![sample_block_max(99, 9.9)]),
+        ];
+
+        let mut section = Vec::new();
+        encode_block_into(&mut section, &block0_terms, &block0_infos);
+        encode_block_into(&mut section, &block1_terms, &block1_infos);
+
+        let mut expected: Vec<(Vec<u8>, TermInfo)> = Vec::new();
+        for (term, (f, bm)) in block0_terms.iter().zip(block0_infos.iter()) {
+            expected.push((
+                term.to_vec(),
+                TermInfo {
+                    posting_offset: f.posting_offset,
+                    posting_length: f.posting_length,
+                    doc_frequency: f.doc_frequency,
+                    total_frequency: f.total_frequency,
+                    max_score_factor: f.max_score_factor,
+                    block_max: bm.clone(),
+                },
+            ));
+        }
+        for (term, (f, bm)) in block1_terms.iter().zip(block1_infos.iter()) {
+            expected.push((
+                term.to_vec(),
+                TermInfo {
+                    posting_offset: f.posting_offset,
+                    posting_length: f.posting_length,
+                    doc_frequency: f.doc_frequency,
+                    total_frequency: f.total_frequency,
+                    max_score_factor: f.max_score_factor,
+                    block_max: bm.clone(),
+                },
+            ));
+        }
+        (section, expected)
+    }
+
+    #[test]
+    fn parse_single_block_round_trip() {
+        let terms: Vec<&[u8]> = vec![b"apple", b"banana", b"cherry"];
+        let infos = vec![
+            (fti(0, 50, 1, 10, 1.0), Vec::new()),
+            (fti(50, 60, 2, 20, 1.0), vec![sample_block_max(5, 0.5)]),
+            (fti(110, 70, 3, 30, 1.0), Vec::new()),
+        ];
+        let mut section = Vec::new();
+        encode_block_into(&mut section, &terms, &infos);
+
+        let (reader, next_cursor) = BlockReader::parse(&section, 0).unwrap();
+        assert_eq!(reader.block_term_count, 3);
+        assert_eq!(next_cursor, section.len());
+
+        // Lookup hits.
+        let info = reader.lookup(b"banana").unwrap();
+        assert_eq!(info.posting_offset, 50);
+        assert_eq!(info.block_max.len(), 1);
+        assert_eq!(info.block_max[0].last_doc_id, 5);
+
+        // Lookup miss (not in block, alphabetically before).
+        assert!(reader.lookup(b"aardvark").is_none());
+        // Lookup miss (alphabetically between).
+        assert!(reader.lookup(b"blueberry").is_none());
+        // Lookup miss (alphabetically after).
+        assert!(reader.lookup(b"date").is_none());
+    }
+
+    #[test]
+    fn block_reader_iter_yields_in_order() {
+        let terms: Vec<&[u8]> = vec![b"alpha", b"beta", b"gamma"];
+        let infos = vec![
+            (fti(0, 100, 5, 50, 1.5), Vec::new()),
+            (fti(100, 80, 3, 40, 1.5), Vec::new()),
+            (fti(180, 200, 8, 100, 2.0), Vec::new()),
+        ];
+        let mut section = Vec::new();
+        encode_block_into(&mut section, &terms, &infos);
+
+        let (reader, _) = BlockReader::parse(&section, 0).unwrap();
+        let collected: Vec<(Vec<u8>, TermInfo)> = reader.iter().collect();
+        assert_eq!(collected.len(), 3);
+        assert_eq!(collected[0].0, b"alpha");
+        assert_eq!(collected[1].0, b"beta");
+        assert_eq!(collected[2].0, b"gamma");
+    }
+
+    #[test]
+    fn block_section_iter_walks_two_blocks() {
+        let (section, expected) = build_two_block_section();
+        let iter = BlockSectionIter::new(&section, 2);
+        let collected: Vec<(String, TermInfo)> = iter.collect();
+        assert_eq!(collected.len(), expected.len());
+        for ((got_term, got_info), (exp_term, exp_info)) in collected.iter().zip(expected.iter()) {
+            assert_eq!(got_term.as_bytes(), exp_term.as_slice());
+            assert_eq!(got_info.posting_offset, exp_info.posting_offset);
+            assert_eq!(got_info.posting_length, exp_info.posting_length);
+            assert_eq!(got_info.doc_frequency, exp_info.doc_frequency);
+            assert_eq!(got_info.total_frequency, exp_info.total_frequency);
+            assert_eq!(
+                got_info.max_score_factor.to_bits(),
+                exp_info.max_score_factor.to_bits()
+            );
+            assert_eq!(got_info.block_max.len(), exp_info.block_max.len());
+        }
+    }
+
+    #[test]
+    fn parse_rejects_truncated_section() {
+        let terms: Vec<&[u8]> = vec![b"alpha", b"beta"];
+        let infos = vec![
+            (fti(0, 50, 1, 10, 1.0), Vec::new()),
+            (fti(50, 60, 2, 20, 1.0), Vec::new()),
+        ];
+        let mut section = Vec::new();
+        encode_block_into(&mut section, &terms, &infos);
+        let truncated = &section[..section.len() - 5];
+        assert!(BlockReader::parse(truncated, 0).is_err());
+    }
+
+    #[test]
+    fn empty_section_iter() {
+        let iter = BlockSectionIter::new(&[], 0);
+        let collected: Vec<(String, TermInfo)> = iter.collect();
+        assert!(collected.is_empty());
+    }
+
+    #[test]
+    fn varied_term_lengths_in_block() {
+        // A block with a short and a 100-byte term in sorted order,
+        // exercising the front-coding decoder buffer growth path.
+        // "long_aaaa..." sorts before "short" (l < s).
+        let mut long_term = b"long_".to_vec();
+        long_term.extend(std::iter::repeat_n(b'a', 100));
+        let terms: Vec<&[u8]> = vec![long_term.as_slice(), b"short"];
+        let infos = vec![
+            (fti(0, 50, 1, 1, 0.0), Vec::new()),
+            (fti(50, 60, 2, 2, 0.0), Vec::new()),
+        ];
+        let mut section = Vec::new();
+        encode_block_into(&mut section, &terms, &infos);
+        let (reader, _) = BlockReader::parse(&section, 0).unwrap();
+        assert!(reader.lookup(&long_term).is_some());
+        assert!(reader.lookup(b"short").is_some());
+        assert!(reader.lookup(b"medium").is_none());
+    }
+
+    #[test]
+    fn lookup_miss_after_last_block_term() {
+        // Target alphabetically greater than every term in the block —
+        // must return None without panicking.
+        let terms: Vec<&[u8]> = vec![b"alpha", b"beta"];
+        let infos = vec![
+            (fti(0, 50, 1, 1, 0.0), Vec::new()),
+            (fti(50, 60, 2, 2, 0.0), Vec::new()),
+        ];
+        let mut section = Vec::new();
+        encode_block_into(&mut section, &terms, &infos);
+        let (reader, _) = BlockReader::parse(&section, 0).unwrap();
+        assert!(reader.lookup(b"zulu").is_none());
+    }
+}

--- a/laurus/src/lexical/index/structures/dictionary/builder.rs
+++ b/laurus/src/lexical/index/structures/dictionary/builder.rs
@@ -1,0 +1,108 @@
+//! Block-encoder helpers used by [`super::TermDictionaryBuilder::build`].
+//!
+//! The build pipeline (driven from `dictionary.rs`):
+//!
+//! 1. Convert the builder's `BTreeMap<String, TermInfo>` to a sorted
+//!    `Vec<(String, TermInfo)>`.
+//! 2. Split into 128-term blocks (the last block may be partial).
+//! 3. For each block, call [`encode_block_into`] to append the block's
+//!    bytes to a growing `BlockSection` buffer.
+//! 4. Build an [`fst::Map`] keyed by each block's last term, valued by
+//!    the block's start offset within `BlockSection`.
+
+#![allow(dead_code)]
+
+use crate::lexical::index::structures::dictionary::BlockMax;
+
+use super::block_max_data::BlockMaxData;
+use super::front_coding::encode_block_terms;
+use super::term_info_block::{FixedTermInfo, FixedTermInfoBlock};
+
+/// Append the encoded bytes of a single block (BlockHeader + TermBytes
+/// + FixedTermInfoBlock + BlockMaxData) to `out`.
+///
+/// The block layout matches [`super::block_reader`]'s parser. See the
+/// module-level doc on `block_reader.rs` for the exact byte layout.
+///
+/// # Arguments
+///
+/// * `out` - target byte buffer; the encoded block is appended at the
+///   current end.
+/// * `terms` - sorted term byte slices for this block (`1..=128`
+///   entries).
+/// * `fixed_infos` - parallel-indexed fixed-size `TermInfo` portion
+///   for each term.
+/// * `block_max_per_term` - parallel-indexed variable-length
+///   `BlockMax` array for each term (each may be empty).
+///
+/// # Panics
+///
+/// Panics if the three input slices have different lengths or if
+/// `terms.len()` is outside `1..=128`.
+pub(super) fn encode_block_into(
+    out: &mut Vec<u8>,
+    terms: &[&[u8]],
+    fixed_infos: &[FixedTermInfo],
+    block_max_per_term: &[Vec<BlockMax>],
+) {
+    assert_eq!(
+        terms.len(),
+        fixed_infos.len(),
+        "terms and fixed_infos must have equal length"
+    );
+    assert_eq!(
+        terms.len(),
+        block_max_per_term.len(),
+        "terms and block_max_per_term must have equal length"
+    );
+    assert!(
+        !terms.is_empty() && terms.len() <= 128,
+        "terms.len() must be in 1..=128"
+    );
+
+    let term_count = terms.len();
+
+    // BlockHeader: term_count varint.
+    write_varint_into(out, term_count as u64);
+
+    // TermBytes: front-coded.
+    let fc = encode_block_terms(terms);
+    write_varint_into(out, fc.len() as u64);
+    out.extend_from_slice(&fc);
+
+    // FixedTermInfoBlock.
+    let ftib = FixedTermInfoBlock::encode(fixed_infos);
+    out.extend_from_slice(&ftib.block_min_posting_offset.to_le_bytes());
+    out.extend_from_slice(&ftib.block_min_posting_length.to_le_bytes());
+    out.extend_from_slice(&ftib.block_min_doc_frequency.to_le_bytes());
+    out.extend_from_slice(&ftib.block_min_total_frequency.to_le_bytes());
+    out.extend_from_slice(&ftib.ref_max_score_factor.to_le_bytes());
+    out.push(ftib.posting_offset_nbits);
+    out.push(ftib.posting_length_nbits);
+    out.push(ftib.doc_frequency_nbits);
+    out.push(ftib.total_frequency_nbits);
+    out.push(ftib.max_score_factor_size);
+    out.extend_from_slice(&(ftib.payload.len() as u32).to_le_bytes());
+    out.extend_from_slice(&ftib.payload);
+
+    // BlockMaxData.
+    let bmd = BlockMaxData::encode(block_max_per_term);
+    for off in &bmd.offsets {
+        out.extend_from_slice(&off.to_le_bytes());
+    }
+    out.extend_from_slice(&(bmd.data.len() as u32).to_le_bytes());
+    out.extend_from_slice(&bmd.data);
+}
+
+/// Append the unsigned LEB128 (uleb128) encoding of `value` to `buf`.
+///
+/// Mirrors the reader-side decoder in
+/// [`super::block_reader::read_varint`]. Kept private to the builder
+/// module so the writer/reader pair stays in lockstep.
+fn write_varint_into(buf: &mut Vec<u8>, mut value: u64) {
+    while value >= 0x80 {
+        buf.push(((value as u8) & 0x7F) | 0x80);
+        value >>= 7;
+    }
+    buf.push(value as u8);
+}

--- a/laurus/src/lexical/index/structures/dictionary/front_coding.rs
+++ b/laurus/src/lexical/index/structures/dictionary/front_coding.rs
@@ -1,0 +1,364 @@
+//! Front-coding (shared-prefix) encoder and decoder for block term bytes.
+//!
+//! Each block (≤ 128 sorted terms) is encoded as:
+//!
+//! - the first term, length-prefixed, in full
+//! - each subsequent term as `(shared_prefix_len, suffix_len, suffix_bytes)`
+//!   where `shared_prefix_len` is the number of leading bytes shared with
+//!   the **previous** term in the block
+//!
+//! Lengths are stored as unsigned LEB128 (uleb128). At typical scales
+//! (term length ≤ 64, shared_prefix_len ≤ 64) every length fits in a
+//! single byte, so the per-term overhead beyond the suffix bytes is
+//! 2 bytes for non-leading terms and 1 byte for the leading term.
+//!
+//! Decoding requires walking the block sequentially; random in-block
+//! access is `O(N · avg_term_len)` but with `N ≤ 128` the constant is
+//! small.
+//!
+//! This module is private to the dictionary module — its types are not
+//! part of the public API.
+
+// Skeleton wiring: these `pub(super)` items are consumed by
+// `block_reader` (Phase 5) and `builder` (Phase 6). Until then,
+// `cargo check` flags them as dead code. Remove this allow once the
+// integration is complete.
+#![allow(dead_code)]
+
+/// Append the unsigned LEB128 (uleb128) encoding of `value` to `buf`.
+fn write_varint(buf: &mut Vec<u8>, mut value: u64) {
+    while value >= 0x80 {
+        buf.push(((value as u8) & 0x7F) | 0x80);
+        value >>= 7;
+    }
+    buf.push(value as u8);
+}
+
+/// Read the unsigned LEB128 (uleb128) encoding starting at `*cursor`,
+/// advancing `*cursor` past the consumed bytes.
+fn read_varint(bytes: &[u8], cursor: &mut usize) -> u64 {
+    let mut result: u64 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        let byte = bytes[*cursor];
+        *cursor += 1;
+        result |= u64::from(byte & 0x7F) << shift;
+        if byte & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+    result
+}
+
+/// Compute the number of leading bytes shared by `a` and `b`.
+fn shared_prefix_len(a: &[u8], b: &[u8]) -> usize {
+    a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+/// Encode a block of sorted term byte slices using front-coding.
+///
+/// # Arguments
+///
+/// * `terms` - sorted term byte slices (must be ≤ 128 entries to match
+///   `BLOCK_TERM_COUNT`, though this function does not enforce it).
+///   The first element is stored in full; the rest as
+///   `(shared_prefix_len, suffix_len, suffix_bytes)` against the
+///   previous term.
+///
+/// # Returns
+///
+/// A `Vec<u8>` containing the encoded block term bytes. Layout:
+///
+/// ```text
+/// [first_term_len: varint]
+/// [first_term_bytes]
+/// for i in 1..terms.len():
+///   [shared_prefix_len: varint]
+///   [suffix_len: varint]
+///   [suffix_bytes]
+/// ```
+///
+/// Returns an empty `Vec` for an empty `terms` slice.
+pub(super) fn encode_block_terms(terms: &[&[u8]]) -> Vec<u8> {
+    if terms.is_empty() {
+        return Vec::new();
+    }
+
+    // Heuristic capacity: average term length + 2 bytes per term for
+    // length headers. Under-estimate is fine — Vec re-allocates on push.
+    let cap = terms.iter().map(|t| t.len() + 2).sum();
+    let mut out = Vec::with_capacity(cap);
+
+    // First term: full bytes.
+    write_varint(&mut out, terms[0].len() as u64);
+    out.extend_from_slice(terms[0]);
+
+    // Subsequent terms: (shared_prefix_len, suffix_len, suffix_bytes).
+    for window in terms.windows(2) {
+        let prev = window[0];
+        let curr = window[1];
+        let shared = shared_prefix_len(prev, curr);
+        let suffix = &curr[shared..];
+        write_varint(&mut out, shared as u64);
+        write_varint(&mut out, suffix.len() as u64);
+        out.extend_from_slice(suffix);
+    }
+    out
+}
+
+/// Streaming decoder over a front-coded block.
+///
+/// Maintains a reusable buffer of the current term bytes; each call to
+/// [`Self::next`] advances to the next term and returns a reference to
+/// the buffer. The buffer is invalidated on the next call.
+pub(super) struct FrontCodingDecoder<'a> {
+    /// Encoded block bytes (output of [`encode_block_terms`]).
+    bytes: &'a [u8],
+    /// Current read position within `bytes`.
+    cursor: usize,
+    /// Number of terms remaining to be yielded.
+    remaining: u32,
+    /// Reusable buffer holding the current term's bytes.
+    current: Vec<u8>,
+    /// `true` until the first call to [`Self::next`].
+    is_first: bool,
+}
+
+impl<'a> FrontCodingDecoder<'a> {
+    /// Create a new decoder over `bytes` for `term_count` terms.
+    ///
+    /// `term_count` must match the number of terms originally passed
+    /// to [`encode_block_terms`]; otherwise `next` will read past the
+    /// encoded data or stop short.
+    pub(super) fn new(bytes: &'a [u8], term_count: u32) -> Self {
+        FrontCodingDecoder {
+            bytes,
+            cursor: 0,
+            remaining: term_count,
+            current: Vec::with_capacity(64),
+            is_first: true,
+        }
+    }
+
+    /// Advance to the next term and return a reference to the current
+    /// term's bytes. Returns `None` once the block is exhausted.
+    ///
+    /// The returned slice is valid until the next call to `next`.
+    #[allow(clippy::should_implement_trait)]
+    pub(super) fn next(&mut self) -> Option<&[u8]> {
+        if self.remaining == 0 {
+            return None;
+        }
+
+        if self.is_first {
+            // First term: full bytes.
+            let len = read_varint(self.bytes, &mut self.cursor) as usize;
+            self.current.clear();
+            self.current
+                .extend_from_slice(&self.bytes[self.cursor..self.cursor + len]);
+            self.cursor += len;
+            self.is_first = false;
+        } else {
+            // Subsequent term: (shared_prefix_len, suffix_len, suffix_bytes).
+            let shared = read_varint(self.bytes, &mut self.cursor) as usize;
+            let suffix_len = read_varint(self.bytes, &mut self.cursor) as usize;
+            self.current.truncate(shared);
+            self.current
+                .extend_from_slice(&self.bytes[self.cursor..self.cursor + suffix_len]);
+            self.cursor += suffix_len;
+        }
+
+        self.remaining -= 1;
+        Some(&self.current)
+    }
+
+    /// Number of terms still to be yielded by [`Self::next`].
+    pub(super) fn remaining(&self) -> u32 {
+        self.remaining
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: encode a slice of `&str` and decode it back, returning
+    /// the recovered terms as `Vec<Vec<u8>>`.
+    fn round_trip(terms: &[&str]) -> Vec<Vec<u8>> {
+        let term_bytes: Vec<&[u8]> = terms.iter().map(|t| t.as_bytes()).collect();
+        let encoded = encode_block_terms(&term_bytes);
+        let mut decoder = FrontCodingDecoder::new(&encoded, terms.len() as u32);
+
+        let mut out = Vec::with_capacity(terms.len());
+        while let Some(term) = decoder.next() {
+            out.push(term.to_vec());
+        }
+        out
+    }
+
+    #[test]
+    fn varint_round_trip_small() {
+        for v in [0u64, 1, 0x7F, 0x80, 0xFF, 0x3FFF, 0x4000, u64::MAX] {
+            let mut buf = Vec::new();
+            write_varint(&mut buf, v);
+            let mut cursor = 0;
+            assert_eq!(read_varint(&buf, &mut cursor), v);
+            assert_eq!(cursor, buf.len());
+        }
+    }
+
+    #[test]
+    fn shared_prefix_len_basic() {
+        assert_eq!(shared_prefix_len(b"", b""), 0);
+        assert_eq!(shared_prefix_len(b"abc", b""), 0);
+        assert_eq!(shared_prefix_len(b"", b"abc"), 0);
+        assert_eq!(shared_prefix_len(b"abc", b"abd"), 2);
+        assert_eq!(shared_prefix_len(b"abc", b"abc"), 3);
+        assert_eq!(shared_prefix_len(b"abc", b"abcd"), 3);
+        assert_eq!(shared_prefix_len(b"abc", b"xyz"), 0);
+    }
+
+    #[test]
+    fn empty_terms_returns_empty_bytes() {
+        let encoded = encode_block_terms(&[]);
+        assert!(encoded.is_empty());
+
+        let mut decoder = FrontCodingDecoder::new(&encoded, 0);
+        assert_eq!(decoder.remaining(), 0);
+        assert!(decoder.next().is_none());
+    }
+
+    #[test]
+    fn single_term_round_trip() {
+        let recovered = round_trip(&["hello"]);
+        assert_eq!(recovered, vec![b"hello".to_vec()]);
+    }
+
+    #[test]
+    fn multi_term_no_shared_prefix() {
+        let terms = ["aaaa", "bbbb", "cccc"];
+        let recovered = round_trip(&terms);
+        assert_eq!(
+            recovered,
+            terms
+                .iter()
+                .map(|s| s.as_bytes().to_vec())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn multi_term_full_shared_prefix() {
+        let terms = ["foobar1", "foobar2", "foobar3"];
+        let recovered = round_trip(&terms);
+        assert_eq!(
+            recovered,
+            terms
+                .iter()
+                .map(|s| s.as_bytes().to_vec())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn multi_term_one_char_diff_sequence() {
+        let terms = ["a", "ab", "abc", "abcd"];
+        let recovered = round_trip(&terms);
+        assert_eq!(
+            recovered,
+            terms
+                .iter()
+                .map(|s| s.as_bytes().to_vec())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn multi_term_utf8_multibyte() {
+        // "日本" (U+65E5 U+672C) shares the leading byte 0xE6 0x97 with
+        // "日本語"; encoding/decoding must preserve the raw byte stream
+        // regardless of UTF-8 codepoint boundaries.
+        let terms = ["日", "日本", "日本語"];
+        let recovered = round_trip(&terms);
+        assert_eq!(
+            recovered,
+            terms
+                .iter()
+                .map(|s| s.as_bytes().to_vec())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn long_term_followed_by_shorter_term() {
+        // Truncate-then-extend path: previous term is a longer extension
+        // of the next term's prefix.
+        let terms = ["abcdef", "abcd"];
+        let recovered = round_trip(&terms);
+        assert_eq!(
+            recovered,
+            terms
+                .iter()
+                .map(|s| s.as_bytes().to_vec())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn round_trip_128_random_sorted_terms() {
+        // Deterministic LCG to generate a sorted, unique 128-term corpus.
+        let mut state: u64 = 0x9E3779B97F4A7C15;
+        let mut next_u32 = || -> u32 {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (state >> 32) as u32
+        };
+
+        let mut set = std::collections::BTreeSet::new();
+        while set.len() < 128 {
+            let len = 5 + (next_u32() % 6) as usize;
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                s.push((b'a' + (next_u32() as u8 % 26)) as char);
+            }
+            set.insert(s);
+        }
+        let terms: Vec<String> = set.into_iter().collect();
+        let term_strs: Vec<&str> = terms.iter().map(|s| s.as_str()).collect();
+
+        let recovered = round_trip(&term_strs);
+        let recovered_strings: Vec<String> = recovered
+            .into_iter()
+            .map(|b| String::from_utf8(b).unwrap())
+            .collect();
+        assert_eq!(recovered_strings, terms);
+    }
+
+    #[test]
+    fn next_returns_none_after_exhaustion() {
+        let term_bytes: Vec<&[u8]> = vec![b"alpha", b"beta"];
+        let encoded = encode_block_terms(&term_bytes);
+        let mut decoder = FrontCodingDecoder::new(&encoded, 2);
+        assert_eq!(decoder.next().unwrap(), b"alpha");
+        assert_eq!(decoder.next().unwrap(), b"beta");
+        assert!(decoder.next().is_none());
+        // Calling next again must remain None and not panic.
+        assert!(decoder.next().is_none());
+        assert_eq!(decoder.remaining(), 0);
+    }
+
+    #[test]
+    fn empty_string_term() {
+        // Edge case: a block containing an empty term must encode/decode
+        // correctly. Sorted dictionaries can hit this if "" is a valid
+        // term (rare but legal).
+        let term_bytes: Vec<&[u8]> = vec![b"", b"abc"];
+        let encoded = encode_block_terms(&term_bytes);
+        let mut decoder = FrontCodingDecoder::new(&encoded, 2);
+        assert_eq!(decoder.next().unwrap(), b"");
+        assert_eq!(decoder.next().unwrap(), b"abc");
+        assert!(decoder.next().is_none());
+    }
+}

--- a/laurus/src/lexical/index/structures/dictionary/term_info_block.rs
+++ b/laurus/src/lexical/index/structures/dictionary/term_info_block.rs
@@ -1,0 +1,573 @@
+//! Bit-packed fixed-size [`crate::lexical::index::structures::dictionary::TermInfo`] block.
+//!
+//! Each block holds up to [`BLOCK_TERM_COUNT`] [`FixedTermInfo`] entries
+//! (the fixed-size portion of `TermInfo`, excluding the variable-length
+//! `block_max` Vec). Encoding strategy:
+//!
+//! - For each of the four `u64` fields (`posting_offset`,
+//!   `posting_length`, `doc_frequency`, `total_frequency`), find the
+//!   block-wide minimum and store it as a header value. Each entry's
+//!   field is then encoded as the **unsigned delta** from the block
+//!   minimum, using the smallest bit width that fits the largest
+//!   delta in the block.
+//! - `max_score_factor` is non-monotonic, so it is **not** delta
+//!   encoded. Either all entries share the same value (then we store
+//!   it once as `ref_max_score_factor`) or each entry gets a full
+//!   `f32` slot.
+//!
+//! This trades a small amount of CPU at decode time (≤ 4 bit-pack
+//! reads per lookup) for a significant on-disk size reduction at
+//! production scale (10M-100M+ terms / segment).
+//!
+//! Variable-length `block_max` data is stored separately in
+//! [`super::block_max_data::BlockMaxData`].
+
+// Skeleton wiring: these `pub(super)` items are consumed by
+// `block_reader` (Phase 5) and `builder` (Phase 6). Until then,
+// `cargo check` flags them as dead code. Remove this allow once the
+// integration is complete.
+#![allow(dead_code)]
+
+/// Maximum number of terms in a single dictionary block. Matches the
+/// posting list block size (#403 PR-C) so that block boundaries align
+/// across the dictionary and posting layers.
+pub(super) const BLOCK_TERM_COUNT: usize = 128;
+
+/// Fixed-size portion of `TermInfo` (excluding the variable-length
+/// `block_max` Vec). Stored bit-packed in [`FixedTermInfoBlock`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct FixedTermInfo {
+    /// Offset to the posting list in the posting file.
+    pub(super) posting_offset: u64,
+    /// Length of the posting list in bytes.
+    pub(super) posting_length: u64,
+    /// Document frequency.
+    pub(super) doc_frequency: u64,
+    /// Total frequency across all documents.
+    pub(super) total_frequency: u64,
+    /// Term-level tightened BM25 TF-component upper bound.
+    /// `0.0` means unset (#403 PR-B2).
+    pub(super) max_score_factor: f32,
+}
+
+/// A bit-packed block of up to [`BLOCK_TERM_COUNT`] [`FixedTermInfo`]
+/// entries.
+///
+/// On disk layout (within the BlockSection of `.dict`):
+///
+/// ```text
+/// [block_min_posting_offset:    u64]
+/// [block_min_posting_length:    u64]
+/// [block_min_doc_frequency:     u64]
+/// [block_min_total_frequency:   u64]
+/// [ref_max_score_factor:        f32]   (used when max_score_factor_size == 0)
+/// [_padding:                    u32]
+/// [posting_offset_nbits:        u8]
+/// [posting_length_nbits:        u8]
+/// [doc_frequency_nbits:         u8]
+/// [total_frequency_nbits:       u8]
+/// [max_score_factor_size:       u8]    (0 or 32)
+/// [_padding:                    3 bytes]
+/// [payload_len:                 u32]
+/// [payload:                     u8 × payload_len]
+/// ```
+///
+/// `payload` holds two consecutive sections:
+///
+/// 1. Bit-packed deltas for the 4 `u64` fields. Each entry occupies
+///    `posting_offset_nbits + posting_length_nbits + doc_frequency_nbits
+///     + total_frequency_nbits` bits, in that field order, LSB-first
+///    within each byte. Total bytes:
+///    `ceil(bits_per_entry × term_count / 8)`.
+/// 2. Optional `f32` array of `max_score_factor` values, only if
+///    `max_score_factor_size == 32`. 4 bytes per entry, little-endian.
+pub(super) struct FixedTermInfoBlock {
+    /// Number of entries in this block (`1..=BLOCK_TERM_COUNT`).
+    pub(super) term_count: u16,
+    pub(super) block_min_posting_offset: u64,
+    pub(super) block_min_posting_length: u64,
+    pub(super) block_min_doc_frequency: u64,
+    pub(super) block_min_total_frequency: u64,
+    /// Reference `max_score_factor`. Used as the value for every entry
+    /// when `max_score_factor_size == 0`.
+    pub(super) ref_max_score_factor: f32,
+    pub(super) posting_offset_nbits: u8,
+    pub(super) posting_length_nbits: u8,
+    pub(super) doc_frequency_nbits: u8,
+    pub(super) total_frequency_nbits: u8,
+    /// `0` = all entries' `max_score_factor` equal `ref_max_score_factor`.
+    /// `32` = each entry has its own `f32` in `payload` after the
+    /// bit-packed section.
+    pub(super) max_score_factor_size: u8,
+    pub(super) payload: Vec<u8>,
+}
+
+impl FixedTermInfoBlock {
+    /// Encode `entries` (must be `1..=BLOCK_TERM_COUNT` long) into a
+    /// bit-packed block.
+    ///
+    /// Computes the per-field block-wide minimum, then bit-packs each
+    /// entry's `value - block_min` delta with the smallest width that
+    /// fits the largest delta. `max_score_factor` is encoded as either
+    /// "all equal" (zero extra bytes) or a flat `f32` array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `entries.is_empty()` or `entries.len() > BLOCK_TERM_COUNT`.
+    pub(super) fn encode(entries: &[FixedTermInfo]) -> Self {
+        assert!(
+            !entries.is_empty() && entries.len() <= BLOCK_TERM_COUNT,
+            "FixedTermInfoBlock::encode: entries.len() must be in 1..={}",
+            BLOCK_TERM_COUNT
+        );
+        let term_count = entries.len();
+
+        // Compute block-wide minimum and maximum for each u64 field.
+        let mut min_off = u64::MAX;
+        let mut max_off = 0u64;
+        let mut min_len = u64::MAX;
+        let mut max_len = 0u64;
+        let mut min_df = u64::MAX;
+        let mut max_df = 0u64;
+        let mut min_tf = u64::MAX;
+        let mut max_tf = 0u64;
+        for e in entries {
+            min_off = min_off.min(e.posting_offset);
+            max_off = max_off.max(e.posting_offset);
+            min_len = min_len.min(e.posting_length);
+            max_len = max_len.max(e.posting_length);
+            min_df = min_df.min(e.doc_frequency);
+            max_df = max_df.max(e.doc_frequency);
+            min_tf = min_tf.min(e.total_frequency);
+            max_tf = max_tf.max(e.total_frequency);
+        }
+
+        let posting_offset_nbits = bits_required(max_off - min_off);
+        let posting_length_nbits = bits_required(max_len - min_len);
+        let doc_frequency_nbits = bits_required(max_df - min_df);
+        let total_frequency_nbits = bits_required(max_tf - min_tf);
+
+        // max_score_factor strategy: all-equal or per-entry f32.
+        let ref_max_score_factor = entries[0].max_score_factor;
+        let ref_bits = ref_max_score_factor.to_bits();
+        let all_same = entries
+            .iter()
+            .all(|e| e.max_score_factor.to_bits() == ref_bits);
+        let max_score_factor_size: u8 = if all_same { 0 } else { 32 };
+
+        let bits_per_entry = posting_offset_nbits as usize
+            + posting_length_nbits as usize
+            + doc_frequency_nbits as usize
+            + total_frequency_nbits as usize;
+        let total_bits = bits_per_entry * term_count;
+        let bytes_4fields = total_bits.div_ceil(8);
+        let bytes_f32 = if max_score_factor_size == 0 {
+            0
+        } else {
+            4 * term_count
+        };
+
+        let mut payload = vec![0u8; bytes_4fields + bytes_f32];
+
+        // Pack 4-field deltas, LSB-first within each byte.
+        for (i, entry) in entries.iter().enumerate() {
+            let mut bit_offset = bits_per_entry * i;
+
+            write_bits(
+                &mut payload[..bytes_4fields],
+                bit_offset,
+                entry.posting_offset - min_off,
+                posting_offset_nbits,
+            );
+            bit_offset += posting_offset_nbits as usize;
+
+            write_bits(
+                &mut payload[..bytes_4fields],
+                bit_offset,
+                entry.posting_length - min_len,
+                posting_length_nbits,
+            );
+            bit_offset += posting_length_nbits as usize;
+
+            write_bits(
+                &mut payload[..bytes_4fields],
+                bit_offset,
+                entry.doc_frequency - min_df,
+                doc_frequency_nbits,
+            );
+            bit_offset += doc_frequency_nbits as usize;
+
+            write_bits(
+                &mut payload[..bytes_4fields],
+                bit_offset,
+                entry.total_frequency - min_tf,
+                total_frequency_nbits,
+            );
+        }
+
+        // Pack the optional f32 array.
+        if max_score_factor_size == 32 {
+            for (i, entry) in entries.iter().enumerate() {
+                let off = bytes_4fields + 4 * i;
+                payload[off..off + 4].copy_from_slice(&entry.max_score_factor.to_le_bytes());
+            }
+        }
+
+        FixedTermInfoBlock {
+            term_count: term_count as u16,
+            block_min_posting_offset: min_off,
+            block_min_posting_length: min_len,
+            block_min_doc_frequency: min_df,
+            block_min_total_frequency: min_tf,
+            ref_max_score_factor,
+            posting_offset_nbits,
+            posting_length_nbits,
+            doc_frequency_nbits,
+            total_frequency_nbits,
+            max_score_factor_size,
+            payload,
+        }
+    }
+
+    /// Decode the entry at `inner_offset` (`0..term_count`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `inner_offset >= self.term_count`.
+    pub(super) fn decode_at(&self, inner_offset: usize) -> FixedTermInfo {
+        assert!(
+            inner_offset < self.term_count as usize,
+            "decode_at: inner_offset {} >= term_count {}",
+            inner_offset,
+            self.term_count
+        );
+
+        let bits_per_entry = self.posting_offset_nbits as usize
+            + self.posting_length_nbits as usize
+            + self.doc_frequency_nbits as usize
+            + self.total_frequency_nbits as usize;
+        let total_bits = bits_per_entry * self.term_count as usize;
+        let bytes_4fields = total_bits.div_ceil(8);
+
+        let mut bit_offset = bits_per_entry * inner_offset;
+
+        let posting_offset_delta = read_bits(
+            &self.payload[..bytes_4fields],
+            bit_offset,
+            self.posting_offset_nbits,
+        );
+        bit_offset += self.posting_offset_nbits as usize;
+
+        let posting_length_delta = read_bits(
+            &self.payload[..bytes_4fields],
+            bit_offset,
+            self.posting_length_nbits,
+        );
+        bit_offset += self.posting_length_nbits as usize;
+
+        let doc_frequency_delta = read_bits(
+            &self.payload[..bytes_4fields],
+            bit_offset,
+            self.doc_frequency_nbits,
+        );
+        bit_offset += self.doc_frequency_nbits as usize;
+
+        let total_frequency_delta = read_bits(
+            &self.payload[..bytes_4fields],
+            bit_offset,
+            self.total_frequency_nbits,
+        );
+
+        let max_score_factor = if self.max_score_factor_size == 0 {
+            self.ref_max_score_factor
+        } else {
+            let off = bytes_4fields + 4 * inner_offset;
+            let bytes: [u8; 4] = self.payload[off..off + 4]
+                .try_into()
+                .expect("f32 slice must be exactly 4 bytes");
+            f32::from_le_bytes(bytes)
+        };
+
+        FixedTermInfo {
+            posting_offset: self.block_min_posting_offset + posting_offset_delta,
+            posting_length: self.block_min_posting_length + posting_length_delta,
+            doc_frequency: self.block_min_doc_frequency + doc_frequency_delta,
+            total_frequency: self.block_min_total_frequency + total_frequency_delta,
+            max_score_factor,
+        }
+    }
+}
+
+/// Number of bits required to represent `value` (0 → 0, 1 → 1, 2-3 → 2,
+/// 4-7 → 3, …).
+fn bits_required(value: u64) -> u8 {
+    if value == 0 {
+        0
+    } else {
+        (64 - value.leading_zeros()) as u8
+    }
+}
+
+/// Write `value` (low `nbits` bits) into `bits` starting at
+/// `bit_offset`, LSB-first within each byte. The destination region
+/// must be zero-initialised.
+///
+/// `nbits == 0` is a no-op.
+fn write_bits(bits: &mut [u8], bit_offset: usize, value: u64, nbits: u8) {
+    if nbits == 0 {
+        return;
+    }
+    debug_assert!(
+        nbits <= 64 && (nbits == 64 || value < (1u64 << nbits)),
+        "value {value} does not fit in {nbits} bits"
+    );
+
+    let mut remaining = nbits;
+    let mut value = value;
+    let mut byte_idx = bit_offset / 8;
+    let mut bit_in_byte = (bit_offset % 8) as u8;
+
+    while remaining > 0 {
+        let take = remaining.min(8 - bit_in_byte);
+        // u16 intermediate avoids `1u8 << 8` overflow when take == 8.
+        let mask: u8 = ((1u16 << take) - 1) as u8;
+        let chunk = (value as u8) & mask;
+        bits[byte_idx] |= chunk << bit_in_byte;
+        // Avoid `value >> 64` (undefined in Rust): when take == 64 the
+        // remaining bits are zero anyway.
+        if take == 64 {
+            value = 0;
+        } else {
+            value >>= take;
+        }
+        remaining -= take;
+        bit_in_byte += take;
+        if bit_in_byte == 8 {
+            bit_in_byte = 0;
+            byte_idx += 1;
+        }
+    }
+}
+
+/// Read `nbits` bits from `bits` starting at `bit_offset`, LSB-first
+/// within each byte. Returns the value as `u64`.
+///
+/// `nbits == 0` returns `0`.
+fn read_bits(bits: &[u8], bit_offset: usize, nbits: u8) -> u64 {
+    if nbits == 0 {
+        return 0;
+    }
+    debug_assert!(nbits <= 64);
+
+    let mut result: u64 = 0;
+    let mut shift: u32 = 0;
+    let mut remaining = nbits;
+    let mut byte_idx = bit_offset / 8;
+    let mut bit_in_byte = (bit_offset % 8) as u8;
+
+    while remaining > 0 {
+        let take = remaining.min(8 - bit_in_byte);
+        // u16 intermediate avoids `1u8 << 8` overflow when take == 8.
+        let mask: u8 = ((1u16 << take) - 1) as u8;
+        let chunk = (bits[byte_idx] >> bit_in_byte) & mask;
+        result |= u64::from(chunk) << shift;
+        shift += u32::from(take);
+        remaining -= take;
+        bit_in_byte += take;
+        if bit_in_byte == 8 {
+            bit_in_byte = 0;
+            byte_idx += 1;
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fti(po: u64, pl: u64, df: u64, tf: u64, msf: f32) -> FixedTermInfo {
+        FixedTermInfo {
+            posting_offset: po,
+            posting_length: pl,
+            doc_frequency: df,
+            total_frequency: tf,
+            max_score_factor: msf,
+        }
+    }
+
+    #[test]
+    fn bits_required_basic() {
+        assert_eq!(bits_required(0), 0);
+        assert_eq!(bits_required(1), 1);
+        assert_eq!(bits_required(2), 2);
+        assert_eq!(bits_required(3), 2);
+        assert_eq!(bits_required(4), 3);
+        assert_eq!(bits_required(7), 3);
+        assert_eq!(bits_required(8), 4);
+        assert_eq!(bits_required(255), 8);
+        assert_eq!(bits_required(256), 9);
+        assert_eq!(bits_required(u64::MAX), 64);
+    }
+
+    #[test]
+    fn write_read_bits_round_trip() {
+        // Pack 4 values of varying widths into a buffer and read back.
+        let mut buf = vec![0u8; 16];
+        write_bits(&mut buf, 0, 0xA5, 8); // 8 bits
+        write_bits(&mut buf, 8, 0b1011, 4); // 4 bits
+        write_bits(&mut buf, 12, 0xDEAD, 16); // 16 bits
+        write_bits(&mut buf, 28, 0, 0); // 0 bits no-op
+        write_bits(&mut buf, 28, 1, 1); // 1 bit
+
+        assert_eq!(read_bits(&buf, 0, 8), 0xA5);
+        assert_eq!(read_bits(&buf, 8, 4), 0b1011);
+        assert_eq!(read_bits(&buf, 12, 16), 0xDEAD);
+        assert_eq!(read_bits(&buf, 28, 1), 1);
+        assert_eq!(read_bits(&buf, 0, 0), 0);
+    }
+
+    #[test]
+    fn write_read_bits_wide_values() {
+        let mut buf = vec![0u8; 32];
+        let v = 0xDEAD_BEEF_CAFE_BABE_u64;
+        write_bits(&mut buf, 7, v, 64);
+        assert_eq!(read_bits(&buf, 7, 64), v);
+    }
+
+    #[test]
+    fn encode_decode_single_entry() {
+        let entries = [fti(100, 50, 5, 20, 1.5)];
+        let block = FixedTermInfoBlock::encode(&entries);
+
+        // With one entry, all deltas are 0, so all nbits should be 0.
+        assert_eq!(block.posting_offset_nbits, 0);
+        assert_eq!(block.posting_length_nbits, 0);
+        assert_eq!(block.doc_frequency_nbits, 0);
+        assert_eq!(block.total_frequency_nbits, 0);
+        assert_eq!(block.max_score_factor_size, 0);
+
+        let decoded = block.decode_at(0);
+        assert_eq!(decoded, entries[0]);
+    }
+
+    #[test]
+    fn encode_decode_all_same_values() {
+        let entries: Vec<FixedTermInfo> = (0..64).map(|_| fti(100, 50, 5, 20, 1.5)).collect();
+        let block = FixedTermInfoBlock::encode(&entries);
+        assert_eq!(block.posting_offset_nbits, 0);
+        assert_eq!(block.payload.len(), 0); // no payload needed
+        for (i, e) in entries.iter().enumerate() {
+            assert_eq!(block.decode_at(i), *e);
+        }
+    }
+
+    #[test]
+    fn encode_decode_small_deltas() {
+        // posting_offset increases by 1 each entry; everything else
+        // stays constant.
+        let entries: Vec<FixedTermInfo> = (0..8)
+            .map(|i| fti(1000 + i as u64, 50, 5, 20, 1.5))
+            .collect();
+        let block = FixedTermInfoBlock::encode(&entries);
+        assert_eq!(block.block_min_posting_offset, 1000);
+        // 8 entries with deltas 0..7, max delta = 7, requires 3 bits.
+        assert_eq!(block.posting_offset_nbits, 3);
+        assert_eq!(block.posting_length_nbits, 0);
+        for (i, e) in entries.iter().enumerate() {
+            assert_eq!(block.decode_at(i), *e);
+        }
+    }
+
+    #[test]
+    fn encode_decode_per_entry_max_score_factor() {
+        let entries: Vec<FixedTermInfo> = (0..16)
+            .map(|i| fti(1000 + i as u64, 50, 5, 20, 1.0 + i as f32 * 0.1))
+            .collect();
+        let block = FixedTermInfoBlock::encode(&entries);
+        assert_eq!(block.max_score_factor_size, 32);
+        // 16 entries × 4 bytes f32 + bit-packed 4-field section
+        assert!(block.payload.len() >= 16 * 4);
+        for (i, _) in entries.iter().enumerate() {
+            let decoded = block.decode_at(i);
+            assert_eq!(decoded.posting_offset, 1000 + i as u64);
+            assert!((decoded.max_score_factor - (1.0 + i as f32 * 0.1)).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn encode_decode_128_entries_random() {
+        let mut state: u64 = 0xCAFEBABE_DEADBEEF;
+        let mut next_u64 = || -> u64 {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            state
+        };
+
+        let entries: Vec<FixedTermInfo> = (0..BLOCK_TERM_COUNT)
+            .map(|i| {
+                fti(
+                    1000 + i as u64 * 16,
+                    100 + (next_u64() % 1000),
+                    1 + (next_u64() % 100),
+                    1 + (next_u64() % 1000),
+                    f32::from_bits(next_u64() as u32),
+                )
+            })
+            .collect();
+        let block = FixedTermInfoBlock::encode(&entries);
+        for (i, e) in entries.iter().enumerate() {
+            let d = block.decode_at(i);
+            assert_eq!(d.posting_offset, e.posting_offset);
+            assert_eq!(d.posting_length, e.posting_length);
+            assert_eq!(d.doc_frequency, e.doc_frequency);
+            assert_eq!(d.total_frequency, e.total_frequency);
+            assert_eq!(
+                d.max_score_factor.to_bits(),
+                e.max_score_factor.to_bits(),
+                "max_score_factor mismatch at i={i}"
+            );
+        }
+    }
+
+    #[test]
+    fn encode_decode_large_max_delta_in_one_field() {
+        // posting_length spans 0..u32::MAX in 4 entries → requires 32
+        // bits. Other fields stay narrow.
+        let entries = [
+            fti(0, 0, 1, 1, 0.0),
+            fti(100, u32::MAX as u64, 2, 2, 0.0),
+            fti(200, 1, 3, 3, 0.0),
+            fti(300, 100_000, 4, 4, 0.0),
+        ];
+        let block = FixedTermInfoBlock::encode(&entries);
+        assert_eq!(block.posting_length_nbits, 32);
+        for (i, e) in entries.iter().enumerate() {
+            assert_eq!(block.decode_at(i), *e);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "entries.len() must be in 1..=128")]
+    fn encode_panics_on_empty_entries() {
+        FixedTermInfoBlock::encode(&[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "entries.len() must be in 1..=128")]
+    fn encode_panics_on_oversize_entries() {
+        let entries: Vec<FixedTermInfo> = (0..BLOCK_TERM_COUNT + 1)
+            .map(|_| fti(0, 0, 0, 0, 0.0))
+            .collect();
+        FixedTermInfoBlock::encode(&entries);
+    }
+
+    #[test]
+    #[should_panic(expected = "decode_at: inner_offset")]
+    fn decode_panics_on_out_of_range() {
+        let entries = [fti(0, 0, 0, 0, 0.0); 4];
+        let block = FixedTermInfoBlock::encode(&entries);
+        let _ = block.decode_at(4);
+    }
+}

--- a/laurus/tests/dict_file_size.rs
+++ b/laurus/tests/dict_file_size.rs
@@ -1,0 +1,92 @@
+//! Integration test verifying the on-disk size of the new Lucene
+//! `BlockTreeTermsWriter`-style term dictionary (#487 PR1).
+//!
+//! Builds a deterministic 100k-term corpus, writes it through
+//! [`BlockTermDictionary::write_to_storage`], and asserts that the
+//! resulting `.dict` byte size stays below the regression guard
+//! threshold derived empirically from the new layout.
+//!
+//! Pre-port reference (legacy `HybridTermDictionary` parallel-array
+//! representation, before #487 Phase 9 removed it):
+//!
+//! - 100k unique 5–10-byte ASCII terms × ~7.5 byte avg + 40 bytes /
+//!   `TermInfo` (4×u64 + f32) = roughly **4.75 MB** of raw payload
+//!   per copy, before any sharing or bit-packing
+//!
+//! New `BlockTermDictionary` `LTDD` layout target:
+//!
+//! - FST over per-block last terms (~ 800 entries for 100k @ 128
+//!   block size) — typically 10–30 KB
+//! - 800 blocks × (front-coded term bytes + bit-packed `TermInfoBlock`
+//!   + `BlockMaxData`) — typically ≤ 2 KB / block at this corpus
+//!
+//! The regression guard below picks **1.6 MB** as a soft ceiling: a
+//! conservative cut-off well above the expected ~1.0–1.4 MB for this
+//! fixture but well below the legacy ~4.75 MB raw size, so a
+//! regression that bloats the layout by 2× will trip the test.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use laurus::lexical::index::structures::dictionary::{TermDictionaryBuilder, TermInfo};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::storage::structured::StructWriter;
+
+/// Generates `n` unique deterministic ASCII terms of length 5..=10.
+fn make_corpus(n: usize, seed: u64) -> Vec<String> {
+    let mut state = seed;
+    let mut next_u32 = || -> u32 {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        (state >> 32) as u32
+    };
+    let mut set = BTreeSet::new();
+    while set.len() < n {
+        let len = 5 + (next_u32() % 6) as usize;
+        let mut s = String::with_capacity(len);
+        for _ in 0..len {
+            s.push((b'a' + (next_u32() as u8 % 26)) as char);
+        }
+        set.insert(s);
+    }
+    set.into_iter().collect()
+}
+
+#[test]
+fn block_term_dictionary_file_size_100k_under_1_6mb() {
+    const N: usize = 100_000;
+    const SEED: u64 = 0x9E3779B97F4A7C15;
+    const SOFT_CEILING_BYTES: usize = 1_600_000;
+
+    let terms = make_corpus(N, SEED);
+    assert_eq!(terms.len(), N);
+
+    let mut builder = TermDictionaryBuilder::new();
+    for (i, term) in terms.iter().enumerate() {
+        builder.add_term(term.clone(), TermInfo::new(i as u64 * 16, 64, 1, 1));
+    }
+    let dict = builder.build().expect("build BlockTermDictionary");
+
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    {
+        let output = storage.create_output("100k.dict").unwrap();
+        let mut writer = StructWriter::new(output);
+        dict.write_to_storage(&mut writer).unwrap();
+        writer.close().unwrap();
+    }
+    let size = storage.file_size("100k.dict").unwrap() as usize;
+    let bytes_per_term = size as f64 / N as f64;
+
+    eprintln!(
+        "BlockTermDictionary 100k corpus: {} bytes ({:.2} bytes/term)",
+        size, bytes_per_term
+    );
+
+    assert!(
+        size < SOFT_CEILING_BYTES,
+        "100k-term .dict is {size} bytes, exceeds soft ceiling {SOFT_CEILING_BYTES}: \
+         either the layout regressed or the threshold needs revisiting"
+    );
+}


### PR DESCRIPTION
## Summary

- Replace `HybridTermDictionary` (HashMap + sorted Vec, three-way `TermInfo` duplication) with a new `BlockTermDictionary` that uses a **Lucene `BlockTreeTermsWriter`-style on-disk format** (`LTDD` magic, schema v1) and an **`AHashMap`-backed in-memory query layer** populated at build / load time.
- File size **-72 %** (100k corpus: 1.25 MB / 12.5 bytes/term vs ~4.5 MB legacy estimate). In-memory **-31 %** at 10M corpus (single `Arc<[TermInfo]>` copy + `AHashMap<String, u32>` ordinal index instead of full `TermInfo` per HashMap entry).
- Query latency parity with `parallel-array (HybridTermDictionary)` baseline at 10M scale (see numbers below). API signatures (`Option<&TermInfo>`, `Vec<(&str, &TermInfo)>`) match the legacy dictionary so caller migration is mechanical.

## Design

The dictionary now has **two equivalent representations** of the same data:

1. **Disk-format scratch** (`fst` + `block_section`) — the compact FST + 128-term BlockSection layout written to `.dict`. Kept in memory so `write_to_storage` re-emits the segment without re-encoding from scratch.
2. **In-memory query layer** (`map` + `sorted_terms` + `term_infos`) — populated at build / load time so that `get` / `iter` / `find_prefix` / `find_range` operate at parallel-array / `AHashMap` speed.

```rust
pub struct BlockTermDictionary {
    // Disk-format scratch (kept for re-write efficiency)
    fst: Arc<FstMap<Vec<u8>>>,
    block_section: Arc<[u8]>,

    // In-memory query layer (the hot path)
    map: AHashMap<String, u32>,
    sorted_terms: Vec<String>,
    term_infos: Arc<[TermInfo]>,

    total_term_count: u64,
    block_count: u32,
}
```

The `.dict` byte layout:

```text
[Header             ]  magic "LTDD" (u32=0x4C544444) + version u32=1
[FstSection         ]  fst::Map<u64> over each block's last term → block start offset
[BlockSection       ]  concatenated 128-term blocks; each block contains:
                         - block_term_count: varint
                         - front-coded term bytes (length-prefixed first term + (shared_prefix_len, suffix) for the rest)
                         - bit-packed FixedTermInfoBlock (block-min + per-field nbits + payload)
                         - BlockMaxData (offsets[term_count+1] + flat 12-byte BlockMax entries)
[Footer             ]  total_term_count u64 + block_count u32 + reserved u32
```

Legacy `STDC` / `HTDC` magic numbers are explicitly rejected at read time with an error pointing to "rebuild required" (pre-release semantics — segment files from older builds are not loadable).

## Bench (`dict_lookup_bench`)

Baseline `pre-fst-port-10m` saved on `main` (commit `69384ac0`) with `HybridTermDictionary`. Both runs use `SAMPLE_SIZE_SLOW = 30`, within-run IQR ±1 %.

### Query latency at 10M (mean of 30 samples)

| Pattern | parallel-array (main) | this PR (BTT + AHashMap) | ratio |
| :--- | ---: | ---: | :---: |
| `get_hit/100 probes` | 881 ns | 1144 ns | 1.30x |
| `get_miss/100 probes` | 727 ns | 622 ns | 0.86x (faster) |
| `iter` (10M terms) | 29.15 ms | 28.84 ms | 0.99x (parity) |
| `find_prefix/a` (~380k matches) | 6.17 ms | 6.79 ms | 1.10x |
| `find_prefix/ab` (~14k matches) | 124 µs | 89 µs | 0.72x (faster) |

The `get_hit` 1.30x slowdown is structural (`AHashMap` cache miss rate at 10M scale). All other operations are within ±15 % of the parallel-array baseline; several are faster.

### File size

| Corpus | parallel-array (legacy) | this PR | reduction |
| :--- | ---: | ---: | :---: |
| 100k unique 5–10 byte terms | ~4.5 MB | **1.25 MB** | -72 % |

Verified by [`laurus/tests/dict_file_size.rs`](laurus/tests/dict_file_size.rs).

## Caller migration

- [`reader.rs:term_info`](laurus/src/lexical/index/inverted/reader.rs) — `dict.get(...)` returns `Option<&TermInfo>` like the legacy implementation; the existing `.cloned()` on the `Result` boundary is unchanged.
- [`core/terms.rs`](laurus/src/lexical/index/inverted/core/terms.rs) — `InvertedIndexTerms`, `InvertedIndexTermsEnum`, `MergedInvertedIndexTerms` now hold `Arc<BlockTermDictionary>` instead of `Arc<HybridTermDictionary>`.
- [`writer.rs`](laurus/src/lexical/index/inverted/writer.rs) and [`segment/merge_engine.rs`](laurus/src/lexical/index/inverted/segment/merge_engine.rs) — call `TermDictionaryBuilder::build()` instead of `build_hybrid()` / `build_sorted()`.

`HybridTermDictionary`, `SortedTermDictionary`, `HashTermDictionary`, and the corresponding builder methods are removed in this PR.

## Test plan

- [x] `cargo test --workspace` — 875 unit tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo bench --bench dict_lookup_bench --baseline pre-fst-port-10m` — numbers in PR description.
- [x] `cargo test --test dict_file_size --release` — file size guard test.
- [x] `markdownlint-cli2 "docs/src/**/*.md" "docs/ja/src/**/*.md"` — clean.
- [ ] CI green.
- [ ] Verify segment write / read on a fresh index after merge.

## Out of scope (follow-up issues)

- **FST automaton intersection for `fuzzy` / `regex` / `wildcard`** queries — currently `AutomatonTermsEnum` walks the in-memory layer linearly. Wiring `fst::Map::search(automaton)` against the on-disk FST would prune the search space substantially.
- **`mmap`-backed `block_section`** (umbrella #463 Tier 2 separate item) — would let read-only segments avoid copying the BlockSection bytes into RAM at load time.
- **Drop `fst` + `block_section` after read** — for read-only segments, the disk-format scratch could be discarded post-load to save ~135 MB at 10M scale (~7 % memory).

Refs #487, Refs #463.