### PR TITLE
docs: re-align all docs with workspace v0.9.0 implementation

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -15,8 +15,9 @@ Lexical 検索、ベクトル検索、ハイブリッド検索をカバーする
 - **Node.js バインディング** — サーバーサイド JavaScript アプリケーション向けネイティブ Node.js アドオン
 - **WebAssembly** — wasm-bindgen によるブラウザおよびエッジランタイムサポート
 - **Ruby バインディング** — Rails や Ruby アプリケーション向けネイティブ Ruby gem
+- **PHP バインディング** — Web アプリケーションや CLI ツール向けネイティブ PHP 拡張
 
-ライブラリとして組み込むことも、スタンドアロンのサーバーとしてデプロイすることも、Python / Node.js / Ruby から呼び出すことも、ブラウザで WASM として実行することも、AI ワークフローに検索機能を組み込むことも可能な、コンポーザブルな検索基盤です。
+ライブラリとして組み込むことも、スタンドアロンのサーバーとしてデプロイすることも、Python / Node.js / Ruby / PHP から呼び出すことも、ブラウザで WASM として実行することも、AI ワークフローに検索機能を組み込むことも可能な、コンポーザブルな検索基盤です。
 
 ## ライブデモ
 
@@ -60,6 +61,7 @@ Lexical 検索、ベクトル検索、ハイブリッド検索をカバーする
   - [laurus-nodejs](https://mosuka.github.io/laurus/ja/laurus-nodejs.html) — Node.js バインディング（npm パッケージ）
   - [laurus-wasm](https://mosuka.github.io/laurus/ja/laurus-wasm.html) — WebAssembly バインディング（npm パッケージ）
   - [laurus-ruby](https://mosuka.github.io/laurus/ja/laurus-ruby.html) — Ruby バインディング（RubyGems パッケージ）
+  - [laurus-php](https://mosuka.github.io/laurus/ja/laurus-php.html) — PHP バインディング（PHP 拡張）
 - **開発**
   - [ビルドとテスト](https://mosuka.github.io/laurus/ja/development/build_and_test.html)
   - [フィーチャーフラグ](https://mosuka.github.io/laurus/ja/development/feature_flags.html)
@@ -71,16 +73,18 @@ Lexical 検索、ベクトル検索、ハイブリッド検索をカバーする
 - **Pure Rust 実装**: ゼロコスト抽象化によるメモリ安全かつ高速なパフォーマンス。
 - **ハイブリッド検索**: BM25 Lexical 検索と HNSW ベクトル検索を設定可能なフュージョン戦略でシームレスに統合。
 - **マルチモーダル対応**: CLIP エンベディングによるテキストから画像、画像から画像への検索をネイティブサポート。
-- **豊富な Query DSL**: Term、Phrase、Boolean、Fuzzy、Wildcard、Range、Geographic、Span クエリに対応。
+- **豊富な Query DSL**: Term、Phrase、Boolean、Fuzzy、Wildcard、Range、2D / 3D Geographic（球、バウンディングボックス、k-NN）、Span クエリに対応。
 - **柔軟な解析**: トークン化、正規化、ステミングの設定可能なパイプライン（[Lindera](https://github.com/lindera/lindera) による CJK サポートを含む）。
 - **プラガブルストレージ**: インメモリ、ファイルシステム、メモリマップドストレージバックエンドのインターフェース。
+- **動的スキーマ**: オプションのスキーマオンライト — 未宣言フィールドは値から型を推論し、`Strict` / `Dynamic` / `Ignore` ポリシーで細やかに制御可能。
+- **多値数値フィールド**: Integer / Float フィールドは 1 ドキュメントあたり複数値を保持でき、Range クエリは「いずれかの値が条件を満たす」ドキュメントにマッチする（Lucene 互換の "any match" 意味論）。
 - **スコアリングとランキング**: BM25 スコアリングとハイブリッド結果向けのカスタマイズ可能なフュージョン戦略。
 - **ファセットとハイライト**: ファセットナビゲーションと検索結果ハイライトの組み込みサポート。
 - **スペル修正**: スペルミスのあるクエリ用語の修正候補を提案。
 
 ## ワークスペース構成
 
-Laurus は 8 つのクレートで構成された Cargo ワークスペースです:
+Laurus は 9 つのクレートで構成された Cargo ワークスペースです:
 
 | クレート | 説明 |
 | --- | --- |
@@ -92,6 +96,7 @@ Laurus は 8 つのクレートで構成された Cargo ワークスペースで
 | [`laurus-nodejs`](laurus-nodejs/) | NAPI-RS で構築した Node.js バインディング（npm パッケージ） |
 | [`laurus-wasm`](laurus-wasm/) | wasm-bindgen で構築した WebAssembly バインディング（npm パッケージ） |
 | [`laurus-ruby`](laurus-ruby/) | magnus と rb-sys で構築した Ruby バインディング（RubyGems パッケージ） |
+| [`laurus-php`](laurus-php/) | ext-php-rs で構築した PHP バインディング（PHP 拡張） |
 
 ## フィーチャーフラグ
 
@@ -183,6 +188,7 @@ async fn main() -> laurus::Result<()> {
 | [lexical_search](laurus/examples/lexical_search.rs) | 全クエリタイプ（Term、Phrase、Boolean、Fuzzy、Wildcard、Range、Geo、Span） | — |
 | [vector_search](laurus/examples/vector_search.rs) | エンベディングによるセマンティック類似度検索 | — |
 | [hybrid_search](laurus/examples/hybrid_search.rs) | フュージョンによる Lexical 検索とベクトル検索の統合 | — |
+| [geo3d_search](laurus/examples/geo3d_search.rs) | 3D ECEF 地理空間検索（球、バウンディングボックス、k-NN） | — |
 | [synonym_graph_filter](laurus/examples/synonym_graph_filter.rs) | 解析パイプラインでの同義語展開 | — |
 | [search_with_candle](laurus/examples/search_with_candle.rs) | Candle によるローカル BERT エンベディング | `embeddings-candle` |
 | [search_with_openai](laurus/examples/search_with_openai.rs) | OpenAI によるクラウドベースエンベディング | `embeddings-openai` |

--- a/docs/ja/src/SUMMARY.md
+++ b/docs/ja/src/SUMMARY.md
@@ -72,6 +72,7 @@
   - [インストール](laurus-python/installation.md)
   - [クイックスタート](laurus-python/quickstart.md)
   - [API リファレンス](laurus-python/api_reference.md)
+  - [開発](laurus-python/development.md)
 
 # laurus-nodejs
 

--- a/docs/ja/src/development/feature_flags.md
+++ b/docs/ja/src/development/feature_flags.md
@@ -19,7 +19,7 @@
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-candle"] }
+laurus = { version = "0.9", features = ["embeddings-candle"] }
 ```
 
 ### `embeddings-openai`
@@ -28,7 +28,7 @@ laurus = { version = "0.1.0", features = ["embeddings-candle"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-openai"] }
+laurus = { version = "0.9", features = ["embeddings-openai"] }
 ```
 
 ### `embeddings-multimodal`
@@ -37,7 +37,7 @@ laurus = { version = "0.1.0", features = ["embeddings-openai"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-multimodal"] }
+laurus = { version = "0.9", features = ["embeddings-multimodal"] }
 ```
 
 ### `embeddings-all`
@@ -46,7 +46,7 @@ laurus = { version = "0.1.0", features = ["embeddings-multimodal"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-all"] }
+laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
 ## Feature Flag がバイナリサイズに与える影響

--- a/docs/ja/src/development/project_structure.md
+++ b/docs/ja/src/development/project_structure.md
@@ -1,12 +1,12 @@
 # プロジェクト構成
 
-Laurus は 3 つのクレートを持つ Cargo ワークスペースとして構成されています。
+Laurus は 9 つのクレートで構成された Cargo ワークスペースです。コアライブラリ、3 つの自製バイナリ（CLI、gRPC サーバー、MCP サーバー）、および 5 つの言語バインディングから成ります。
 
 ## ワークスペースレイアウト
 
 ```text
 laurus/                          # リポジトリルート
-├── Cargo.toml                   # ワークスペース定義
+├── Cargo.toml                   # ワークスペース定義（members + workspace.package）
 ├── laurus/                      # コア検索エンジンライブラリ
 │   ├── Cargo.toml
 │   ├── src/
@@ -25,19 +25,36 @@ laurus/                          # リポジトリルート
 ├── laurus-cli/                  # コマンドラインインターフェース
 │   ├── Cargo.toml
 │   └── src/
-│       └── main.rs              # CLI エントリーポイント（clap）
+│       ├── main.rs              # CLI エントリーポイント（clap）
+│       ├── cli.rs               # サブコマンド定義
+│       └── commands/            # サブコマンドごとの実装
 ├── laurus-server/               # gRPC サーバー + HTTP ゲートウェイ
 │   ├── Cargo.toml
-│   ├── proto/                   # Protobuf サービス定義
+│   ├── proto/laurus/v1/         # Protobuf サービス定義
 │   └── src/
 │       ├── lib.rs               # サーバーライブラリ
 │       ├── config.rs            # TOML 設定
-│       ├── grpc/                # gRPC サービス実装
+│       ├── service/             # gRPC サービス実装（tonic）
 │       └── gateway/             # HTTP/JSON ゲートウェイ（axum）
+├── laurus-mcp/                  # MCP（Model Context Protocol）stdio サーバー
+│   ├── Cargo.toml
+│   └── src/
+│       ├── lib.rs
+│       ├── server.rs            # rmcp ツールルーター（12 ツール）
+│       └── convert.rs           # JSON ↔ DataValue 変換ヘルパー
+├── laurus-python/               # Python バインディング（PyO3 + Maturin）
+├── laurus-nodejs/               # Node.js バインディング（NAPI-RS）
+├── laurus-wasm/                 # WebAssembly バインディング（wasm-bindgen）
+├── laurus-ruby/                 # Ruby バインディング（magnus + rb-sys）
+├── laurus-php/                  # PHP バインディング（ext-php-rs）
 └── docs/                        # mdBook ドキュメント
-    ├── book.toml
-    └── src/
-        └── SUMMARY.md           # 目次
+    ├── book.toml                # 英語版 mdBook 設定
+    ├── src/                     # 英語版ソース
+    │   └── SUMMARY.md           # 英語版目次
+    └── ja/                      # 日本語版 mdBook（独立ビルド）
+        ├── book.toml
+        └── src/
+            └── SUMMARY.md
 ```
 
 ## クレートの役割
@@ -45,10 +62,16 @@ laurus/                          # リポジトリルート
 | クレート | 種類 | 説明 |
 | :--- | :--- | :--- |
 | `laurus` | ライブラリ | Lexical 検索、ベクトル検索、ハイブリッド検索を備えたコア検索エンジン |
-| `laurus-cli` | バイナリ | インデックス管理、ドキュメント CRUD、検索、REPL のための CLI ツール |
+| `laurus-cli` | バイナリ | インデックス管理、ドキュメント CRUD、検索、REPL、および `serve` / `mcp` ランチャーを提供する CLI ツール |
 | `laurus-server` | ライブラリ + バイナリ | オプションの HTTP/JSON ゲートウェイ付き gRPC サーバー |
+| `laurus-mcp` | バイナリ | 稼働中の laurus-server へツール呼び出しをプロキシする MCP stdio サーバー |
+| `laurus-python` | 動的ライブラリ | PyO3 / Maturin で構築する Python パッケージ（PyPI） |
+| `laurus-nodejs` | 動的ライブラリ | NAPI-RS で構築する Node.js パッケージ（npm） |
+| `laurus-wasm` | WebAssembly | wasm-bindgen で構築するブラウザ・エッジランタイム向け npm パッケージ |
+| `laurus-ruby` | 動的ライブラリ | magnus と rb-sys で構築する Ruby gem |
+| `laurus-php` | PHP 拡張 | ext-php-rs で構築する PHP 拡張（スタンドアロン構成。ワークスペースからは除外。詳細は [ビルドとテスト](build_and_test.md) を参照） |
 
-`laurus-cli` と `laurus-server` はどちらも `laurus` ライブラリクレートに依存しています。
+すべてのバインディングクレートと 3 つの自製バイナリは `laurus` に依存します。
 
 ## 設計規約
 

--- a/docs/ja/src/getting_started/installation.md
+++ b/docs/ja/src/getting_started/installation.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-laurus = "0.1.0"
+laurus = "0.9"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -28,28 +28,28 @@ Laurus はデフォルトで最小限の機能セットで提供されます。�
 
 ```toml
 [dependencies]
-laurus = "0.1.0"
+laurus = "0.9"
 ```
 
 **ローカルモデルによる Vector 検索**（API キー不要）:
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-candle"] }
+laurus = { version = "0.9", features = ["embeddings-candle"] }
 ```
 
 **OpenAI による Vector 検索**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-openai"] }
+laurus = { version = "0.9", features = ["embeddings-openai"] }
 ```
 
 **すべての機能**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-all"] }
+laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
 ## インストールの確認

--- a/docs/ja/src/laurus-cli/commands.md
+++ b/docs/ja/src/laurus-cli/commands.md
@@ -450,3 +450,31 @@ laurus serve [OPTIONS]
 - [はじめに](../laurus-server/getting_started.md) — 起動オプションと gRPC 接続例
 - [設定](../laurus-server/configuration.md) — TOML 設定ファイル、環境変数、優先順位
 - [ハンズオンチュートリアル](../laurus-server/tutorial.md) — ステップバイステップの操作ガイド
+
+---
+
+## `mcp`
+
+[Model Context Protocol](https://modelcontextprotocol.io/)（MCP）サーバーを stdio 上で起動します。MCP サーバーを介して、Claude Code や Claude Desktop のような AI アシスタントが標準化されたツール群（`create_index`、`add_document`、`search` など）で稼働中の laurus-server を操作できます。
+
+```bash
+laurus mcp [--endpoint <URL>]
+```
+
+**引数:**
+
+| フラグ | 環境変数 | 必須 | 説明 |
+| :--- | :--- | :--- | :--- |
+| `--endpoint <URL>` | `LAURUS_ENDPOINT` | いいえ | 稼働中の laurus-server の gRPC エンドポイント（例: `http://localhost:50051`）。省略すると未接続で起動し、クライアントから後で `connect` MCP ツールを呼び出して接続できます。 |
+
+**使用例:**
+
+```bash
+# ローカルの laurus-server に事前接続して MCP サーバーを起動
+laurus mcp --endpoint http://localhost:50051
+
+# 未接続で起動し、クライアントが最初に `connect` を呼ぶ運用
+laurus mcp
+```
+
+MCP サーバーが公開する全ツールの一覧、および Claude Code や Claude Desktop と連携する設定方法については [laurus-mcp のドキュメント](../laurus-mcp.md)を参照してください。

--- a/docs/ja/src/laurus-mcp/tools.md
+++ b/docs/ja/src/laurus-mcp/tools.md
@@ -91,9 +91,16 @@ schema_json: {"fields": {"title": {"Text": {}}, "body": {"Text": {}}}}
 ```json
 {
   "document_count": 42,
-  "vector_fields": ["embedding"]
+  "vector_fields": {
+    "embedding": {
+      "vector_count": 42,
+      "dimension": 384
+    }
+  }
 }
 ```
+
+`vector_fields` はフィールド名をキーとするマップで、各エントリにはインデックス済みベクトル数とフィールドに設定された次元数が含まれます。
 
 ---
 

--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -34,10 +34,19 @@ class Index {
 | `searchVector(field, vector, limit?, offset?)` | 事前計算ベクトルで検索。 |
 | `searchVectorText(field, text, limit?, offset?)` | テキストを自動埋め込みして検索。 |
 | `searchWithRequest(request)` | `SearchRequest` で検索。 |
-| `stats()` | インデックス統計を返す。 |
+| `stats()` | インデックス統計（`documentCount`、`vectorFields`）を返す。 |
 
 ドキュメント操作と検索メソッドはすべて非同期で Promise を返します。
 `stats()` は同期メソッドです。
+
+`stats()` は次の形のオブジェクトを返します:
+
+```typescript
+interface IndexStats {
+  documentCount: number;
+  vectorFields: Record<string, { count: number; dimension: number }>;
+}
+```
 
 ---
 

--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -399,4 +399,5 @@ Python の値は自動的に Laurus の `DataValue` 型に変換されます：
 | `bytes` | `Bytes` | |
 | `list[float]` | `Vector` | 要素は `f32` に変換 |
 | `(lat, lon)` タプル | `Geo` | 2 つの `float` 値 |
+| `(x, y, z)` タプル | `Geo3d` | 3 つの `float` 値（ECEF 直交座標系、メートル単位） |
 | `datetime.datetime` | `DateTime` | `isoformat()` 経由で変換 |

--- a/docs/ja/src/laurus-server/configuration.md
+++ b/docs/ja/src/laurus-server/configuration.md
@@ -39,7 +39,7 @@ port = 50051
 http_port = 8080  # オプション: HTTP ゲートウェイを有効化
 
 [index]
-data_dir = "./laurus_index"
+data_dir = "./laurus_data"
 ```
 
 ログの詳細度は設定ファイルではなく、`RUST_LOG` 環境変数で制御します（デフォルト: `info`）。
@@ -58,7 +58,7 @@ data_dir = "./laurus_index"
 
 | フィールド | 型 | デフォルト | 説明 |
 | :--- | :--- | :--- | :--- |
-| `data_dir` | String | `"./laurus_index"` | インデックスデータディレクトリのパス |
+| `data_dir` | String | `"./laurus_data"` | インデックスデータディレクトリのパス |
 
 ## 環境変数
 

--- a/docs/ja/src/laurus-server/grpc_api.md
+++ b/docs/ja/src/laurus-server/grpc_api.md
@@ -167,7 +167,7 @@ rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse);
 | :--- | :--- | :--- |
 | `schema` | `Schema` | インデックスのスキーマ |
 
-### AddField
+### `AddField`
 
 稼働中のインデックスにフィールドを動的に追加します。
 
@@ -175,12 +175,20 @@ rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse);
 rpc AddField(AddFieldRequest) returns (AddFieldResponse);
 ```
 
+**リクエストフィールド:**
+
 | フィールド | 型 | 説明 |
 | :--- | :--- | :--- |
 | `name` | `string` | フィールド名 |
 | `field_option` | `FieldOption` | フィールド設定 |
 
-**レスポンス:** 更新後の `Schema` を返します。
+**レスポンスフィールド:**
+
+| フィールド | 型 | 説明 |
+| :--- | :--- | :--- |
+| `schema` | `Schema` | フィールド追加後の更新済みスキーマ |
+
+**HTTP ゲートウェイ:** `POST /v1/schema/fields`
 
 ### DeleteField
 
@@ -239,13 +247,15 @@ message Document {
 | :--- | :--- | :--- |
 | Null | `null_value` | Null 値 |
 | Boolean | `bool_value` | ブール値 |
-| Integer | `int64_value` | 64 ビット整数 |
+| Integer | `int64_value` | 64 ビット符号付き整数 |
 | Float | `float64_value` | 64 ビット浮動小数点数 |
 | Text | `text_value` | UTF-8 文字列 |
 | Bytes | `bytes_value` | バイト列 |
 | Vector | `vector_value` | `VectorValue`（浮動小数点数のリスト） |
 | DateTime | `datetime_value` | Unix マイクロ秒（UTC） |
 | Geo | `geo_value` | `GeoPoint`（緯度、経度） |
+| Int64Array | `int64_array_value` | `Int64ArrayValue`（多値整数。`IntegerOption.multi_valued = true` を要求） |
+| Float64Array | `float64_array_value` | `Float64ArrayValue`（多値浮動小数点数。`FloatOption.multi_valued = true` を要求） |
 | Geo3d | `geo3d_value` | `Geo3dPoint`（x, y, z メートル単位、ECEF 直交座標系） |
 
 **Geo3dPoint:**

--- a/docs/ja/src/laurus-server/http_gateway.md
+++ b/docs/ja/src/laurus-server/http_gateway.md
@@ -32,13 +32,13 @@ laurus serve --config config.toml
 | POST | `/v1/index` | `IndexService/CreateIndex` | 新しいインデックスを作成 |
 | GET | `/v1/index` | `IndexService/GetIndex` | インデックスの統計情報を取得 |
 | GET | `/v1/schema` | `IndexService/GetSchema` | インデックスのスキーマを取得 |
-| PUT | `/v1/documents/:id` | `DocumentService/PutDocument` | ドキュメントの Upsert |
-| POST | `/v1/documents/:id` | `DocumentService/AddDocument` | ドキュメントの追加（チャンク） |
-| GET | `/v1/documents/:id` | `DocumentService/GetDocuments` | ID でドキュメントを取得 |
-| DELETE | `/v1/documents/:id` | `DocumentService/DeleteDocuments` | ID でドキュメントを削除 |
+| POST | `/v1/schema/fields` | `IndexService/AddField` | フィールドを動的に追加 |
+| DELETE | `/v1/schema/fields/{name}` | `IndexService/DeleteField` | スキーマからフィールドを削除 |
+| PUT | `/v1/documents/{id}` | `DocumentService/PutDocument` | ドキュメントの Upsert |
+| POST | `/v1/documents/{id}` | `DocumentService/AddDocument` | ドキュメントの追加（チャンク） |
+| GET | `/v1/documents/{id}` | `DocumentService/GetDocuments` | ID でドキュメントを取得 |
+| DELETE | `/v1/documents/{id}` | `DocumentService/DeleteDocuments` | ID でドキュメントを削除 |
 | POST | `/v1/commit` | `DocumentService/Commit` | 保留中の変更をコミット |
-| POST | `/v1/schema/fields` | `IndexService/AddField` | フィールドの追加 |
-| DELETE | `/v1/schema/fields/:name` | `IndexService/DeleteField` | フィールドの削除 |
 | POST | `/v1/search` | `SearchService/Search` | 検索（単発） |
 | POST | `/v1/search/stream` | `SearchService/SearchStream` | 検索（Server-Sent Events） |
 
@@ -80,6 +80,31 @@ curl http://localhost:8080/v1/index
 ```bash
 curl http://localhost:8080/v1/schema
 ```
+
+### フィールドの動的追加
+
+稼働中のインデックスにフィールドを追加します。リクエストボディは `POST /v1/index` と同じ `FieldOption` JSON 形式を使います:
+
+```bash
+curl -X POST http://localhost:8080/v1/schema/fields \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "category",
+    "field_option": {"text": {"indexed": true, "stored": true}}
+  }'
+```
+
+レスポンスでは更新後のスキーマが返されます。
+
+### フィールドの削除
+
+スキーマからフィールドを削除します。フィールド名はパスで指定します:
+
+```bash
+curl -X DELETE http://localhost:8080/v1/schema/fields/category
+```
+
+既にインデックスされたデータはストレージに残りますが、アクセスできなくなります。フィールド固有のアナライザとエンベッダーは解除されます。
 
 ### ドキュメントの Upsert（PUT）
 
@@ -186,8 +211,8 @@ data: {"id":"doc2","score":0.4210,"document":{...}}
 
 ## JSON フィールド値の型推論
 
-ドキュメント投入リクエスト（`PUT /v1/documents/:id` または
-`POST /v1/documents/:id`）のボディに含まれる `document.fields` の各値は、
+ドキュメント投入リクエスト（`PUT /v1/documents/{id}` または
+`POST /v1/documents/{id}`）のボディに含まれる `document.fields` の各値は、
 スキーマレス取り込みと同じ推論ルールでエンジンの
 [`DataValue`](../concepts/schema_and_fields.md) に変換されます。これにより
 HTTP 経路と gRPC 経路で挙動が一致します。

--- a/docs/ja/src/laurus.md
+++ b/docs/ja/src/laurus.md
@@ -47,15 +47,15 @@ graph TB
 ```toml
 # Lexical検索のみ（Embeddingなし）
 [dependencies]
-laurus = "0.1.0"
+laurus = "0.9"
 
 # ローカルBERT Embeddingを使用
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-candle"] }
+laurus = { version = "0.9", features = ["embeddings-candle"] }
 
 # すべてのFeatureを有効化
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-all"] }
+laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
 ## セクション

--- a/docs/ja/src/laurus/api_reference.md
+++ b/docs/ja/src/laurus/api_reference.md
@@ -20,6 +20,7 @@ cargo doc --open
 | `engine.search(request).await?` | 検索リクエストの実行 |
 | `engine.commit().await?` | 保留中のすべての変更をストレージにフラッシュ |
 | `engine.add_field(name, field_option).await?` | 稼働中のエンジンにフィールドを動的に追加 |
+| `engine.delete_field(name).await?` | 稼働中のエンジンからフィールドを動的に削除 |
 | `engine.schema()` | 現在のスキーマへの参照を取得 |
 | `engine.stats()?` | インデックス統計の取得 |
 
@@ -47,16 +48,20 @@ cargo doc --open
 | メソッド | 説明 |
 | :--- | :--- |
 | `.add_text_field(name, TextOption)` | 全文検索フィールドを追加 |
-| `.add_integer_field(name, IntegerOption)` | 整数フィールドを追加 |
-| `.add_float_field(name, FloatOption)` | 浮動小数点フィールドを追加 |
+| `.add_integer_field(name, IntegerOption)` | 整数フィールドを追加（`IntegerOption::multi_valued = true` で多値配列対応） |
+| `.add_float_field(name, FloatOption)` | 浮動小数点フィールドを追加（`FloatOption::multi_valued = true` で多値配列対応） |
 | `.add_boolean_field(name, BooleanOption)` | 真偽値フィールドを追加 |
 | `.add_datetime_field(name, DateTimeOption)` | 日時フィールドを追加 |
-| `.add_geo_field(name, GeoOption)` | 地理フィールドを追加 |
+| `.add_geo_field(name, GeoOption)` | 2D 地理（緯度/経度）フィールドを追加 |
+| `.add_geo3d_field(name, Geo3dOption)` | 3D ECEF 直交座標系の点フィールド（x, y, z メートル単位）を追加 |
 | `.add_bytes_field(name, BytesOption)` | バイナリフィールドを追加 |
 | `.add_hnsw_field(name, HnswOption)` | HNSWベクトルフィールドを追加 |
 | `.add_flat_field(name, FlatOption)` | Flatベクトルフィールドを追加 |
 | `.add_ivf_field(name, IvfOption)` | IVFベクトルフィールドを追加 |
 | `.add_default_field(name)` | デフォルト検索フィールドを設定 |
+| `.add_analyzer(name, AnalyzerDefinition)` | カスタム Analyzer パイプラインを登録 |
+| `.add_embedder(name, EmbedderDefinition)` | Embedder 定義を登録 |
+| `.dynamic_field_policy(DynamicFieldPolicy)` | 未宣言フィールドのポリシー（`Strict` / `Dynamic` / `Ignore`）を設定 |
 | `.build()` | `Schema` を構築 |
 
 ## Document
@@ -74,13 +79,17 @@ cargo doc --open
 
 | メソッド | 説明 |
 | :--- | :--- |
+| `.add_field(name, DataValue)` | 任意の `DataValue` を追加 |
 | `.add_text(name, value)` | テキストフィールドを追加 |
-| `.add_integer(name, value)` | 整数フィールドを追加 |
-| `.add_float(name, value)` | 浮動小数点フィールドを追加 |
+| `.add_integer(name, value)` | 単一値の整数フィールドを追加 |
+| `.add_float(name, value)` | 単一値の浮動小数点フィールドを追加 |
 | `.add_boolean(name, value)` | 真偽値フィールドを追加 |
 | `.add_datetime(name, value)` | 日時フィールドを追加 |
 | `.add_vector(name, vec)` | 事前計算済みベクトルを追加 |
-| `.add_geo(name, lat, lon)` | 地理ポイントを追加 |
+| `.add_geo(name, lat, lon)` | 2D 地理ポイントを追加 |
+| `.add_geo_ecef(name, x, y, z)` | 3D ECEF 直交座標系の点（メートル単位）を追加 |
+| `.add_int64_array(name, values)` | 多値整数フィールドを追加 |
+| `.add_float64_array(name, values)` | 多値浮動小数点フィールドを追加 |
 | `.add_bytes(name, data)` | バイナリデータを追加 |
 | `.build()` | `Document` を構築 |
 
@@ -146,7 +155,11 @@ cargo doc --open
 | `FuzzyQuery::new(field, term)` | あいまい一致（デフォルト max_edits=2） | `FuzzyQuery::new("body", "programing").max_edits(1)` |
 | `WildcardQuery::new(field, pattern)` | ワイルドカード | `WildcardQuery::new("file", "*.pdf")` |
 | `NumericRangeQuery::new(...)` | 数値範囲 | [Lexical Search](../concepts/search.md) を参照 |
-| `GeoQuery::within_radius(...)` | 地理半径 | [Lexical Search](../concepts/search.md) を参照 |
+| `GeoDistanceQuery::within_radius(...)` | 2D 地理半径 | [Lexical Search](../concepts/search.md) を参照 |
+| `GeoBoundingBoxQuery::within_bounding_box(...)` | 2D 地理バウンディングボックス | [Lexical Search](../concepts/search.md) を参照 |
+| `Geo3dDistanceQuery::within_sphere(...)` | 3D ECEF 球 | [3D 地理検索](../concepts/geo3d.md) を参照 |
+| `Geo3dBoundingBoxQuery::within_box(...)` | 3D ECEF 軸並行バウンディングボックス | [3D 地理検索](../concepts/geo3d.md) を参照 |
+| `Geo3dNearestQuery::k_nearest(...)` | 3D ECEF k-NN | [3D 地理検索](../concepts/geo3d.md) を参照 |
 | `SpanNearQuery::new(...)` | 近接 | [Lexical Search](../concepts/search.md) を参照 |
 | `PrefixQuery::new(field, prefix)` | 前方一致 | `PrefixQuery::new("body", "pro")` |
 | `RegexpQuery::new(field, pattern)?` | 正規表現一致 | `RegexpQuery::new("body", "^pro.*ing$")?` |
@@ -155,9 +168,9 @@ cargo doc --open
 
 | パーサー | 説明 |
 | :--- | :--- |
-| `QueryParser::new(analyzer)` | Lexical DSLクエリをパース |
-| `VectorQueryParser::new(embedder)` | Vector DSLクエリをパース |
-| `UnifiedQueryParser::new(lexical, vector)` | ハイブリッドDSLクエリをパース |
+| `LexicalQueryParser::new(analyzer)` | Lexical DSL クエリをパース |
+| `VectorQueryParser::new(embedder)` | Vector DSL クエリをパース |
+| `UnifiedQueryParser::new(lexical, vector)` | Lexical / Vector 両方を含むハイブリッド DSL クエリをパース |
 
 ## Analyzer
 
@@ -199,6 +212,9 @@ cargo doc --open
 | `DataValue::Float64(f64)` | `f64` |
 | `DataValue::Text(String)` | `String` |
 | `DataValue::Bytes(Vec<u8>, Option<String>)` | `(data, mime_type)` |
-| `DataValue::Vector(Vec<f32>)` | `Vec<f32>` |
+| `DataValue::Vector(Vec<f32>)` | 事前計算済みベクトル |
 | `DataValue::DateTime(DateTime<Utc>)` | `chrono::DateTime<Utc>` |
-| `DataValue::Geo(f64, f64)` | `(latitude, longitude)` |
+| `DataValue::Geo(GeoPoint)` | `(latitude, longitude)`（WGS84） |
+| `DataValue::GeoEcef(GeoEcefPoint)` | `(x, y, z)` ECEF 直交座標系（メートル単位） |
+| `DataValue::Int64Array(Vec<i64>)` | 多値整数（`multi_valued` フィールドオプションが必要） |
+| `DataValue::Float64Array(Vec<f64>)` | 多値浮動小数点数（`multi_valued` フィールドオプションが必要） |

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -72,6 +72,7 @@
   - [Installation](laurus-python/installation.md)
   - [Quick Start](laurus-python/quickstart.md)
   - [API Reference](laurus-python/api_reference.md)
+  - [Development](laurus-python/development.md)
 
 # laurus-nodejs
 

--- a/docs/src/development/feature_flags.md
+++ b/docs/src/development/feature_flags.md
@@ -19,7 +19,7 @@ Enables `CandleBertEmbedder` for running BERT models locally on the CPU. Models 
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-candle"] }
+laurus = { version = "0.9", features = ["embeddings-candle"] }
 ```
 
 ### `embeddings-openai`
@@ -28,7 +28,7 @@ Enables `OpenAIEmbedder` for calling the OpenAI Embeddings API. Requires an `OPE
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-openai"] }
+laurus = { version = "0.9", features = ["embeddings-openai"] }
 ```
 
 ### `embeddings-multimodal`
@@ -37,7 +37,7 @@ Enables `CandleClipEmbedder` for CLIP-based text and image embeddings. Implies `
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-multimodal"] }
+laurus = { version = "0.9", features = ["embeddings-multimodal"] }
 ```
 
 ### `embeddings-all`
@@ -46,7 +46,7 @@ Convenience flag that enables all embedding features.
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-all"] }
+laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
 ## Feature Flag Impact on Binary Size

--- a/docs/src/development/project_structure.md
+++ b/docs/src/development/project_structure.md
@@ -1,12 +1,12 @@
 # Project Structure
 
-Laurus is organized as a Cargo workspace with three crates.
+Laurus is organized as a Cargo workspace with nine crates: the core library, three first-party binaries (CLI, gRPC server, MCP server), and five language bindings.
 
 ## Workspace Layout
 
 ```text
 laurus/                          # Repository root
-├── Cargo.toml                   # Workspace definition
+├── Cargo.toml                   # Workspace definition (members + workspace.package)
 ├── laurus/                      # Core search engine library
 │   ├── Cargo.toml
 │   ├── src/
@@ -25,19 +25,36 @@ laurus/                          # Repository root
 ├── laurus-cli/                  # Command-line interface
 │   ├── Cargo.toml
 │   └── src/
-│       └── main.rs              # CLI entry point (clap)
+│       ├── main.rs              # CLI entry point (clap)
+│       ├── cli.rs               # Subcommand definitions
+│       └── commands/            # Per-subcommand implementations
 ├── laurus-server/               # gRPC server + HTTP gateway
 │   ├── Cargo.toml
-│   ├── proto/                   # Protobuf service definitions
+│   ├── proto/laurus/v1/         # Protobuf service definitions
 │   └── src/
 │       ├── lib.rs               # Server library
 │       ├── config.rs            # TOML configuration
-│       ├── grpc/                # gRPC service implementations
+│       ├── service/             # gRPC service implementations (tonic)
 │       └── gateway/             # HTTP/JSON gateway (axum)
+├── laurus-mcp/                  # MCP (Model Context Protocol) stdio server
+│   ├── Cargo.toml
+│   └── src/
+│       ├── lib.rs
+│       ├── server.rs            # rmcp tool router (12 tools)
+│       └── convert.rs           # JSON ↔ DataValue helpers
+├── laurus-python/               # Python bindings (PyO3 + Maturin)
+├── laurus-nodejs/               # Node.js bindings (NAPI-RS)
+├── laurus-wasm/                 # WebAssembly bindings (wasm-bindgen)
+├── laurus-ruby/                 # Ruby bindings (magnus + rb-sys)
+├── laurus-php/                  # PHP bindings (ext-php-rs)
 └── docs/                        # mdBook documentation
-    ├── book.toml
-    └── src/
-        └── SUMMARY.md           # Table of contents
+    ├── book.toml                # English mdBook config
+    ├── src/                     # English source
+    │   └── SUMMARY.md           # English table of contents
+    └── ja/                      # Japanese mdBook (independent build)
+        ├── book.toml
+        └── src/
+            └── SUMMARY.md
 ```
 
 ## Crate Responsibilities
@@ -45,10 +62,16 @@ laurus/                          # Repository root
 | Crate | Type | Description |
 | :--- | :--- | :--- |
 | `laurus` | Library | Core search engine with lexical, vector, and hybrid search |
-| `laurus-cli` | Binary | CLI tool for index management, document CRUD, search, and REPL |
+| `laurus-cli` | Binary | CLI tool for index management, document CRUD, search, REPL, and `serve` / `mcp` launchers |
 | `laurus-server` | Library + Binary | gRPC server with optional HTTP/JSON gateway |
+| `laurus-mcp` | Binary | MCP server on stdio that proxies tool calls to a running laurus-server |
+| `laurus-python` | Dynamic library | Python package (PyPI) built with PyO3 / Maturin |
+| `laurus-nodejs` | Dynamic library | Node.js package (npm) built with NAPI-RS |
+| `laurus-wasm` | WebAssembly | npm package for browser and edge runtimes, built with wasm-bindgen |
+| `laurus-ruby` | Dynamic library | Ruby gem built with magnus and rb-sys |
+| `laurus-php` | PHP extension | PHP extension built with ext-php-rs (standalone — excluded from the workspace; see [Build & Test](build_and_test.md)) |
 
-Both `laurus-cli` and `laurus-server` depend on the `laurus` library crate.
+All binding crates and the three first-party binaries depend on `laurus`.
 
 ## Design Conventions
 

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -6,7 +6,7 @@ Add `laurus` and `tokio` (async runtime) to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-laurus = "0.1.0"
+laurus = "0.9"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -28,28 +28,28 @@ Laurus ships with a minimal default feature set. Enable additional features as n
 
 ```toml
 [dependencies]
-laurus = "0.1.0"
+laurus = "0.9"
 ```
 
 **Vector search with local model** (no API key required):
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-candle"] }
+laurus = { version = "0.9", features = ["embeddings-candle"] }
 ```
 
 **Vector search with OpenAI**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-openai"] }
+laurus = { version = "0.9", features = ["embeddings-openai"] }
 ```
 
 **Everything**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-all"] }
+laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
 ## Verify Installation

--- a/docs/src/laurus-cli/commands.md
+++ b/docs/src/laurus-cli/commands.md
@@ -454,3 +454,31 @@ For startup options, configuration, and usage examples, see the [laurus-server d
 - [Getting Started](../laurus-server/getting_started.md) — startup options and gRPC connection examples
 - [Configuration](../laurus-server/configuration.md) — TOML config file, environment variables, and priority rules
 - [Hands-on Tutorial](../laurus-server/tutorial.md) — step-by-step walkthrough
+
+---
+
+## `mcp`
+
+Start the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server on stdio. The MCP server lets AI assistants such as Claude Code or Claude Desktop drive a running laurus-server through a standard set of tools (`create_index`, `add_document`, `search`, etc.).
+
+```bash
+laurus mcp [--endpoint <URL>]
+```
+
+**Arguments:**
+
+| Flag | Environment Variable | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `--endpoint <URL>` | `LAURUS_ENDPOINT` | No | gRPC endpoint of a running laurus-server (e.g. `http://localhost:50051`). If omitted, the server starts without a connection; clients can call the `connect` MCP tool later to attach. |
+
+**Examples:**
+
+```bash
+# Start the MCP server pre-connected to a local laurus-server
+laurus mcp --endpoint http://localhost:50051
+
+# Start the MCP server without a connection; clients call `connect` first
+laurus mcp
+```
+
+For the full list of MCP tools exposed by this server and how to wire it into Claude Code or Claude Desktop, see the [laurus-mcp documentation](../laurus-mcp.md).

--- a/docs/src/laurus-mcp/tools.md
+++ b/docs/src/laurus-mcp/tools.md
@@ -147,9 +147,16 @@ None.
 ```json
 {
   "document_count": 42,
-  "vector_fields": ["embedding"]
+  "vector_fields": {
+    "embedding": {
+      "vector_count": 42,
+      "dimension": 384
+    }
+  }
 }
 ```
+
+`vector_fields` is a map keyed by field name; each entry reports the number of indexed vectors and the field's configured dimension.
 
 ---
 

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -34,10 +34,19 @@ class Index {
 | `searchVector(field, vector, limit?, offset?)` | Search with a pre-computed vector. |
 | `searchVectorText(field, text, limit?, offset?)` | Search with text (auto-embedded). |
 | `searchWithRequest(request)` | Search with a `SearchRequest`. |
-| `stats()` | Return index statistics. |
+| `stats()` | Return index statistics (`documentCount`, `vectorFields`). |
 
 All document methods and search methods are async
 and return Promises. `stats()` is synchronous.
+
+`stats()` returns an object shaped like:
+
+```typescript
+interface IndexStats {
+  documentCount: number;
+  vectorFields: Record<string, { count: number; dimension: number }>;
+}
+```
 
 ---
 

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -404,4 +404,5 @@ Python values are automatically converted to Laurus `DataValue` types:
 | `bytes` | `Bytes` | |
 | `list[float]` | `Vector` | Elements coerced to `f32` |
 | `(lat, lon)` tuple | `Geo` | Two `float` values |
+| `(x, y, z)` tuple | `Geo3d` | Three `float` values (ECEF Cartesian, metres) |
 | `datetime.datetime` | `DateTime` | Converted via `isoformat()` |

--- a/docs/src/laurus-server/configuration.md
+++ b/docs/src/laurus-server/configuration.md
@@ -39,7 +39,7 @@ port = 50051
 http_port = 8080  # Optional: enables HTTP Gateway
 
 [index]
-data_dir = "./laurus_index"
+data_dir = "./laurus_data"
 ```
 
 Log verbosity is controlled by the `RUST_LOG` environment variable (default: `info`), not through the config file.
@@ -58,7 +58,7 @@ Log verbosity is controlled by the `RUST_LOG` environment variable (default: `in
 
 | Field | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `data_dir` | String | `"./laurus_index"` | Path to the index data directory |
+| `data_dir` | String | `"./laurus_data"` | Path to the index data directory |
 
 ## Environment Variables
 

--- a/docs/src/laurus-server/grpc_api.md
+++ b/docs/src/laurus-server/grpc_api.md
@@ -157,12 +157,24 @@ Each `VectorFieldStats` contains `vector_count` and `dimension`.
 
 Add a new field to the running index at runtime.
 
+```protobuf
+rpc AddField(AddFieldRequest) returns (AddFieldResponse);
+```
+
+**Request fields:**
+
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `name` | `string` | The field name |
 | `field_option` | `FieldOption` | The field configuration |
 
-**Response:** Returns the updated `Schema`.
+**Response fields:**
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `schema` | `Schema` | The updated schema after the field has been added |
+
+**HTTP gateway:** `POST /v1/schema/fields`
 
 ### `DeleteField`
 
@@ -236,13 +248,15 @@ Each `Value` is a `oneof` with these types:
 | :--- | :--- | :--- |
 | Null | `null_value` | Null value |
 | Boolean | `bool_value` | Boolean value |
-| Integer | `int64_value` | 64-bit integer |
+| Integer | `int64_value` | 64-bit signed integer |
 | Float | `float64_value` | 64-bit floating point |
 | Text | `text_value` | UTF-8 string |
 | Bytes | `bytes_value` | Raw bytes |
 | Vector | `vector_value` | `VectorValue` (list of floats) |
 | DateTime | `datetime_value` | Unix microseconds (UTC) |
 | Geo | `geo_value` | `GeoPoint` (latitude, longitude) |
+| Int64Array | `int64_array_value` | `Int64ArrayValue` (multi-valued integers; requires `IntegerOption.multi_valued = true`) |
+| Float64Array | `float64_array_value` | `Float64ArrayValue` (multi-valued floats; requires `FloatOption.multi_valued = true`) |
 | Geo3d | `geo3d_value` | `Geo3dPoint` (x, y, z meters; ECEF Cartesian) |
 
 **Geo3dPoint:**

--- a/docs/src/laurus-server/http_gateway.md
+++ b/docs/src/laurus-server/http_gateway.md
@@ -32,10 +32,12 @@ If `http_port` is not set, only the gRPC server starts.
 | POST | `/v1/index` | `IndexService/CreateIndex` | Create a new index |
 | GET | `/v1/index` | `IndexService/GetIndex` | Get index statistics |
 | GET | `/v1/schema` | `IndexService/GetSchema` | Get the index schema |
-| PUT | `/v1/documents/:id` | `DocumentService/PutDocument` | Upsert a document |
-| POST | `/v1/documents/:id` | `DocumentService/AddDocument` | Add a document (chunk) |
-| GET | `/v1/documents/:id` | `DocumentService/GetDocuments` | Get documents by ID |
-| DELETE | `/v1/documents/:id` | `DocumentService/DeleteDocuments` | Delete documents by ID |
+| POST | `/v1/schema/fields` | `IndexService/AddField` | Dynamically add a field |
+| DELETE | `/v1/schema/fields/{name}` | `IndexService/DeleteField` | Remove a field from the schema |
+| PUT | `/v1/documents/{id}` | `DocumentService/PutDocument` | Upsert a document |
+| POST | `/v1/documents/{id}` | `DocumentService/AddDocument` | Add a document (chunk) |
+| GET | `/v1/documents/{id}` | `DocumentService/GetDocuments` | Get documents by ID |
+| DELETE | `/v1/documents/{id}` | `DocumentService/DeleteDocuments` | Delete documents by ID |
 | POST | `/v1/commit` | `DocumentService/Commit` | Commit pending changes |
 | POST | `/v1/search` | `SearchService/Search` | Search (unary) |
 | POST | `/v1/search/stream` | `SearchService/SearchStream` | Search (Server-Sent Events) |
@@ -82,6 +84,31 @@ curl http://localhost:8080/v1/index
 ```bash
 curl http://localhost:8080/v1/schema
 ```
+
+### Add a Field (Dynamic Schema)
+
+Adds a new field to the running index. The request body uses the same `FieldOption` JSON shape as `POST /v1/index`:
+
+```bash
+curl -X POST http://localhost:8080/v1/schema/fields \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "category",
+    "field_option": {"text": {"indexed": true, "stored": true}}
+  }'
+```
+
+The response returns the updated schema.
+
+### Delete a Field
+
+Removes a field from the schema. The field name is supplied in the path:
+
+```bash
+curl -X DELETE http://localhost:8080/v1/schema/fields/category
+```
+
+Existing indexed data for the field remains in storage but becomes inaccessible. Per-field analyzers and embedders are unregistered.
 
 ### Upsert a Document (PUT)
 
@@ -188,8 +215,8 @@ data: {"id":"doc2","score":0.4210,"document":{...}}
 
 ## JSON Field Value Inference
 
-When the gateway accepts a document body (`PUT /v1/documents/:id` or
-`POST /v1/documents/:id`), each value inside `document.fields` is converted
+When the gateway accepts a document body (`PUT /v1/documents/{id}` or
+`POST /v1/documents/{id}`), each value inside `document.fields` is converted
 to the engine's [`DataValue`](../concepts/schema_and_fields.md) type using
 the same inference rules as schema-less ingestion. This keeps the HTTP and
 gRPC paths in sync.

--- a/docs/src/laurus.md
+++ b/docs/src/laurus.md
@@ -47,15 +47,15 @@ The `laurus` crate has no default features enabled. Enable embedding support as 
 ```toml
 # Lexical search only (no embedding)
 [dependencies]
-laurus = "0.1.0"
+laurus = "0.9"
 
 # With local BERT embeddings
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-candle"] }
+laurus = { version = "0.9", features = ["embeddings-candle"] }
 
 # All features
 [dependencies]
-laurus = { version = "0.1.0", features = ["embeddings-all"] }
+laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
 ## Sections

--- a/docs/src/laurus/api_reference.md
+++ b/docs/src/laurus/api_reference.md
@@ -48,16 +48,20 @@ Defines document structure.
 | Method | Description |
 | :--- | :--- |
 | `.add_text_field(name, TextOption)` | Add a full-text field |
-| `.add_integer_field(name, IntegerOption)` | Add an integer field |
-| `.add_float_field(name, FloatOption)` | Add a float field |
+| `.add_integer_field(name, IntegerOption)` | Add an integer field (set `IntegerOption::multi_valued = true` for arrays) |
+| `.add_float_field(name, FloatOption)` | Add a float field (set `FloatOption::multi_valued = true` for arrays) |
 | `.add_boolean_field(name, BooleanOption)` | Add a boolean field |
 | `.add_datetime_field(name, DateTimeOption)` | Add a datetime field |
-| `.add_geo_field(name, GeoOption)` | Add a geographic field |
+| `.add_geo_field(name, GeoOption)` | Add a 2D geographic (lat/lon) field |
+| `.add_geo3d_field(name, Geo3dOption)` | Add a 3D ECEF Cartesian point field (x, y, z in metres) |
 | `.add_bytes_field(name, BytesOption)` | Add a binary field |
 | `.add_hnsw_field(name, HnswOption)` | Add an HNSW vector field |
 | `.add_flat_field(name, FlatOption)` | Add a Flat vector field |
 | `.add_ivf_field(name, IvfOption)` | Add an IVF vector field |
 | `.add_default_field(name)` | Set a default search field |
+| `.add_analyzer(name, AnalyzerDefinition)` | Register a custom analyzer pipeline |
+| `.add_embedder(name, EmbedderDefinition)` | Register an embedder definition |
+| `.dynamic_field_policy(DynamicFieldPolicy)` | Set the policy for undeclared fields (`Strict` / `Dynamic` / `Ignore`) |
 | `.build()` | Build the `Schema` |
 
 ## Document
@@ -75,13 +79,17 @@ A collection of named field values.
 
 | Method | Description |
 | :--- | :--- |
+| `.add_field(name, DataValue)` | Add an arbitrary `DataValue` |
 | `.add_text(name, value)` | Add a text field |
-| `.add_integer(name, value)` | Add an integer field |
-| `.add_float(name, value)` | Add a float field |
+| `.add_integer(name, value)` | Add a single integer field |
+| `.add_float(name, value)` | Add a single float field |
 | `.add_boolean(name, value)` | Add a boolean field |
 | `.add_datetime(name, value)` | Add a datetime field |
 | `.add_vector(name, vec)` | Add a pre-computed vector |
-| `.add_geo(name, lat, lon)` | Add a geographic point |
+| `.add_geo(name, lat, lon)` | Add a 2D geographic point |
+| `.add_geo_ecef(name, x, y, z)` | Add a 3D ECEF Cartesian point (metres) |
+| `.add_int64_array(name, values)` | Add a multi-valued integer field |
+| `.add_float64_array(name, values)` | Add a multi-valued float field |
 | `.add_bytes(name, data)` | Add binary data |
 | `.build()` | Build the `Document` |
 
@@ -147,7 +155,11 @@ A collection of named field values.
 | `FuzzyQuery::new(field, term)` | Fuzzy match (default max_edits=2) | `FuzzyQuery::new("body", "programing").max_edits(1)` |
 | `WildcardQuery::new(field, pattern)` | Wildcard | `WildcardQuery::new("file", "*.pdf")` |
 | `NumericRangeQuery::new(...)` | Numeric range | See [Lexical Search](../concepts/search.md) |
-| `GeoQuery::within_radius(...)` | Geo radius | See [Lexical Search](../concepts/search.md) |
+| `GeoDistanceQuery::within_radius(...)` | 2D geo radius | See [Lexical Search](../concepts/search.md) |
+| `GeoBoundingBoxQuery::within_bounding_box(...)` | 2D geo bounding box | See [Lexical Search](../concepts/search.md) |
+| `Geo3dDistanceQuery::within_sphere(...)` | 3D ECEF sphere | See [3D Geographic Search](../concepts/geo3d.md) |
+| `Geo3dBoundingBoxQuery::within_box(...)` | 3D ECEF axis-aligned box | See [3D Geographic Search](../concepts/geo3d.md) |
+| `Geo3dNearestQuery::k_nearest(...)` | 3D ECEF k-NN | See [3D Geographic Search](../concepts/geo3d.md) |
 | `SpanNearQuery::new(...)` | Proximity | See [Lexical Search](../concepts/search.md) |
 | `PrefixQuery::new(field, prefix)` | Prefix match | `PrefixQuery::new("body", "pro")` |
 | `RegexpQuery::new(field, pattern)?` | Regex match | `RegexpQuery::new("body", "^pro.*ing$")?` |
@@ -156,9 +168,9 @@ A collection of named field values.
 
 | Parser | Description |
 | :--- | :--- |
-| `QueryParser::new(analyzer)` | Parse lexical DSL queries |
+| `LexicalQueryParser::new(analyzer)` | Parse lexical DSL queries |
 | `VectorQueryParser::new(embedder)` | Parse vector DSL queries |
-| `UnifiedQueryParser::new(lexical, vector)` | Parse hybrid DSL queries |
+| `UnifiedQueryParser::new(lexical, vector)` | Parse hybrid DSL queries that mix lexical and vector clauses |
 
 ## Analyzers
 
@@ -200,6 +212,9 @@ A collection of named field values.
 | `DataValue::Float64(f64)` | `f64` |
 | `DataValue::Text(String)` | `String` |
 | `DataValue::Bytes(Vec<u8>, Option<String>)` | `(data, mime_type)` |
-| `DataValue::Vector(Vector)` | `Vector` |
+| `DataValue::Vector(Vec<f32>)` | Pre-computed vector |
 | `DataValue::DateTime(DateTime<Utc>)` | `chrono::DateTime<Utc>` |
-| `DataValue::Geo(f64, f64)` | `(latitude, longitude)` |
+| `DataValue::Geo(GeoPoint)` | `(latitude, longitude)` (WGS84) |
+| `DataValue::GeoEcef(GeoEcefPoint)` | `(x, y, z)` ECEF Cartesian (metres) |
+| `DataValue::Int64Array(Vec<i64>)` | Multi-valued integers (requires `multi_valued` field option) |
+| `DataValue::Float64Array(Vec<f64>)` | Multi-valued floats (requires `multi_valued` field option) |

--- a/laurus/README.md
+++ b/laurus/README.md
@@ -23,15 +23,15 @@ Core search engine library for the [Laurus](https://github.com/mosuka/laurus) pr
 ```toml
 # Lexical search only (no embedding)
 [dependencies]
-laurus = "0.2"
+laurus = "0.9"
 
 # With local BERT embeddings
 [dependencies]
-laurus = { version = "0.2", features = ["embeddings-candle"] }
+laurus = { version = "0.9", features = ["embeddings-candle"] }
 
 # All embedding backends
 [dependencies]
-laurus = { version = "0.2", features = ["embeddings-all"] }
+laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
 ## Feature Flags

--- a/laurus/README_ja.md
+++ b/laurus/README_ja.md
@@ -23,15 +23,15 @@
 ```toml
 # Lexical 検索のみ（エンベディングなし）
 [dependencies]
-laurus = "0.2"
+laurus = "0.9"
 
 # ローカル BERT エンベディング付き
 [dependencies]
-laurus = { version = "0.2", features = ["embeddings-candle"] }
+laurus = { version = "0.9", features = ["embeddings-candle"] }
 
 # 全エンベディングバックエンド
 [dependencies]
-laurus = { version = "0.2", features = ["embeddings-all"] }
+laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
 ## フィーチャーフラグ


### PR DESCRIPTION
## Summary

Re-align every README and every page under `docs/src/` (English) and `docs/ja/src/` (Japanese) with the current `0.9.0` workspace surface. This is the umbrella PR for the documentation pass requested in the project chat: bump version strings, fix concrete factual mistakes, and close gaps where APIs added since the docs were last touched were never described.

12 logical commits, kept small so each can be reviewed independently. Every doc change is mirrored EN ↔ JA in the same commit.

## What was wrong before

- Crate readers were pointed at `laurus = "0.1.0"` / `"0.2"` even though the workspace ships `0.9.0`.
- `laurus-server` config docs claimed `./laurus_index` for the default `data_dir`; the actual default in `laurus-server/src/config.rs` is `./laurus_data` (the CLI's `--index-dir` global option keeps its own `./laurus_index` default and is left untouched).
- `laurus mcp` is implemented in `laurus-cli/src/cli.rs` but never appeared in the CLI command reference.
- `README_ja.md` lagged the English README by several releases: no PHP binding, "8 crates" instead of 9, no Dynamic Schema or multi-valued numeric fields in the feature list, missing the `geo3d_search` example.
- gRPC reference omitted `Int64Array` / `Float64Array` from the `Value` oneof and did not give `AddField` the same shape as the surrounding RPCs (rpc block, request/response tables, HTTP gateway mapping).
- HTTP gateway docs used axum 0.7 `:id` placeholders even though `gateway.rs` is on axum 0.8 (`{id}` / `{name}`), and the EN page was missing `POST /v1/schema/fields` and `DELETE /v1/schema/fields/{name}` entirely.
- MCP `get_stats` was documented as returning a list of vector field names, but the underlying `IndexService.GetIndex` returns `map<string, VectorFieldStats>` with `vector_count` / `dimension`.
- Python field-value table did not document the `(x, y, z)` → `Geo3d` mapping that `convert.rs::py_to_data_value` has supported for a while.
- Node.js `stats()` had no shape documented — readers had to read the Rust source to know the field names.
- Core `laurus/api_reference.md` was missing many APIs already exposed from `lib.rs`: `add_geo3d_field`, multi-valued integer/float, `add_analyzer` / `add_embedder` / `dynamic_field_policy`, several DocumentBuilder methods, the `Geo3d*` query types, the `Int64Array` / `Float64Array` / `GeoEcef` DataValue variants. The Query Parsers section still listed `QueryParser` (renamed to `LexicalQueryParser`).
- `docs/{src,ja/src}/laurus-python/development.md` existed but was not linked from `SUMMARY.md`, so mdbook never surfaced it.
- `development/project_structure.md` claimed Laurus was a three-crate workspace and only diagrammed `laurus` / `laurus-cli` / `laurus-server` — the six crates added since (`laurus-mcp` and the five language bindings) were absent.

## Commits (12)

1. `docs: bump documented laurus version to 0.9 across all crates`
2. `docs(server): correct default data_dir to ./laurus_data`
3. `docs(cli): add mcp subcommand reference`
4. `docs: align README_ja with English README (PHP binding, 9 crates)`
5. `docs(grpc): align Value oneof and AddField with current proto`
6. `docs(http): align gateway endpoints with current router`
7. `docs(mcp): correct get_stats result to current shape`
8. `docs(python): document Geo3d tuple field value mapping`
9. `docs(nodejs): document stats() return shape`
10. `docs(laurus): document Geo3d, multi-valued, and dynamic schema APIs`
11. `docs(summary): wire orphan laurus-python/development.md into TOC`
12. `docs(dev): expand project structure to 9-crate workspace`

## What was already correct (and therefore not touched)

- The WASM, Ruby, and PHP binding API references were already in lock-step with their `src/*.rs` macro exposures.
- `concepts/*` pages, the `query_dsl` grammar, `concepts/geo3d`, and the MCP tools list (apart from `get_stats`) all matched the implementation.

## Verification

Run from the repo root:

- `mdbook build docs` — succeeds.
- `mdbook build docs/ja` — succeeds.
- `npx --yes markdownlint-cli2 "docs/src/**/*.md"` — `0 error(s)` across 77 files.
- `npx --yes markdownlint-cli2 "docs/ja/src/**/*.md"` — `0 error(s)` across 77 files.
- Residual keyword sweep returns empty:
  - `grep -rn --include="*.md" '0\.1\.0' README*.md docs/ laurus*/README*.md`
  - `grep -rn --include="*.md" 'laurus = "0\.[0-8]' .`
  - `grep -rn --include="*.md" '"\./laurus_index"' docs/src/laurus-server/configuration.md docs/ja/src/laurus-server/configuration.md`
  - `grep -rn --include="*.md" '8 つのクレート\|8 crates' .`
- SUMMARY orphan check (script in the verification log) returns no orphans.

## Test plan

- [x] EN mdBook builds cleanly
- [x] JA mdBook builds cleanly
- [x] EN markdownlint passes (0 errors)
- [x] JA markdownlint passes (0 errors)
- [x] No residual `0.1.0` / `"0.2"` / `8 crates` / server-side `laurus_index` / `:id` axum-0.7 placeholders
- [x] SUMMARY references every non-README markdown file under `docs/src` and `docs/ja/src`
- [ ] (Reviewer) Sanity-check a few mdBook pages render as expected after deploy preview