### PR TITLE
perf(storage): use stack buffer in StructReader::read_varint (#520)

### DIFF
--- a/laurus/src/storage/structured.rs
+++ b/laurus/src/storage/structured.rs
@@ -513,18 +513,30 @@ impl<R: StorageInput> StructReader<R> {
     ///
     /// Returns an error if the underlying I/O operation or decoding fails.
     pub fn read_varint(&mut self) -> Result<u64> {
-        let mut bytes = Vec::new();
+        // A u64 varint is at most 10 bytes (7 data bits per byte, 64 / 7 = 9.14).
+        // Using a stack-allocated buffer avoids the per-call heap allocation that
+        // `Vec::new()` + `push()` would incur — a hot path uncovered by perf
+        // profiling (see #520).
+        let mut buf = [0u8; 10];
+        let mut len = 0;
         loop {
             let byte = self.reader.read_u8()?;
-            bytes.push(byte);
+            buf[len] = byte;
+            len += 1;
             if byte & 0x80 == 0 {
                 break;
             }
+            if len == buf.len() {
+                // Malformed varint: continuation bit still set after the 10th byte.
+                // `decode_u64` would also catch this via its `shift >= 64` check,
+                // but we'd panic on the next `buf[len] = byte` before reaching it.
+                return Err(LaurusError::other("VarInt overflow"));
+            }
         }
 
-        let (value, _) = decode_u64(&bytes)?;
-        self.update_checksum(&bytes);
-        self.position += bytes.len() as u64;
+        let (value, _) = decode_u64(&buf[..len])?;
+        self.update_checksum(&buf[..len]);
+        self.position += len as u64;
         Ok(value)
     }
 


### PR DESCRIPTION
## Summary

- Replace per-call `Vec::new()` + `push()` in `StructReader::read_varint` with a stack-allocated `[u8; 10]` buffer (max length of a u64 varint)
- Eliminates the heap allocation chain `read_varint` → `RawVecInner::finish_grow` → `malloc` that perf profiling identified as a major hot path
- Adds explicit overflow check after byte 10 to preserve existing error semantics for malformed varints (otherwise the stack buffer would panic before `decode_u64`'s `shift >= 64` check fires)

10-line change, no public API change.

## Bench results

`lexical_search_bench`, 5k corpus, `cargo bench --baseline pre-520`:

| Scenario | Before | After | Change | p-value |
| --- | --- | --- | --- | --- |
| `term_query/search/5000` | 83.5 µs | 67.5 µs | **−18.1%** (1.22×) | 0.00 |
| `boolean_query/should_or/5000` | 348 µs | 294 µs | **−15.5%** (1.18×) | 0.00 |
| `fuzzy_query/edit1/5000` | 6.13 ms | 5.24 ms | **−14.6%** (1.17×) | 0.00 |

All three scenarios show Criterion-significant improvement (p = 0.00) and exceed the issue's 5–15% estimate.

## Profile diff (perf record)

`perf record -F 999 -g` on `term_query/search/5000` (`profile-time 10`):

| Metric | Before | After |
| --- | --- | --- |
| `read_varint` self % | 7.01% | 5.67% |
| `read_varint` inclusive % | **36.0%** | **6.89%** |
| `malloc` self % | 14.67% | 12.99% |

The `finish_grow` → `malloc` chain inside `read_varint` is essentially gone. Remaining `malloc` cost (12.99%) is from other allocation sites tracked under #523, #524, #525.

## Test plan

- [x] `cargo test -p laurus --lib storage::structured` (4 passed)
- [x] `cargo test -p laurus --lib util::varint` (4 passed)
- [x] `cargo test -p laurus --lib` (1011 passed, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p laurus --lib -- -D warnings`
- [x] Bench before/after with `--save-baseline pre-520` / `--baseline pre-520`
- [x] `perf record` before/after to confirm hot path attribution

Refs #520, #519.