### PR TITLE
perf(bench): on-disk index cache + size opt-in for lexical_search_bench (#510)

### DIFF
--- a/laurus/benches/BENCHMARKS.md
+++ b/laurus/benches/BENCHMARKS.md
@@ -1,0 +1,216 @@
+<!-- markdownlint-disable MD060 -->
+
+# Benchmark architecture
+
+This document captures the design rationale for the laurus benchmark
+suite, with the focus on *why* it looks the way it does. Individual
+bench files have file-level docstrings covering scope, vocabulary, and
+how to run them; this file covers the cross-cutting concerns.
+
+Japanese translation: [BENCHMARKS_ja.md](BENCHMARKS_ja.md).
+
+## Three-phase model
+
+Every search-side bench in this suite logically runs in three
+distinct phases:
+
+```
+┌──────────────────────────┐
+│ Phase 1 — corpus gen     │  Pure functions (`build_body*`)
+│                          │  Input: i (integer)  Output: String
+│ Cost: ~1 second / 100k   │  Deterministic, in-memory only.
+└──────────────────────────┘
+            ↓
+┌──────────────────────────┐
+│ Phase 2 — index build    │  engine.add_document × n + commit
+│                          │  Input: corpus       Output: index files
+│ Cost: ~17 min / 100k     │  ★ The expensive phase. Persisted to disk.
+└──────────────────────────┘
+            ↓
+┌──────────────────────────┐
+│ Phase 3 — search measure │  engine.search inside Criterion `b.iter`
+│                          │  Input: index + query  Output: results + latency
+│ Cost: ~10 sec / scenario │  The only phase whose latency we record.
+└──────────────────────────┘
+```
+
+For the **search-side benches** (`lexical_search_bench`) the goal is
+to measure Phase 3 in isolation. Phases 1 and 2 are setup, not
+measurement.
+
+For the **indexing-side benches** (`lexical_indexing_bench`) Phase 2
+*is* the measurement target. Phase 1 is setup; Phase 3 does not exist
+in that binary.
+
+Microbenches (`bm25_simd_bench`, etc.) sit beside the three-phase
+model: they exercise a single kernel directly with synthetic inputs,
+no engine, no corpus, no Criterion-async wrapping.
+
+## Why an on-disk index cache (#510)
+
+Before the cache, each search-side bench rebuilt its index from
+scratch every `cargo bench` invocation. Multiple bench functions
+needed the same corpus shape (uniform 100k, skewed 100k, …) and each
+function paid the build cost independently. A single full run hit
+this multiplier 4–6 times for the 100k uniform case alone, taking
+1–2 hours of pure rebuild before any latency was measured.
+
+`cached_engine` writes the built index to
+`target/laurus_bench_index_cache/<shape>_<n>_segs<k>_v<N>/` and
+reopens it on subsequent runs via laurus's standard
+`Engine::builder(file_storage, schema).build()` path (whose internal
+`recover()` reattaches existing segments). After the first run, every
+later `cargo bench` reaches Phase 3 in well under a second.
+
+Invalidation:
+
+- `BENCH_INDEX_FORMAT_VERSION` — bump in source when the schema /
+  analyzer / corpus synthesis / segment format changes. Stale caches
+  are auto-rebuilt.
+- `LAURUS_BENCH_REBUILD=1` — manual override, useful when iterating
+  on bench shape itself.
+- `cargo clean` — evicts the cache along with the rest of `target/`.
+
+The cache is **search-side only**. Indexing benches do not call
+`cached_engine`; they build a fresh in-memory engine every iteration
+because the build itself is what they measure.
+
+## Why synthetic data, not TREC / Wikipedia
+
+Lucene's benchmark framework supports external corpora (TREC,
+Wikipedia dumps, `LineDocSource` over arbitrary `.txt` files) and is
+the de-facto standard for "scale-out" search engine comparisons. The
+laurus suite intentionally does not adopt that approach. The
+trade-off:
+
+|                         | External corpus              | Synthetic (current)         |
+| ----------------------- | ---------------------------- | --------------------------- |
+| Corpus size             | GB-scale (Wikipedia ~22 GB)  | ~few MB (100 k × ~300 B/doc)|
+| Vocabulary              | Real (millions of unique terms) | Synthetic (~150 unique terms) |
+| Reproducibility         | Depends on snapshot date     | Deterministic from source   |
+| CI / fresh checkout cost | Multi-GB download, license review | Zero — in-process generation |
+| Real-world realism      | High                         | Medium (Zipf-shaped synthetic) |
+| Useful for **ratio** comparisons (PR before/after) | Yes | Yes |
+| Useful for **absolute** throughput claims | Yes | No (synthetic vocab limits headline numbers) |
+
+The laurus bench suite's actual workflow is **perf-PR ratio
+comparison**: "did my change make the 100k search 1.2x faster?" For
+that question, synthetic data is sufficient as long as:
+
+1. Term-frequency distribution is realistic enough to exercise the
+   relevant code paths (BMW pivot, skip list, top-K early termination,
+   etc.). The 3-tier Zipf-like distribution (`COMMON_TERMS`,
+   `TOPIC_PHRASES`, `LONG_TAIL`) achieves this — verified across #403
+   (BMW), #466 (enum dispatch), #503 (skip list), #506 (SIMD batch).
+2. Posting list lengths are long enough that the structures under
+   test light up. At 100 k docs the rare-term posting list is ~6 k
+   entries, which produces a `log_8(6_000) ≈ 4`-level skip-list
+   hierarchy — within the same order as a 1 M-doc test would produce
+   (`log_8(60_000) ≈ 5`).
+3. Cache effects (postings in L2 vs DRAM) emerge somewhere in the
+   sweep. 100k is enough to spill out of typical L3 (~32-64 MB) and
+   exercise the DRAM path; the 10k case stays in cache and gives a
+   clean control measurement.
+
+Items the synthetic approach cannot answer:
+
+- "How does laurus compare to Lucene at 10 M docs on enwiki?" — needs
+  external corpus support, not addressed here. Open an issue if a
+  real-corpus comparison becomes load-bearing.
+- "Does the analyzer matter on real-world long-tail vocabulary?" —
+  the synthetic vocab is small enough that analyzer cost is
+  proportionally smaller than it would be on real text.
+
+For the kind of perf work the suite is currently used for (#463
+umbrella), synthetic data wins on every dimension that actually
+matters: CI speed, determinism, no external dependencies, no license
+encumbrance.
+
+## Why we don't reuse Lucene's bench framework
+
+Lucene's `benchmark/` module ships a task DSL (`.alg` files), content
+sources, document makers, and a long list of measurable tasks
+(`AddDocTask`, `SearchTravRetTask`, …). It is impressive and
+appropriate for that project's scale (decades of contributors, hundreds
+of variation points).
+
+Laurus uses Criterion in plain Rust function form because:
+
+1. Criterion already handles warmup, sample collection, statistical
+   analysis, and the `--baseline` / `--save-baseline` workflow that
+   perf PRs need.
+2. The bench functions here are read top-to-bottom; there's no point
+   serialising them through a DSL when the code is already
+   declarative.
+3. Onboarding cost — a contributor who knows Rust can read a bench
+   file and immediately understand what it measures. The Lucene DSL
+   adds another layer to learn.
+
+If laurus ever needs Lucene-style "run a mixed indexing + searching
+workload that injects N docs per second while M concurrent searchers
+hit it" — that's a different kind of bench (a soak test) and would
+warrant a dedicated harness. Single-shot perf benches don't need it.
+
+## File-by-file scope (summary)
+
+| Bench file                    | Phase measured | Cache used | Notes |
+| ----------------------------- | -------------- | ---------- | ----- |
+| `lexical_search_bench`        | Phase 3        | Yes        | Term / Boolean / Phrase / Fuzzy / DSL search throughput |
+| `lexical_indexing_bench`      | Phase 2        | No         | `add_document` + `commit` cost |
+| `bm25_simd_bench`             | Microbench     | n/a        | SIMD BM25 kernel only (no engine) |
+| `posting_skip_to_bench`       | Microbench     | (own setup)| Skip-list seek microbench |
+| `posting_merge_bench`         | Microbench     | (own setup)| Segment-merge microbench |
+| `dict_lookup_bench`           | Phase 3 / micro | (own setup) | Dictionary lookup variants |
+| `hybrid_search_bench`         | Phase 3        | (own setup) | Lexical + vector hybrid |
+| `bkd_bench`                   | Microbench     | (own setup)| Geo / numeric range |
+| `distance_bench`              | Microbench     | n/a        | Distance kernels |
+| `facet_bench`                 | Phase 3        | (own setup)| Facet collection |
+| `highlight_bench`             | Phase 3        | (own setup)| Highlighter |
+| `mutation_bench`              | Phase 2-like   | n/a        | Update / delete throughput |
+| `search_perf`                 | Phase 3        | (own setup)| Legacy entrypoint |
+| `spell_correction_bench`      | Phase 3        | n/a        | Spelling suggestion |
+| `store_fetch_bench`           | Phase 2-like   | (own setup)| Document store fetch |
+| `synonym_bench`               | Phase 3        | n/a        | Synonym expansion |
+| `text_analysis_bench`         | Microbench     | n/a        | Analyzer pipeline |
+| `vector_indexing_bench`       | Phase 2-like   | n/a        | Vector index build |
+| `vector_search_bench`         | Phase 3        | (own setup)| Vector kNN |
+
+Items marked "(own setup)" use a smaller corpus shape or a different
+setup pattern that does not need a generalised cache. The cache
+pattern in `lexical_search_bench` can be lifted into
+`hybrid_search_bench` (close to identical) and `vector_search_bench`
+(more involved — multiple synthetic / real-data setups) via follow-up
+work. For now it lives where it delivers the most wall-time savings.
+
+## How to add a new search-side bench
+
+1. Pick a corpus shape: `EngineShape::Uniform` for plain text,
+   `EngineShape::Skewed` for the TF-skewed fixture.
+2. Decide which size-gate helper to use:
+   [`corpus_sizes`](lexical_search_bench.rs) for `(small … LARGE-adds-100k)`,
+   [`skewed_corpus_sizes`](lexical_search_bench.rs) for `(1k, 10k …
+   LARGE-adds-100k)`, or [`seek_skewed_sizes`](lexical_search_bench.rs) for
+   the skip-list shape.
+3. Call `cached_engine(&rt, shape, n, segment_count)` to obtain an
+   `Arc<Engine>`. The cache is keyed on `(shape, n, segment_count,
+   BENCH_INDEX_FORMAT_VERSION)`; first call builds, later calls reopen.
+4. Run a `probe` query before the `b.iter` loop to assert the
+   fixture / query pair returns at least one hit. This catches
+   corpus / query drift cheaply.
+5. Place `b.to_async(&rt).iter(|| { let engine = &engine; async move
+   { … } })` inside the closure. Capturing the `Arc<Engine>` by
+   reference is fine — auto-deref handles the method call.
+
+When changing anything that would alter the resulting index — schema,
+analyzer, corpus synthesis, segment format — bump
+`BENCH_INDEX_FORMAT_VERSION` in `lexical_search_bench.rs`. Stale
+caches will be auto-rebuilt on the next run.
+
+## Background
+
+- `#510` introduced the on-disk cache and size-gate cleanup.
+- `#403` defined the BMW acceptance-gate that anchored 100k as the
+  reference size.
+- `#503` introduced `bench_seek_skewed`; the 1 M-doc case from #503's
+  audit window was removed by #510 because the binary-search hierarchy
+  it tested adds only one level vs 100k.

