### PR TITLE
chore(ci): replace arduino/setup-protoc@v3 with direct install (#516)

### DIFF
--- a/.github/actions/install-protoc/action.yml
+++ b/.github/actions/install-protoc/action.yml
@@ -1,0 +1,50 @@
+name: Install protoc
+description: |
+  Download protoc from the official protocolbuffers/protobuf release
+  assets and add it to PATH. Replaces arduino/setup-protoc@v3 which
+  pins Node.js 20 internally and is incompatible with the GitHub
+  Actions Node.js 24 default-runtime cutover on 2026-06-02. See Issue
+  #516 for the migration rationale.
+
+inputs:
+  version:
+    description: |
+      protoc version (without the leading 'v'). Must match an upstream
+      release asset name, e.g. "24.4". Pinning to a concrete patch
+      release replaces the previous "24.x" floating pin so CI is
+      reproducible.
+    required: false
+    default: "24.4"
+
+runs:
+  using: composite
+  steps:
+    - name: Download and install protoc
+      shell: bash
+      env:
+        PROTOC_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)   suffix="linux-x86_64" ;;
+          Linux-ARM64) suffix="linux-aarch_64" ;;
+          macOS-X64)   suffix="osx-x86_64" ;;
+          macOS-ARM64) suffix="osx-aarch_64" ;;
+          Windows-X64) suffix="win64" ;;
+          *)
+            echo "Unsupported runner: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+            exit 1
+            ;;
+        esac
+
+        url="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${suffix}.zip"
+        install_dir="${RUNNER_TEMP}/protoc"
+        mkdir -p "${install_dir}"
+
+        echo "Downloading ${url}"
+        curl -fsSL --retry 3 --retry-delay 5 "${url}" -o "${install_dir}/protoc.zip"
+        unzip -q "${install_dir}/protoc.zip" -d "${install_dir}"
+
+        echo "${install_dir}/bin" >> "${GITHUB_PATH}"
+        "${install_dir}/bin/protoc" --version

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -37,10 +37,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -128,10 +127,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -177,10 +175,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -226,10 +223,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -177,10 +177,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -270,10 +269,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -320,10 +318,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -370,10 +367,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -129,10 +128,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -178,10 +176,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -227,10 +224,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -542,10 +538,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -937,10 +932,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: ./.github/actions/install-protoc
         with:
-          version: "24.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "24.4"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1


### PR DESCRIPTION
## Summary

`arduino/setup-protoc@v3` is pinned to Node.js 20 internally; GitHub Actions defaults the Node.js runtime to **24** on **2026-06-02**, and there is no Node.js 24-compatible v4 release in sight (latest release: `v3.0.0`, 2024-01-31; upstream tracking ticket `arduino/setup-protoc#113` has not moved). Replace the action with a small local composite action that downloads `protoc` directly from the `protocolbuffers/protobuf` release assets and adds it to `PATH`.

- New: `.github/actions/install-protoc/action.yml` — composite action; per-OS asset suffix selection in a single bash `case`; bash works on Windows runners via Git for Windows.
- Replaces all 14 call sites across the three workflow files:
  - `release.yml` — 6 occurrences
  - `regression.yml` — 4 occurrences
  - `periodic.yml` — 4 occurrences
- Version pin changes from the floating `"24.x"` to the concrete `"24.4"` so CI is reproducible — no new 24-series patch release has shipped since the action originally pinned `24.x`, so behaviour is unchanged in practice.
- `repo-token` input dropped — the protobuf release CDN does not need a GitHub token.

## Verification

| Check | Status |
| ----- | ------ |
| `grep -c arduino/setup-protoc .github/workflows/*.yml` | 0 |
| `grep -c install-protoc .github/workflows/*.yml` | `release.yml: 6 / regression.yml: 4 / periodic.yml: 4` (= 14, matches audit) |
| YAML syntax (Ruby YAML.safe_load) | OK on all four files |
| Release-asset URL reachability | `linux-x86_64` and `osx-aarch_64` returned 302 → CDN (curl -sI on `v24.4` assets) |

The CI matrix on this PR (Linux x86_64, Linux aarch64, macOS arm64, macOS intel, Windows x86_64) is the real end-to-end test — every job that previously ran `arduino/setup-protoc@v3` now flows through the new composite action.

## Test plan

- [x] Replace 14 call sites
- [x] Local YAML parse OK
- [ ] All CI jobs green on this PR (Linux x86_64 / Linux aarch64 / macOS arm64 / macOS intel / Windows)
- [ ] `protoc --version` step in CI prints `libprotoc 24.4` on every runner

## Out of scope

- protoc version bump (still on 24-series — that's a separate concern).
- Switching the protobuf toolchain (`buf`, `prost-build`-only, etc.).
- Touching the Rust-side `tonic-build` / `prost-build` integration.

Closes #516