### PR TITLE
perf(vector): lazily cache input handle in VectorStorage::OnDemand (#522)

### DIFF
--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -196,6 +196,7 @@ impl FlatVectorIndexReader {
                         file_name: file_name.clone(),
                         offsets: Arc::new(offsets),
                         quant_params: Some(params),
+                        cached_input: Arc::new(std::sync::RwLock::new(None)),
                     },
                     vector_ids,
                 )

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -305,6 +305,7 @@ impl HnswIndexReader {
                         file_name: file_name.clone(),
                         offsets: Arc::new(offsets),
                         quant_params: Some(*params),
+                        cached_input: Arc::new(std::sync::RwLock::new(None)),
                     },
                     vector_ids,
                     graph,

--- a/laurus/src/vector/index/ivf/reader.rs
+++ b/laurus/src/vector/index/ivf/reader.rs
@@ -238,6 +238,7 @@ impl IvfIndexReader {
                         file_name: file_name.clone(),
                         offsets: Arc::new(offsets),
                         quant_params: Some(params),
+                        cached_input: Arc::new(std::sync::RwLock::new(None)),
                     },
                     vector_ids,
                 )

--- a/laurus/src/vector/index/storage.rs
+++ b/laurus/src/vector/index/storage.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::error::{LaurusError, Result};
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageInput};
 use crate::vector::core::quantization::{QuantizedVectorMeta, ScalarQuantParams};
 use crate::vector::core::vector::Vector;
 use crate::vector::index::pq_storage::PqVectorPool;
@@ -60,6 +60,19 @@ pub enum VectorStorage {
         /// format is the Stage-1 quantized layout. `None` means the
         /// legacy f32 layout.
         quant_params: Option<ScalarQuantParams>,
+        /// Lazily-opened input handle, shared across `get()` calls in
+        /// the same search. Avoids paying the
+        /// `Storage::open_input(file_name)` cost (`statx` syscall via
+        /// the mmap-cache metadata check, mmap-cache lookup, `Arc`
+        /// clone, and `Box` allocation) on every candidate-vector
+        /// lookup. Subsequent gets call `clone_input()` to obtain a
+        /// fresh seek cursor without re-opening the file. See #522.
+        ///
+        /// The lock is read-heavy: after the first `get()` populates
+        /// it, every subsequent `get()` takes a read lock and never
+        /// blocks another reader, so concurrent HNSW searches do not
+        /// serialise on this field.
+        cached_input: Arc<RwLock<Option<Box<dyn StorageInput>>>>,
     },
 }
 
@@ -154,13 +167,44 @@ impl VectorStorage {
                 file_name,
                 offsets,
                 quant_params,
+                cached_input,
             } => {
                 let Some(&offset) = offsets.get(key) else {
                     return Ok(None);
                 };
-                let mut input = storage.open_input(file_name).map_err(|e| {
-                    LaurusError::internal(format!("Failed to open vector file: {e}"))
-                })?;
+                // Reuse the cached input handle if it has been opened by a
+                // previous `get()` on this storage. The cache is read-heavy:
+                // after the first opener wins the write lock, every subsequent
+                // call takes the read lock and clones via `clone_input()` —
+                // no `statx` syscall, no mmap-cache lookup, just an `Arc`
+                // clone and a `Box` allocation for the fresh cursor.
+                let mut input = {
+                    let guard = cached_input
+                        .read()
+                        .map_err(|_| LaurusError::internal("cached_input RwLock poisoned"))?;
+                    if let Some(cached) = guard.as_ref() {
+                        cached.clone_input()?
+                    } else {
+                        // First call — drop the read lock and acquire the
+                        // write lock so we can lazily open the file. The
+                        // double-check after locking handles the rare case
+                        // where another thread populated the cache between
+                        // our read-lock release and write-lock acquisition.
+                        drop(guard);
+                        let mut wguard = cached_input
+                            .write()
+                            .map_err(|_| LaurusError::internal("cached_input RwLock poisoned"))?;
+                        if wguard.is_none() {
+                            *wguard = Some(storage.open_input(file_name).map_err(|e| {
+                                LaurusError::internal(format!("Failed to open vector file: {e}"))
+                            })?);
+                        }
+                        wguard
+                            .as_ref()
+                            .expect("cached_input populated above")
+                            .clone_input()?
+                    }
+                };
 
                 input
                     .seek(SeekFrom::Start(offset))


### PR DESCRIPTION
Closes #522.

## Summary

- `VectorStorage::OnDemand::get` was opening the vector file via `storage.open_input` on every candidate-vector lookup. With HNSW search visiting hundreds of candidates per query, this paid the FileStorage mmap-cache validation cost (`statx` syscall via `is_mmap_file_unchanged`, `RwLock<HashMap>` lookup, `Arc` clone, `Box` allocation) hundreds of times per search.
- Add a lazily-populated `cached_input: Arc<RwLock<Option<Box<dyn StorageInput>>>>` field to the `OnDemand` variant. First call opens the file under a write lock; subsequent calls take a read lock and `clone_input()` to get a fresh seek cursor — no syscall, just `Arc::clone` + `Box` allocation for the cursor.
- Concurrency: the lock is read-heavy after the first call, so concurrent HNSW searches do not serialise on it.

## Bench results

`vector_search_bench`, vs main pre-fix (`cargo bench --baseline pre-522`):

| Scenario | Before | After | Change | p-value |
| --- | --- | --- | --- | --- |
| `HNSW Graph Search/top10/1000` | 834 µs | **160 µs** | **−81.1%** (5.2×) | 0.00 |
| `HNSW Graph Search/top10/5000` | 1.42 ms | **284 µs** | **−79.8%** (5.0×) | 0.00 |
| `HNSW Fallback Search/top10/5000` | 7.62 ms | **2.05 ms** | **−73.1%** (3.7×) | 0.00 |

Far exceeds the issue's 20–30% estimate.

## Profile diff (`perf record`)

`perf record -F 999 -g` on `HNSW Graph Search/top10/5000`:

- Before: `FileStorage::open_input` was the largest non-allocator self-time symbol at 3.35%.
- After: `FileStorage::open_input` falls out of the top-12 self-time symbols entirely.
- The new top hot spot is `simd_dot_and_norms` (9.88% self) — the actual SIMD distance computation, not file I/O setup.

## Hot-path attribution note (re #522 issue body)

The original issue body proposed caching at the `HnswSearcher` layer. Investigation showed `open_input` was not called inside `HnswSearcher::search` itself — the per-call open was one layer down in `VectorStorage::OnDemand::get`, which `HnswSearcher` invokes for every candidate when running on disk-backed storage (i.e. without int8/PQ quantization). Caching at `VectorStorage::OnDemand` covers this path for HNSW, Flat, and IVF.

## Test plan

- [x] `cargo test -p laurus --lib vector::index::storage` (passes, 0 tests in scope after type change)
- [x] `cargo test -p laurus --lib vector::index` (131 passed)
- [x] `cargo test -p laurus --lib` (1012 passed, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p laurus --lib -- -D warnings`
- [x] Bench before/after with `--save-baseline pre-522` / `--baseline pre-522`
- [x] `perf record` before/after to confirm `FileStorage::open_input` falls out of top hot symbols