### PR TITLE
perf(lexical/automaton): use threshold-aware Levenshtein in fuzzy matches (#530)

### DIFF
--- a/laurus/src/lexical/index/inverted/core/automaton.rs
+++ b/laurus/src/lexical/index/inverted/core/automaton.rs
@@ -4,7 +4,9 @@
 
 use crate::error::Result;
 use crate::lexical::index::inverted::core::terms::{TermStats, TermsEnum};
-use crate::util::levenshtein::{damerau_levenshtein_distance, levenshtein_distance};
+use crate::util::levenshtein::{
+    damerau_levenshtein_distance_threshold, levenshtein_distance_threshold,
+};
 
 /// A simple Levenshtein automaton for fuzzy string matching.
 ///
@@ -32,6 +34,11 @@ pub trait Automaton: Send + Sync {
 pub struct LevenshteinAutomaton {
     /// The pattern string to match against
     pattern: String,
+    /// Precomputed prefix of `pattern` of length `prefix_length`, if any. Stored
+    /// to avoid recomputing `pattern.chars().take(prefix_length).collect()` on
+    /// every `matches` call — that allocation showed up under inlined
+    /// `AutomatonTermsEnum::next` as a per-term hot spot (see #530).
+    pattern_prefix: Option<String>,
     /// Maximum edit distance
     max_edits: u32,
     /// Minimum prefix length that must match exactly
@@ -48,8 +55,15 @@ impl LevenshteinAutomaton {
         prefix_length: usize,
         transpositions: bool,
     ) -> Self {
+        let pattern: String = pattern.into();
+        let pattern_prefix = if prefix_length > 0 {
+            Some(pattern.chars().take(prefix_length).collect())
+        } else {
+            None
+        };
         LevenshteinAutomaton {
-            pattern: pattern.into(),
+            pattern,
+            pattern_prefix,
             max_edits,
             prefix_length,
             transpositions,
@@ -79,30 +93,29 @@ impl LevenshteinAutomaton {
 
 impl Automaton for LevenshteinAutomaton {
     fn matches(&self, candidate: &str) -> bool {
-        // Check prefix requirement
-        if self.prefix_length > 0 {
-            let pattern_prefix: String = self.pattern.chars().take(self.prefix_length).collect();
-            if !candidate.starts_with(&pattern_prefix) {
-                return false;
-            }
+        // Check prefix requirement against the precomputed prefix.
+        if let Some(prefix) = &self.pattern_prefix
+            && !candidate.starts_with(prefix.as_str())
+        {
+            return false;
         }
 
-        // Calculate edit distance
+        // Calculate edit distance using the threshold-aware variants. They use
+        // a 2-row (or 3-row for Damerau) sliding buffer instead of the full
+        // N × M matrix, terminate early when the per-row minimum exceeds the
+        // threshold, and avoid heap allocations for the matrix on the
+        // non-matching majority of candidates.
+        let threshold = self.max_edits as usize;
         let distance = if self.transpositions {
-            damerau_levenshtein_distance(&self.pattern, candidate) as u32
+            damerau_levenshtein_distance_threshold(&self.pattern, candidate, threshold)
         } else {
-            levenshtein_distance(&self.pattern, candidate) as u32
+            levenshtein_distance_threshold(&self.pattern, candidate, threshold)
         };
-
-        distance <= self.max_edits
+        distance.is_some()
     }
 
     fn initial_seek_term(&self) -> Option<String> {
-        if self.prefix_length > 0 {
-            Some(self.pattern.chars().take(self.prefix_length).collect())
-        } else {
-            None
-        }
+        self.pattern_prefix.clone()
     }
 }
 

--- a/laurus/src/util/levenshtein.rs
+++ b/laurus/src/util/levenshtein.rs
@@ -188,6 +188,101 @@ pub fn damerau_levenshtein_distance(s1: &str, s2: &str) -> usize {
     matrix[len1][len2]
 }
 
+/// Calculate Damerau-Levenshtein distance with a maximum threshold for early
+/// termination. Mirrors [`levenshtein_distance_threshold`] but additionally
+/// handles transpositions (adjacent character swaps count as a single edit).
+///
+/// Returns `None` if the distance exceeds the threshold.
+///
+/// Uses a 3-row sliding buffer (instead of the full N×M matrix used by
+/// [`damerau_levenshtein_distance`]) because the transposition rule needs to
+/// reference `matrix[i-2][j-2]`. This drops working set to O(min(N, M)) and
+/// enables early termination when the per-row minimum exceeds the threshold.
+#[allow(clippy::needless_range_loop)]
+pub fn damerau_levenshtein_distance_threshold(
+    s1: &str,
+    s2: &str,
+    threshold: usize,
+) -> Option<usize> {
+    let len1 = s1.chars().count();
+    let len2 = s2.chars().count();
+
+    // Early termination if length difference exceeds threshold
+    if len1.abs_diff(len2) > threshold {
+        return None;
+    }
+
+    if len1 == 0 {
+        return if len2 <= threshold { Some(len2) } else { None };
+    }
+    if len2 == 0 {
+        return if len1 <= threshold { Some(len1) } else { None };
+    }
+
+    let s1_chars: Vec<char> = s1.chars().collect();
+    let s2_chars: Vec<char> = s2.chars().collect();
+
+    // Use three rows: prev2 (i-2), prev (i-1), curr (i).
+    let mut prev2_row = vec![0usize; len2 + 1];
+    let mut prev_row = vec![0usize; len2 + 1];
+    let mut curr_row = vec![0usize; len2 + 1];
+
+    // Initialize first row (i = 0)
+    for j in 0..=len2 {
+        prev_row[j] = j;
+    }
+
+    for i in 1..=len1 {
+        curr_row[0] = i;
+        let mut min_in_row = i;
+
+        for j in 1..=len2 {
+            let cost = if s1_chars[i - 1] == s2_chars[j - 1] {
+                0
+            } else {
+                1
+            };
+
+            curr_row[j] = min(
+                min(
+                    prev_row[j] + 1,     // deletion
+                    curr_row[j - 1] + 1, // insertion
+                ),
+                prev_row[j - 1] + cost, // substitution
+            );
+
+            // Check for transposition (needs i >= 2 and j >= 2)
+            if i > 1
+                && j > 1
+                && s1_chars[i - 1] == s2_chars[j - 2]
+                && s1_chars[i - 2] == s2_chars[j - 1]
+            {
+                curr_row[j] = min(curr_row[j], prev2_row[j - 2] + cost);
+            }
+
+            min_in_row = min(min_in_row, curr_row[j]);
+        }
+
+        // Early termination if minimum in row exceeds threshold
+        if min_in_row > threshold {
+            return None;
+        }
+
+        // Rotate rows: prev2 <- prev <- curr; reuse the old prev2 buffer as
+        // the next curr to avoid reallocating.
+        std::mem::swap(&mut prev2_row, &mut prev_row);
+        std::mem::swap(&mut prev_row, &mut curr_row);
+    }
+
+    // After the final swap, `prev_row` holds the last computed row.
+    let distance = prev_row[len2];
+    if distance <= threshold {
+        Some(distance)
+    } else {
+        None
+    }
+}
+
 /// A matcher that pre-stores a query string for calculating Levenshtein distance
 /// against multiple candidates.
 ///
@@ -275,6 +370,58 @@ mod tests {
         assert_eq!(damerau_levenshtein_distance("ab", "ba"), 1); // transposition
         assert_eq!(damerau_levenshtein_distance("search", "serach"), 1); // transposition
         assert_eq!(damerau_levenshtein_distance("kitten", "sitting"), 3);
+    }
+
+    #[test]
+    fn test_damerau_levenshtein_distance_threshold() {
+        // Within threshold
+        assert_eq!(
+            damerau_levenshtein_distance_threshold("ab", "ba", 1),
+            Some(1)
+        );
+        assert_eq!(
+            damerau_levenshtein_distance_threshold("search", "serach", 1),
+            Some(1)
+        );
+        assert_eq!(
+            damerau_levenshtein_distance_threshold("kitten", "sitting", 3),
+            Some(3)
+        );
+
+        // Exceeds threshold
+        assert_eq!(
+            damerau_levenshtein_distance_threshold("kitten", "sitting", 2),
+            None
+        );
+        assert_eq!(
+            damerau_levenshtein_distance_threshold("abc", "def", 2),
+            None
+        );
+
+        // Edge cases
+        assert_eq!(damerau_levenshtein_distance_threshold("", "", 0), Some(0));
+        assert_eq!(damerau_levenshtein_distance_threshold("", "a", 1), Some(1));
+        assert_eq!(damerau_levenshtein_distance_threshold("a", "", 1), Some(1));
+        assert_eq!(damerau_levenshtein_distance_threshold("a", "", 0), None);
+
+        // Length-difference early termination
+        assert_eq!(damerau_levenshtein_distance_threshold("a", "abcd", 2), None);
+
+        // Equivalence with the non-threshold variant when within threshold
+        for (a, b) in &[
+            ("ab", "ba"),
+            ("search", "serach"),
+            ("kitten", "sitting"),
+            ("hello", "hallo"),
+            ("programming", "programing"),
+        ] {
+            let full = damerau_levenshtein_distance(a, b);
+            assert_eq!(
+                damerau_levenshtein_distance_threshold(a, b, full),
+                Some(full),
+                "mismatch for ({a:?}, {b:?})"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #530. Replaces the wrong-target #521 (closed as wontfix).

## Summary

- Replace `levenshtein_distance` / `damerau_levenshtein_distance` calls in `LevenshteinAutomaton::matches` with the threshold-aware variants (2-row or 3-row sliding buffer + per-row early termination + length-difference early-out)
- Add `damerau_levenshtein_distance_threshold` to `util/levenshtein.rs` (the parity Damerau threshold variant did not exist)
- Precompute `pattern_prefix` once at construction so `pattern.chars().take(N).collect()` is amortized away from `matches` and `initial_seek_term`

## Bench results

`lexical_search_bench`, 5k corpus, `cargo bench --baseline pre-521`:

| Scenario | Before | After | Change | p-value |
| --- | --- | --- | --- | --- |
| `fuzzy_query/edit1/1000` | 1.22 ms | **345 µs** | **−71.3%** (3.5×) | 0.00 |
| `fuzzy_query/edit1/5000` | 5.42 ms | **1.45 ms** | **−73.2%** (3.7×) | 0.00 |
| `fuzzy_query/edit2/5000` | 5.00 ms | **1.41 ms** | **−71.3%** (3.5×) | 0.00 |

Far exceeds the issue's 30–50% estimate.

## Profile diff (`perf record`)

`perf record -F 999 -g` on `fuzzy_query/edit1/5000`:

| Metric | Before | After |
| --- | --- | --- |
| `AutomatonTermsEnum::next` self % | **25.04%** | **7.31%** |
| `AutomatonTermsEnum::next` inclusive % | **46.10%** | **11.37%** |

The dominant cost was inlined `LevenshteinAutomaton::matches` allocating a full N×M matrix per candidate term. Switching to the threshold variants drops the working set to O(min(N, M)) and prunes the majority of candidates before the inner DP loop ever runs.

## How this differs from the originally-targeted #521

#521 proposed making `TermsEnum::next` return a borrowed `&TermStats` to amortize iterator-layer allocations. That fix was implemented as a prototype, benched, and reverted: 2/3 fuzzy scenarios regressed because the dominant cost was not in the iterator but in inlined `LevenshteinAutomaton::matches`. `perf`'s self% attribution includes inlined sub-functions, which is the lesson encoded here.

The post-revert profile reading and source audit identified `LevenshteinAutomaton::matches` as the real hot path, leading to this PR.

## Test plan

- [x] `cargo test -p laurus --lib util::levenshtein` (6 passed, including new `test_damerau_levenshtein_distance_threshold`)
- [x] `cargo test -p laurus --lib lexical::index::inverted::core::automaton` (2 passed)
- [x] `cargo test -p laurus --lib lexical::query::fuzzy` (2 passed)
- [x] `cargo test -p laurus --lib` (1012 passed, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p laurus --lib -- -D warnings`
- [x] Bench before/after with `--baseline pre-521`
- [x] `perf record` before/after to confirm hot path attribution