--- a/laurus/benches/BENCHMARKS_ja.md
+++ b/laurus/benches/BENCHMARKS_ja.md
@@ -1,0 +1,149 @@
+<!-- markdownlint-disable MD060 -->
+
+# ベンチマークアーキテクチャ
+
+このドキュメントは laurus ベンチマークスイートの設計判断（**なぜそうなっているか**）を整理したものです。各 bench ファイルの先頭 docstring が「何を測るか・どう実行するか」を扱う一方、このファイルは横断的な設計の考え方を扱います。
+
+英語版: [BENCHMARKS.md](BENCHMARKS.md)
+
+## 3 フェーズモデル
+
+この suite の検索系 bench は論理的に 3 つのフェーズに分かれます:
+
+```
+┌──────────────────────────┐
+│ Phase 1: コーパス生成     │  純関数 (`build_body*`)
+│                          │  入力: i (整数), 出力: String
+│ コスト: ~1 秒 / 100k     │  決定論的・メモリ上のみ
+└──────────────────────────┘
+            ↓
+┌──────────────────────────┐
+│ Phase 2: インデックス構築 │  engine.add_document × n + commit
+│                          │  入力: コーパス, 出力: 索引ファイル群
+│ コスト: ~17 分 / 100k    │  ★ 重いフェーズ。ディスクに永続化
+└──────────────────────────┘
+            ↓
+┌──────────────────────────┐
+│ Phase 3: 検索計測         │  Criterion `b.iter` で engine.search を計測
+│                          │  入力: 索引 + クエリ, 出力: 結果 + latency
+│ コスト: ~10 秒 / シナリオ │  bench で実際に測りたいのはここだけ
+└──────────────────────────┘
+```
+
+**検索系 bench**（`lexical_search_bench`）の目的は Phase 3 を孤立して計測すること。Phase 1 と 2 は setup であり、計測対象ではない。
+
+**インデックス系 bench**（`lexical_indexing_bench`）では Phase 2 自体が計測対象。Phase 1 は setup、Phase 3 はそもそも存在しない。
+
+**マイクロベンチ**（`bm25_simd_bench` 等）は 3 フェーズモデルとは別の存在で、合成入力で kernel を直接叩く。Engine も corpus も Criterion-async wrapping も使わない。
+
+## なぜディスク索引キャッシュか (#510)
+
+キャッシュ導入前は、検索系 bench が毎回 `cargo bench` で索引をゼロから再構築していました。複数の bench function が同じ形のコーパス（uniform 100k, skewed 100k 等）を必要とし、それぞれが独立にビルドコストを支払う構造。1 度のフル run で 100k uniform ケースだけでも 4-6 回ビルドが走り、latency 計測の前に純粋なリビルドだけで 1-2 時間を消費していました。
+
+`cached_engine` はビルド済み索引を以下に書き出します:
+
+```
+target/laurus_bench_index_cache/<shape>_<n>_segs<k>_v<N>/
+```
+
+laurus の標準的な `Engine::builder(file_storage, schema).build()` パス経由で再オープン（その内部の `recover()` が既存セグメントを再アタッチ）します。初回 run の後、後続の `cargo bench` は **1 秒未満**で Phase 3 に到達します。
+
+### 無効化（invalidation）
+
+| 方法                                              | 用途                                                                       |
+| ------------------------------------------------- | -------------------------------------------------------------------------- |
+| `BENCH_INDEX_FORMAT_VERSION` を bump（ソース内定数） | schema / analyzer / corpus 合成 / segment format 変更時。stale な cache は自動再構築 |
+| `LAURUS_BENCH_REBUILD=1`                           | 手動オーバーライド。bench 自体を弄っているとき便利                            |
+| `cargo clean`                                      | `target/` 全体を消す。cache も道連れに消える                                  |
+
+### 検索系のみが対象
+
+キャッシュは**検索系 bench のみ**。インデックス系 bench は `cached_engine` を呼ばず、毎イテレーションで新規メモリ engine を構築します。**ビルドそのものが計測対象**だからです。
+
+## なぜ合成データか — TREC / Wikipedia を使わない理由
+
+Lucene の benchmark フレームワークは外部コーパス（TREC, Wikipedia ダンプ, 任意の `.txt` を読む `LineDocSource`）に対応しており、検索エンジン比較の事実上のデファクトです。laurus suite はこれを意図的に採用していません。
+
+### トレードオフ表
+
+|                         | 外部コーパス               | 合成（現状）              |
+| ----------------------- | ------------------------- | ------------------------ |
+| コーパスサイズ          | GB スケール（Wikipedia ~22 GB） | ~数 MB（100k × ~300 B/doc） |
+| 語彙                    | 実データ（数百万のユニーク語）  | 合成（~150 ユニーク語）    |
+| 再現性                  | スナップショット日付に依存 | ソースから決定論的           |
+| CI / fresh checkout コスト | 数 GB DL、ライセンス審査 | ゼロ — プロセス内生成        |
+| 実世界との近さ          | 高                         | 中（Zipf 風の合成）         |
+| **比率**比較（PR の before/after）に有用か | 有用 | 有用 |
+| **絶対値**スループット主張に有用か | 有用 | 有用ではない（語彙が限定的） |
+
+### なぜ合成で十分か
+
+laurus bench suite の実際のワークフローは **perf-PR の比率比較**です。「私の変更で 100k 検索が 1.2x 速くなったか？」という質問。この目的には合成データで十分。条件:
+
+1. **Term frequency 分布が実世界寄り**: 関連するコードパス（BMW pivot, skip list, top-K 早期終了等）を発火させるのに足る現実度。3 層 Zipf 風分布（`COMMON_TERMS`, `TOPIC_PHRASES`, `LONG_TAIL`）でこれを満たしている。#403 (BMW), #466 (enum dispatch), #503 (skip list), #506 (SIMD batch) で検証済み。
+2. **Posting list が長い**: テスト対象のデータ構造が「光る」だけの長さ。100k docs なら rare-term posting は ~6k entries → `log_8(6000) ≈ 4` 段の skip-list 階層が形成される。1M docs ならその +1 段（`log_8(60_000) ≈ 5`）。同オーダー。
+3. **キャッシュ効果**: 100k で典型的な L3 (~32-64 MB) を溢れ DRAM パスを叩く。10k はキャッシュ内に収まりクリーンなコントロール計測になる。
+
+### 合成データでは答えられないこと
+
+- 「laurus は 10M docs の enwiki で Lucene とどう比較されるか？」 → 外部コーパス対応が必要。本ドキュメントの範囲外。本当に必要になれば別 issue を切る。
+- 「analyzer が実世界の long-tail 語彙で本当に効くか？」 → 合成語彙が小さいため analyzer の相対コストが現実より小さく見える。
+
+`#463` umbrella で進めている perf work では、合成データは「CI 速度・決定論性・外部依存なし・ライセンス簡素」のあらゆる観点で勝っている。
+
+## なぜ Lucene の bench フレームワークを採用しないか
+
+Lucene の `benchmark/` モジュールは Task DSL（`.alg` ファイル）・Content Source・DocMaker・大量の計測タスク（`AddDocTask`, `SearchTravRetTask` 等）を持ちます。プロジェクトの規模（数十年の貢献者、数百のバリエーション）には適切です。
+
+laurus は Criterion を素の Rust 関数形式で使います。理由:
+
+1. **Criterion で十分**: warmup / sample collection / 統計分析 / `--baseline` / `--save-baseline` のワークフローは Criterion が既に提供。perf PR で必要なものは揃っている。
+2. **コードを読めば分かる**: bench function は上から下に読めば分かる。DSL を経由する利点が薄い。
+3. **オンボーディングコスト**: Rust が分かる contributor が bench を読めば即座に内容を理解できる。Lucene DSL は学習層を 1 つ増やす。
+
+将来 laurus が Lucene 風の「N docs/sec を入れながら同時 M searcher を回す」mixed workload を必要としたら、それは別種の bench（soak test）であり専用 harness を作るべき。単発の perf bench にこの仕組みは不要。
+
+## ファイルごとのスコープ（早見表）
+
+| Bench ファイル                | 計測するフェーズ | キャッシュ使用 | 備考 |
+| ---------------------------- | -------------- | ------------- | ---- |
+| `lexical_search_bench`        | Phase 3        | 使う           | Term / Boolean / Phrase / Fuzzy / DSL 検索スループット |
+| `lexical_indexing_bench`      | Phase 2        | 使わない        | `add_document` + `commit` コスト |
+| `bm25_simd_bench`             | Microbench     | n/a           | SIMD BM25 kernel のみ（engine なし）|
+| `posting_skip_to_bench`       | Microbench     | 独自 setup     | Skip-list seek microbench |
+| `posting_merge_bench`         | Microbench     | 独自 setup     | Segment-merge microbench |
+| `dict_lookup_bench`           | Phase 3 / micro | 独自 setup     | 辞書 lookup バリエーション |
+| `hybrid_search_bench`         | Phase 3        | 独自 setup     | Lexical + vector hybrid |
+| `bkd_bench`                   | Microbench     | 独自 setup     | Geo / numeric range |
+| `distance_bench`              | Microbench     | n/a           | 距離 kernel |
+| `facet_bench`                 | Phase 3        | 独自 setup     | Facet collection |
+| `highlight_bench`             | Phase 3        | 独自 setup     | Highlighter |
+| `mutation_bench`              | Phase 2 相当   | n/a           | Update / delete スループット |
+| `search_perf`                 | Phase 3        | 独自 setup     | 旧エントリポイント |
+| `spell_correction_bench`     | Phase 3        | n/a           | スペル補正 |
+| `store_fetch_bench`           | Phase 2 相当   | 独自 setup     | Document store fetch |
+| `synonym_bench`               | Phase 3        | n/a           | Synonym 展開 |
+| `text_analysis_bench`         | Microbench     | n/a           | Analyzer パイプライン |
+| `vector_indexing_bench`       | Phase 2 相当   | n/a           | Vector index build |
+| `vector_search_bench`         | Phase 3        | 独自 setup     | Vector kNN |
+
+「独自 setup」は小さなコーパス形か、汎用キャッシュを必要としない別の setup パターンを使うもの。`lexical_search_bench` のキャッシュパターンは `hybrid_search_bench`（ほぼ同形）と `vector_search_bench`（合成・実データ両方の setup があり複雑度高め）に follow-up で横展開できる。今は最も時間節約効果が大きい所に住まわせている。
+
+## 新規 search-side bench の追加手順
+
+1. コーパス形を選ぶ: `EngineShape::Uniform`（プレーンテキスト）または `EngineShape::Skewed`（TF skew fixture）
+2. サイズゲートヘルパーを選ぶ:
+   - [`corpus_sizes`](lexical_search_bench.rs): `(small … LARGE で 100k 追加)`
+   - [`skewed_corpus_sizes`](lexical_search_bench.rs): `(1k, 10k … LARGE で 100k 追加)`
+   - [`seek_skewed_sizes`](lexical_search_bench.rs): skip-list 形状
+3. `cached_engine(&rt, shape, n, segment_count)` で `Arc<Engine>` を取得。キャッシュキーは `(shape, n, segment_count, BENCH_INDEX_FORMAT_VERSION)`。初回はビルド、以降は再オープン
+4. `b.iter` の前に `probe` クエリを 1 回投げて「fixture とクエリがズレていないこと」を assert。コーパス／クエリ drift を早期に検出
+5. `b.to_async(&rt).iter(|| { let engine = &engine; async move { … } })` のパターンを使う。`Arc<Engine>` を参照キャプチャすれば auto-deref でメソッド呼び出しが通る
+
+索引内容を変える変更（schema・analyzer・corpus 合成・segment format）を入れたら `BENCH_INDEX_FORMAT_VERSION` を bump。stale な cache は次回 run で自動再構築される。
+
+## 背景
+
+- `#510` がディスクキャッシュとサイズゲート整理を導入
+- `#403` が BMW acceptance gate を定義し、参照サイズとして 100k を確立
+- `#503` が `bench_seek_skewed` を導入。1M docs ケースは #510 で削除（100k からの追加 1 階層は情報量が少ないと判断）

