### PR TITLE
perf(vector): add PQ FastScan pool + scalar reference kernel (Part A) (#692)

### DIFF
--- a/laurus/src/vector/core.rs
+++ b/laurus/src/vector/core.rs
@@ -5,6 +5,7 @@
 //! distance metrics, and quantization methods.
 
 pub mod distance;
+pub mod distance_pq_fastscan;
 pub mod distance_quantized;
 pub mod field;
 pub mod quantization;

--- a/laurus/src/vector/core/distance_pq_fastscan.rs
+++ b/laurus/src/vector/core/distance_pq_fastscan.rs
@@ -1,0 +1,561 @@
+//! FastScan-style PQ ADC query state and scalar reference kernel
+//! (Issue [#651](https://github.com/mosuka/laurus/issues/651) /
+//! part A [#692](https://github.com/mosuka/laurus/issues/692)).
+//!
+//! Parallel to
+//! [`crate::vector::core::distance_quantized::PqQuery`] (the existing
+//! K=256 8-bit PQ query); the differences are:
+//!
+//! - The per-query lookup table is sized for K=16 (16 entries per
+//!   sub-quantiser) so it fits in a single 128-bit SIMD register, which
+//!   the AVX2 / NEON kernels (parts B #693, C #694) consume via
+//!   `pshufb` / `vqtbl1q_u8`.
+//! - The LUT is **quantised to `u8`** per sub-quantiser with a
+//!   min-max affine map so the SIMD path can accumulate distances in
+//!   `u8` lanes; the [`PqFastScanQuery::lut_f32`] field preserves the
+//!   unquantised LUT so the scalar reference here can be cross-checked
+//!   against the true f32 distance.
+//!
+//! This module only ships scalar kernels. The SIMD kernels and the
+//! production wiring live in later parts of #651.
+
+use crate::error::{LaurusError, Result};
+use crate::vector::core::distance::DistanceMetric;
+use crate::vector::core::quantization::PqParams;
+use crate::vector::index::pq_fastscan_storage::{BLOCK_SIZE, BYTES_PER_SUB_PER_BLOCK};
+
+/// K constant for FastScan (4-bit codes).
+const K: usize = 16;
+
+/// Per-query state for the FastScan PQ ADC kernel.
+///
+/// Built once per search via [`PqFastScanQuery::prepare`] and reused
+/// for every candidate. The scalar reference kernels offer two paths:
+///
+/// - [`distance_pq_fastscan_f32_scalar`] uses [`Self::lut_f32`]
+///   directly — this is the mathematically-exact ADC distance and
+///   serves as the ground truth for tests.
+/// - [`distance_pq_fastscan_u8_scalar`] uses [`Self::lut4`] plus the
+///   per-sub-quantiser [`Self::lut_scale`] / [`Self::lut_bias`] to
+///   recover an f32 distance, matching what the SIMD kernels in
+///   parts B / C will compute.
+#[derive(Debug, Clone)]
+pub struct PqFastScanQuery {
+    /// PQ parameters this LUT was built against. `params.k` must be
+    /// `16`; the constructor returns an error otherwise.
+    pub params: PqParams,
+    /// Unquantised LUT, row-major `[m][k]` of length `m * K`. Kept
+    /// alongside the quantised LUT so tests can isolate the kernel
+    /// logic from the quantisation drift.
+    pub lut_f32: Vec<f32>,
+    /// Quantised LUT, row-major `[m][k]` of length `m * K`. Each
+    /// entry is in `[0, 255]` and decodes to
+    /// `lut_f32 ≈ u8 * lut_scale[m] + lut_bias[m]`.
+    pub lut4: Vec<u8>,
+    /// Per-sub-quantiser scale of the affine quantisation. Length is
+    /// `M`.
+    pub lut_scale: Vec<f32>,
+    /// Per-sub-quantiser bias of the affine quantisation. Length is
+    /// `M`.
+    pub lut_bias: Vec<f32>,
+    /// `||query||² = Σ_i query[i]²`, cached for the metrics that need
+    /// it (currently unused by the scalar kernels but kept for API
+    /// parity with [`crate::vector::core::distance_quantized::PqQuery`]).
+    pub query_norm_sq: f32,
+}
+
+impl PqFastScanQuery {
+    /// Build the per-query LUT (`f32` and `u8` variants) from a raw
+    /// f32 query and the segment's K=16 codebook.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The raw f32 query vector, length must match
+    ///   `params.original_dim()`.
+    /// * `params` - PQ parameters with `k == 16`.
+    /// * `codebook` - Row-major `[m][k][sub_dim]` codebook from
+    ///   [`crate::vector::core::quantization::pq_train_codebook`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LaurusError::InvalidOperation`] if `params.k != 16`,
+    /// if `query.len() != params.original_dim()`, or if
+    /// `codebook.len() != params.codebook_len()`.
+    pub fn prepare(query: &[f32], params: PqParams, codebook: &[f32]) -> Result<Self> {
+        if params.k as usize != K {
+            return Err(LaurusError::InvalidOperation(format!(
+                "PqFastScanQuery requires PqParams::k == {K} (got {})",
+                params.k
+            )));
+        }
+        if query.len() != params.original_dim() {
+            return Err(LaurusError::InvalidOperation(format!(
+                "PqFastScanQuery: query length {} does not match params.original_dim() {}",
+                query.len(),
+                params.original_dim()
+            )));
+        }
+        if codebook.len() != params.codebook_len() {
+            return Err(LaurusError::InvalidOperation(format!(
+                "PqFastScanQuery: codebook length {} does not match params.codebook_len() {}",
+                codebook.len(),
+                params.codebook_len()
+            )));
+        }
+
+        let m = params.m as usize;
+        let sub_dim = params.sub_dim as usize;
+        let mut lut_f32 = vec![0.0_f32; m * K];
+
+        for sub in 0..m {
+            let q_sub = &query[sub * sub_dim..(sub + 1) * sub_dim];
+            let cb_base = sub * K * sub_dim;
+            for ki in 0..K {
+                let c = &codebook[cb_base + ki * sub_dim..cb_base + (ki + 1) * sub_dim];
+                let mut acc = 0.0_f32;
+                for d in 0..sub_dim {
+                    let diff = q_sub[d] - c[d];
+                    acc += diff * diff;
+                }
+                lut_f32[sub * K + ki] = acc;
+            }
+        }
+
+        let (lut4, lut_scale, lut_bias) = quantise_lut_per_sub(&lut_f32, m);
+        let query_norm_sq: f32 = query.iter().map(|x| x * x).sum();
+
+        Ok(Self {
+            params,
+            lut_f32,
+            lut4,
+            lut_scale,
+            lut_bias,
+            query_norm_sq,
+        })
+    }
+}
+
+/// Quantise a per-sub-quantiser-grouped f32 LUT to `u8`.
+///
+/// For each sub-quantiser `m`, finds the min / max of
+/// `lut_f32[m * K .. (m + 1) * K]`, builds an affine map
+/// `u8 = round((f32 - min) / (max - min) * 255)`, and records the
+/// inverse `(scale, bias)` so the kernel can recover an f32
+/// approximation.
+///
+/// Returns `(lut4, lut_scale, lut_bias)`:
+///
+/// - `lut4.len() == m * K`
+/// - `lut_scale.len() == m`, `lut_bias.len() == m`
+/// - `f32_approx = u8_value * lut_scale[m] + lut_bias[m]`
+///
+/// If a sub-quantiser's LUT has zero range (min == max), the affine
+/// map collapses to a zero-scale dequantiser; every code decodes to
+/// the constant `min` value.
+pub fn quantise_lut_per_sub(lut_f32: &[f32], m: usize) -> (Vec<u8>, Vec<f32>, Vec<f32>) {
+    debug_assert_eq!(lut_f32.len(), m * K);
+    let mut lut4 = vec![0u8; m * K];
+    let mut lut_scale = vec![0.0_f32; m];
+    let mut lut_bias = vec![0.0_f32; m];
+
+    for sub in 0..m {
+        let chunk = &lut_f32[sub * K..(sub + 1) * K];
+        let min = chunk.iter().copied().fold(f32::INFINITY, f32::min);
+        let max = chunk.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let span = max - min;
+        if span > 0.0 {
+            let scale = span / 255.0;
+            lut_scale[sub] = scale;
+            lut_bias[sub] = min;
+            for (i, &v) in chunk.iter().enumerate() {
+                let q = ((v - min) / span * 255.0).round().clamp(0.0, 255.0) as u8;
+                lut4[sub * K + i] = q;
+            }
+        } else {
+            // Degenerate LUT: every entry collapses to `min`. The u8
+            // codes are arbitrary; we choose 0 so the dequantiser
+            // recovers `bias = min` exactly.
+            lut_scale[sub] = 0.0;
+            lut_bias[sub] = min;
+        }
+    }
+
+    (lut4, lut_scale, lut_bias)
+}
+
+/// Decode the M 4-bit codes for `vec_idx_in_block` out of a single
+/// block of packed FastScan storage.
+///
+/// `packed_block` must point at the start of one block, i.e. its
+/// length is `m * BYTES_PER_SUB_PER_BLOCK`. `vec_idx_in_block` is in
+/// `[0, BLOCK_SIZE)`.
+fn decode_codes_in_block(packed_block: &[u8], m: usize, vec_idx_in_block: usize) -> Vec<u8> {
+    debug_assert_eq!(packed_block.len(), m * BYTES_PER_SUB_PER_BLOCK);
+    debug_assert!(vec_idx_in_block < BLOCK_SIZE);
+    let mut codes = vec![0u8; m];
+    let (j, shift) = if vec_idx_in_block < 16 {
+        (vec_idx_in_block, 0)
+    } else {
+        (vec_idx_in_block - 16, 4)
+    };
+    for sub in 0..m {
+        let byte = packed_block[sub * BYTES_PER_SUB_PER_BLOCK + j];
+        codes[sub] = (byte >> shift) & 0x0F;
+    }
+    codes
+}
+
+/// Scalar FastScan ADC distance using the **unquantised** f32 LUT.
+///
+/// Returns the mathematically-exact ADC distance (i.e. the value the
+/// per-block sum `Σ_m lut_f32[m * K + code_m]` produces), with the
+/// metric-specific post-processing applied. Used as the ground truth
+/// for testing the `u8` kernel and (later) the SIMD kernels.
+///
+/// `packed_block` must be one block's worth of storage and
+/// `vec_idx_in_block` is in `[0, BLOCK_SIZE)`. Out-of-range candidates
+/// (positions past `n_vectors` inside the trailing block) are the
+/// caller's responsibility — this kernel decodes whatever nibbles are
+/// in the buffer.
+pub fn distance_pq_fastscan_f32_scalar(
+    metric: DistanceMetric,
+    query: &PqFastScanQuery,
+    packed_block: &[u8],
+    vec_idx_in_block: usize,
+) -> f32 {
+    let m = query.params.m as usize;
+    let codes = decode_codes_in_block(packed_block, m, vec_idx_in_block);
+    let mut l2_sq = 0.0_f32;
+    for (sub, &code) in codes.iter().enumerate() {
+        l2_sq += query.lut_f32[sub * K + code as usize];
+    }
+    apply_metric(metric, l2_sq)
+}
+
+/// Scalar FastScan ADC distance using the **quantised** u8 LUT.
+///
+/// Mirrors what the SIMD kernels in parts B (#693) and C (#694) will
+/// compute: accumulate `u8` LUT entries (using a `u32` accumulator
+/// here to side-step the saturation bookkeeping the SIMD path needs)
+/// and convert back to f32 via the per-sub-quantiser scale + bias.
+///
+/// Equivalent to `Σ_m (lut4[m * K + code_m] * lut_scale[m] + lut_bias[m])`,
+/// which matches the kernel-level dequantisation step the SIMD path
+/// will perform once it has emitted the final accumulator value.
+pub fn distance_pq_fastscan_u8_scalar(
+    metric: DistanceMetric,
+    query: &PqFastScanQuery,
+    packed_block: &[u8],
+    vec_idx_in_block: usize,
+) -> f32 {
+    let m = query.params.m as usize;
+    let codes = decode_codes_in_block(packed_block, m, vec_idx_in_block);
+    let mut l2_sq = 0.0_f32;
+    for (sub, &code) in codes.iter().enumerate() {
+        let q = query.lut4[sub * K + code as usize] as f32;
+        l2_sq += q * query.lut_scale[sub] + query.lut_bias[sub];
+    }
+    apply_metric(metric, l2_sq)
+}
+
+/// Apply the metric-specific post-processing to the raw L2² sum.
+///
+/// Same convention as
+/// [`crate::vector::core::distance_quantized::distance_pq_adc`]:
+/// Euclidean returns `sqrt(L2²)`, Cosine halves and clamps to `[0, 2]`,
+/// any other metric returns `f32::INFINITY` to make the searcher's
+/// dispatch fail cleanly.
+#[inline]
+fn apply_metric(metric: DistanceMetric, l2_sq: f32) -> f32 {
+    match metric {
+        DistanceMetric::Euclidean => l2_sq.max(0.0).sqrt(),
+        DistanceMetric::Cosine => (l2_sq * 0.5).clamp(0.0, 2.0),
+        _ => f32::INFINITY,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vector::core::quantization::{PqParams, pq_train_codebook};
+    use crate::vector::core::vector::Vector;
+    use crate::vector::index::pq_fastscan_storage::{PqFastScanPool, pack_codes_into_blocks};
+
+    /// Train a small K=16 codebook from `n` random-ish vectors of
+    /// dimension `m * sub_dim`. Deterministic for reproducible tests.
+    fn train_small_codebook(
+        m: usize,
+        sub_dim: usize,
+        n: usize,
+    ) -> (PqParams, Vec<f32>, Vec<Vector>) {
+        let dim = m * sub_dim;
+        let params = PqParams::new(m as u16, K as u16, sub_dim as u16).unwrap();
+        let mut vectors = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut v = Vec::with_capacity(dim);
+            for d in 0..dim {
+                // Cheap pseudo-random pattern with broad spread so the
+                // K-means inside `pq_train_codebook` produces a real
+                // (non-degenerate) codebook.
+                let x = ((i * 31 + d * 17) % 257) as f32 - 128.0;
+                let y = ((i.wrapping_mul(d + 1)) % 91) as f32 * 0.1;
+                v.push(x + y);
+            }
+            vectors.push(Vector::new(v));
+        }
+        let codebook = pq_train_codebook(dim, params, &vectors).unwrap();
+        (params, codebook, vectors)
+    }
+
+    /// Round-trip a single vector through encode → decode (codebook
+    /// lookup) to obtain the reconstruction the kernel implicitly uses.
+    fn decode_via_codebook(codes: &[u8], params: PqParams, codebook: &[f32]) -> Vec<f32> {
+        let sub_dim = params.sub_dim as usize;
+        let mut out = vec![0.0_f32; params.original_dim()];
+        for (sub, &code) in codes.iter().enumerate() {
+            let cb_base = sub * K * sub_dim;
+            let centroid = &codebook
+                [cb_base + (code as usize) * sub_dim..cb_base + (code as usize + 1) * sub_dim];
+            out[sub * sub_dim..(sub + 1) * sub_dim].copy_from_slice(centroid);
+        }
+        out
+    }
+
+    fn encode_vec(v: &[f32], params: PqParams, codebook: &[f32]) -> Vec<u8> {
+        crate::vector::core::quantization::pq_encode(v, params, codebook)
+    }
+
+    #[test]
+    fn quantise_lut_round_trip_within_tolerance() {
+        // Build a tiny synthetic LUT with a known range per sub.
+        let m = 4;
+        let mut lut_f32 = vec![0.0_f32; m * K];
+        for sub in 0..m {
+            for i in 0..K {
+                lut_f32[sub * K + i] = (sub as f32) * 10.0 + (i as f32) * (1.0 + sub as f32);
+            }
+        }
+        let (lut4, scale, bias) = quantise_lut_per_sub(&lut_f32, m);
+        // Dequantise and compare against the original LUT. The max
+        // per-sub error is `span / 255 / 2` for round-to-nearest.
+        for sub in 0..m {
+            let chunk = &lut_f32[sub * K..(sub + 1) * K];
+            let span = chunk.iter().copied().fold(f32::NEG_INFINITY, f32::max)
+                - chunk.iter().copied().fold(f32::INFINITY, f32::min);
+            let tolerance = (span / 255.0 / 2.0) + 1e-5;
+            for i in 0..K {
+                let reconstructed = lut4[sub * K + i] as f32 * scale[sub] + bias[sub];
+                let original = lut_f32[sub * K + i];
+                assert!(
+                    (reconstructed - original).abs() <= tolerance,
+                    "sub={sub} i={i}: |{reconstructed} - {original}| > {tolerance}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn quantise_lut_handles_constant_sub() {
+        // A sub-quantiser whose LUT is entirely the same value
+        // (degenerate range). The dequantiser should still return
+        // that constant.
+        let m = 2;
+        let mut lut_f32 = vec![0.0_f32; m * K];
+        // sub 0: all 7.5
+        for slot in lut_f32.iter_mut().take(K) {
+            *slot = 7.5;
+        }
+        // sub 1: linearly increasing
+        for (i, slot) in lut_f32.iter_mut().enumerate().skip(K).take(K) {
+            *slot = (i - K) as f32;
+        }
+        let (lut4, scale, bias) = quantise_lut_per_sub(&lut_f32, m);
+        assert_eq!(scale[0], 0.0);
+        assert_eq!(bias[0], 7.5);
+        for &code in lut4.iter().take(K) {
+            let r = code as f32 * scale[0] + bias[0];
+            assert_eq!(r, 7.5);
+        }
+        // sub 1 is non-degenerate and round-trips within tolerance.
+        let span1 = 15.0_f32; // 15 - 0
+        let tol = span1 / 255.0 / 2.0 + 1e-5;
+        for i in 0..K {
+            let r = lut4[K + i] as f32 * scale[1] + bias[1];
+            assert!((r - lut_f32[K + i]).abs() <= tol);
+        }
+    }
+
+    #[test]
+    fn f32_scalar_matches_direct_decoded_distance() {
+        // The f32-LUT kernel must equal the squared distance between
+        // the query and the reconstruction(codes through the codebook).
+        let (params, codebook, vectors) = train_small_codebook(4, 3, 64);
+        let query: Vec<f32> = vectors[0].data.to_vec();
+        let pq_query = PqFastScanQuery::prepare(&query, params, &codebook).unwrap();
+
+        // Encode and pack vectors[1..17] into a single block.
+        let n_test = 16;
+        let codes: Vec<Vec<u8>> = (1..=n_test)
+            .map(|i| encode_vec(&vectors[i].data, params, &codebook))
+            .collect();
+        let m = params.m as usize;
+        let packed = pack_codes_into_blocks(&codes, m);
+
+        for (i, vec_codes) in codes.iter().enumerate() {
+            let decoded = decode_via_codebook(vec_codes, params, &codebook);
+            let mut direct_l2_sq = 0.0_f32;
+            for d in 0..query.len() {
+                let diff = query[d] - decoded[d];
+                direct_l2_sq += diff * diff;
+            }
+            let direct_dist = direct_l2_sq.max(0.0).sqrt();
+            let kernel_dist =
+                distance_pq_fastscan_f32_scalar(DistanceMetric::Euclidean, &pq_query, &packed, i);
+            assert!(
+                (kernel_dist - direct_dist).abs() < 1e-3,
+                "vec {i}: kernel={kernel_dist} direct={direct_dist}"
+            );
+        }
+    }
+
+    #[test]
+    fn u8_scalar_matches_f32_scalar_within_quantisation_tolerance() {
+        // The u8-LUT kernel must equal the f32-LUT kernel up to the
+        // documented per-sub-quantiser quantisation drift.
+        let (params, codebook, vectors) = train_small_codebook(8, 4, 64);
+        let query: Vec<f32> = vectors[0].data.to_vec();
+        let pq_query = PqFastScanQuery::prepare(&query, params, &codebook).unwrap();
+        let m = params.m as usize;
+
+        let codes: Vec<Vec<u8>> = (1..=BLOCK_SIZE)
+            .map(|i| encode_vec(&vectors[i].data, params, &codebook))
+            .collect();
+        let packed = pack_codes_into_blocks(&codes, m);
+
+        // Per-sub-quantiser quantisation drift accumulates over M
+        // sub-quantisers — bound the total tolerance by the sum of
+        // the per-sub max errors so the test remains a tight check
+        // rather than a "looks roughly right" smoke screen.
+        let mut total_l2_sq_tolerance = 0.0_f32;
+        for sub in 0..m {
+            let chunk = &pq_query.lut_f32[sub * K..(sub + 1) * K];
+            let span = chunk.iter().copied().fold(f32::NEG_INFINITY, f32::max)
+                - chunk.iter().copied().fold(f32::INFINITY, f32::min);
+            total_l2_sq_tolerance += span / 255.0 / 2.0;
+        }
+
+        for i in 0..codes.len() {
+            let f32_dist =
+                distance_pq_fastscan_f32_scalar(DistanceMetric::Euclidean, &pq_query, &packed, i);
+            let u8_dist =
+                distance_pq_fastscan_u8_scalar(DistanceMetric::Euclidean, &pq_query, &packed, i);
+            // Both distances are sqrt(L2²); compare L2² to bound the
+            // tolerance correctly.
+            let f32_l2_sq = f32_dist * f32_dist;
+            let u8_l2_sq = u8_dist * u8_dist;
+            assert!(
+                (u8_l2_sq - f32_l2_sq).abs() <= total_l2_sq_tolerance + 1e-4,
+                "vec {i}: u8_l2_sq={u8_l2_sq} f32_l2_sq={f32_l2_sq} tol={total_l2_sq_tolerance}"
+            );
+        }
+    }
+
+    #[test]
+    fn prepare_rejects_wrong_k() {
+        let params = PqParams::new(4, 256, 2).unwrap();
+        let codebook = vec![0.0f32; params.codebook_len()];
+        let query = vec![0.0f32; params.original_dim()];
+        let err = PqFastScanQuery::prepare(&query, params, &codebook).unwrap_err();
+        assert!(err.to_string().contains("k == 16"));
+    }
+
+    #[test]
+    fn prepare_rejects_dim_mismatch() {
+        let params = PqParams::new(4, 16, 2).unwrap();
+        let codebook = vec![0.0f32; params.codebook_len()];
+        let query = vec![0.0f32; params.original_dim() + 1];
+        let err = PqFastScanQuery::prepare(&query, params, &codebook).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match params.original_dim()")
+        );
+    }
+
+    #[test]
+    fn apply_metric_unsupported_returns_infinity() {
+        // Manhattan / Angular / DotProduct return INFINITY through
+        // either scalar kernel, mirroring `distance_pq_adc`.
+        let (params, codebook, vectors) = train_small_codebook(4, 2, 16);
+        let query: Vec<f32> = vectors[0].data.to_vec();
+        let pq_query = PqFastScanQuery::prepare(&query, params, &codebook).unwrap();
+        let _m = params.m as usize;
+        let codes: Vec<Vec<u8>> = (0..BLOCK_SIZE)
+            .map(|i| encode_vec(&vectors[i % vectors.len()].data, params, &codebook))
+            .collect();
+        let packed = pack_codes_into_blocks(&codes, params.m as usize);
+        for metric in [
+            DistanceMetric::Manhattan,
+            DistanceMetric::Angular,
+            DistanceMetric::DotProduct,
+        ] {
+            let d = distance_pq_fastscan_f32_scalar(metric, &pq_query, &packed, 0);
+            assert!(
+                d.is_infinite(),
+                "f32 scalar metric={metric:?} should be inf"
+            );
+            let d = distance_pq_fastscan_u8_scalar(metric, &pq_query, &packed, 0);
+            assert!(d.is_infinite(), "u8 scalar metric={metric:?} should be inf");
+        }
+    }
+
+    #[test]
+    fn end_to_end_pool_and_query_round_trip() {
+        // Use the full PqFastScanPool path (which calls
+        // pack_codes_into_blocks internally) and assert the f32
+        // scalar kernel still produces the right distance for each
+        // stored vector.
+        let (params, codebook, vectors) = train_small_codebook(4, 3, 50);
+        let query: Vec<f32> = vectors[0].data.to_vec();
+        let pq_query = PqFastScanQuery::prepare(&query, params, &codebook).unwrap();
+
+        let records: Vec<(u64, String, Vec<u8>)> = vectors
+            .iter()
+            .enumerate()
+            .skip(1) // skip the query itself
+            .map(|(i, v)| {
+                (
+                    i as u64,
+                    "f".to_string(),
+                    encode_vec(&v.data, params, &codebook),
+                )
+            })
+            .collect();
+        let pool = PqFastScanPool::build(params, codebook.clone(), records).unwrap();
+
+        for vec_idx in 0..pool.n_vectors {
+            let block_idx = vec_idx / BLOCK_SIZE;
+            let in_block = vec_idx % BLOCK_SIZE;
+            let block_base = block_idx * pool.block_stride();
+            let block = &pool.packed[block_base..block_base + pool.block_stride()];
+
+            let codes = pool.codes_at(vec_idx);
+            let decoded = decode_via_codebook(&codes, params, &codebook);
+            let mut l2 = 0.0_f32;
+            for d in 0..query.len() {
+                let diff = query[d] - decoded[d];
+                l2 += diff * diff;
+            }
+            let direct = l2.max(0.0).sqrt();
+            let kernel = distance_pq_fastscan_f32_scalar(
+                DistanceMetric::Euclidean,
+                &pq_query,
+                block,
+                in_block,
+            );
+            assert!(
+                (kernel - direct).abs() < 1e-3,
+                "vec_idx={vec_idx}: kernel={kernel} direct={direct}"
+            );
+        }
+    }
+}

--- a/laurus/src/vector/core/quantization.rs
+++ b/laurus/src/vector/core/quantization.rs
@@ -455,18 +455,25 @@ impl PqParams {
     /// # Errors
     ///
     /// Returns [`LaurusError::InvalidOperation`] if any field is zero
-    /// or if `k` is not the supported value (256).
+    /// or if `k` is not one of the supported centroid counts (`16` or
+    /// `256`).
+    ///
+    /// `k = 256` is the 8-bit PQ variant shipped in Issue #481 Stage 3.
+    /// `k = 16` is the FastScan 4-bit variant introduced in Issue #651
+    /// part A (#692); the on-disk format and search-time kernels live
+    /// in parallel modules under [`crate::vector::core::distance_pq_fastscan`]
+    /// and [`crate::vector::index::pq_fastscan_storage`].
     pub fn new(m: u16, k: u16, sub_dim: u16) -> Result<Self> {
         if m == 0 || k == 0 || sub_dim == 0 {
             return Err(LaurusError::InvalidOperation(format!(
                 "PqParams components must be > 0 (got m={m}, k={k}, sub_dim={sub_dim})"
             )));
         }
-        if k != 256 {
+        if !matches!(k, 16 | 256) {
             return Err(LaurusError::InvalidOperation(format!(
-                "PqParams::k is currently fixed at 256 (got {k}); the on-disk \
-                 format reserves the field for future 4-bit variants but no \
-                 reader for those exists yet"
+                "PqParams::k must be one of {{16, 256}} (got {k}); 256 is the \
+                 8-bit PQ variant (Issue #481 Stage 3), 16 is the FastScan \
+                 4-bit variant (Issue #651 / #692)"
             )));
         }
         Ok(Self { m, k, sub_dim })

--- a/laurus/src/vector/index.rs
+++ b/laurus/src/vector/index.rs
@@ -14,6 +14,7 @@ pub mod format;
 pub mod hnsw;
 pub mod io;
 pub mod ivf;
+pub mod pq_fastscan_storage;
 pub mod pq_io;
 pub mod pq_storage;
 pub mod quantized_io;

--- a/laurus/src/vector/index/pq_fastscan_storage.rs
+++ b/laurus/src/vector/index/pq_fastscan_storage.rs
@@ -1,0 +1,416 @@
+//! FastScan-style PQ vector pool (Issue
+//! [#651](https://github.com/mosuka/laurus/issues/651) / part A
+//! [#692](https://github.com/mosuka/laurus/issues/692)).
+//!
+//! Parallel to
+//! [`crate::vector::index::pq_storage::PqVectorPool`] (the existing
+//! K=256 8-bit PQ storage); the difference is the on-disk / in-memory
+//! layout of the per-vector codes:
+//!
+//! - `PqVectorPool` stores `M` bytes per vector in array-of-structs
+//!   (AoS) order. Each byte is one K=256 code.
+//! - `PqFastScanPool` stores 4-bit codes (K=16) packed two-per-byte
+//!   and **transposed across 32-vector blocks** so the SIMD shuffle
+//!   kernel introduced in parts B (#693, AVX2) and C (#694, NEON) can
+//!   evaluate 32 candidates per iteration with a single `pshufb` /
+//!   `vqtbl1q_u8`.
+//!
+//! Part A of #651 only builds the storage layout and a scalar
+//! reference kernel; production wiring lives in part D (#695).
+//!
+//! # Block layout
+//!
+//! For a pool of `n_vectors` vectors and `M` sub-quantisers, the
+//! `packed` buffer holds `ceil(n_vectors / BLOCK_SIZE)` blocks. Each
+//! block occupies `M * BYTES_PER_SUB_PER_BLOCK` bytes (i.e.
+//! `M * 16` bytes), and within a block the byte at offset
+//! `m * BYTES_PER_SUB_PER_BLOCK + j` (0 ≤ j < 16) carries:
+//!
+//! - the **low nibble** of vector `block_idx * BLOCK_SIZE + j`'s code
+//!   for sub-quantiser `m`;
+//! - the **high nibble** of vector `block_idx * BLOCK_SIZE + j + 16`'s
+//!   code for sub-quantiser `m`.
+//!
+//! Vectors past `n_vectors` in the trailing block are zero-padded.
+//! The kernel must not read past `n_vectors`; callers enforce this via
+//! [`PqFastScanPool::n_vectors`] and the field-position index.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::error::{LaurusError, Result};
+use crate::vector::core::quantization::PqParams;
+
+/// Number of vectors packed into one FastScan block.
+///
+/// Chosen to match FAISS `IndexPQFastScan`: a 128-bit SIMD register
+/// holds 16 nibbles, and packing the low + high nibbles per byte
+/// doubles that to 32 vectors per SIMD iteration.
+pub const BLOCK_SIZE: usize = 32;
+
+/// Bytes occupied by one sub-quantiser's slice within a single block.
+/// Equal to `BLOCK_SIZE / 2` because each byte carries two nibbles
+/// (i.e. two 4-bit codes for two different vectors).
+pub const BYTES_PER_SUB_PER_BLOCK: usize = BLOCK_SIZE / 2;
+
+/// In-memory FastScan PQ representation of one segment's vectors.
+///
+/// Built once at reader load time and shared across search threads via
+/// `Arc<PqFastScanPool>`. All fields are immutable after construction.
+#[derive(Debug)]
+pub struct PqFastScanPool {
+    /// Per-segment PQ parameters. `params.k` must be `16`; the
+    /// constructor returns an error otherwise.
+    pub params: PqParams,
+    /// Original vector dimension (`m * sub_dim`). Cached so callers
+    /// don't multiply on every access.
+    pub dim: usize,
+    /// Per-segment codebook in row-major layout. Length is
+    /// `params.codebook_len()` (= `m * 16 * sub_dim` for K=16).
+    pub codebook: Vec<f32>,
+    /// 4-bit packed codes in block-transposed layout. Length is
+    /// `block_count() * params.m * BYTES_PER_SUB_PER_BLOCK`.
+    pub packed: Vec<u8>,
+    /// Number of vectors stored in the pool. The trailing block may
+    /// hold fewer than `BLOCK_SIZE` real vectors; the remainder is
+    /// zero-padded.
+    pub n_vectors: usize,
+    /// Per-field doc_id → vector position. Position is the index into
+    /// `0..n_vectors`; the kernel derives (block_idx, in_block_idx)
+    /// from it.
+    pub field_index: HashMap<String, Arc<HashMap<u64, u32>>>,
+}
+
+impl PqFastScanPool {
+    /// Number of blocks the pool spans (ceil(n_vectors / BLOCK_SIZE)).
+    #[inline]
+    pub fn block_count(&self) -> usize {
+        n_blocks_for(self.n_vectors)
+    }
+
+    /// Byte size of one block (`M * BYTES_PER_SUB_PER_BLOCK`).
+    #[inline]
+    pub fn block_stride(&self) -> usize {
+        self.params.m as usize * BYTES_PER_SUB_PER_BLOCK
+    }
+
+    /// Build a [`PqFastScanPool`] from a sequence of
+    /// `(doc_id, field_name, codes)` records, where each `codes` is a
+    /// `Vec<u8>` of length `params.m` with every value in `[0, 15]`.
+    ///
+    /// The records may be in any order; the field index is built from
+    /// the iteration order, and the codes are written at the position
+    /// equal to the iteration index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LaurusError::InvalidOperation`] if `params.k != 16`,
+    /// if any code is out of the 4-bit range, or if any per-record
+    /// `codes` length disagrees with `params.m`.
+    pub fn build(
+        params: PqParams,
+        codebook: Vec<f32>,
+        records: impl IntoIterator<Item = (u64, String, Vec<u8>)>,
+    ) -> Result<Self> {
+        if params.k != 16 {
+            return Err(LaurusError::InvalidOperation(format!(
+                "PqFastScanPool requires PqParams::k == 16 (got {})",
+                params.k
+            )));
+        }
+        if codebook.len() != params.codebook_len() {
+            return Err(LaurusError::InvalidOperation(format!(
+                "PqFastScanPool: codebook length {} does not match params.codebook_len() {}",
+                codebook.len(),
+                params.codebook_len()
+            )));
+        }
+
+        let m = params.m as usize;
+        let mut all_codes: Vec<Vec<u8>> = Vec::new();
+        let mut by_field: HashMap<String, HashMap<u64, u32>> = HashMap::new();
+
+        for (doc_id, field, codes) in records {
+            if codes.len() != m {
+                return Err(LaurusError::InvalidOperation(format!(
+                    "PqFastScanPool: code length {} does not match params.m {}",
+                    codes.len(),
+                    m
+                )));
+            }
+            for &c in &codes {
+                if c >= 16 {
+                    return Err(LaurusError::InvalidOperation(format!(
+                        "PqFastScanPool: code value {c} exceeds 4-bit range [0, 15]"
+                    )));
+                }
+            }
+            let pos = all_codes.len() as u32;
+            all_codes.push(codes);
+            by_field.entry(field).or_default().insert(doc_id, pos);
+        }
+
+        let n_vectors = all_codes.len();
+        let packed = pack_codes_into_blocks(&all_codes, m);
+
+        let field_index: HashMap<String, Arc<HashMap<u64, u32>>> = by_field
+            .into_iter()
+            .map(|(field, map)| (field, Arc::new(map)))
+            .collect();
+
+        Ok(Self {
+            params,
+            dim: params.original_dim(),
+            codebook,
+            packed,
+            n_vectors,
+            field_index,
+        })
+    }
+
+    /// Decode the M codes for `vec_idx` from the packed layout.
+    ///
+    /// Primarily for tests and the scalar reference kernel; the SIMD
+    /// kernel (#693/#694) walks the packed buffer directly without
+    /// going through this helper.
+    pub fn codes_at(&self, vec_idx: usize) -> Vec<u8> {
+        let m = self.params.m as usize;
+        let mut out = vec![0u8; m];
+        let block_idx = vec_idx / BLOCK_SIZE;
+        let in_block = vec_idx % BLOCK_SIZE;
+        let block_base = block_idx * self.block_stride();
+        let (j, shift) = if in_block < 16 {
+            (in_block, 0)
+        } else {
+            (in_block - 16, 4)
+        };
+        for (sub, slot) in out.iter_mut().enumerate().take(m) {
+            let byte = self.packed[block_base + sub * BYTES_PER_SUB_PER_BLOCK + j];
+            *slot = (byte >> shift) & 0x0F;
+        }
+        out
+    }
+}
+
+/// Number of FastScan blocks needed to hold `n_vectors` vectors.
+#[inline]
+pub fn n_blocks_for(n_vectors: usize) -> usize {
+    n_vectors.div_ceil(BLOCK_SIZE)
+}
+
+/// Pack a flat slice of per-vector codes into the FastScan block
+/// layout described in the module docs.
+///
+/// `codes[i]` must have length `m` and each entry must be in `[0,
+/// 15]`. The returned `Vec<u8>` has length `n_blocks * m * BYTES_PER_SUB_PER_BLOCK`,
+/// zero-padded for vectors past `codes.len()`.
+///
+/// The caller is responsible for input validation (see
+/// [`PqFastScanPool::build`]).
+pub fn pack_codes_into_blocks(codes: &[Vec<u8>], m: usize) -> Vec<u8> {
+    let n_vectors = codes.len();
+    let n_blocks = n_blocks_for(n_vectors);
+    let block_stride = m * BYTES_PER_SUB_PER_BLOCK;
+    let mut packed = vec![0u8; n_blocks * block_stride];
+
+    for (vec_idx, v_codes) in codes.iter().enumerate().take(n_vectors) {
+        let block_idx = vec_idx / BLOCK_SIZE;
+        let in_block = vec_idx % BLOCK_SIZE;
+        let (j, shift) = if in_block < 16 {
+            (in_block, 0)
+        } else {
+            (in_block - 16, 4)
+        };
+        let block_base = block_idx * block_stride;
+        for (sub, &code) in v_codes.iter().enumerate() {
+            // Caller already validated codes are 4-bit; mask just in
+            // case to avoid corrupting the neighbouring nibble if a
+            // bad caller slips through.
+            let nibble = code & 0x0F;
+            packed[block_base + sub * BYTES_PER_SUB_PER_BLOCK + j] |= nibble << shift;
+        }
+    }
+
+    packed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a tiny K=16 codebook with deterministic content.
+    fn dummy_codebook(m: usize, sub_dim: usize) -> Vec<f32> {
+        let k = 16usize;
+        let len = m * k * sub_dim;
+        (0..len).map(|i| i as f32 * 0.01).collect()
+    }
+
+    #[test]
+    fn round_trip_packs_and_unpacks_codes_for_n_below_block() {
+        let m = 4;
+        let codes: Vec<Vec<u8>> = vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7], vec![15, 0, 8, 9]];
+        let packed = pack_codes_into_blocks(&codes, m);
+        let params = PqParams::new(m as u16, 16, 2).unwrap();
+        let pool = PqFastScanPool::build(
+            params,
+            dummy_codebook(m, 2),
+            codes
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i as u64, "f".to_string(), c.clone())),
+        )
+        .unwrap();
+        assert_eq!(pool.packed, packed);
+        assert_eq!(pool.codes_at(0), vec![0, 1, 2, 3]);
+        assert_eq!(pool.codes_at(1), vec![4, 5, 6, 7]);
+        assert_eq!(pool.codes_at(2), vec![15, 0, 8, 9]);
+    }
+
+    #[test]
+    fn round_trip_packs_and_unpacks_codes_at_block_boundaries() {
+        let m = 8;
+        // Build n=33 so we span block boundary (32 → 33) and exercise
+        // both nibble halves plus a sparsely-populated second block.
+        let n = 33;
+        let codes: Vec<Vec<u8>> = (0..n)
+            .map(|i| (0..m).map(|sub| ((i * 7 + sub * 3) % 16) as u8).collect())
+            .collect();
+        let params = PqParams::new(m as u16, 16, 2).unwrap();
+        let pool = PqFastScanPool::build(
+            params,
+            dummy_codebook(m, 2),
+            codes
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i as u64, "f".to_string(), c.clone())),
+        )
+        .unwrap();
+        assert_eq!(pool.block_count(), 2, "n=33 spans 2 blocks");
+        for (i, expected) in codes.iter().enumerate().take(n) {
+            assert_eq!(&pool.codes_at(i), expected, "vector {i} mismatch");
+        }
+    }
+
+    #[test]
+    fn round_trip_works_for_exactly_one_block() {
+        let m = 4;
+        let n = BLOCK_SIZE;
+        let codes: Vec<Vec<u8>> = (0..n)
+            .map(|i| (0..m).map(|sub| ((i + sub * 5) % 16) as u8).collect())
+            .collect();
+        let params = PqParams::new(m as u16, 16, 1).unwrap();
+        let pool = PqFastScanPool::build(
+            params,
+            dummy_codebook(m, 1),
+            codes
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i as u64, "f".to_string(), c.clone())),
+        )
+        .unwrap();
+        assert_eq!(pool.block_count(), 1);
+        for (i, expected) in codes.iter().enumerate().take(n) {
+            assert_eq!(&pool.codes_at(i), expected, "vector {i} mismatch");
+        }
+    }
+
+    #[test]
+    fn round_trip_works_for_two_full_blocks() {
+        let m = 2;
+        let n = BLOCK_SIZE * 2;
+        let codes: Vec<Vec<u8>> = (0..n)
+            .map(|i| vec![(i % 16) as u8, ((i / 2) % 16) as u8])
+            .collect();
+        let params = PqParams::new(m as u16, 16, 2).unwrap();
+        let pool = PqFastScanPool::build(
+            params,
+            dummy_codebook(m, 2),
+            codes
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i as u64, "f".to_string(), c.clone())),
+        )
+        .unwrap();
+        assert_eq!(pool.block_count(), 2);
+        for (i, expected) in codes.iter().enumerate().take(n) {
+            assert_eq!(&pool.codes_at(i), expected);
+        }
+    }
+
+    #[test]
+    fn build_rejects_wrong_k() {
+        let params = PqParams::new(4, 256, 2).unwrap();
+        let codebook = vec![0.0f32; params.codebook_len()];
+        let err = PqFastScanPool::build(
+            params,
+            codebook,
+            std::iter::empty::<(u64, String, Vec<u8>)>(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("k == 16"));
+    }
+
+    #[test]
+    fn build_rejects_out_of_range_codes() {
+        let m = 4;
+        let params = PqParams::new(m as u16, 16, 2).unwrap();
+        let codebook = dummy_codebook(m, 2);
+        let err = PqFastScanPool::build(
+            params,
+            codebook,
+            std::iter::once((0u64, "f".to_string(), vec![0u8, 1, 16, 3])),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("exceeds 4-bit range"));
+    }
+
+    #[test]
+    fn build_rejects_code_length_mismatch() {
+        let m = 4;
+        let params = PqParams::new(m as u16, 16, 2).unwrap();
+        let codebook = dummy_codebook(m, 2);
+        let err = PqFastScanPool::build(
+            params,
+            codebook,
+            std::iter::once((0u64, "f".to_string(), vec![0u8, 1, 2])),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("does not match params.m"));
+    }
+
+    #[test]
+    fn build_zero_pads_trailing_partial_block() {
+        let m = 2;
+        let n = 5; // one partial block of 5/32 vectors
+        let codes: Vec<Vec<u8>> = (0..n)
+            .map(|i| vec![(i % 16) as u8, ((i + 1) % 16) as u8])
+            .collect();
+        let params = PqParams::new(m as u16, 16, 1).unwrap();
+        let pool = PqFastScanPool::build(
+            params,
+            dummy_codebook(m, 1),
+            codes
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i as u64, "f".to_string(), c.clone())),
+        )
+        .unwrap();
+        assert_eq!(pool.block_count(), 1);
+        assert_eq!(
+            pool.packed.len(),
+            pool.block_count() * pool.block_stride(),
+            "packed buffer is sized to whole blocks"
+        );
+        for (i, expected) in codes.iter().enumerate().take(n) {
+            assert_eq!(&pool.codes_at(i), expected);
+        }
+        // Padding region: codes for vec_idx in [n, 32) decode as all
+        // zeros (codebook entry 0 for every sub-quantiser).
+        for i in n..BLOCK_SIZE {
+            assert!(
+                pool.codes_at(i).iter().all(|&c| c == 0),
+                "vec {i} in padding should be all-zero codes"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Part A of [#651](https://github.com/mosuka/laurus/issues/651) (PQ FastScan: 4-bit codes + SIMD LUT distance). This PR lands the **foundational data structures and scalar reference kernel only** — no SIMD, no writer/reader integration. Subsequent parts:

- Part B (#693): AVX2 SIMD kernel for x86_64
- Part C (#694): NEON SIMD kernel for aarch64
- Part D (#695): writer/reader integration + persistence + benchmark

## Changes

- `PqParams::new` now accepts `k ∈ {16, 256}` (was `k == 256` only). 256 keeps the existing 8-bit PQ path (#481); 16 enables FastScan 4-bit codes.
- New module `laurus/src/vector/index/pq_fastscan_storage.rs` (+416 lines)
  - `PqFastScanPool` with block-transposed 4-bit packing (`BLOCK_SIZE = 32`, `BYTES_PER_SUB_PER_BLOCK = 16`) ready for AVX2 `_mm256_shuffle_epi8` / NEON `vqtbl1q_u8` direct loads.
- New module `laurus/src/vector/core/distance_pq_fastscan.rs` (+561 lines)
  - `PqFastScanQuery::prepare()` builds the f32 LUT and applies per-sub min-max u8 quantisation (`scale[m]`, `bias[m]`).
  - `distance_pq_fastscan_f32_scalar` — reference using unquantised f32 LUT.
  - `distance_pq_fastscan_u8_scalar` — production-target with post-hoc dequantisation.

Scope kept intentionally small per [#646](https://github.com/mosuka/laurus/issues/646) lessons (cache-footprint surprise): new modules only, no impact on existing hot paths. Benchmark gate runs in #695.

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo fmt --check` (no diff)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` — laurus: **1029 pass** (16 new), 0 regressions; laurus-mcp: 12 pass; laurus-server: 28 pass.
- [x] `markdownlint-cli2 "docs/src/**/*.md"` — 154 files, 0 error.

### New unit tests (16)

`vector::index::pq_fastscan_storage::tests` (8):
- block-packing round-trip at boundaries (n=3, 32, 33, 64)
- build rejection (k≠16, codes ≥ 16, length mismatch)
- zero-padding of trailing partial block

`vector::core::distance_pq_fastscan::tests` (8):
- prepare rejection (k≠16, dim mismatch)
- LUT quantisation reconstruction within `(span/255)/2`
- degenerate constant-LUT sub-quantiser handled
- unsupported metric → `f32::INFINITY`
- scalar f32 vs direct decoded vector distance (exact)
- scalar u8 vs scalar f32 within quantisation tolerance
- end-to-end pool + query round-trip

Refs #692
Refs #651
Refs #536