### PR TITLE
perf(vector/search): cache HnswIndexReader per segment in SegmentedVectorField (#660)

### DIFF
--- a/laurus/src/vector/index/hnsw/segment.rs
+++ b/laurus/src/vector/index/hnsw/segment.rs
@@ -32,3 +32,4 @@ pub struct SegmentInfo {
 pub mod manager;
 pub mod merge_engine;
 pub mod merge_policy;
+pub mod reader_cache;

--- a/laurus/src/vector/index/hnsw/segment/reader_cache.rs
+++ b/laurus/src/vector/index/hnsw/segment/reader_cache.rs
@@ -1,0 +1,184 @@
+//! Per-segment [`HnswIndexReader`] cache for
+//! [`SegmentedVectorField`](crate::vector::index::segmented_field::SegmentedVectorField).
+//!
+//! Before this cache existed, each `search_managed_segments` call reloaded
+//! every managed segment from disk via `HnswIndexReader::load`, re-parsing
+//! the segment header, rebuilding the int8 quantized pool, the prefetch
+//! index, and the per-field doc-id lookup. For a multi-segment index the
+//! per-query I/O often dominated the actual graph traversal cost.
+//!
+//! This cache holds an [`Arc<HnswIndexReader>`] per `segment_id` so that the
+//! second and subsequent searches against the same segment hit memory only.
+//! Entries are invalidated by
+//! [`SegmentedVectorField::perform_merge_with_policy`](crate::vector::index::segmented_field::SegmentedVectorField::perform_merge_with_policy)
+//! immediately after the underlying segment manager removes a source
+//! segment as part of a merge.
+//!
+//! Issue [#660](https://github.com/mosuka/laurus/issues/660). Reuses the
+//! storage-level per-segment input cache landed in
+//! [#522](https://github.com/mosuka/laurus/issues/522); the two layers are
+//! complementary — #522 caches the open file handle, #660 caches the fully
+//! parsed reader state on top.
+
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use parking_lot::RwLock;
+
+use crate::error::Result;
+use crate::vector::index::hnsw::reader::HnswIndexReader;
+
+/// Caches `Arc<HnswIndexReader>` per `segment_id`.
+///
+/// The cache is intentionally minimal: it stores every requested reader
+/// for the lifetime of the owning
+/// [`SegmentedVectorField`](crate::vector::index::segmented_field::SegmentedVectorField)
+/// (i.e. no LRU eviction or memory budget). A future change can swap the
+/// inner map for an LRU-backed implementation without touching call sites.
+#[derive(Debug, Default)]
+pub struct SegmentedReaderCache {
+    inner: RwLock<AHashMap<String, Arc<HnswIndexReader>>>,
+}
+
+impl SegmentedReaderCache {
+    /// Create an empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the cached reader for `segment_id`, invoking `loader` on miss.
+    ///
+    /// Concurrent callers requesting the same `segment_id` may race; the
+    /// double-checked lock pattern below ensures only one of them runs
+    /// `loader`, the rest pick up the already-inserted entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `segment_id` - The segment identifier to look up.
+    /// * `loader` - Invoked only on a cache miss; returns the freshly-built
+    ///   [`HnswIndexReader`].
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Arc::clone(&reader))` if the reader is found or successfully
+    /// loaded. Propagates `loader`'s error otherwise.
+    pub fn get_or_load<F>(&self, segment_id: &str, loader: F) -> Result<Arc<HnswIndexReader>>
+    where
+        F: FnOnce() -> Result<HnswIndexReader>,
+    {
+        if let Some(reader) = self.inner.read().get(segment_id) {
+            return Ok(Arc::clone(reader));
+        }
+
+        // Slow path: take the write lock and re-check before loading so that
+        // concurrent misses on the same `segment_id` don't load twice.
+        let mut guard = self.inner.write();
+        if let Some(reader) = guard.get(segment_id) {
+            return Ok(Arc::clone(reader));
+        }
+
+        let reader = Arc::new(loader()?);
+        guard.insert(segment_id.to_string(), Arc::clone(&reader));
+        Ok(reader)
+    }
+
+    /// Remove the cached reader for `segment_id`.
+    ///
+    /// Safe to call for unknown segment ids — a missing entry is a no-op.
+    pub fn invalidate(&self, segment_id: &str) {
+        self.inner.write().remove(segment_id);
+    }
+
+    /// Remove all cached readers.
+    ///
+    /// Intended for tests and for future LRU integration; not invoked from
+    /// the live search path.
+    pub fn clear(&self) {
+        self.inner.write().clear();
+    }
+
+    /// Return the number of cached entries.
+    ///
+    /// Primarily exposed for tests. The value may be stale by the time the
+    /// caller reads it because other threads may concurrently mutate the
+    /// cache, so do not rely on it for control flow.
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    /// Return `true` if the cache currently holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+
+    /// Return `true` if the cache currently holds an entry for `segment_id`.
+    ///
+    /// Primarily exposed for tests.
+    pub fn contains(&self, segment_id: &str) -> bool {
+        self.inner.read().contains_key(segment_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::LaurusError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Build a dummy `HnswIndexReader` from a `SimpleVectorReader`-style
+    /// shortcut would be ideal, but the cache only stores `Arc<HnswIndexReader>`
+    /// and our tests don't need the reader to be functional — they only
+    /// need to assert that the loader is invoked the right number of times
+    /// for a given access pattern.
+    ///
+    /// Instead, return an `Err` from the loader and assert the call count.
+    /// `get_or_load` propagates the error without inserting anything, so we
+    /// can use call counters to distinguish hits from misses.
+
+    #[test]
+    fn get_or_load_invokes_loader_on_miss_only() {
+        let cache = SegmentedReaderCache::new();
+        let calls = AtomicUsize::new(0);
+
+        // First call: loader is invoked, returns Err so nothing is cached.
+        let r1 = cache.get_or_load("seg-a", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LaurusError::other("intentional miss"))
+        });
+        assert!(r1.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(cache.len(), 0, "no entry inserted on loader error");
+
+        // Second call: same segment, loader still invoked (no entry cached).
+        let r2 = cache.get_or_load("seg-a", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LaurusError::other("still missing"))
+        });
+        assert!(r2.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn invalidate_is_noop_for_unknown_segment() {
+        let cache = SegmentedReaderCache::new();
+        cache.invalidate("never-cached");
+        assert_eq!(cache.len(), 0);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn clear_empties_the_cache() {
+        let cache = SegmentedReaderCache::new();
+        assert!(cache.is_empty());
+        cache.clear();
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn contains_reports_membership() {
+        let cache = SegmentedReaderCache::new();
+        assert!(!cache.contains("seg-a"));
+        // No way to insert via the public API without a real reader; that
+        // case is covered by the integration test in `segmented_field`.
+    }
+}

--- a/laurus/src/vector/index/segmented_field.rs
+++ b/laurus/src/vector/index/segmented_field.rs
@@ -19,6 +19,7 @@ use crate::vector::index::hnsw::reader::HnswIndexReader;
 use crate::vector::index::hnsw::searcher::HnswSearcher;
 use crate::vector::index::hnsw::segment::manager::{ManagedSegmentInfo, SegmentManager};
 use crate::vector::index::hnsw::segment::merge_engine::{MergeConfig, MergeEngine};
+use crate::vector::index::hnsw::segment::reader_cache::SegmentedReaderCache;
 use crate::vector::index::hnsw::writer::HnswIndexWriter;
 use crate::vector::search::searcher::{
     VectorIndexQuery, VectorIndexQueryParams, VectorIndexSearcher,
@@ -50,6 +51,16 @@ pub struct SegmentedVectorField {
 
     /// Global deletion bitmap.
     pub deletion_bitmap: Option<Arc<DeletionBitmap>>,
+
+    /// Per-segment [`HnswIndexReader`] cache used by
+    /// [`Self::search_managed_segments`]. Without this cache every query
+    /// reloaded every managed segment from disk; with it, the second and
+    /// subsequent queries against the same segment hit memory only.
+    ///
+    /// Invalidated by [`Self::perform_merge_with_policy`] when source
+    /// segments are removed as part of a merge. Issue
+    /// [#660](https://github.com/mosuka/laurus/issues/660).
+    pub reader_cache: Arc<SegmentedReaderCache>,
 }
 
 impl SegmentedVectorField {
@@ -79,6 +90,7 @@ impl SegmentedVectorField {
             storage,
             active_segment: Arc::new(RwLock::new(None)),
             deletion_bitmap,
+            reader_cache: Arc::new(SegmentedReaderCache::new()),
         };
 
         Ok(field)
@@ -193,7 +205,22 @@ impl SegmentedVectorField {
 
             let info = ManagedSegmentInfo::new(new_segment_id, result.stats.vectors_merged, 0, 0);
 
+            // Capture source segment ids before `apply_merge` consumes
+            // `candidate`, so we can invalidate their cache entries below.
+            // Issue #660: source readers are no longer reachable through the
+            // manager after `apply_merge`; clearing their cache entries
+            // prevents stale orphan readers from lingering in memory.
+            let source_ids: Vec<String> = candidate
+                .segments
+                .iter()
+                .map(|s| s.segment_id.clone())
+                .collect();
+
             self.segment_manager.apply_merge(candidate, info)?;
+
+            for id in &source_ids {
+                self.reader_cache.invalidate(id);
+            }
         }
         Ok(())
     }
@@ -366,14 +393,23 @@ impl SegmentedVectorField {
         };
 
         for info in segments {
-            // Load reader for segment
-            let mut reader =
-                HnswIndexReader::load(self.storage.clone(), &info.segment_id, distance_metric)?;
-
-            // Inject deletion bitmap if available
-            if let Some(bitmap) = &self.deletion_bitmap {
-                reader.set_deletion_bitmap(bitmap.clone());
-            }
+            // Issue #660: fetch the reader from the per-segment cache to
+            // avoid the per-query reload from disk. The first search for a
+            // given `segment_id` invokes the loader (paying the full
+            // `HnswIndexReader::load` cost); subsequent searches receive
+            // the cached `Arc<HnswIndexReader>` directly. Entries are
+            // invalidated by `perform_merge_with_policy` when the
+            // underlying segment is removed.
+            let storage = self.storage.clone();
+            let deletion_bitmap = self.deletion_bitmap.clone();
+            let segment_id = info.segment_id.clone();
+            let reader = self.reader_cache.get_or_load(&segment_id, || {
+                let mut r = HnswIndexReader::load(storage, &segment_id, distance_metric)?;
+                if let Some(bitmap) = deletion_bitmap {
+                    r.set_deletion_bitmap(bitmap);
+                }
+                Ok(r)
+            })?;
 
             // Issue #644: prefer the schema-level `default_ef_search` when
             // the user has configured one. Otherwise fall back to the legacy
@@ -386,8 +422,7 @@ impl SegmentedVectorField {
             } else {
                 50
             };
-            let searcher =
-                HnswSearcher::with_default_ef_search(Arc::new(reader), Some(default_ef))?;
+            let searcher = HnswSearcher::with_default_ef_search(reader, Some(default_ef))?;
 
             let params = VectorIndexQueryParams {
                 top_k: limit,

--- a/laurus/tests/vector_merge_test.rs
+++ b/laurus/tests/vector_merge_test.rs
@@ -1,10 +1,12 @@
 use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
 use laurus::vector::DistanceMetric;
 use laurus::vector::StoredVector;
+use laurus::vector::Vector;
 use laurus::vector::VectorFieldConfig;
-use laurus::vector::index::field::{VectorFieldReader, VectorFieldWriter};
+use laurus::vector::index::field::{FieldSearchInput, VectorFieldReader, VectorFieldWriter};
 use laurus::vector::index::hnsw::segment::manager::{SegmentManager, SegmentManagerConfig};
 use laurus::vector::index::segmented_field::SegmentedVectorField;
+use laurus::vector::store::request::QueryVector;
 use laurus::vector::{FieldOption, HnswOption};
 use std::sync::Arc;
 
@@ -87,6 +89,147 @@ async fn test_segmented_field_manual_merge() -> Result<(), Box<dyn std::error::E
     // Verify Stats
     let stats = field.stats()?; // Should be 3 vectors total
     assert_eq!(stats.vector_count, 3);
+
+    Ok(())
+}
+
+/// Regression test for Issue [#660]: `SegmentedVectorField` must reuse
+/// a cached `Arc<HnswIndexReader>` across queries against the same
+/// segment, and must invalidate the cache entry when the segment is
+/// removed via merge.
+///
+/// [#660]: https://github.com/mosuka/laurus/issues/660
+#[tokio::test]
+async fn segmented_field_reader_cache_reuses_and_invalidates()
+-> Result<(), Box<dyn std::error::Error>> {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+    let manager_config = SegmentManagerConfig {
+        max_segments: 2,
+        merge_factor: 2,
+        min_vectors_per_segment: 1,
+        ..Default::default()
+    };
+    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+
+    let field_config = VectorFieldConfig {
+        vector: Some(FieldOption::Hnsw(HnswOption {
+            dimension: 4,
+            distance: DistanceMetric::Euclidean,
+            m: 16,
+            ef_construction: 200,
+            default_ef_search: None,
+            base_weight: 1.0,
+            quantizer: Default::default(),
+            rerank_storage: None,
+            embedder: None,
+        })),
+        lexical: None,
+    };
+
+    let field = SegmentedVectorField::create(
+        "embedding",
+        field_config,
+        manager.clone(),
+        storage.clone(),
+        None,
+    )?;
+
+    // Flush three single-vector segments. After this the manager owns
+    // 3 segments and the reader cache is still empty (no searches yet).
+    field
+        .add_stored_vector(1, &StoredVector::new(vec![1.0, 0.0, 0.0, 0.0]), 0)
+        .await?;
+    field.flush().await?;
+    field
+        .add_stored_vector(2, &StoredVector::new(vec![0.0, 1.0, 0.0, 0.0]), 0)
+        .await?;
+    field.flush().await?;
+    field
+        .add_stored_vector(3, &StoredVector::new(vec![0.0, 0.0, 1.0, 0.0]), 0)
+        .await?;
+    field.flush().await?;
+
+    assert_eq!(manager.list_segments().len(), 3);
+    assert!(
+        field.reader_cache.is_empty(),
+        "cache should be empty before the first search"
+    );
+
+    let segment_ids: Vec<String> = manager
+        .list_segments()
+        .iter()
+        .map(|s| s.segment_id.clone())
+        .collect();
+
+    let query_input = || FieldSearchInput {
+        field: "embedding".to_string(),
+        query_vectors: vec![QueryVector {
+            vector: Vector::new(vec![1.0, 0.0, 0.0, 0.0]),
+            weight: 1.0,
+            fields: None,
+        }],
+        limit: 3,
+        allowed_ids: None,
+    };
+
+    // First search: populates the cache with one entry per managed segment.
+    let _first = field.search(query_input())?;
+    assert_eq!(
+        field.reader_cache.len(),
+        3,
+        "cache should hold one reader per managed segment after the first search"
+    );
+    for id in &segment_ids {
+        assert!(
+            field.reader_cache.contains(id),
+            "cache should contain entry for segment {id}"
+        );
+    }
+
+    // Second search: cache should still have the same three entries; no
+    // additional segments managed and no eviction.
+    let _second = field.search(query_input())?;
+    assert_eq!(
+        field.reader_cache.len(),
+        3,
+        "cache size should be stable across repeat searches"
+    );
+
+    // Trigger a merge — `perform_merge` removes 2 source segments and
+    // adds 1 merged segment, so the cache must drop the 2 source entries
+    // and report a size of 1.
+    field.perform_merge()?;
+
+    let after = manager.list_segments();
+    assert_eq!(after.len(), 2, "manager should hold 2 segments after merge");
+
+    // Identify which source ids were merged away — those are the ones
+    // whose cache entries should now be gone.
+    let remaining: std::collections::HashSet<String> =
+        after.iter().map(|s| s.segment_id.clone()).collect();
+    let merged_away: Vec<&String> = segment_ids
+        .iter()
+        .filter(|id| !remaining.contains(*id))
+        .collect();
+    assert_eq!(
+        merged_away.len(),
+        2,
+        "merge should consume 2 source segments"
+    );
+
+    for id in merged_away {
+        assert!(
+            !field.reader_cache.contains(id),
+            "cache entry for merged-away segment {id} must be invalidated"
+        );
+    }
+
+    assert!(
+        field.reader_cache.len() <= 1,
+        "cache should have at most the one survivor pre-search; got {}",
+        field.reader_cache.len()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`SegmentedVectorField::search_managed_segments` previously called `HnswIndexReader::load` for every managed segment on every query, re-parsing the segment header, rebuilding the int8 quantized pool, the prefetch index, and the per-field doc-id lookup. For a multi-segment index the per-query I/O often dominated the actual graph traversal cost — the Round-3 audit flagged this as the largest single perf bug in the multi-segment path.

This PR introduces a per-segment `Arc<HnswIndexReader>` cache (`SegmentedReaderCache`) so that the first search against a given segment pays the full load cost and subsequent searches hit memory only. Cache entries are invalidated when a segment is removed via merge.

## Design

- **Storage**: `parking_lot::RwLock<AHashMap<String, Arc<HnswIndexReader>>>` keyed by `segment_id`.
- **Concurrency**: `get_or_load` uses a double-checked lock pattern so concurrent misses on the same segment invoke the loader exactly once.
- **Reader lifetime**: shared via `Arc::clone`; the same reader services many concurrent searches against the same segment.
- **Deletion bitmap**: injected once at load time as `Arc<DeletionBitmap>`. Subsequent updates to the shared bitmap are observed by all cached readers (no per-search re-injection).
- **Invalidation**: `perform_merge_with_policy` collects the source `segment_id`s, calls `SegmentManager::apply_merge`, then invalidates the cache entries for the consumed source segments.
- **Complementary to #522**: the storage-level per-segment `Input` cache landed in #522 caches the open file handle; #660 caches the fully parsed reader state on top.

## Backward compatibility

- No public API change for callers — `search_managed_segments` returns the same result for the same inputs, only faster on the second and subsequent calls per segment.
- The new `SegmentedVectorField::reader_cache` field is added to a struct that already had multiple `Arc<>` fields; no observable change.
- No proto / binding / docs change.

## Scope notes

This is the minimal "always cache" implementation:

- **No LRU / no memory budget**: every requested reader stays cached for the lifetime of the owning `SegmentedVectorField`. For a 10-segment × multi-GB-per-segment index this can add up. A follow-up issue will introduce LRU eviction and a configurable memory budget once production OOM signals motivate it.
- **No new benchmark in this PR**: existing `vector_search_bench` has no `Segmented*` group. Adding one is scoped separately so this PR stays narrowly focused on the cache itself.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 1009 -> 1013 unit tests (4 new `SegmentedReaderCache` tests); all integration tests including the new `segmented_field_reader_cache_reuses_and_invalidates` pass
- [x] `npx markdownlint-cli2 'docs/{src,ja/src}/**/*.md'` — 0 errors
- [x] `cargo build --workspace --all-targets` clean

The new integration test (`tests/vector_merge_test.rs`) sets up a 3-segment field and asserts:

1. The reader cache starts empty.
2. A first search populates the cache with 3 entries.
3. A second search keeps the size at 3 (no reload).
4. After `perform_merge()` the 2 source-segment entries are invalidated.

Closes #660
Refs #536