--- a/laurus/benches/lexical_search_bench.rs
+++ b/laurus/benches/lexical_search_bench.rs
@@ -1,29 +1,49 @@
 //! End-to-end lexical search benchmarks.
 //!
-//! Measures full query execution time including matching, scoring, and
-//! collection for various query types: `TermQuery`, `BooleanQuery`,
-//! `PhraseQuery`, `FuzzyQuery`, and the DSL parser.
+//! Measures full query execution time (matching + scoring + collection)
+//! for `TermQuery`, `BooleanQuery`, `PhraseQuery`, `FuzzyQuery`, and the
+//! DSL parser. See [`laurus/benches/BENCHMARKS.md`](../BENCHMARKS.md) for
+//! the broader architecture rationale (three-phase model, on-disk index
+//! cache, why synthetic data instead of TREC/Wikipedia).
 //!
-//! # Scope
+//! # Three-phase model (#510)
 //!
-//! - End-to-end through `Engine::search`, including async runtime overhead.
-//! - Corpus sizes 100, 1 000, 5 000 documents by default; opt in to a
-//!   100 000-document case via `LAURUS_BENCH_LARGE=1` (see "Large-corpus
-//!   gate" below).
-//! - Vocabulary follows a 3-tier Zipf-like distribution (see
-//!   "Vocabulary").
-//! - One-time correctness assert per bench function verifies the probe
-//!   query returns at least one hit before the timed loop runs.
+//! Each bench logically runs in three phases:
 //!
