### PR TITLE
fix(lexical/searcher): restore BKD-backed queries in per-segment fanout

### DIFF
--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -2375,4 +2375,226 @@ mod tests {
             "soft-deleted doc must NOT be returned by geo3d_distance",
         );
     }
+
+    /// Regression test for #480 (`e7c206ad`): the per-segment fanout
+    /// path in [`InvertedIndexSearcher::search_with_collector_parallel`]
+    /// wraps each segment in a [`PerSegmentReaderView`] that did not
+    /// override `get_bkd_tree`, so the trait default (`Ok(None)`)
+    /// silently disabled every BKD-backed query (geo / geo3d / numeric
+    /// range) once an index accumulated two or more segments. Reported
+    /// in production via the `laurus-wasm/examples/geo3d` demo, where
+    /// the second auto-refresh commit added a second segment and every
+    /// subsequent `geo3d_nearest` returned 0 hits.
+    ///
+    /// Steps:
+    ///   1. Put one doc, commit — segment 0.
+    ///   2. Put another doc, commit — segment 1. Reader now has
+    ///      `segment_count() == 2`, the fanout condition triggers.
+    ///   3. Run `geo3d_distance(...)` over a sphere covering both
+    ///      points — must find 2 hits, NOT 0.
+    #[tokio::test]
+    async fn test_geo3d_distance_multi_segment_returns_hits() {
+        use crate::data::DataValue;
+        use crate::engine::schema::FieldOption;
+        use crate::lexical::core::field::Geo3dOption;
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field("position", FieldOption::Geo3d(Geo3dOption::default()))
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        // Two distinct ECEF points roughly 50 km apart near Tokyo.
+        let mut doc_a = crate::data::Document::new();
+        doc_a.fields.insert(
+            "position".into(),
+            DataValue::GeoEcef(crate::data::GeoEcefPoint::new(
+                -3955182.0, 3350553.0, 3700276.0,
+            )),
+        );
+        engine.put_document("A", doc_a).await.unwrap();
+        engine.commit().await.unwrap();
+
+        let mut doc_b = crate::data::Document::new();
+        doc_b.fields.insert(
+            "position".into(),
+            DataValue::GeoEcef(crate::data::GeoEcefPoint::new(
+                -3960000.0, 3350000.0, 3700000.0,
+            )),
+        );
+        engine.put_document("B", doc_b).await.unwrap();
+        engine.commit().await.unwrap();
+
+        // 100 km sphere covers both points. With the bug, fanout makes
+        // this return 0 because PerSegmentReaderView.get_bkd_tree falls
+        // through to the trait default `Ok(None)`.
+        let dsl = "position:geo3d_distance(-3957000.0, 3350000.0, 3700000.0, 100000.0)";
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from(dsl))
+            .limit(10)
+            .build();
+        let hits = engine.search(request).await.unwrap();
+        assert_eq!(
+            hits.len(),
+            2,
+            "geo3d_distance must find both docs across two segments; \
+             got {} (bug: per-segment fanout drops BKD-backed queries)",
+            hits.len()
+        );
+    }
+
+    /// Regression test for #480: same as
+    /// [`test_geo3d_distance_multi_segment_returns_hits`] but for
+    /// `geo3d_nearest`, which is the query path the demo exercises.
+    #[tokio::test]
+    async fn test_geo3d_nearest_multi_segment_returns_hits() {
+        use crate::data::DataValue;
+        use crate::engine::schema::FieldOption;
+        use crate::lexical::core::field::Geo3dOption;
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field("position", FieldOption::Geo3d(Geo3dOption::default()))
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        let mut doc_a = crate::data::Document::new();
+        doc_a.fields.insert(
+            "position".into(),
+            DataValue::GeoEcef(crate::data::GeoEcefPoint::new(
+                -3955182.0, 3350553.0, 3700276.0,
+            )),
+        );
+        engine.put_document("A", doc_a).await.unwrap();
+        engine.commit().await.unwrap();
+
+        let mut doc_b = crate::data::Document::new();
+        doc_b.fields.insert(
+            "position".into(),
+            DataValue::GeoEcef(crate::data::GeoEcefPoint::new(
+                -3960000.0, 3350000.0, 3700000.0,
+            )),
+        );
+        engine.put_document("B", doc_b).await.unwrap();
+        engine.commit().await.unwrap();
+
+        let dsl = "position:geo3d_nearest(-3957000.0, 3350000.0, 3700000.0, 5)";
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from(dsl))
+            .limit(10)
+            .build();
+        let hits = engine.search(request).await.unwrap();
+        assert_eq!(
+            hits.len(),
+            2,
+            "geo3d_nearest must find both docs across two segments; \
+             got {} (bug: per-segment fanout returns no BKD tree)",
+            hits.len()
+        );
+    }
+
+    /// Regression test for #480 on numeric range queries. Same
+    /// underlying cause — BKD-backed query through the fanout view.
+    #[tokio::test]
+    async fn test_numeric_range_multi_segment_returns_hits() {
+        use crate::data::DataValue;
+        use crate::engine::schema::FieldOption;
+        use crate::lexical::core::field::IntegerOption;
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field("score", FieldOption::Integer(IntegerOption::default()))
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        let mut doc_a = crate::data::Document::new();
+        doc_a.fields.insert("score".into(), DataValue::Int64(10));
+        engine.put_document("A", doc_a).await.unwrap();
+        engine.commit().await.unwrap();
+
+        let mut doc_b = crate::data::Document::new();
+        doc_b.fields.insert("score".into(), DataValue::Int64(20));
+        engine.put_document("B", doc_b).await.unwrap();
+        engine.commit().await.unwrap();
+
+        let dsl = "score:[5 TO 25]";
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from(dsl))
+            .limit(10)
+            .build();
+        let hits = engine.search(request).await.unwrap();
+        assert_eq!(
+            hits.len(),
+            2,
+            "numeric range query must find both docs across two \
+             segments; got {} (bug: per-segment fanout drops BKD tree)",
+            hits.len()
+        );
+    }
+
+    /// Combined regression test: per-segment fanout must restore BKD
+    /// query hits (#480 fix) AND continue to filter out soft-deleted
+    /// hits within each segment (#400 fix). Without per-segment
+    /// deletion filtering in `PerSegmentReaderView::get_bkd_tree`,
+    /// the #480 fix would re-introduce the #400 ghost-hit regression.
+    #[tokio::test]
+    async fn test_geo3d_distance_multi_segment_filters_deleted() {
+        use crate::data::DataValue;
+        use crate::engine::schema::FieldOption;
+        use crate::lexical::core::field::Geo3dOption;
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field("position", FieldOption::Geo3d(Geo3dOption::default()))
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        // Segment 0: two docs near Tokyo.
+        for id in &["A", "B"] {
+            let mut doc = crate::data::Document::new();
+            doc.fields.insert(
+                "position".into(),
+                DataValue::GeoEcef(crate::data::GeoEcefPoint::new(
+                    -3955182.0, 3350553.0, 3700276.0,
+                )),
+            );
+            engine.put_document(id, doc).await.unwrap();
+        }
+        engine.commit().await.unwrap();
+
+        // Soft-delete A in segment 0 and commit so segment 0 carries
+        // a deletion bitmap when the fanout view consults it.
+        engine.delete_documents("A").await.unwrap();
+        engine.commit().await.unwrap();
+
+        // Segment 1: one new doc.
+        let mut doc_c = crate::data::Document::new();
+        doc_c.fields.insert(
+            "position".into(),
+            DataValue::GeoEcef(crate::data::GeoEcefPoint::new(
+                -3960000.0, 3350000.0, 3700000.0,
+            )),
+        );
+        engine.put_document("C", doc_c).await.unwrap();
+        engine.commit().await.unwrap();
+
+        let dsl = "position:geo3d_distance(-3957000.0, 3350000.0, 3700000.0, 100000.0)";
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from(dsl))
+            .limit(10)
+            .build();
+        let hits = engine.search(request).await.unwrap();
+        assert_eq!(
+            hits.len(),
+            2,
+            "must return live docs B and C across two segments; \
+             got {} (regression: either #480 fanout BKD or #400 \
+             per-segment deletion filter)",
+            hits.len()
+        );
+    }
 }

