### PR TITLE
perf(vector/search): add HNSW ef_search config (#644)

### DIFF
--- a/docs/ja/src/concepts/schema_and_fields.md
+++ b/docs/ja/src/concepts/schema_and_fields.md
@@ -107,11 +107,21 @@ let opt = HnswOption {
     distance: DistanceMetric::Cosine,                // distance metric
     m: 16,                                           // max connections per layer
     ef_construction: 200,                            // construction search width
+    default_ef_search: Some(100),                    // schema-level ef_search default (issue #644)
     base_weight: 1.0,                                // default scoring weight
     quantizer: QuantizationMethod::Scalar8Bit,       // 必須（デフォルト Scalar8Bit）
     embedder: None,                                  // 任意の embedder 名
 };
 ```
+
+#### `default_ef_search`: 検索時の recall 調整パラメータ
+
+`ef_search` はクエリ時の動的候補リストのサイズを制御するパラメータです（`ef_construction` がインデックス**ビルド時**にだけ影響するのとは別物です）。値を大きくするほどグラフ近傍の探索範囲が広がり、レイテンシと引き換えに recall が上がります。
+
+- **スキーマレベルのデフォルト**: `HnswOption.default_ef_search = Some(ef)` でフィールドごとのデフォルトを引き上げられます。`None` の場合、サーチャは内部 fallback (`50`) を使用します。
+- **クエリごとのオーバーライド**: 検索リクエスト側で [`SearchRequestBuilder::vector_ef_search`](../laurus.md) を指定すると、スキーマデフォルトより優先されます。
+- **自動引き上げ**: いずれの経路で `ef_search` を指定した場合でも、サーチャは少なくとも `top_k`（`rerank_factor` 併用時は `top_k * rerank_factor`）まで持ち上げるため、`top_k` 要求に対して候補ヒープが不足することはありません。
+- Issue [#644](https://github.com/mosuka/laurus/issues/644) で対応。
 
 パラメータの詳細なガイダンスについては、[Vector インデクシング](indexing/vector_indexing.md)を参照してください。
 

--- a/docs/src/concepts/schema_and_fields.md
+++ b/docs/src/concepts/schema_and_fields.md
@@ -108,11 +108,31 @@ let opt = HnswOption {
     distance: DistanceMetric::Cosine,                // distance metric
     m: 16,                                           // max connections per layer
     ef_construction: 200,                            // construction search width
+    default_ef_search: Some(100),                    // schema-level ef_search default (issue #644)
     base_weight: 1.0,                                // default scoring weight
     quantizer: QuantizationMethod::Scalar8Bit,       // mandatory; default Scalar8Bit
     embedder: None,                                  // optional named embedder
 };
 ```
+
+#### `default_ef_search`: the search-time recall knob
+
+`ef_search` controls the dynamic candidate list size during query time
+(distinct from `ef_construction`, which only affects index *build*). Higher
+values explore more graph neighbours and yield higher recall at the cost of
+latency.
+
+- **Schema-level default**: set `HnswOption.default_ef_search = Some(ef)` to
+  raise the per-field default. When `None`, the searcher falls back to its
+  built-in `50`.
+- **Per-query override**: search requests honour
+  [`SearchRequestBuilder::vector_ef_search`](../laurus.md). The per-query
+  value takes precedence over the schema default.
+- **Auto-lifting**: regardless of which source provides `ef_search`, the
+  searcher lifts the effective value to at least `top_k` (and
+  `top_k * rerank_factor` when both are set) so the candidate heap is never
+  undersized for the requested `top_k`.
+- Tracked under Issue [#644](https://github.com/mosuka/laurus/issues/644).
 
 See [Vector Indexing](indexing/vector_indexing.md) for detailed parameter guidance.
 

--- a/laurus-cli/src/commands/create.rs
+++ b/laurus-cli/src/commands/create.rs
@@ -378,6 +378,7 @@ fn prompt_hnsw_option() -> Result<FieldOption> {
         distance,
         m,
         ef_construction,
+        default_ef_search: None,
         base_weight: 1.0,
         quantizer,
         rerank_storage,

--- a/laurus-nodejs/src/schema.rs
+++ b/laurus-nodejs/src/schema.rs
@@ -257,8 +257,13 @@ impl JsSchema {
     /// * `distance` - Distance metric — "cosine" (default), "euclidean", "dot_product".
     /// * `m` - HNSW branching factor (default 16).
     /// * `ef_construction` - Build-time expansion factor (default 200).
+    /// * `defaultEfSearch` - Schema-level default for the search-time
+    ///   `ef_search` candidate-list size (Issue #644). When omitted, the
+    ///   searcher uses an internal fallback of 50. Per-query overrides
+    ///   via the search request still take precedence.
     /// * `embedder` - Optional embedder name registered via `addEmbedder`.
     #[napi]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
         &mut self,
         name: String,
@@ -266,6 +271,7 @@ impl JsSchema {
         distance: Option<String>,
         m: Option<u32>,
         ef_construction: Option<u32>,
+        default_ef_search: Option<u32>,
         embedder: Option<String>,
     ) -> Result<()> {
         let opt = HnswOption {
@@ -273,6 +279,7 @@ impl JsSchema {
             distance: parse_distance(distance.as_deref().unwrap_or("cosine"))?,
             m: m.unwrap_or(16) as usize,
             ef_construction: ef_construction.unwrap_or(200) as usize,
+            default_ef_search: default_ef_search.map(|v| v as usize),
             embedder,
             ..Default::default()
         };

--- a/laurus-php/src/schema.rs
+++ b/laurus-php/src/schema.rs
@@ -225,8 +225,13 @@ impl PhpSchema {
     /// * `distance` - Distance metric (default: "cosine").
     /// * `m` - HNSW branching factor (default: 16).
     /// * `ef_construction` - Build-time expansion factor (default: 200).
+    /// * `default_ef_search` - Schema-level default for the search-time
+    ///   `ef_search` candidate-list size (Issue #644). When `null`, the
+    ///   searcher uses an internal fallback of 50. Per-query overrides
+    ///   via the search request still take precedence.
     /// * `embedder` - Embedder name registered via `addEmbedder` (default: "" for none).
     #[php(defaults(m = 16, ef_construction = 200))]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
         &self,
         name: String,
@@ -234,6 +239,7 @@ impl PhpSchema {
         distance: Option<String>,
         m: i64,
         ef_construction: i64,
+        default_ef_search: Option<i64>,
         embedder: Option<String>,
     ) -> PhpResult<()> {
         let dist_str = distance.unwrap_or_else(|| "cosine".to_string());
@@ -242,6 +248,7 @@ impl PhpSchema {
             distance: parse_distance(&dist_str)?,
             m: m as usize,
             ef_construction: ef_construction as usize,
+            default_ef_search: default_ef_search.map(|v| v as usize),
             embedder,
             ..Default::default()
         };

--- a/laurus-python/src/schema.rs
+++ b/laurus-python/src/schema.rs
@@ -249,9 +249,14 @@ impl PySchema {
     ///     distance: Distance metric — "cosine" (default), "euclidean", "dot_product".
     ///     m: HNSW branching factor (default 16).
     ///     ef_construction: Build-time expansion factor (default 200).
+    ///     default_ef_search: Schema-level default for the search-time
+    ///         `ef_search` candidate-list size (Issue #644). When unset,
+    ///         the searcher uses an internal fallback of 50. Per-query
+    ///         overrides via the search request still take precedence.
     ///     embedder: Optional embedder name registered via `add_embedder`.
     ///         When set, text payloads are automatically embedded by the Rust engine.
-    #[pyo3(signature = (name, dimension, *, distance="cosine", m=16, ef_construction=200, embedder=None))]
+    #[pyo3(signature = (name, dimension, *, distance="cosine", m=16, ef_construction=200, default_ef_search=None, embedder=None))]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
         &mut self,
         name: &str,
@@ -259,6 +264,7 @@ impl PySchema {
         distance: &str,
         m: usize,
         ef_construction: usize,
+        default_ef_search: Option<usize>,
         embedder: Option<String>,
     ) -> PyResult<()> {
         let opt = HnswOption {
@@ -266,6 +272,7 @@ impl PySchema {
             distance: parse_distance(distance)?,
             m,
             ef_construction,
+            default_ef_search,
             embedder,
             ..Default::default()
         };

--- a/laurus-ruby/src/schema.rs
+++ b/laurus-ruby/src/schema.rs
@@ -303,6 +303,10 @@ impl RbSchema {
     ///   - `distance:` (String, default "cosine"): Distance metric.
     ///   - `m:` (usize, default 16): HNSW branching factor.
     ///   - `ef_construction:` (usize, default 200): Build-time expansion factor.
+    ///   - `default_ef_search:` (usize, optional): Schema-level default for the
+    ///     search-time `ef_search` candidate-list size (Issue #644). When
+    ///     omitted, the searcher uses an internal fallback of 50. Per-query
+    ///     overrides via the search request still take precedence.
     ///   - `embedder:` (String, optional): Embedder name registered via `add_embedder`.
     fn add_hnsw_field(&self, args: &[Value]) -> Result<(), Error> {
         let args = scan_args::<(String, usize), (), (), (), RHash, ()>(args)?;
@@ -314,21 +318,29 @@ impl RbSchema {
                 Option<String>,
                 Option<usize>,
                 Option<usize>,
+                Option<usize>,
                 Option<Option<String>>,
             ),
             (),
         >(
             args.keywords,
             &[],
-            &["distance", "m", "ef_construction", "embedder"],
+            &[
+                "distance",
+                "m",
+                "ef_construction",
+                "default_ef_search",
+                "embedder",
+            ],
         )?;
-        let (distance, m, ef_construction, embedder) = kwargs.optional;
+        let (distance, m, ef_construction, default_ef_search, embedder) = kwargs.optional;
         let distance_str = distance.as_deref().unwrap_or("cosine");
         let opt = HnswOption {
             dimension,
             distance: parse_distance(distance_str)?,
             m: m.unwrap_or(16),
             ef_construction: ef_construction.unwrap_or(200),
+            default_ef_search,
             embedder: embedder.flatten(),
             ..Default::default()
         };

--- a/laurus-server/proto/laurus/v1/index.proto
+++ b/laurus-server/proto/laurus/v1/index.proto
@@ -197,6 +197,11 @@ message HnswOption {
   optional QuantizationConfig quantizer = 6;
   // Embedder name (empty = no auto-embedding).
   string embedder = 7;
+  // Schema-level default for the `ef_search` candidate-list size used
+  // during search. Per-query overrides via the search request still
+  // take precedence. When unset, the searcher uses an internal
+  // fallback (`50`). Issue #644.
+  optional uint32 default_ef_search = 8;
 }
 
 message FlatOption {

--- a/laurus-server/proto/laurus/v1/search.proto
+++ b/laurus-server/proto/laurus/v1/search.proto
@@ -95,6 +95,14 @@ message VectorParams {
   // is reserved at proto tag 5 so older / newer clients can negotiate
   // the upgrade without another schema bump.
   optional uint32 rerank_factor = 5;
+
+  // Per-query override for the HNSW `ef_search` candidate-list size
+  // (Issue #644). When unset, the searcher uses the schema-level
+  // `HnswOption.default_ef_search` or an internal fallback (`50`).
+  // The effective ef is always lifted to `max(top_k, top_k * rerank_factor)`
+  // so the candidate heap is never undersized for the requested
+  // `top_k`.
+  optional uint32 ef_search = 6;
 }
 
 enum VectorScoreMode {

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -145,6 +145,7 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
             base_weight: o.base_weight,
             quantizer: Some(quantization_to_proto(&o.quantizer)),
             embedder: o.embedder.clone().unwrap_or_default(),
+            default_ef_search: o.default_ef_search.map(|v| v as u32),
         })),
         FieldOption::Flat(o) => Some(Opt::Flat(v1::FlatOption {
             dimension: o.dimension as u32,
@@ -214,6 +215,7 @@ pub fn field_option_from_proto(fo: &v1::FieldOption) -> Option<FieldOption> {
             distance: distance_from_proto(o.distance),
             m: o.m as usize,
             ef_construction: o.ef_construction as usize,
+            default_ef_search: o.default_ef_search.map(|v| v as usize),
             base_weight: o.base_weight,
             quantizer: o
                 .quantizer

--- a/laurus-server/src/gateway/convert.rs
+++ b/laurus-server/src/gateway/convert.rs
@@ -620,6 +620,11 @@ fn json_to_hnsw_option(json: &Value) -> Result<v1::HnswOption, String> {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string(),
+        // Issue #644: optional schema-level `ef_search` default.
+        default_ef_search: json
+            .get("default_ef_search")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32),
     })
 }
 
@@ -864,6 +869,11 @@ fn json_to_vector_params(json: &Value) -> Option<v1::VectorParams> {
         // falls back to Stage 1 ranking.
         rerank_factor: obj
             .get("rerank_factor")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32),
+        // Issue #644: per-query override for HNSW `ef_search`.
+        ef_search: obj
+            .get("ef_search")
             .and_then(|v| v.as_u64())
             .map(|n| n as u32),
     })

--- a/laurus-wasm/src/schema.rs
+++ b/laurus-wasm/src/schema.rs
@@ -224,8 +224,13 @@ impl WasmSchema {
     /// * `distance` - Distance metric (default "cosine").
     /// * `m` - HNSW branching factor (default 16).
     /// * `ef_construction` - Build-time expansion factor (default 200).
+    /// * `defaultEfSearch` - Schema-level default for the search-time
+    ///   `ef_search` candidate-list size (Issue #644). When omitted, the
+    ///   searcher uses an internal fallback of 50. Per-query overrides
+    ///   via the search request still take precedence.
     /// * `embedder` - Optional embedder name registered via `addEmbedder`.
     #[wasm_bindgen(js_name = "addHnswField")]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
         &mut self,
         name: String,
@@ -233,6 +238,7 @@ impl WasmSchema {
         distance: Option<String>,
         m: Option<u32>,
         ef_construction: Option<u32>,
+        default_ef_search: Option<u32>,
         embedder: Option<String>,
     ) -> Result<(), JsValue> {
         let opt = HnswOption {
@@ -240,6 +246,7 @@ impl WasmSchema {
             distance: parse_distance(distance.as_deref().unwrap_or("cosine"))?,
             m: m.unwrap_or(16) as usize,
             ef_construction: ef_construction.unwrap_or(200) as usize,
+            default_ef_search: default_ef_search.map(|v| v as usize),
             embedder,
             ..Default::default()
         };

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -873,6 +873,7 @@ impl Engine {
                 min_score: opts.min_score,
                 allowed_ids: None,
                 rerank_factor: opts.rerank_factor,
+                ef_search: opts.ef_search,
             },
         }
     }

--- a/laurus/src/engine/search.rs
+++ b/laurus/src/engine/search.rs
@@ -141,6 +141,17 @@ pub struct VectorSearchOptions {
     /// `rerank_storage`; other configurations silently ignore the value.
     /// `None` keeps Stage 1 behavior (int8-only).
     pub rerank_factor: Option<usize>,
+
+    /// Per-query override for the HNSW `ef_search` candidate-list size
+    /// (Issue [#644](https://github.com/mosuka/laurus/issues/644)).
+    ///
+    /// When `None` (the default), the searcher uses the schema-level
+    /// [`HnswOption::default_ef_search`](crate::vector::core::field::HnswOption::default_ef_search)
+    /// or its internal fallback (`50`). Ignored by non-HNSW index types.
+    /// The effective `ef_search` is always lifted to at least `top_k`
+    /// (and `top_k * rerank_factor` when both are set) so the candidate
+    /// heap is never undersized for the requested `top_k`.
+    pub ef_search: Option<usize>,
 }
 
 impl Default for VectorSearchOptions {
@@ -149,6 +160,7 @@ impl Default for VectorSearchOptions {
             score_mode: VectorScoreMode::WeightedSum,
             min_score: 0.0,
             rerank_factor: None,
+            ef_search: None,
         }
     }
 }
@@ -415,6 +427,18 @@ impl SearchRequestBuilder {
     /// Other vector configurations silently ignore the value.
     pub fn vector_rerank_factor(mut self, factor: usize) -> Self {
         self.vector_options.rerank_factor = Some(factor);
+        self
+    }
+
+    /// Override the HNSW `ef_search` candidate-list size for this
+    /// search (Issue [#644](https://github.com/mosuka/laurus/issues/644)).
+    ///
+    /// When unset, the searcher uses the schema-level
+    /// [`HnswOption::default_ef_search`](crate::vector::core::field::HnswOption::default_ef_search)
+    /// or its internal fallback (`50`). Per-query overrides always
+    /// take precedence. Ignored by non-HNSW index types.
+    pub fn vector_ef_search(mut self, ef: usize) -> Self {
+        self.vector_options.ef_search = Some(ef);
         self
     }
 

--- a/laurus/src/vector/core/field.rs
+++ b/laurus/src/vector/core/field.rs
@@ -154,6 +154,24 @@ pub struct HnswOption {
     /// build times. Defaults to `200`.
     #[serde(default = "default_getting_ef_construction")]
     pub ef_construction: usize,
+    /// Default size of the dynamic candidate list during search (`ef_search`).
+    ///
+    /// Controls the recall / latency trade-off at query time. Higher values
+    /// explore more graph neighbours, improving recall at the cost of latency.
+    ///
+    /// When `None` (the default), the searcher uses an internal fallback of
+    /// `50` so existing schemas behave unchanged. Per-query
+    /// [`VectorIndexQueryParams::ef_search`] always takes precedence over this
+    /// schema-level default.
+    ///
+    /// Regardless of which source is used, the effective `ef_search` is also
+    /// lifted to `max(ef_search, top_k * rerank_factor.unwrap_or(1), top_k)`
+    /// so the candidate heap is never undersized for the requested `top_k`
+    /// (or for the candidate-widening implied by Stage-2 rerank).
+    ///
+    /// Issue [#644](https://github.com/mosuka/laurus/issues/644).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_ef_search: Option<usize>,
     /// Base weight applied to similarity scores from this field. Defaults to `1.0`.
     #[serde(default = "default_weight")]
     pub base_weight: f32,
@@ -190,6 +208,7 @@ impl Default for HnswOption {
             distance: default_distance_metric(),
             m: default_getting_m(),
             ef_construction: default_getting_ef_construction(),
+            default_ef_search: None,
             base_weight: default_weight(),
             quantizer: quantization::QuantizationMethod::Scalar8Bit,
             rerank_storage: None,
@@ -356,6 +375,17 @@ impl HnswOption {
 
     pub fn ef_construction(mut self, ef: usize) -> Self {
         self.ef_construction = ef;
+        self
+    }
+
+    /// Set the schema-level default for `ef_search` at query time.
+    ///
+    /// Per-query [`crate::vector::search::searcher::VectorIndexQueryParams::ef_search`]
+    /// still takes precedence. When this builder method is not called, the
+    /// searcher falls back to its internal default (`50`). See
+    /// [`HnswOption::default_ef_search`] for the full precedence rules.
+    pub fn default_ef_search(mut self, ef: usize) -> Self {
+        self.default_ef_search = Some(ef);
         self
     }
 

--- a/laurus/src/vector/index/config.rs
+++ b/laurus/src/vector/index/config.rs
@@ -438,6 +438,19 @@ pub struct HnswIndexConfig {
     /// Higher values improve index quality but increase construction time.
     pub ef_construction: usize,
 
+    /// Default size of the dynamic candidate list during search
+    /// (`ef_search`).
+    ///
+    /// When `None` (the default), the searcher uses an internal
+    /// fallback of `50` so existing schemas keep their previous
+    /// behaviour. Per-query
+    /// [`crate::vector::search::searcher::VectorIndexQueryParams::ef_search`]
+    /// always takes precedence over this schema-level default.
+    ///
+    /// Issue [#644](https://github.com/mosuka/laurus/issues/644).
+    #[serde(default)]
+    pub default_ef_search: Option<usize>,
+
     /// Maximum number of vectors per segment.
     pub max_vectors_per_segment: u64,
 
@@ -486,6 +499,7 @@ impl Default for HnswIndexConfig {
             normalize_vectors: true,
             m: 16,
             ef_construction: 200,
+            default_ef_search: None,
             max_vectors_per_segment: 1000000,
             write_buffer_size: 1024 * 1024, // 1MB
             use_quantization: false,
@@ -507,6 +521,7 @@ impl std::fmt::Debug for HnswIndexConfig {
             .field("normalize_vectors", &self.normalize_vectors)
             .field("m", &self.m)
             .field("ef_construction", &self.ef_construction)
+            .field("default_ef_search", &self.default_ef_search)
             .field("max_vectors_per_segment", &self.max_vectors_per_segment)
             .field("write_buffer_size", &self.write_buffer_size)
             .field("use_quantization", &self.use_quantization)

--- a/laurus/src/vector/index/field_factory.rs
+++ b/laurus/src/vector/index/field_factory.rs
@@ -68,6 +68,7 @@ impl VectorFieldFactory {
                     distance_metric: opt.distance,
                     m: opt.m,
                     ef_construction: opt.ef_construction,
+                    default_ef_search: opt.default_ef_search,
                     quantization_method: opt.quantizer,
                     rerank_storage: opt.rerank_storage,
                     embedder: embedder.clone(),

--- a/laurus/src/vector/index/hnsw.rs
+++ b/laurus/src/vector/index/hnsw.rs
@@ -260,7 +260,14 @@ impl VectorIndex for HnswIndex {
     fn searcher(&self) -> Result<Box<dyn VectorIndexSearcher>> {
         self.check_closed()?;
         let reader = self.reader()?;
-        Ok(Box::new(HnswSearcher::new(reader)?))
+        // Pull the schema-level default `ef_search` from the config so the
+        // monolithic search path honours `HnswOption.default_ef_search`
+        // (Issue #644). Per-query overrides via
+        // `VectorIndexQueryParams.ef_search` still take precedence.
+        Ok(Box::new(HnswSearcher::with_default_ef_search(
+            reader,
+            self.config.default_ef_search,
+        )?))
     }
 
     fn embedder(&self) -> Arc<dyn Embedder> {

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -98,27 +98,84 @@ impl QuantizedSearchCtx {
     }
 }
 
+/// Fallback `ef_search` used when neither the per-query
+/// [`VectorIndexQueryParams::ef_search`] nor the schema-level
+/// [`crate::vector::core::field::HnswOption::default_ef_search`] is set.
+///
+/// Issue [#644](https://github.com/mosuka/laurus/issues/644).
+pub(crate) const HNSW_DEFAULT_EF_SEARCH: usize = 50;
+
 /// HNSW vector searcher that performs approximate nearest neighbor search.
+///
+/// The searcher's `default_ef_search` field holds the schema-level
+/// fallback for the `ef_search` parameter. Per-query callers can override
+/// it via [`VectorIndexQueryParams::ef_search`]; the effective value used
+/// by the graph traversal is computed by [`Self::effective_ef`] for each
+/// search request.
 #[derive(Debug)]
 pub struct HnswSearcher {
     index_reader: Arc<dyn VectorIndexReader>,
-    ef_search: usize,
+    default_ef_search: usize,
 }
 
 impl HnswSearcher {
-    /// Create a new HNSW searcher.
+    /// Create a new HNSW searcher with the built-in fallback `ef_search`
+    /// of [`HNSW_DEFAULT_EF_SEARCH`].
+    ///
+    /// For schemas that opt into a higher schema-level default, use
+    /// [`Self::with_default_ef_search`] instead. Per-query overrides are
+    /// honoured regardless of how the searcher was constructed.
     pub fn new(index_reader: Arc<dyn VectorIndexReader>) -> Result<Self> {
-        // Default ef_search value
-        let ef_search = 50;
         Ok(Self {
             index_reader,
-            ef_search,
+            default_ef_search: HNSW_DEFAULT_EF_SEARCH,
         })
     }
 
-    /// Set the search parameter ef.
+    /// Create a new HNSW searcher with an explicit schema-level
+    /// `default_ef_search`. Pass `None` to use the built-in fallback
+    /// ([`HNSW_DEFAULT_EF_SEARCH`]).
+    ///
+    /// Issue [#644](https://github.com/mosuka/laurus/issues/644).
+    pub fn with_default_ef_search(
+        index_reader: Arc<dyn VectorIndexReader>,
+        default_ef_search: Option<usize>,
+    ) -> Result<Self> {
+        Ok(Self {
+            index_reader,
+            default_ef_search: default_ef_search.unwrap_or(HNSW_DEFAULT_EF_SEARCH),
+        })
+    }
+
+    /// Override the schema-level default `ef_search`. Equivalent to
+    /// constructing the searcher with [`Self::with_default_ef_search`]
+    /// after the fact.
+    ///
+    /// Per-query [`VectorIndexQueryParams::ef_search`] overrides this
+    /// value at search time.
     pub fn set_ef_search(&mut self, ef_search: usize) {
-        self.ef_search = ef_search;
+        self.default_ef_search = ef_search;
+    }
+
+    /// Compute the `ef_search` used for a specific request.
+    ///
+    /// Precedence:
+    /// 1. Per-query [`VectorIndexQueryParams::ef_search`] (highest)
+    /// 2. The searcher's schema-level `default_ef_search`
+    /// 3. The built-in fallback [`HNSW_DEFAULT_EF_SEARCH`] (= `50`)
+    ///
+    /// In all cases the result is lifted to at least
+    /// `max(top_k, top_k * rerank_factor.unwrap_or(1))` so the
+    /// candidate heap is never undersized for the requested `top_k`
+    /// (Issue [#644](https://github.com/mosuka/laurus/issues/644)).
+    #[inline]
+    fn effective_ef(&self, request: &VectorIndexQuery) -> usize {
+        let params = &request.params;
+        let user_ef = params.ef_search.unwrap_or(self.default_ef_search);
+        let rerank = params.rerank_factor.unwrap_or(1).max(1);
+        user_ef
+            .max(params.top_k.saturating_mul(rerank))
+            .max(params.top_k)
     }
 }
 
@@ -324,7 +381,7 @@ impl HnswSearcher {
         };
 
         let query = &request.query;
-        let ef_search = self.ef_search;
+        let ef_search = self.effective_ef(request);
 
         // Prepare the quantized hot path according to the segment's
         // storage kind:
@@ -634,5 +691,102 @@ impl HnswSearcher {
                 offset += 64;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod ef_search_tests {
+    //! Unit tests for `HnswSearcher::effective_ef` (Issue #644).
+    //!
+    //! These tests verify the precedence and `max` formula in isolation —
+    //! integration tests in `tests.rs` cover the end-to-end flow.
+
+    use super::*;
+    use crate::vector::core::distance::DistanceMetric;
+    use crate::vector::core::vector::Vector;
+    use crate::vector::reader::SimpleVectorReader;
+    use crate::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryParams};
+
+    fn make_searcher(default_ef: Option<usize>) -> HnswSearcher {
+        let reader = Arc::new(
+            SimpleVectorReader::new(
+                vec![(1u64, "f".to_string(), Vector::new(vec![1.0, 0.0]))],
+                2,
+                DistanceMetric::Cosine,
+            )
+            .expect("reader"),
+        );
+        HnswSearcher::with_default_ef_search(reader, default_ef).expect("searcher")
+    }
+
+    fn req(top_k: usize, ef: Option<usize>, rerank: Option<usize>) -> VectorIndexQuery {
+        VectorIndexQuery {
+            query: Vector::new(vec![1.0, 0.0]),
+            params: VectorIndexQueryParams {
+                top_k,
+                ef_search: ef,
+                rerank_factor: rerank,
+                ..Default::default()
+            },
+            field_name: Some("f".to_string()),
+        }
+    }
+
+    #[test]
+    fn fallback_default_is_50_when_no_override() {
+        let s = make_searcher(None);
+        // top_k below the fallback => the fallback (50) wins.
+        assert_eq!(s.effective_ef(&req(10, None, None)), 50);
+    }
+
+    #[test]
+    fn lifts_to_top_k_when_top_k_exceeds_default() {
+        let s = make_searcher(None);
+        // top_k = 100 > 50 fallback => effective_ef is lifted to top_k.
+        assert_eq!(s.effective_ef(&req(100, None, None)), 100);
+    }
+
+    #[test]
+    fn schema_default_takes_precedence_over_fallback() {
+        let s = make_searcher(Some(300));
+        // Schema default 300 wins over the 50 fallback.
+        assert_eq!(s.effective_ef(&req(10, None, None)), 300);
+    }
+
+    #[test]
+    fn per_query_override_beats_schema_default_and_fallback() {
+        let s = make_searcher(Some(300));
+        // Per-query 200 wins over schema default 300 *only when it is >= the
+        // top_k floor*. With top_k = 10 the formula returns 200 since 200 > 10.
+        assert_eq!(s.effective_ef(&req(10, Some(200), None)), 200);
+    }
+
+    #[test]
+    fn rerank_factor_lifts_effective_ef() {
+        let s = make_searcher(None);
+        // top_k * rerank = 10 * 10 = 100 > 50 fallback => 100 wins.
+        assert_eq!(s.effective_ef(&req(10, None, Some(10))), 100);
+    }
+
+    #[test]
+    fn user_ef_still_wins_if_larger_than_top_k_times_rerank() {
+        let s = make_searcher(None);
+        // top_k * rerank = 100, user ef = 500 => 500 wins.
+        assert_eq!(s.effective_ef(&req(10, Some(500), Some(10))), 500);
+    }
+
+    #[test]
+    fn top_k_zero_is_safe() {
+        let s = make_searcher(None);
+        // top_k = 0 is degenerate; effective_ef should at least equal the fallback (50).
+        assert_eq!(s.effective_ef(&req(0, None, None)), 50);
+    }
+
+    #[test]
+    fn rerank_zero_is_treated_as_one() {
+        let s = make_searcher(None);
+        // rerank_factor = Some(0) is treated as 1 (defensive) so we never
+        // collapse the candidate widening to zero.
+        assert_eq!(s.effective_ef(&req(10, None, Some(0))), 50);
     }
 }

--- a/laurus/src/vector/index/hnsw/tests.rs
+++ b/laurus/src/vector/index/hnsw/tests.rs
@@ -496,3 +496,64 @@ fn test_hnsw_pq_search_returns_corpus_neighbour() -> Result<()> {
     assert!(ids.contains(&5), "missing doc_id 5; got {:?}", ids);
     Ok(())
 }
+
+/// Regression / parity test for Issue #644: HNSW `ef_search` must honour
+/// the per-query override and the schema-level default, instead of being
+/// permanently capped at the historical `50` constant.
+#[test]
+fn hnsw_searcher_honours_per_query_and_schema_ef_search() -> Result<()> {
+    use crate::vector::index::hnsw::searcher::HnswSearcher;
+    use crate::vector::search::searcher::{VectorIndexQuery, VectorIndexSearcher};
+
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+    let config = HnswIndexConfig {
+        dimension: 3,
+        m: 16,
+        ef_construction: 64,
+        // Schema-level default lifts the searcher's fallback well above
+        // the legacy hardcoded `50`.
+        default_ef_search: Some(300),
+        distance_metric: DistanceMetric::Cosine,
+        ..Default::default()
+    };
+
+    let index = HnswIndex::create(storage.clone(), "ef_test", config)?;
+    let mut writer = index.writer()?;
+    let vectors = (0..32u64)
+        .map(|i| {
+            let mut v = vec![0.0_f32; 3];
+            v[(i as usize) % 3] = 1.0 + (i as f32) * 0.01;
+            (i, "vec".to_string(), Vector::new(v))
+        })
+        .collect::<Vec<_>>();
+    writer.build(vectors)?;
+    writer.finalize()?;
+    writer.commit()?;
+
+    // The searcher built via `HnswIndex::searcher()` must pick up the
+    // schema-level `default_ef_search` (Issue #644).
+    let searcher = index.searcher()?;
+    let request = VectorIndexQuery::new(Vector::new(vec![1.0, 0.0, 0.0]))
+        .top_k(5)
+        .field_name("vec".to_string());
+    let results = searcher.search(&request)?;
+    assert!(
+        !results.results.is_empty(),
+        "expected non-empty results from schema-default search path"
+    );
+
+    // Construct a direct HnswSearcher and exercise the per-query override.
+    let reader = index.reader()?;
+    let direct = HnswSearcher::new(reader.clone())?;
+    let override_request = VectorIndexQuery::new(Vector::new(vec![1.0, 0.0, 0.0]))
+        .top_k(5)
+        .field_name("vec".to_string())
+        .ef_search(400);
+    let with_override = direct.search(&override_request)?;
+    assert!(
+        !with_override.results.is_empty(),
+        "expected non-empty results from per-query override search path"
+    );
+
+    Ok(())
+}

--- a/laurus/src/vector/index/segmented_field.rs
+++ b/laurus/src/vector/index/segmented_field.rs
@@ -101,10 +101,15 @@ impl SegmentedVectorField {
         let segment_id = self.segment_manager.generate_segment_id();
 
         // Get HNSW parameters from config
-        let (dimension, distance, m, ef_construction) = match &self.config.vector {
-            Some(FieldOption::Hnsw(opt)) => {
-                (opt.dimension, opt.distance, opt.m, opt.ef_construction)
-            }
+        let (dimension, distance, m, ef_construction, default_ef_search) = match &self.config.vector
+        {
+            Some(FieldOption::Hnsw(opt)) => (
+                opt.dimension,
+                opt.distance,
+                opt.m,
+                opt.ef_construction,
+                opt.default_ef_search,
+            ),
             _ => {
                 return Err(LaurusError::invalid_config(
                     "SegmentedVectorField requires HNSW configuration".to_string(),
@@ -117,6 +122,7 @@ impl SegmentedVectorField {
             distance_metric: distance,
             m,
             ef_construction,
+            default_ef_search,
             normalize_vectors: distance == crate::vector::core::distance::DistanceMetric::Cosine,
             ..Default::default()
         };
@@ -148,8 +154,13 @@ impl SegmentedVectorField {
         policy: &dyn crate::vector::index::hnsw::segment::merge_policy::MergePolicy,
     ) -> Result<()> {
         if let Some(candidate) = self.segment_manager.check_merge(policy) {
-            let (dimension, m, ef_construction) = match &self.config.vector {
-                Some(FieldOption::Hnsw(opt)) => (opt.dimension, opt.m, opt.ef_construction),
+            let (dimension, m, ef_construction, default_ef_search) = match &self.config.vector {
+                Some(FieldOption::Hnsw(opt)) => (
+                    opt.dimension,
+                    opt.m,
+                    opt.ef_construction,
+                    opt.default_ef_search,
+                ),
                 _ => {
                     return Err(LaurusError::invalid_config(
                         "SegmentedVectorField requires HNSW configuration".to_string(),
@@ -164,6 +175,7 @@ impl SegmentedVectorField {
                     dimension,
                     m,
                     ef_construction,
+                    default_ef_search,
                     ..Default::default()
                 },
                 VectorIndexWriterConfig {
@@ -363,13 +375,19 @@ impl SegmentedVectorField {
                 reader.set_deletion_bitmap(bitmap.clone());
             }
 
-            let mut searcher = HnswSearcher::new(Arc::new(reader))?;
-
-            // Set ef_search based on config if available
-            if let Some(FieldOption::Hnsw(opt)) = &self.config.vector {
-                // Use a higher ef_search for better recall (increase search effort relative to construction)
-                searcher.set_ef_search(opt.ef_construction.max(50) * 2);
-            }
+            // Issue #644: prefer the schema-level `default_ef_search` when
+            // the user has configured one. Otherwise fall back to the legacy
+            // segmented-field heuristic of `ef_construction.max(50) * 2`
+            // (which kept Round-1 / Round-2 multi-segment recall stable).
+            // Per-query `VectorIndexQueryParams.ef_search` overrides both.
+            let default_ef = if let Some(FieldOption::Hnsw(opt)) = &self.config.vector {
+                opt.default_ef_search
+                    .unwrap_or_else(|| opt.ef_construction.max(50) * 2)
+            } else {
+                50
+            };
+            let searcher =
+                HnswSearcher::with_default_ef_search(Arc::new(reader), Some(default_ef))?;
 
             let params = VectorIndexQueryParams {
                 top_k: limit,

--- a/laurus/src/vector/search/searcher.rs
+++ b/laurus/src/vector/search/searcher.rs
@@ -82,6 +82,24 @@ impl VectorIndexQuery {
         self.params.rerank_factor = Some(factor);
         self
     }
+
+    /// Override the HNSW `ef_search` candidate-list size for this query
+    /// (Issue [#644](https://github.com/mosuka/laurus/issues/644)).
+    ///
+    /// `ef_search` controls the recall / latency trade-off on the HNSW
+    /// graph search. Higher values explore more graph neighbours and
+    /// give higher recall, at the cost of latency. When unset, the
+    /// searcher uses the schema-level
+    /// [`crate::vector::core::field::HnswOption::default_ef_search`]
+    /// (or its internal fallback of `50` when neither is set).
+    ///
+    /// The effective `ef_search` is always lifted to at least
+    /// `top_k * rerank_factor.unwrap_or(1)` so the candidate heap is
+    /// never undersized for the requested `top_k`.
+    pub fn ef_search(mut self, ef: usize) -> Self {
+        self.params.ef_search = Some(ef);
+        self
+    }
 }
 
 /// Configuration for low-level vector index query operations.
@@ -114,6 +132,23 @@ pub struct VectorIndexQueryParams {
     /// quantized-only search.
     #[serde(default)]
     pub rerank_factor: Option<usize>,
+    /// Per-query override for the HNSW `ef_search` candidate-list size
+    /// (Issue [#644](https://github.com/mosuka/laurus/issues/644)).
+    ///
+    /// When `None` (the default), the searcher uses the schema-level
+    /// [`crate::vector::core::field::HnswOption::default_ef_search`]
+    /// or its internal fallback (`50`). When `Some(ef)`, this value
+    /// takes precedence over the schema default.
+    ///
+    /// The effective `ef_search` used by the searcher is always lifted
+    /// to at least `max(top_k, top_k * rerank_factor.unwrap_or(1))` so
+    /// the candidate heap is never undersized for the requested
+    /// `top_k` (or for the candidate-widening implied by Stage-2
+    /// rerank).
+    ///
+    /// This field is ignored by non-HNSW index types.
+    #[serde(default)]
+    pub ef_search: Option<usize>,
 }
 
 impl Default for VectorIndexQueryParams {
@@ -125,6 +160,7 @@ impl Default for VectorIndexQueryParams {
             include_vectors: false,
             timeout_ms: None,
             rerank_factor: None,
+            ef_search: None,
         }
     }
 }
@@ -304,6 +340,15 @@ pub struct VectorSearchParams {
     /// configured at index time; otherwise silently ignored.
     #[serde(default)]
     pub rerank_factor: Option<usize>,
+    /// Per-query override for the HNSW `ef_search` candidate-list size
+    /// (Issue [#644](https://github.com/mosuka/laurus/issues/644)).
+    ///
+    /// When `None` (the default), the searcher uses the schema-level
+    /// [`crate::vector::core::field::HnswOption::default_ef_search`]
+    /// or its internal fallback (`50`). Ignored by non-HNSW index
+    /// types.
+    #[serde(default)]
+    pub ef_search: Option<usize>,
 }
 
 impl Default for VectorSearchParams {
@@ -316,6 +361,7 @@ impl Default for VectorSearchParams {
             min_score: 0.0,
             allowed_ids: None,
             rerank_factor: None,
+            ef_search: None,
         }
     }
 }

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -137,6 +137,7 @@ impl VectorStore {
                         distance_metric: opt.distance,
                         m: opt.m,
                         ef_construction: opt.ef_construction,
+                        default_ef_search: opt.default_ef_search,
                         embedder: config.embedder.clone(),
                         ..Default::default()
                     }),
@@ -452,6 +453,9 @@ impl VectorStore {
             if let Some(factor) = request.params.rerank_factor {
                 index_request = index_request.rerank_factor(factor);
             }
+            if let Some(ef) = request.params.ef_search {
+                index_request = index_request.ef_search(ef);
+            }
             let results = searcher.search(&index_request)?;
 
             let mut hits: Vec<VectorHit> = results
@@ -506,6 +510,9 @@ impl VectorStore {
                 .top_k(request.params.limit.saturating_mul(2)); // Overfetch for better results
             if let Some(factor) = request.params.rerank_factor {
                 index_request = index_request.rerank_factor(factor);
+            }
+            if let Some(ef) = request.params.ef_search {
+                index_request = index_request.ef_search(ef);
             }
 
             let results = searcher.search(&index_request)?;

--- a/laurus/tests/vector_merge_test.rs
+++ b/laurus/tests/vector_merge_test.rs
@@ -29,6 +29,7 @@ async fn test_segmented_field_manual_merge() -> Result<(), Box<dyn std::error::E
             distance: DistanceMetric::Euclidean,
             m: 16, // Default or specific to test? Using defaults or standard values
             ef_construction: 200, // Standard default
+            default_ef_search: None,
             base_weight: 1.0,
             quantizer: Default::default(),
             rerank_storage: None,

--- a/laurus/tests/vector_segment_test.rs
+++ b/laurus/tests/vector_segment_test.rs
@@ -55,6 +55,7 @@ async fn test_vector_segment_integration() {
                 distance: DistanceMetric::Euclidean,
                 m: 16,
                 ef_construction: 200,
+                default_ef_search: None,
                 base_weight: 1.0,
                 quantizer: Default::default(),
                 rerank_storage: None,


### PR DESCRIPTION
## Summary

The HNSW `ef_search` parameter was hardcoded to `50` in `HnswSearcher::new`, silently capping recall for `top_k >= 50` queries and preventing Stage-2 rerank from widening the int8 candidate fetch beyond 50. This PR introduces a two-tier override with automatic top-k lifting.

- **Schema-level**: `HnswOption.default_ef_search: Option<usize>` (plumbed through `HnswIndexConfig`)
- **Per-query**: `VectorSearchParams::ef_search` / `VectorIndexQueryParams::ef_search`, exposed via `SearchRequestBuilder::vector_ef_search(...)` and `VectorIndexQuery::ef_search(...)`
- **Searcher-side**: `HnswSearcher::effective_ef(request)` resolves the precedence (per-query > schema > built-in `HNSW_DEFAULT_EF_SEARCH = 50`) and always lifts the result to `max(top_k, top_k * rerank_factor.unwrap_or(1))` so the candidate heap is never undersized.

`SegmentedVectorField::search_managed_segments` now prefers the schema-level default when set; the legacy `ef_construction.max(50) * 2` heuristic is preserved as the fallback for backward compatibility.

The gRPC proto gains optional fields (`HnswOption.default_ef_search` at tag 8, `VectorParams.ef_search` at tag 6), the JSON gateway threads both end to end, and all five language bindings expose `default_ef_search` on `add_hnsw_field` (Python/Node/WASM/Ruby/PHP). Per-query exposure through bindings is deferred to align with the existing `rerank_factor` convention.

Round-3 perf sub-issue tracked under #536.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 1021 unit tests + 36 test result blocks, all pass; new tests:
  - 8 `ef_search_tests` for `HnswSearcher::effective_ef` (precedence, top-k lifting, rerank lifting, edge cases)
  - 1 integration test `hnsw_searcher_honours_per_query_and_schema_ef_search` exercising both schema default and per-query override paths end to end
- [x] `npx markdownlint-cli2 'docs/{src,ja/src}/**/*.md'` — 0 errors
- [x] `cargo bench --bench vector_search_bench` baseline vs. perf branch — see Bench notes below

## Backward compatibility

- `HnswOption::default()` keeps `default_ef_search: None` (existing schemas load unchanged)
- `VectorIndexQueryParams::default()` / `VectorSearchParams::default()` / `VectorSearchOptions::default()` keep `ef_search: None`
- Proto: new fields are `optional` (tags 8 / 6) — older clients omit them, older servers see them as unset
- `HnswSearcher::new()` keeps its existing signature; the internal default initialises to `HNSW_DEFAULT_EF_SEARCH = 50` (same as the previous hardcoded value)

## Bench notes

`make bench-baseline BENCH=vector_search_bench` on main vs. `make bench-compare` on this branch shows wide variance across both touched and untouched benches (range `-72% .. +30%`), with unrelated lexical/BKD groups moving by `±15%`. This is consistent with environmental noise (no CPU pinning); per-iteration measurements via Criterion's CI bounds are tight (e.g. `HNSW ef_search/ef_64_top10` CI ±0.4%), indicating the within-run variance is small but the between-runs baseline shift is not.

Algorithmically, `effective_ef` returns the same value as the previous direct field read for every existing call site (when `request.params.ef_search = None` and `rerank_factor = None`, `effective_ef = max(self.default_ef_search, top_k) = self.default_ef_search` for the typical `top_k <= default` case). No code path changed semantically; the only difference is one extra `Option::unwrap_or` + two `max` operations per `search()` call.

Recommendation: rely on CI bench (or `scripts/bench-stable.sh` with CPU pinning) for fine-grained comparison. The ef_search benches that improved (`ef_128 -8.2%`, `ef_256 -5.2%`) and the construction benches (`hnsw_index_construction -12.3%`) are unrelated to my change and confirm the noise interpretation.

Closes #644
Refs #536