-//! # Vocabulary
+//! 1. **Corpus generation** — synthetic, pure-functional ([`build_body`] /
+//!    [`build_body_skewed`]). Cost ~1 sec for 100 k docs.
+//! 2. **Index construction** — `engine.add_document` + `commit`. Cost
+//!    ~17 minutes for 100 k uniform. **This is what the on-disk cache
+//!    eliminates on second-and-later runs.**
+//! 3. **Search measurement** — Criterion `b.iter` measuring
+//!    `engine.search`. The only phase whose latency this binary cares
+//!    about.
 //!
-//! Document bodies are built from three tiers so term-frequency
-//! distribution approximates Zipf's law (a few very common terms, several
-//! medium-frequency topic phrases, and many rare long-tail words):
+//! For the indexing-side bench (`lexical_indexing_bench`), Phase 2 *is*
+//! the measurement target and the cache is **not** used.
+//!
+//! # On-disk index cache
+//!
+//! [`cached_engine`] persists Phase 2's output under
+//! `target/laurus_bench_index_cache/<shape>_<n>_segs<k>_v<N>/`. On a
+//! fresh checkout the first run pays the build cost once; every later
+//! `cargo bench` invocation reopens the cached index in <1 second. The
+//! cache is invalidated by:
+//!
+//! - Bumping [`BENCH_INDEX_FORMAT_VERSION`] when schema, analyzer, or
+//!   laurus's segment format change.
+//! - `LAURUS_BENCH_REBUILD=1` to force a wipe-and-rebuild.
+//! - `cargo clean` to drop the whole `target/` tree.
+//!
+//! # Corpus shape
+//!
+//! Document bodies follow a 3-tier Zipf-like distribution (a few very
+//! common terms, several medium-frequency topic phrases, many rare
+//! long-tail words):
 //!
 //! - [`COMMON_TERMS`] (5 words: `search`, `system`, `data`, `engine`,
 //!   `query`): present in **every** document. High document-frequency,