--- a/laurus/src/lexical/index/inverted/per_segment_view.rs
+++ b/laurus/src/lexical/index/inverted/per_segment_view.rs
@@ -37,6 +37,7 @@ use std::sync::{Arc, RwLock};
 use crate::error::Result;
 use crate::lexical::core::document::Document;
 use crate::lexical::index::inverted::reader::SegmentReader;
+use crate::lexical::index::structures::bkd_tree::BKDTree;
 use crate::lexical::reader::{FieldStats, LexicalIndexReader, PostingIterator, ReaderTermInfo};
 
 /// Cross-segment term-info lookup function. Returns the **global**
@@ -180,6 +181,22 @@ impl LexicalIndexReader for PerSegmentReaderView {
         // would otherwise under-bound).
         let seg = self.segment.read().unwrap();
         seg.field_stats(field)
+    }
+
+    fn get_bkd_tree(&self, field: &str) -> Result<Option<Arc<dyn BKDTree>>> {
+        // Override the trait default (which returns `Ok(None)`) so that
+        // BKD-backed queries (geo / geo3d / numeric range) still find
+        // hits when the per-segment fanout (#480) routes the query
+        // through this view. Without this override the fanout path
+        // silently returns 0 hits for every BKD-backed query as soon
+        // as the index accumulates two or more segments.
+        //
+        // Wraps the segment's raw BKD tree in this segment's deletion
+        // filter so soft-deleted docs within the segment do not
+        // resurface (#400 invariant — must hold per-segment in the
+        // fanout path as well).
+        let seg = self.segment.read().unwrap();
+        seg.get_filtered_bkd_tree(field)
     }
 
     fn close(&mut self) -> Result<()> {

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -1122,6 +1122,55 @@ impl SegmentReader {
 
         Ok(None)
     }
+
+    /// Return this segment's BKD tree wrapped in a deletion filter that
+    /// drops hits whose doc-id is recorded in the segment's deletion
+    /// bitmap.
+    ///
+    /// Used by the per-segment fanout path
+    /// ([`super::per_segment_view::PerSegmentReaderView`]) where the
+    /// caller only sees one segment at a time, so the cross-segment
+    /// snapshot built by [`InvertedIndexReader::get_bkd_tree`] is not
+    /// applicable. Without per-segment filtering here, the fanout
+    /// path would either drop every BKD hit (when the wrapper falls
+    /// back to the trait default returning `None`) or resurrect
+    /// soft-deleted hits — re-introducing the #400 ghost-hit
+    /// regression on top of the #480 fanout-path failure.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - The field name whose per-segment BKD tree to return.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(None)` if this segment has no BKD entries for `field`,
+    /// `Ok(Some(...))` otherwise. The returned tree is wrapped in
+    /// [`DeletionFilteringBKDTree`] only when the segment carries
+    /// recorded deletions; otherwise the raw tree is returned with
+    /// zero overhead.
+    pub(crate) fn get_filtered_bkd_tree(&self, field: &str) -> Result<Option<Arc<dyn BKDTree>>> {
+        let Some(tree) = self.get_bkd_tree(field)? else {
+            return Ok(None);
+        };
+        if !self.info.has_deletions {
+            return Ok(Some(tree));
+        }
+        // Ensure the bitmap is loaded; the load is idempotent and
+        // tolerates the "metadata says deletions but file is missing"
+        // case by leaving the bitmap unset, in which case we forward
+        // the raw tree.
+        self.load_deletion_bitmap()?;
+        let Some(bitmap) = self.deletion_bitmap.read().unwrap().clone() else {
+            return Ok(Some(tree));
+        };
+        let snapshot = Arc::new(DeletionSnapshot {
+            bitmaps: vec![(self.info.min_doc_id, self.info.max_doc_id, bitmap)],
+        });
+        Ok(Some(Arc::new(DeletionFilteringBKDTree {
+            inner: tree,
+            snapshot,
+        })))
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

- Override `get_bkd_tree` on `PerSegmentReaderView` so per-segment fanout (#480) keeps BKD-backed queries (geo / geo3d / numeric range) functional once the index has 2+ segments.
- Add `SegmentReader::get_filtered_bkd_tree` that returns a deletion-filtered BKD tree for a single segment, preserving #400's "no ghost hits" invariant on the fanout path.
- Add 4 regression tests covering `geo3d_distance`, `geo3d_nearest`, numeric range, and multi-segment + soft-delete.

## Root cause

`InvertedIndexSearcher::search_with_collector_parallel` dispatches to `search_per_segment_fanout` when `collector.bmw_capable() && segment_count() >= 2`. The fanout wraps each segment in `PerSegmentReaderView`, but the view did not override `LexicalIndexReader::get_bkd_tree` — so the trait's default `Ok(None)` was returned to every BKD-backed query, which then short-circuits to 0 hits.

Surfaced in production via `laurus-wasm/examples/geo3d`: the second auto-refresh commit added a second segment, and every subsequent `position:geo3d_nearest(...)` returned `0 hit(s) in ~2 ms`.

## Test plan

- [x] `cargo test --lib --package laurus multi_segment` — 4 new regression tests pass
- [x] `cargo test --lib --package laurus` — 879 tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] Manual: open `laurus-wasm/examples/geo3d`, observe non-zero hits after the second auto-refresh

## Known limitation (follow-up)

`geo3d_nearest` distance-normalises scores against each segment's local farthest hit, so the fanout merge can rank hits slightly differently from the legacy single-pass path. The fanout path is structurally a poor fit for distance-ordered queries; out of scope for this PR (which targets the 0-hit regression).

Refs #480