### PR TITLE
perf(bench): on-disk index cache for vector_search_bench (#513 Stage 2)

### DIFF
--- a/laurus/benches/BENCHMARKS.md
+++ b/laurus/benches/BENCHMARKS.md
@@ -161,7 +161,7 @@ warrant a dedicated harness. Single-shot perf benches don't need it.
 | `posting_skip_to_bench`       | Microbench     | (own setup)| Skip-list seek microbench |
 | `posting_merge_bench`         | Microbench     | (own setup)| Segment-merge microbench |
 | `dict_lookup_bench`           | Phase 3 / micro | (own setup) | Dictionary lookup variants |
-| `hybrid_search_bench`         | Phase 3        | (own setup) | Lexical + vector hybrid |
+| `hybrid_search_bench`         | Phase 3        | Yes        | Lexical + vector hybrid (cached via `cached_hybrid_engine`, #513 Stage 1) |
 | `bkd_bench`                   | Microbench     | (own setup)| Geo / numeric range |
 | `distance_bench`              | Microbench     | n/a        | Distance kernels |
 | `facet_bench`                 | Phase 3        | (own setup)| Facet collection |
@@ -173,14 +173,15 @@ warrant a dedicated harness. Single-shot perf benches don't need it.
 | `synonym_bench`               | Phase 3        | n/a        | Synonym expansion |
 | `text_analysis_bench`         | Microbench     | n/a        | Analyzer pipeline |
 | `vector_indexing_bench`       | Phase 2-like   | n/a        | Vector index build |
-| `vector_search_bench`         | Phase 3        | (own setup)| Vector kNN |
+| `vector_search_bench`         | Phase 3        | Yes        | Vector kNN (search-only benches cached via `cached_vector_reader`, #513 Stage 2; construction benches unchanged) |
 
 Items marked "(own setup)" use a smaller corpus shape or a different
-setup pattern that does not need a generalised cache. The cache
-pattern in `lexical_search_bench` can be lifted into
-`hybrid_search_bench` (close to identical) and `vector_search_bench`
-(more involved — multiple synthetic / real-data setups) via follow-up
-work. For now it lives where it delivers the most wall-time savings.
+setup pattern that does not need a generalised cache. With #513
+Stage 1 (`hybrid_search_bench`) and Stage 2 (`vector_search_bench`)
+shipped, every search-side bench in the table above reuses an
+on-disk cache. The cache helpers live next to the bench files that
+use them rather than being lifted into `benches/common.rs`; that
+extraction is a separate design discussion (issue #513 body).
 
 ## How to add a new search-side bench
 
@@ -208,7 +209,11 @@ caches will be auto-rebuilt on the next run.
 
 ## Background
 
-- `#510` introduced the on-disk cache and size-gate cleanup.
+- `#510` introduced the on-disk cache and size-gate cleanup for
+  `lexical_search_bench`.
+- `#513` extended the cache to `hybrid_search_bench` (Stage 1, PR #514)
+  and `vector_search_bench` (Stage 2, search-only benches via
+  `cached_vector_reader`).
 - `#403` defined the BMW acceptance-gate that anchored 100k as the
   reference size.
 - `#503` introduced `bench_seek_skewed`; the 1 M-doc case from #503's

--- a/laurus/benches/BENCHMARKS_ja.md
+++ b/laurus/benches/BENCHMARKS_ja.md
@@ -113,7 +113,7 @@ laurus は Criterion を素の Rust 関数形式で使います。理由:
 | `posting_skip_to_bench`       | Microbench     | 独自 setup     | Skip-list seek microbench |
 | `posting_merge_bench`         | Microbench     | 独自 setup     | Segment-merge microbench |
 | `dict_lookup_bench`           | Phase 3 / micro | 独自 setup     | 辞書 lookup バリエーション |
-| `hybrid_search_bench`         | Phase 3        | 独自 setup     | Lexical + vector hybrid |
+| `hybrid_search_bench`         | Phase 3        | 使う           | Lexical + vector hybrid（`cached_hybrid_engine` で cache 化、#513 Stage 1）|
 | `bkd_bench`                   | Microbench     | 独自 setup     | Geo / numeric range |
 | `distance_bench`              | Microbench     | n/a           | 距離 kernel |
 | `facet_bench`                 | Phase 3        | 独自 setup     | Facet collection |
@@ -125,9 +125,9 @@ laurus は Criterion を素の Rust 関数形式で使います。理由:
 | `synonym_bench`               | Phase 3        | n/a           | Synonym 展開 |
 | `text_analysis_bench`         | Microbench     | n/a           | Analyzer パイプライン |
 | `vector_indexing_bench`       | Phase 2 相当   | n/a           | Vector index build |
-| `vector_search_bench`         | Phase 3        | 独自 setup     | Vector kNN |
+| `vector_search_bench`         | Phase 3        | 使う           | Vector kNN（検索系 bench は `cached_vector_reader` で cache 化、#513 Stage 2。Construction 系は変更なし）|
 
-「独自 setup」は小さなコーパス形か、汎用キャッシュを必要としない別の setup パターンを使うもの。`lexical_search_bench` のキャッシュパターンは `hybrid_search_bench`（ほぼ同形）と `vector_search_bench`（合成・実データ両方の setup があり複雑度高め）に follow-up で横展開できる。今は最も時間節約効果が大きい所に住まわせている。
+「独自 setup」は小さなコーパス形か、汎用キャッシュを必要としない別の setup パターンを使うもの。#513 Stage 1 (`hybrid_search_bench`) と Stage 2 (`vector_search_bench`) の merge により、上表の検索系 bench はすべて on-disk cache を再利用するようになった。cache helper は各 bench ファイルに同居しており、`benches/common.rs` への抽出は別途設計議論が必要（issue #513 本文参照）。
 
 ## 新規 search-side bench の追加手順
 
@@ -144,6 +144,7 @@ laurus は Criterion を素の Rust 関数形式で使います。理由:
 
 ## 背景
 
-- `#510` がディスクキャッシュとサイズゲート整理を導入
+- `#510` が `lexical_search_bench` 向けのディスクキャッシュとサイズゲート整理を導入
+- `#513` がキャッシュを `hybrid_search_bench`（Stage 1, PR #514）および `vector_search_bench`（Stage 2, `cached_vector_reader` 経由で検索系 bench のみ）へ拡張
 - `#403` が BMW acceptance gate を定義し、参照サイズとして 100k を確立
 - `#503` が `bench_seek_skewed` を導入。1M docs ケースは #510 で削除（100k からの追加 1 階層は情報量が少ないと判断）

--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -66,11 +66,36 @@
 //! this case is opt-in. Default runs (no env var) finish in well under
 //! five minutes on a typical workstation.
 //!
+//! # On-disk index cache (#513 Stage 2)
+//!
+//! [`cached_vector_reader`] persists the built vector index under
+//! `target/laurus_bench_index_cache/<slot>_v<N>/`, mirroring the
+//! lexical bench's `cached_engine` (#510) and the hybrid bench's
+//! `cached_hybrid_engine` (#513 Stage 1). On a fresh checkout the
+//! first run pays the index-build cost once per case; later
+//! `cargo bench` runs reopen the cached index via the type-specific
+//! reader loader (`FlatVectorIndexReader::load`,
+//! `IvfIndexReader::load`, `HnswIndexReader::load`) in well under a
+//! second. The cache is applied to **search-only** benches; the
+//! Construction benches (`bench_flat_construction`,
+//! `bench_ivf_construction`, `bench_hnsw_construction`) and the SIFT
+//! real-data benches' Criterion measurement window are unchanged.
+//! Bump [`BENCH_INDEX_FORMAT_VERSION`] when anything that would alter
+//! the resulting index changes; `LAURUS_BENCH_REBUILD=1` forces a
+//! wipe-and-rebuild. See `benches/BENCHMARKS.md` for the architecture
+//! rationale.
+//!
 //! # Run
 //!
 //! ```sh
+//! # Daily iteration (fast — uses cache after first run):
 //! cargo bench --bench vector_search_bench                          # default sizes
+//!
+//! # Acceptance / large-corpus sweep:
 //! LAURUS_BENCH_LARGE=1 cargo bench --bench vector_search_bench     # adds 100 k
+//!
+//! # Force a fresh cache build:
+//! LAURUS_BENCH_REBUILD=1 cargo bench --bench vector_search_bench
 //! ```
 //!
 //! Filter by group / case (substring match against the criterion id):
@@ -87,14 +112,19 @@
 //! cargo bench --bench vector_search_bench --no-run
 //! ```
 //!
-//! See `benches/common.rs` for the suite-wide hygiene rules.
+//! See `benches/common.rs` for the suite-wide hygiene rules and
+//! `benches/BENCHMARKS.md` for the cross-cutting bench architecture.
 
 mod common;
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use laurus::storage::Storage;
+use laurus::storage::file::FileStorageConfig;
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::vector::HnswIndexReader;
 use laurus::vector::core::distance::DistanceMetric;
 use laurus::vector::core::rerank::RerankStorageKind;
 use laurus::vector::core::vector::Vector;
@@ -102,6 +132,9 @@ use laurus::vector::index::ManagedVectorIndex;
 use laurus::vector::index::config::{
     FlatIndexConfig, HnswIndexConfig, IvfIndexConfig, VectorIndexTypeConfig,
 };
+use laurus::vector::index::flat::reader::FlatVectorIndexReader;
+use laurus::vector::index::ivf::reader::IvfIndexReader;
+use laurus::vector::reader::VectorIndexReader;
 use laurus::vector::{
     FlatVectorSearcher, HnswSearcher, IvfSearcher, VectorIndexQuery, VectorIndexSearcher,
 };
@@ -195,6 +228,159 @@ fn hnsw_corpus_sizes() -> Vec<usize> {
         sizes.push(100_000);
     }
     sizes
+}
+
+// ---------------------------------------------------------------------------
+// On-disk index cache (#513 Stage 2)
+// ---------------------------------------------------------------------------
+
+/// Bump when anything about the persisted on-disk vector index would
+/// change: index-config defaults, vector synthesis ([`generate_vectors`]
+/// / [`generate_multi_field_vectors`]), or laurus's segment format.
+/// Caches written under a stale version are auto-rebuilt by
+/// [`cached_vector_reader`].
+const BENCH_INDEX_FORMAT_VERSION: &str = "1";
+
+/// Index path used inside every cache slot's storage tree. Kept
+/// constant so [`open_cached_reader`] can locate the file without
+/// caller-supplied bookkeeping.
+const CACHE_INDEX_NAME: &str = "bench";
+
+/// Cache root, mirroring the lexical / hybrid bench layout
+/// (`target/laurus_bench_index_cache/...`). `CARGO_TARGET_DIR`
+/// (if set) overrides the workspace `target/` location.
+fn cache_root() -> PathBuf {
+    if let Ok(custom) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(custom).join("laurus_bench_index_cache");
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    Path::new(manifest_dir)
+        .parent()
+        .map(|p| p.join("target"))
+        .unwrap_or_else(|| PathBuf::from("target"))
+        .join("laurus_bench_index_cache")
+}
+
+/// Resolve the cache directory for `slot`. `slot` must encode every
+/// input that affects the persisted index (index type, dim, n,
+/// per-config parameters, corpus shape, optional fixture-size proxy);
+/// the version key is appended automatically.
+fn cache_dir_for(slot: &str) -> PathBuf {
+    cache_root().join(format!("{slot}_v{BENCH_INDEX_FORMAT_VERSION}"))
+}
+
+/// Verify a cache entry: directory exists and `.bench_version` marker
+/// matches [`BENCH_INDEX_FORMAT_VERSION`].
+fn cache_is_valid(dir: &Path) -> bool {
+    let marker = dir.join(".bench_version");
+    if !marker.exists() {
+        return false;
+    }
+    matches!(
+        std::fs::read_to_string(&marker).map(|s| s.trim().to_string()),
+        Ok(v) if v == BENCH_INDEX_FORMAT_VERSION
+    )
+}
+
+/// Open an existing on-disk vector index. Dispatches to the
+/// type-specific loader so the cached segments are mmap-/file-loaded
+/// in their persisted form rather than rebuilt from an in-memory
+/// writer.
+fn open_cached_reader(
+    dir: &Path,
+    config: &VectorIndexTypeConfig,
+) -> laurus::Result<Arc<dyn VectorIndexReader>> {
+    let file_config = FileStorageConfig::new(dir);
+    let storage = StorageFactory::create(StorageConfig::File(file_config))?;
+    let distance = config.distance_metric();
+    let reader: Arc<dyn VectorIndexReader> = match config {
+        VectorIndexTypeConfig::Flat(_) => Arc::new(FlatVectorIndexReader::load(
+            storage,
+            CACHE_INDEX_NAME,
+            distance,
+        )?),
+        VectorIndexTypeConfig::IVF(_) => {
+            Arc::new(IvfIndexReader::load(storage, CACHE_INDEX_NAME, distance)?)
+        }
+        VectorIndexTypeConfig::HNSW(_) => {
+            Arc::new(HnswIndexReader::load(storage, CACHE_INDEX_NAME, distance)?)
+        }
+    };
+    Ok(reader)
+}
+
+/// Build the cache slot at `dir` from scratch: instantiates a
+/// `ManagedVectorIndex` on a fresh `FileStorage`, ingests the vectors
+/// produced by `build_vectors`, finalises, writes, and drops the
+/// version marker. Returns the reader handle the bench will hand to
+/// its searcher.
+fn build_cached_reader(
+    dir: &Path,
+    config: VectorIndexTypeConfig,
+    vectors: Vec<(u64, String, Vector)>,
+) -> laurus::Result<Arc<dyn VectorIndexReader>> {
+    let file_config = FileStorageConfig::new(dir);
+    let storage = StorageFactory::create(StorageConfig::File(file_config))?;
+    let mut index = ManagedVectorIndex::new(config, storage, CACHE_INDEX_NAME)?;
+    index.add_vectors(vectors)?;
+    index.finalize()?;
+    index.write()?;
+    let reader = index.reader()?;
+    std::fs::write(dir.join(".bench_version"), BENCH_INDEX_FORMAT_VERSION)?;
+    Ok(reader)
+}
+
+/// Return a reader for the cached vector index identified by `slot`,
+/// building it on disk the first time and re-opening it on subsequent
+/// runs (#513 Stage 2). Mirrors `lexical_search_bench::cached_engine`
+/// (#510 / #512) and `hybrid_search_bench::cached_hybrid_engine`
+/// (#513 Stage 1), specialised for vector indexes.
+///
+/// # Arguments
+///
+/// * `slot` - Cache-key fragment that must uniquely encode every input
+///   affecting the persisted index (index type, dim, n, config knobs,
+///   corpus shape, fixture-size proxy for real-data corpora). The
+///   version key from [`BENCH_INDEX_FORMAT_VERSION`] is appended
+///   automatically by [`cache_dir_for`].
+/// * `config` - The `VectorIndexTypeConfig` to build under (used both
+///   for the cache-miss build path and to dispatch the cache-hit
+///   loader to the right reader type).
+/// * `build_vectors` - Closure that produces the corpus when the cache
+///   is missing. Called only on cache miss so deterministic vector
+///   generation does not run when the cache hits.
+///
+/// # Invalidation
+///
+/// - Bump [`BENCH_INDEX_FORMAT_VERSION`] in source. Stale slots are
+///   auto-rebuilt on the next call.
+/// - `LAURUS_BENCH_REBUILD=1` forces a wipe-and-rebuild without
+///   touching the rest of `target/`.
+/// - `cargo clean` evicts the cache along with the rest of `target/`.
+fn cached_vector_reader(
+    slot: &str,
+    config: VectorIndexTypeConfig,
+    build_vectors: impl FnOnce() -> Vec<(u64, String, Vector)>,
+) -> Arc<dyn VectorIndexReader> {
+    let dir = cache_dir_for(slot);
+    let force_rebuild = std::env::var("LAURUS_BENCH_REBUILD").is_ok();
+
+    if !force_rebuild && cache_is_valid(&dir) {
+        match open_cached_reader(&dir, &config) {
+            Ok(reader) => return reader,
+            Err(err) => {
+                eprintln!(
+                    "vector bench cache open failed at {} ({err}); rebuilding",
+                    dir.display()
+                );
+            }
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create vector bench cache dir");
+
+    build_cached_reader(&dir, config, build_vectors()).expect("vector bench cache build failed")
 }
 
 // ---------------------------------------------------------------------------
@@ -295,20 +481,15 @@ fn bench_flat_search(c: &mut Criterion) {
     let dim = 128;
 
     for &count in &search_corpus_sizes() {
-        let vectors = generate_vectors(count, dim);
-        let storage = create_storage();
         let config = FlatIndexConfig {
             dimension: dim,
             distance_metric: DistanceMetric::Cosine,
             ..Default::default()
         };
-        let mut index =
-            ManagedVectorIndex::new(VectorIndexTypeConfig::Flat(config), storage, "flat_bench")
-                .unwrap();
-        index.add_vectors(vectors).unwrap();
-        index.finalize().unwrap();
-
-        let reader = index.reader().unwrap();
+        let slot = format!("flat_n{count}_dim{dim}_synthetic");
+        let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::Flat(config), || {
+            generate_vectors(count, dim)
+        });
         let searcher = FlatVectorSearcher::new(reader).unwrap();
         let query = generate_query(dim);
 
@@ -336,8 +517,6 @@ fn bench_ivf_search(c: &mut Criterion) {
     let dim = 128;
 
     for &count in &search_corpus_sizes() {
-        let vectors = generate_vectors(count, dim);
-        let storage = create_storage();
         let config = IvfIndexConfig {
             dimension: dim,
             distance_metric: DistanceMetric::Cosine,
@@ -345,14 +524,10 @@ fn bench_ivf_search(c: &mut Criterion) {
             n_probe: 3,
             ..Default::default()
         };
-        let mut index =
-            ManagedVectorIndex::new(VectorIndexTypeConfig::IVF(config), storage, "ivf_bench")
-                .unwrap();
-        index.add_vectors(vectors).unwrap();
-        index.finalize().unwrap();
-        index.write().unwrap();
-
-        let reader = index.reader().unwrap();
+        let slot = format!("ivf_n{count}_dim{dim}_nc10_synthetic");
+        let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::IVF(config), || {
+            generate_vectors(count, dim)
+        });
         let searcher = IvfSearcher::new(reader).unwrap();
         let query = generate_query(dim);
 
@@ -387,8 +562,6 @@ fn bench_hnsw_fallback_search(c: &mut Criterion) {
     let dim = 128;
 
     for &count in &hnsw_corpus_sizes() {
-        let vectors = generate_vectors(count, dim);
-        let storage = create_storage();
         let config = HnswIndexConfig {
             dimension: dim,
             m: 16,
@@ -396,17 +569,10 @@ fn bench_hnsw_fallback_search(c: &mut Criterion) {
             distance_metric: DistanceMetric::Cosine,
             ..Default::default()
         };
-        let mut index = ManagedVectorIndex::new(
-            VectorIndexTypeConfig::HNSW(config),
-            storage,
-            "hnsw_fallback_bench",
-        )
-        .unwrap();
-        index.add_vectors(vectors).unwrap();
-        index.finalize().unwrap();
-        index.write().unwrap();
-
-        let reader = index.reader().unwrap();
+        let slot = format!("hnsw_n{count}_dim{dim}_m16_efc200_synthetic");
+        let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::HNSW(config), || {
+            generate_vectors(count, dim)
+        });
         let searcher = HnswSearcher::new(reader).unwrap();
         let query = generate_query(dim);
 
@@ -470,8 +636,6 @@ fn bench_hnsw_graph_search_rerank(c: &mut Criterion) {
     let dim = 128;
 
     for &count in &hnsw_corpus_sizes() {
-        let vectors = generate_vectors(count, dim);
-        let storage = create_storage();
         let config = HnswIndexConfig {
             dimension: dim,
             m: 16,
@@ -480,17 +644,10 @@ fn bench_hnsw_graph_search_rerank(c: &mut Criterion) {
             rerank_storage: Some(RerankStorageKind::F32),
             ..Default::default()
         };
-        let mut index = ManagedVectorIndex::new(
-            VectorIndexTypeConfig::HNSW(config),
-            storage,
-            "hnsw_graph_rerank_bench",
-        )
-        .unwrap();
-        index.add_vectors(vectors).unwrap();
-        index.finalize().unwrap();
-        index.write().unwrap();
-
-        let reader = index.reader().unwrap();
+        let slot = format!("hnsw_n{count}_dim{dim}_m16_efc200_rerankF32_synthetic");
+        let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::HNSW(config), || {
+            generate_vectors(count, dim)
+        });
         let searcher = HnswSearcher::new(reader).unwrap();
         let query = generate_query(dim);
 
@@ -528,8 +685,6 @@ fn bench_hnsw_graph_search(c: &mut Criterion) {
     let dim = 128;
 
     for &count in &hnsw_corpus_sizes() {
-        let vectors = generate_vectors(count, dim);
-        let storage = create_storage();
         let config = HnswIndexConfig {
             dimension: dim,
             m: 16,
@@ -537,17 +692,12 @@ fn bench_hnsw_graph_search(c: &mut Criterion) {
             distance_metric: DistanceMetric::Cosine,
             ..Default::default()
         };
-        let mut index = ManagedVectorIndex::new(
-            VectorIndexTypeConfig::HNSW(config),
-            storage,
-            "hnsw_graph_bench",
-        )
-        .unwrap();
-        index.add_vectors(vectors).unwrap();
-        index.finalize().unwrap();
-        index.write().unwrap();
-
-        let reader = index.reader().unwrap();
+        // Shares the slot with `bench_hnsw_fallback_search` /
+        // `bench_hnsw_ef_search_sweep` — same persisted index.
+        let slot = format!("hnsw_n{count}_dim{dim}_m16_efc200_synthetic");
+        let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::HNSW(config), || {
+            generate_vectors(count, dim)
+        });
         let searcher = HnswSearcher::new(reader).unwrap();
         let query = generate_query(dim);
 
@@ -590,8 +740,6 @@ fn bench_hnsw_ef_search_sweep(c: &mut Criterion) {
     let dim = 128;
     let count = 5000usize;
 
-    let vectors = generate_vectors(count, dim);
-    let storage = create_storage();
     let config = HnswIndexConfig {
         dimension: dim,
         m: 16,
@@ -599,17 +747,12 @@ fn bench_hnsw_ef_search_sweep(c: &mut Criterion) {
         distance_metric: DistanceMetric::Cosine,
         ..Default::default()
     };
-    let mut index = ManagedVectorIndex::new(
-        VectorIndexTypeConfig::HNSW(config),
-        storage,
-        "hnsw_ef_bench",
-    )
-    .unwrap();
-    index.add_vectors(vectors).unwrap();
-    index.finalize().unwrap();
-    index.write().unwrap();
-
-    let reader = index.reader().unwrap();
+    // Same slot as `bench_hnsw_fallback_search` /
+    // `bench_hnsw_graph_search` at n=5000.
+    let slot = format!("hnsw_n{count}_dim{dim}_m16_efc200_synthetic");
+    let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::HNSW(config), || {
+        generate_vectors(count, dim)
+    });
     let query = generate_query(dim);
 
     for &ef in &[16usize, 64, 128, 256, 512] {
@@ -659,8 +802,6 @@ fn bench_hnsw_multi_field_search(c: &mut Criterion) {
     let dim = 128;
     let count = 5000usize;
 
-    let vectors = generate_multi_field_vectors(count, dim);
-    let storage = create_storage();
     let config = HnswIndexConfig {
         dimension: dim,
         m: 16,
@@ -668,17 +809,10 @@ fn bench_hnsw_multi_field_search(c: &mut Criterion) {
         distance_metric: DistanceMetric::Cosine,
         ..Default::default()
     };
-    let mut index = ManagedVectorIndex::new(
-        VectorIndexTypeConfig::HNSW(config),
-        storage,
-        "hnsw_multi_field_bench",
-    )
-    .unwrap();
-    index.add_vectors(vectors).unwrap();
-    index.finalize().unwrap();
-    index.write().unwrap();
-
-    let reader = index.reader().unwrap();
+    let slot = format!("hnsw_n{count}_dim{dim}_m16_efc200_multifield");
+    let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::HNSW(config), || {
+        generate_multi_field_vectors(count, dim)
+    });
     let searcher = HnswSearcher::new(reader).unwrap();
     let query = generate_query(dim);
 
@@ -725,23 +859,15 @@ fn bench_flat_multi_field_search(c: &mut Criterion) {
     let dim = 128;
 
     for &count in &search_corpus_sizes() {
-        let vectors = generate_multi_field_vectors(count, dim);
-        let storage = create_storage();
         let config = FlatIndexConfig {
             dimension: dim,
             distance_metric: DistanceMetric::Cosine,
             ..Default::default()
         };
-        let mut index = ManagedVectorIndex::new(
-            VectorIndexTypeConfig::Flat(config),
-            storage,
-            "flat_multi_field_bench",
-        )
-        .unwrap();
-        index.add_vectors(vectors).unwrap();
-        index.finalize().unwrap();
-
-        let reader = index.reader().unwrap();
+        let slot = format!("flat_n{count}_dim{dim}_multifield");
+        let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::Flat(config), || {
+            generate_multi_field_vectors(count, dim)
+        });
         let searcher = FlatVectorSearcher::new(reader).unwrap();
         let query = generate_query(dim);
 
@@ -851,18 +977,12 @@ fn bench_hnsw_graph_search_rerank_real_data(c: &mut Criterion) {
     let m: usize = 16;
     let ef_construction: usize = 200;
 
-    let mut corpus =
-        common::load_fvecs(&base_path, dim, Some(n_corpus)).expect("load sift_base.fvecs");
     let mut queries =
         common::load_fvecs(&query_path, dim, Some(n_queries)).expect("load sift_query.fvecs");
-    for v in corpus.iter_mut() {
-        common::l2_normalise(v);
-    }
     for v in queries.iter_mut() {
         common::l2_normalise(v);
     }
 
-    let storage = create_storage();
     let config = HnswIndexConfig {
         dimension: dim,
         m,
@@ -871,22 +991,27 @@ fn bench_hnsw_graph_search_rerank_real_data(c: &mut Criterion) {
         rerank_storage: Some(RerankStorageKind::F32),
         ..Default::default()
     };
-    let mut index = ManagedVectorIndex::new(
-        VectorIndexTypeConfig::HNSW(config),
-        storage,
-        "hnsw_sift_rerank_real_data_bench",
-    )
-    .unwrap();
-    let docs: Vec<(u64, String, Vector)> = corpus
-        .into_iter()
-        .enumerate()
-        .map(|(i, v)| (i as u64, "field".to_string(), Vector::new(v)))
-        .collect();
-    index.add_vectors(docs).unwrap();
-    index.finalize().unwrap();
-    index.write().unwrap();
-
-    let reader = index.reader().unwrap();
+    // Include sift_base.fvecs size as a cheap "did the fixture
+    // change?" proxy: re-fetching a different SIFT subset will give
+    // a different size and miss the cache cleanly.
+    let base_size = std::fs::metadata(&base_path)
+        .map(|m| m.len())
+        .unwrap_or_default();
+    let slot = format!(
+        "hnsw_sift_n{n_corpus}_dim{dim}_m{m}_efc{ef_construction}_rerankF32_size{base_size}",
+    );
+    let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::HNSW(config), || {
+        let mut corpus =
+            common::load_fvecs(&base_path, dim, Some(n_corpus)).expect("load sift_base.fvecs");
+        for v in corpus.iter_mut() {
+            common::l2_normalise(v);
+        }
+        corpus
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| (i as u64, "field".to_string(), Vector::new(v)))
+            .collect()
+    });
     let mut searcher = HnswSearcher::new(reader).unwrap();
     searcher.set_ef_search(ef_search);
 
@@ -988,18 +1113,12 @@ fn bench_hnsw_graph_search_pq_rerank_real_data(c: &mut Criterion) {
     let m: usize = 16;
     let ef_construction: usize = 200;
 
-    let mut corpus =
-        common::load_fvecs(&base_path, dim, Some(n_corpus)).expect("load sift_base.fvecs");
     let mut queries =
         common::load_fvecs(&query_path, dim, Some(n_queries)).expect("load sift_query.fvecs");
-    for v in corpus.iter_mut() {
-        common::l2_normalise(v);
-    }
     for v in queries.iter_mut() {
         common::l2_normalise(v);
     }
 
-    let storage = create_storage();
     let config = HnswIndexConfig {
         dimension: dim,
         m,
@@ -1012,22 +1131,24 @@ fn bench_hnsw_graph_search_pq_rerank_real_data(c: &mut Criterion) {
         rerank_storage: Some(RerankStorageKind::F32),
         ..Default::default()
     };
-    let mut index = ManagedVectorIndex::new(
-        VectorIndexTypeConfig::HNSW(config),
-        storage,
-        "hnsw_sift_pq_rerank_real_data_bench",
-    )
-    .unwrap();
-    let docs: Vec<(u64, String, Vector)> = corpus
-        .into_iter()
-        .enumerate()
-        .map(|(i, v)| (i as u64, "field".to_string(), Vector::new(v)))
-        .collect();
-    index.add_vectors(docs).unwrap();
-    index.finalize().unwrap();
-    index.write().unwrap();
-
-    let reader = index.reader().unwrap();
+    let base_size = std::fs::metadata(&base_path)
+        .map(|m| m.len())
+        .unwrap_or_default();
+    let slot = format!(
+        "hnsw_sift_n{n_corpus}_dim{dim}_m{m}_efc{ef_construction}_pq{subvector_count}_rerankF32_size{base_size}",
+    );
+    let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::HNSW(config), || {
+        let mut corpus =
+            common::load_fvecs(&base_path, dim, Some(n_corpus)).expect("load sift_base.fvecs");
+        for v in corpus.iter_mut() {
+            common::l2_normalise(v);
+        }
+        corpus
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| (i as u64, "field".to_string(), Vector::new(v)))
+            .collect()
+    });
     let mut searcher = HnswSearcher::new(reader).unwrap();
     searcher.set_ef_search(ef_search);
 


### PR DESCRIPTION
## Summary

Stage 2 of #513: extend the on-disk Phase 2 index cache (lexical: #510 / PR #512, hybrid: PR #514) to `vector_search_bench`. Search-only benches now reopen a persisted vector index via `cached_vector_reader(slot, config, build_vectors)`; Construction benches still build fresh per iteration.

- Add `cached_vector_reader` helper plus `cache_root`, `cache_dir_for`, `cache_is_valid`, `open_cached_reader`, `build_cached_reader`, and the `BENCH_INDEX_FORMAT_VERSION = "1"` constant.
- Switch 11 search-side bench functions to the cache: `bench_flat_search`, `bench_ivf_search`, `bench_hnsw_fallback_search`, `bench_hnsw_graph_search`, `bench_hnsw_graph_search_rerank`, `bench_hnsw_ef_search_sweep`, `bench_hnsw_multi_field_search`, `bench_flat_multi_field_search`, `bench_hnsw_graph_search_rerank_real_data`, `bench_hnsw_graph_search_pq_rerank_real_data`.
- The three HNSW search benches that share an HNSW config (`bench_hnsw_fallback_search`, `bench_hnsw_graph_search`, `bench_hnsw_ef_search_sweep`) intentionally share a cache slot — same persisted index, the second-and-later callers reopen without rebuild.
- SIFT real-data benches include `size{filesize}` of `sift_base.fvecs` in their slot key as a cheap "did the fixture change?" proxy without forcing a content hash.
- File-level docstring gets a new "On-disk index cache (#513 Stage 2)" section pointing at `BENCH_INDEX_FORMAT_VERSION`, `LAURUS_BENCH_REBUILD=1`, and `benches/BENCHMARKS.md`.

Construction benches (`bench_flat_construction`, `bench_ivf_construction`, `bench_hnsw_construction`) are deliberately untouched — their measurement target *is* the build cost.

## Smoke (Flat, n = 1000)

```sh
rm -rf target/laurus_bench_index_cache/flat_n1000_*
/usr/bin/time -f \"%e wall\" cargo bench --bench vector_search_bench -- '^Flat Search/top10/1000\$'   # pass 1
/usr/bin/time -f \"%e wall\" cargo bench --bench vector_search_bench -- '^Flat Search/top10/1000\$'   # pass 2
LAURUS_BENCH_REBUILD=1 /usr/bin/time -f \"%e wall\" cargo bench --bench vector_search_bench -- '^Flat Search/top10/1000\$'  # pass 3
/usr/bin/time -f \"%e wall\" cargo bench --bench vector_search_bench -- '^Flat Search/top10/1000\$'   # pass 4
```

| Pass                              | Wall   | Note                                              |
| --------------------------------- | ------ | ------------------------------------------------- |
| 1 (cache miss + first compile)    | 76.93s | `Compiling laurus v0.9.0` + Phase 2 + measurement |
| 2 (cache hit)                     | 12.92s | reader load + measurement                         |
| 3 (`LAURUS_BENCH_REBUILD=1`)      | 64.32s | force wipe + rebuild (≈ pass 1 minus compile)     |
| 4 (cache hit after REBUILD)       | 14.78s | reader load + measurement                         |

## HNSW Graph Search (n = 50000) — the big win

```sh
rm -rf target/laurus_bench_index_cache/hnsw_n50000_*
/usr/bin/time -f \"%e wall\" cargo bench --bench vector_search_bench -- '^HNSW Graph Search/top10/50000\$'   # pass 1
/usr/bin/time -f \"%e wall\" cargo bench --bench vector_search_bench -- '^HNSW Graph Search/top10/50000\$'   # pass 2
```

| Pass            | Wall   | Note                                          |
| --------------- | ------ | --------------------------------------------- |
| 1 (cache miss)  | 40.30s | HNSW graph build + measurement                |
| 2 (cache hit)   | 15.25s | reader load + measurement (≈ 2.6× wall-time reduction) |

Measurement itself stays inside the noise band:

```
HNSW Graph Search/top10/50000
                  time:   [1.9920 ms 1.9965 ms 2.0018 ms]
                  change: [-7.9606% -4.9590% -0.9006%] (p = 0.00 < 0.05)
                  Change within noise threshold.
```

For `LAURUS_BENCH_LARGE=1` (adds 100 k) the absolute savings compound further — the multi-minute HNSW build at 100 k collapses to a single reader load on second-and-later runs.

## Shared-slot effect

`bench_hnsw_fallback_search`, `bench_hnsw_graph_search`, and `bench_hnsw_ef_search_sweep` all back onto the same persisted index per `n`. After pass 2 above, running

```sh
cargo bench --bench vector_search_bench -- '^HNSW Fallback Search/top10/1000\$'
```

returns in 14.14 s (reuses the existing `hnsw_n1000_dim128_m16_efc200_synthetic_v1/` slot — no new directory created).

## Invalidation

Same conventions as #512 / #514:

- `BENCH_INDEX_FORMAT_VERSION = \"1\"` in source. Bump on index-config defaults / vector synthesis / segment format change. Stale caches auto-rebuild.
- `LAURUS_BENCH_REBUILD=1` — force wipe-and-rebuild without touching the rest of `target/`.
- `cargo clean` — drops the whole cache.

## Tests

- `cargo check --benches`: pass
- `cargo clippy --benches -p laurus -- -D warnings`: pass
- `cargo fmt --check`: pass

## Docs

- `laurus/benches/vector_search_bench.rs` file-level docstring extended.
- `laurus/benches/BENCHMARKS.md` + `BENCHMARKS_ja.md`: the `vector_search_bench` (and `hybrid_search_bench`) rows in the file-by-file table now read \"Yes\" under Cache used, plus the follow-up paragraph that used to mention the lifting work has been rewritten to reflect that both Stage 1 and Stage 2 have shipped.

## Test plan

- [x] Implement \`cached_vector_reader\` helper and migrate the 11 search-side bench functions
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --benches -p laurus -- -D warnings\` clean
- [x] \`cargo check --benches\` clean
- [x] Cache miss → cache hit smoke at Flat n=1000 and HNSW n=1000
- [x] \`LAURUS_BENCH_REBUILD=1\` invalidation smoke
- [x] HNSW Graph Search n=50000 cache-miss vs cache-hit measurement
- [x] Shared-slot reuse confirmed for HNSW fallback/graph at the same \`n\`
- [ ] (Optional, follow-up) lift the helper into \`benches/common.rs\` as a generic — separate design discussion per issue body

Refs #513
Refs #463