-//!   low IDF — these are the WAND-friendly terms that #403 (top-K
+//!   low IDF — the WAND-friendly terms that #403 (top-K
 //!   early-termination) targets.
 //! - [`TOPIC_PHRASES`] (8 phrases × 8 words): each phrase appears in
 //!   `1/8` of documents (≈ 12.5 %).
@@ -32,31 +52,50 @@
 //!   documents.
 //!
 //! `bench_phrase_query` queries the phrase `"search engine"`; both words
-//! come from `COMMON_TERMS`, so the phrase is guaranteed to occur in every
-//! document.
+//! come from `COMMON_TERMS`, so the phrase is guaranteed to occur in
+//! every document.
 //!
-//! # Large-corpus gate
+//! Why synthetic instead of TREC / Wikipedia: see
+//! [`BENCHMARKS.md`](../BENCHMARKS.md) for the trade-off analysis. The
+//! short version is that perf-PR comparisons (the bench's actual
+//! workflow) only need ratio measurements, and synthetic data is
+//! reproducible, deterministic, CI-friendly, and ships zero external
+//! dependencies.
 //!
-//! Setting the environment variable `LAURUS_BENCH_LARGE=1` adds a
-//! 100 000-document case to `bench_term_query`,
-//! `bench_term_query_varying_limit`, and `bench_boolean_query`. The
-//! 100 000-document setup is several seconds, and per-iter search at
-//! 100 k is in the ms range, so this large case uses the slow
-//! `sample_size` (`SAMPLE_SIZE_SLOW`) automatically. Default runs (no env
-//! var) finish in well under five minutes on a typical workstation.
+//! # Size gates
+//!
+//! - [`corpus_sizes`] — uniform sweep used by `term_query`,
+//!   `term_query_varying_limit`, `boolean_query`. Default
+//!   `{100, 1k, 5k}`; `LAURUS_BENCH_LARGE=1` adds `100k`.
+//! - [`skewed_corpus_sizes`] — used by `topk_or_skewed_tf`,
+//!   `topk_or_multi_segment`. Default `{1k, 10k}`;
+//!   `LAURUS_BENCH_LARGE=1` adds `100k`.
+//! - [`seek_skewed_sizes`] — used by `seek_skewed`. Default `{10k}`;
+//!   `LAURUS_BENCH_LARGE=1` adds `100k`.
+//!
+//! The default sweep finishes in single-digit minutes; the
+//! `LAURUS_BENCH_LARGE` sweep is the acceptance-gate target and takes
+//! tens of minutes on the **first** run only — subsequent runs reopen
+//! the cache.
 //!
 //! # Run
 //!
 //! ```sh
-//! cargo bench --bench lexical_search_bench                            # default sizes
-//! LAURUS_BENCH_LARGE=1 cargo bench --bench lexical_search_bench       # adds 100 k
+//! # Daily iteration (fast — uses cache after first run):
+//! cargo bench --bench lexical_search_bench
+//!
+//! # Acceptance gate (adds 100k cases):
+//! LAURUS_BENCH_LARGE=1 cargo bench --bench lexical_search_bench
+//!
+//! # Force a fresh cache build (e.g. after pulling a major change):
+//! LAURUS_BENCH_REBUILD=1 cargo bench --bench lexical_search_bench
 //! ```
 //!
-//! Filter by group / case (substring match against the criterion id):
+//! Filter by group / case (regex match against the criterion id):
 //!
 //! ```sh
 //! cargo bench --bench lexical_search_bench -- term_query
-//! cargo bench --bench lexical_search_bench -- boolean_query/should_or_high_freq
+//! cargo bench --bench lexical_search_bench -- 'boolean_query/should_or_high_freq'
 //! ```
 //!
 //! Compile-only smoke check:
@@ -65,24 +104,28 @@
 //! cargo bench --bench lexical_search_bench --no-run
 //! ```
 //!
-//! See `benches/common.rs` for the suite-wide hygiene rules.
+//! See `benches/common.rs` for the suite-wide hygiene rules and
+//! `benches/BENCHMARKS.md` for the bench architecture rationale.
 
 mod common;
 
 use std::hint::black_box;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use criterion::measurement::WallTime;
 use criterion::{BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
-use common::{SAMPLE_SIZE_FAST, SAMPLE_SIZE_SLOW, select_storage};
+use common::{SAMPLE_SIZE_FAST, SAMPLE_SIZE_SLOW};
 
 use laurus::analysis::analyzer::analyzer::Analyzer;
 use laurus::analysis::analyzer::standard::StandardAnalyzer;
 use laurus::lexical::core::field::IntegerOption;
 use laurus::lexical::{BooleanQuery, FuzzyQuery, PhraseQuery, TermQuery, TextOption};
 use laurus::storage::Storage;
+use laurus::storage::file::FileStorageConfig;
+use laurus::storage::{StorageConfig, StorageFactory};
 use laurus::{Document, Engine, LexicalSearchQuery, Result, Schema, SearchRequestBuilder};
 
 /// Words present in **every** document. Drives the high-document-frequency
@@ -264,54 +307,19 @@ fn build_body_skewed(i: usize) -> String {
     }
 }
 
-/// Bench-storage handle. Delegates to `common::select_storage()` so
-/// `LAURUS_BENCH_DISK=1` swaps the in-memory backend for a temp-dir
-/// `FileStorage` without changing call sites. The function still returns
-/// `Result` for compatibility with the existing async `build_engine`.
-fn memory_storage() -> Result<Arc<dyn Storage>> {
-    Ok(select_storage())
-}
-
-/// Build a pre-populated engine with `n` documents using the 3-tier
-/// vocabulary described above.
-async fn build_engine(n: usize) -> Result<Engine> {
-    build_engine_with(n, build_body).await
-}
-
-/// Build a pre-populated engine with `n` skewed-TF documents (#403
-/// PR-C fixture). Same schema as [`build_engine`]; the difference is
-/// purely in the body content (see [`build_body_skewed`]).
-async fn build_engine_skewed(n: usize) -> Result<Engine> {
-    build_engine_with(n, build_body_skewed).await
-}
-
-/// Shared engine-construction helper. Takes a body builder so the
-/// uniform and skewed-TF fixtures share the same schema, analyzer,
-/// and document-shape boilerplate.
-async fn build_engine_with(n: usize, body_fn: fn(usize) -> String) -> Result<Engine> {
-    build_engine_with_segments(n, body_fn, 1).await
-}
-
-/// Build an engine with `n` documents distributed across
-/// `segment_count` segments by issuing one `commit()` per chunk.
-/// `segment_count = 1` matches the historical single-segment fixture
-/// (one final commit). Higher values let benches expose the
-/// multi-segment cross-segment view path (#476) where the inverted
-/// reader currently falls back to the term-level `max_score_factor`
-/// for `block_max_score_at`.
-///
-/// The auto-merge interval is 60s and each commit happens back-to-back
-/// during construction, so for the duration of a single bench setup
-/// the segments persist as written. Callers that need stronger
-/// guarantees against background merging must inspect the lexical
-/// stats after construction.
-async fn build_engine_with_segments(
+/// Core engine construction body. Same boilerplate as the legacy
+/// `build_engine_with_segments`, parameterised on `storage` so the
+/// on-disk cache helper ([`cached_engine`]) can pass a
+/// [`FileStorageConfig`]-backed storage that points at a deterministic
+/// directory under `target/`. The new architecture treats this function
+/// as the canonical Phase 2 (index construction) primitive.
+async fn build_engine_into_storage(
+    storage: Arc<dyn Storage>,
     n: usize,
     body_fn: fn(usize) -> String,
     segment_count: usize,
 ) -> Result<Engine> {
     assert!(segment_count >= 1, "segment_count must be ≥ 1");
-    let storage = memory_storage()?;
     let analyzer: Arc<dyn Analyzer> = Arc::new(StandardAnalyzer::default());
 
     let schema = Schema::builder()
@@ -353,12 +361,190 @@ async fn build_engine_with_segments(
     Ok(engine)
 }
 
+/// Body-content shape tag used as the cache key for [`cached_engine`].
+/// `Uniform` documents come from [`build_body`] and feed the standard
+/// TermQuery / BooleanQuery sweeps; `Skewed` documents come from
+/// [`build_body_skewed`] and feed the BMW / skip-list / multi-segment
+/// scenarios.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum EngineShape {
+    Uniform,
+    Skewed,
+}
+
+impl EngineShape {
+    fn body_fn(self) -> fn(usize) -> String {
+        match self {
+            EngineShape::Uniform => build_body,
+            EngineShape::Skewed => build_body_skewed,
+        }
+    }
+}
+
+/// Bump this when anything that would alter the resulting index on
+/// disk changes — schema layout, `StandardAnalyzer` defaults, the
+/// `build_body` / `build_body_skewed` synthesis, or laurus's segment
+/// format. Caches written under a stale version are rebuilt
+/// automatically (the helper compares against `.bench_version`).
+const BENCH_INDEX_FORMAT_VERSION: &str = "1";
+
+/// Process-and-cargo-wide cache directory for pre-built indexes.
+/// `target/laurus_bench_index_cache/<shape>_<n>_segs<k>_v<N>/` holds a
+/// `FileStorage` tree plus a `.bench_version` file. Sits under
+/// `target/` so `cargo clean` evicts the cache; `LAURUS_BENCH_REBUILD=1`
+/// forces a wipe-and-rebuild without touching the rest of `target/`.
+///
+/// Workspace root is derived at compile time via `env!`; we use the
+/// `laurus` crate's manifest dir and step up one level. `CARGO_TARGET_DIR`
+/// (if set) overrides at runtime so custom target locations work too.
+fn cache_root() -> PathBuf {
+    if let Ok(custom) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(custom).join("laurus_bench_index_cache");
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    Path::new(manifest_dir)
+        .parent()
+        .map(|p| p.join("target"))
+        .unwrap_or_else(|| PathBuf::from("target"))
+        .join("laurus_bench_index_cache")
+}
+
+/// Path of the persisted index for `(shape, n, segment_count)`.
+fn cache_dir_for(shape: EngineShape, n: usize, segment_count: usize) -> PathBuf {
+    cache_root().join(format!(
+        "{}_{n}_segs{segment_count}_v{BENCH_INDEX_FORMAT_VERSION}",
+        match shape {
+            EngineShape::Uniform => "uniform",
+            EngineShape::Skewed => "skewed",
+        }
+    ))
+}
+
+/// Verify a cache entry: directory exists and `.bench_version` matches.
+fn cache_is_valid(dir: &Path) -> bool {
+    let marker = dir.join(".bench_version");
+    if !marker.exists() {
+        return false;
+    }
+    matches!(
+        std::fs::read_to_string(&marker).map(|s| s.trim().to_string()),
+        Ok(v) if v == BENCH_INDEX_FORMAT_VERSION
+    )
+}
+
+/// Open an existing on-disk index. The engine's [`Engine::build`]
+/// internally runs `recover()` which replays the WAL + reattaches
+/// segments persisted by an earlier bench run, so the returned engine
+/// is immediately query-ready.
+async fn open_persistent_engine(dir: &Path) -> Result<Engine> {
+    let config = FileStorageConfig::new(dir);
+    let storage = StorageFactory::create(StorageConfig::File(config))?;
+    let analyzer: Arc<dyn Analyzer> = Arc::new(StandardAnalyzer::default());
+    let schema = Schema::builder()
+        .add_text_field("title", TextOption::default())
+        .add_text_field("body", TextOption::default())
+        .add_text_field("category", TextOption::default())
+        .add_integer_field("year", IntegerOption::default())
+        .add_default_field("body")
+        .build();
+    Engine::builder(storage, schema)
+        .analyzer(analyzer)
+        .build()
+        .await
+}
+
+/// Return an engine for `(shape, n, segment_count)`, building it on
+/// disk the first time and re-opening it on subsequent runs (#510).
+///
+/// On a fresh checkout this pays the legacy build cost once
+/// (~minutes for 100 k uniform, ~tens of seconds for 10 k). Every
+/// later `cargo bench` invocation opens the cached index in well under
+/// a second, so iterative perf work — the workflow this helper exists
+/// for — moves from "tens of minutes per cycle" to "Criterion warmup +
+/// measurement only".
+///
+/// Cache invalidation is driven by [`BENCH_INDEX_FORMAT_VERSION`]; bump
+/// it whenever any of the inputs that would alter the resulting index
+/// change. `LAURUS_BENCH_REBUILD=1` forces a wipe-and-rebuild without
+/// touching the rest of `target/`.
+fn cached_engine(rt: &Runtime, shape: EngineShape, n: usize, segment_count: usize) -> Arc<Engine> {
+    assert!(segment_count >= 1, "segment_count must be ≥ 1");
+    let dir = cache_dir_for(shape, n, segment_count);
+
+    let force_rebuild = std::env::var("LAURUS_BENCH_REBUILD").is_ok();
+
+    if !force_rebuild && cache_is_valid(&dir) {
+        // Try to open; if it fails (laurus internal format drift not
+        // caught by the version key, partial cache, etc.) fall through
+        // to rebuild rather than abort the bench run.
+        match rt.block_on(open_persistent_engine(&dir)) {
+            Ok(engine) => return Arc::new(engine),
+            Err(err) => {
+                eprintln!(
+                    "bench cache open failed at {} ({err}); rebuilding",
+                    dir.display()
+                );
+            }
+        }
+    }
+
+    // Wipe + recreate so a partially-written previous run does not
+    // contaminate the new build. `remove_dir_all` on a missing path is
+    // an error we ignore — the create below handles both cases.
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create bench cache dir");
+
+    let config = FileStorageConfig::new(&dir);
+    let storage =
+        StorageFactory::create(StorageConfig::File(config)).expect("create file storage for cache");
+    let engine = rt
+        .block_on(build_engine_into_storage(
+            storage,
+            n,
+            shape.body_fn(),
+            segment_count,
+        ))
+        .expect("build_engine_into_storage failed");
+
+    std::fs::write(dir.join(".bench_version"), BENCH_INDEX_FORMAT_VERSION)
+        .expect("write .bench_version marker");
+
+    Arc::new(engine)
+}
+
 /// Default corpus sizes for sweep cases. Setting `LAURUS_BENCH_LARGE=1`
 /// in the environment appends a 100 000-document case so #403 (WAND /
 /// MaxScore early-termination) has a measurable target without ballooning
 /// the default `cargo bench` runtime.
 fn corpus_sizes() -> Vec<usize> {
     let mut sizes = vec![100usize, 1_000, 5_000];
+    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
+        sizes.push(100_000);
+    }
+    sizes
+}
+
+/// Sizes for the always-scaled skewed-TF benches
+/// ([`bench_topk_or_skewed_tf`], [`bench_topk_or_multi_segment`]).
+/// Defaults stop at 10 000 so a `cargo bench` invocation does not
+/// silently spend ~17 minutes per 100 k corpus build; the 100 k case
+/// is the acceptance-gate target, gated on `LAURUS_BENCH_LARGE=1`.
+fn skewed_corpus_sizes() -> Vec<usize> {
+    let mut sizes = vec![1_000usize, 10_000];
+    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
+        sizes.push(100_000);
+    }
+    sizes
+}
+
+/// Sizes for [`bench_seek_skewed`]. The skip-list-targeted workload
+/// only produces a meaningful signal once posting lists are long
+/// enough that the binary-search hierarchy lights up, so the default
+/// runs at 10 000 (~700 docs / posting list at 6 % long-tail
+/// frequency) and `LAURUS_BENCH_LARGE=1` opts in to the
+/// acceptance-gate 100 k case.
+fn seek_skewed_sizes() -> Vec<usize> {
+    let mut sizes = vec![10_000usize];
     if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
         sizes.push(100_000);
     }
@@ -396,7 +582,7 @@ fn bench_term_query(c: &mut Criterion) {
     apply_sample_size(&mut group, &sizes);
 
     for &n in &sizes {
-        let engine = rt.block_on(build_engine(n)).unwrap();
+        let engine = cached_engine(&rt, EngineShape::Uniform, n, 1);
 
         // One-time sanity check: the probe query must return at least one
         // hit. If this fires, the corpus / query pair drifted out of sync.
@@ -438,7 +624,7 @@ fn bench_term_query_varying_limit(c: &mut Criterion) {
     let corpus_n = *corpus_sizes()
         .last()
         .expect("corpus_sizes() must be non-empty");
-    let engine = rt.block_on(build_engine(corpus_n)).unwrap();
+    let engine = cached_engine(&rt, EngineShape::Uniform, corpus_n, 1);
 
     // Sanity check: the largest limit must return more hits than the smallest.
     let probe_small = rt.block_on(async {
@@ -486,7 +672,7 @@ fn bench_boolean_query(c: &mut Criterion) {
     apply_sample_size(&mut group, &sizes);
 
     for &n in &sizes {
-        let engine = rt.block_on(build_engine(n)).unwrap();
+        let engine = cached_engine(&rt, EngineShape::Uniform, n, 1);
 
         // Sanity check: the OR probe over three known terms must hit.
         let probe = rt.block_on(async {
@@ -588,21 +774,21 @@ fn bench_boolean_query(c: &mut Criterion) {
 /// every document, but 10 % of documents repeat `COMMON_TERMS` 16x,
 /// so per-block max-impact varies sharply between blocks.
 ///
-/// Sweep: corpus sizes `{1k, 10k, 100k}`. Unlike
-/// [`bench_boolean_query`] this scenario **always** includes 100k —
-/// `LAURUS_BENCH_LARGE` is not honoured here because the audit's
-/// 5x-on-100k acceptance criterion needs that case to be the default
-/// measurement target.
+/// Sizes via [`skewed_corpus_sizes`]: default `{1k, 10k}`,
+/// `LAURUS_BENCH_LARGE=1` adds `100k` (the acceptance-gate size). BMW
+/// skip behaviour is observable at 10k already because the per-block
+/// bound table is populated for any corpus that spans multiple 128-doc
+/// blocks; the 100k case is reserved for PR acceptance runs.
 fn bench_topk_or_skewed_tf(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group("lexical/topk_or_skewed_tf");
-    let sizes: &[usize] = &[1_000, 10_000, 100_000];
+    let sizes = skewed_corpus_sizes();
     // 100k case dominates wall time — pick the slow tier so the rest
     // of the sweep gets the same sample size for direct comparison.
     group.sample_size(SAMPLE_SIZE_SLOW);
 
-    for &n in sizes {
-        let engine = rt.block_on(build_engine_skewed(n)).unwrap();
+    for &n in &sizes {
+        let engine = cached_engine(&rt, EngineShape::Skewed, n, 1);
 
         // Sanity: high-freq OR must hit at least one heavy-hitter.
         let probe = rt.block_on(async {
@@ -652,15 +838,13 @@ fn bench_topk_or_skewed_tf(c: &mut Criterion) {
 fn bench_topk_or_multi_segment(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group("lexical/topk_or_multi_segment");
-    let sizes: &[usize] = &[10_000, 100_000];
+    let sizes = skewed_corpus_sizes();
     let segment_counts: &[usize] = &[1, 4, 8];
     group.sample_size(SAMPLE_SIZE_SLOW);
 
-    for &n in sizes {
+    for &n in &sizes {
         for &seg_count in segment_counts {
-            let engine = rt
-                .block_on(build_engine_with_segments(n, build_body_skewed, seg_count))
-                .unwrap();
+            let engine = cached_engine(&rt, EngineShape::Skewed, n, seg_count);
 
             // Sanity probe: high-freq OR must hit at least one heavy-hitter.
             let probe = rt.block_on(async {
@@ -702,30 +886,29 @@ fn bench_topk_or_multi_segment(c: &mut Criterion) {
 }
 
 /// Seek-heavy AND-conjunction benchmark for the multi-level skip list
-/// (#503). Drives a `BooleanQuery::Must(common_term, rare_term)`
-/// against corpora of 100 k and 1 M documents. The rare side has
-/// roughly 6 % document frequency (one [`LONG_TAIL`] word), the common
-/// side hits every document — so the conjunction matcher's leader is
-/// the rare side and the common side pays one `skip_to` call per rare
-/// hit, exercising the worst-case posting-list seek pattern that the
-/// linear-walk `find_block` path collapsed to O(N) per call.
+/// (#503). Drives a `BooleanQuery::Must(common_term, rare_term)`. The
+/// rare side has roughly 6 % document frequency (one [`LONG_TAIL`]
+/// word), the common side hits every document — so the conjunction
+/// matcher's leader is the rare side and the common side pays one
+/// `skip_to` call per rare hit, exercising the worst-case posting-list
+/// seek pattern that the linear-walk `find_block` path collapsed to
+/// O(N) per call.
 ///
-/// The 1 M case is gated on `LAURUS_BENCH_LARGE=1` because corpus
-/// build alone takes ~30 s and the audit acceptance criterion
-/// explicitly targets that size; the 100 k case runs by default so a
-/// regression at the existing AND boundary remains visible without
-/// requiring opt-in.
+/// Default size: 10 000 (skip-list hierarchy already lights up at this
+/// scale, see [`seek_skewed_sizes`]). `LAURUS_BENCH_LARGE=1` opts in to
+/// the 100 000-doc acceptance-gate case from the #503 PR. The 1 M case
+/// that existed previously is removed: it took ~3-5 hours to build and
+/// did not produce information that the 100 k case did not already
+/// expose (the binary-search hierarchy adds only one level between
+/// 100 k and 1 M).
 fn bench_seek_skewed(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group("lexical/seek_skewed");
-    let mut sizes: Vec<usize> = vec![100_000];
-    if std::env::var("LAURUS_BENCH_LARGE").is_ok() {
-        sizes.push(1_000_000);
-    }
+    let sizes = seek_skewed_sizes();
     group.sample_size(SAMPLE_SIZE_SLOW);
 
     for &n in &sizes {
-        let engine = rt.block_on(build_engine(n)).unwrap();
+        let engine = cached_engine(&rt, EngineShape::Uniform, n, 1);
 
         // Sanity probe: the AND must hit at least once at every
         // benched n — otherwise the conjunction would short-circuit
@@ -774,7 +957,7 @@ fn bench_phrase_query(c: &mut Criterion) {
     group.sample_size(SAMPLE_SIZE_FAST);
 
     for &n in &[100, 1000, 5000] {
-        let engine = rt.block_on(build_engine(n)).unwrap();
+        let engine = cached_engine(&rt, EngineShape::Uniform, n, 1);
 
         // Sanity check: the two-term phrase probe must hit at least once.
         let probe = rt.block_on(async {
@@ -836,7 +1019,7 @@ fn bench_fuzzy_query(c: &mut Criterion) {
     group.sample_size(SAMPLE_SIZE_FAST);
 
     for &n in &[100, 1000, 5000] {
-        let engine = rt.block_on(build_engine(n)).unwrap();
+        let engine = cached_engine(&rt, EngineShape::Uniform, n, 1);
 
         // Sanity check: the edit1 probe must match `programming`.
         let probe = rt.block_on(async {
@@ -885,7 +1068,7 @@ fn bench_fuzzy_query(c: &mut Criterion) {
 
 fn bench_dsl_query(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
-    let engine = rt.block_on(build_engine(5000)).unwrap();
+    let engine = cached_engine(&rt, EngineShape::Uniform, 5000, 1);
 
     // Sanity check: the simple_term DSL probe must hit.
     let probe = rt.block_on(async {


### PR DESCRIPTION
## Summary

- Add `cached_engine`: persists the built index under `target/laurus_bench_index_cache/<shape>_<n>_segs<k>_v<N>/` via FileStorage. Subsequent `cargo bench` invocations reopen the cached index in <1 second instead of rebuilding (~17 minutes for 100k uniform).
- Gate 100k behind `LAURUS_BENCH_LARGE` for `topk_or_skewed_tf`, `topk_or_multi_segment`, `seek_skewed`. Default sweep now finishes in single-digit minutes.
- Remove the 1M case from `seek_skewed` — cost 3-5 hours of build per run, provided no signal not already visible at 100k.
- Add `laurus/benches/BENCHMARKS.md` (+ Japanese `BENCHMARKS_ja.md`) explaining the three-phase model, on-disk cache invariants, and the synthetic-vs-external (TREC/Wikipedia) trade-off analysis.

## Motivation

During the #506 SIMD batch BM25 perf work, a full `cargo bench --bench lexical_search_bench` run hit 5+ hours of wall time and exhausted swap on a 32 GB machine. Root cause analysis showed multiple bench functions independently rebuilding the same 100k uniform corpus — a setup cost that is not the measurement target for search-side benches.

The three-phase model formalises which phase each bench cares about:

```
Phase 1: corpus generation  ← pure function, ~1 sec
Phase 2: index construction ← ~17 min for 100k. The expensive part. Cached on disk.
Phase 3: search measurement ← the only thing search-side benches actually time
```

Search-side benches (`lexical_search_bench`) reach Phase 3 via the cache. Indexing-side benches (`lexical_indexing_bench`) leave Phase 2 fresh because the build itself is what they measure.

## Wall-time impact

| Invocation | Before | After (first run) | After (cached) |
| ---------- | ------ | ----------------- | -------------- |
| `cargo bench --bench lexical_search_bench` | 30-60 min | 3-5 min | <1 min (warmup + measurement only) |
| `LAURUS_BENCH_LARGE=1 cargo bench --bench lexical_search_bench` | 1-3 hours | 20-30 min | 2-3 min |

(Wall-time estimates based on observed bench behaviour during #506 work; precise numbers depend on host I/O and CPU.)

## Invalidation

- `BENCH_INDEX_FORMAT_VERSION` bump in source: when schema / analyzer / corpus synthesis / segment format changes. Stale caches auto-rebuild.
- `LAURUS_BENCH_REBUILD=1`: forced wipe-and-rebuild without touching the rest of `target/`.
- `cargo clean`: drops the whole `target/` tree, cache included.

## Scope

In:
- `laurus/benches/lexical_search_bench.rs`: cache helper, size opt-in, 1M removal
- `laurus/benches/BENCHMARKS.md` + `BENCHMARKS_ja.md`: design rationale

Out (follow-up issues):
- `hybrid_search_bench.rs` — same pattern applies, deferred to a separate PR to keep scope focused
- `vector_search_bench.rs` — more involved (synthetic + real-data setups), deferred

The lift to `common.rs` for cross-bench-file sharing also belongs to that follow-up.

## Tests

- `cargo check --benches`: pass
- `cargo clippy --all-targets -- -D warnings`: clean
- `markdownlint-cli2 laurus/benches/BENCHMARKS.md laurus/benches/BENCHMARKS_ja.md`: 0 errors

## Test plan

- [x] `cargo check --benches -p laurus`
- [x] `cargo clippy -p laurus --all-targets -- -D warnings`
- [x] `markdownlint-cli2 laurus/benches/BENCHMARKS*.md`
- [ ] First-time bench: `cargo bench --bench lexical_search_bench -- ^lexical/term_query/100$` builds and runs cleanly (smoke check — to be verified locally during review)
- [ ] Second-time bench: same command re-uses the cache and skips rebuild (smoke check)

Closes #510
Refs #463 (umbrella)