### PR TITLE
perf(vector): add PQ FastScan AVX2 SIMD kernel for x86_64 (Part B) (#693)

### DIFF
--- a/laurus/src/vector/core/distance_pq_fastscan.rs
+++ b/laurus/src/vector/core/distance_pq_fastscan.rs
@@ -58,6 +58,21 @@ pub struct PqFastScanQuery {
     /// Per-sub-quantiser bias of the affine quantisation. Length is
     /// `M`.
     pub lut_bias: Vec<f32>,
+    /// Globally-quantised LUT for the SIMD path (#693 AVX2 / #694 NEON
+    /// kernels). Row-major `[m][k]` of length `m * K`. All entries
+    /// share the single [`Self::lut_scale_global`] and decode to
+    /// `lut_f32 ≈ u8 * lut_scale_global + lut_bias_per_sub[m]`, where
+    /// the per-sub bias is folded into [`Self::lut_bias_sum`] for the
+    /// distance reconstruction.
+    pub lut4_global: Vec<u8>,
+    /// Single global scale shared across all sub-quantisers. Built by
+    /// [`quantise_lut_global`] so the SIMD u8 saturating accumulator
+    /// pattern is correct (FAISS pq4_fast_scan convention).
+    pub lut_scale_global: f32,
+    /// Sum of per-sub-quantiser biases (`Σ_m bias[m]`). The SIMD
+    /// kernel adds this once per vector after the u16 reduction:
+    /// `distance = u16_sum * lut_scale_global + lut_bias_sum`.
+    pub lut_bias_sum: f32,
     /// `||query||² = Σ_i query[i]²`, cached for the metrics that need
     /// it (currently unused by the scalar kernels but kept for API
     /// parity with [`crate::vector::core::distance_quantized::PqQuery`]).
@@ -122,6 +137,7 @@ impl PqFastScanQuery {
         }
 
         let (lut4, lut_scale, lut_bias) = quantise_lut_per_sub(&lut_f32, m);
+        let (lut4_global, lut_scale_global, lut_bias_sum) = quantise_lut_global(&lut_f32, m);
         let query_norm_sq: f32 = query.iter().map(|x| x * x).sum();
 
         Ok(Self {
@@ -130,6 +146,9 @@ impl PqFastScanQuery {
             lut4,
             lut_scale,
             lut_bias,
+            lut4_global,
+            lut_scale_global,
+            lut_bias_sum,
             query_norm_sq,
         })
     }
@@ -181,6 +200,64 @@ pub fn quantise_lut_per_sub(lut_f32: &[f32], m: usize) -> (Vec<u8>, Vec<f32>, Ve
     }
 
     (lut4, lut_scale, lut_bias)
+}
+
+/// Quantise an f32 LUT to `u8` using a single **global scale** and
+/// per-sub-quantiser biases, the form the FastScan SIMD kernels in
+/// parts B (#693 AVX2) and C (#694 NEON) consume.
+///
+/// Unlike [`quantise_lut_per_sub`], all sub-quantisers share one
+/// `scale_global`, so the SIMD path can accumulate distances in a u8
+/// saturating accumulator across sub-quantisers and dequantise once
+/// per vector at the end via
+/// `distance = u8_sum * scale_global + bias_sum`.
+///
+/// Algorithm:
+/// 1. For each sub `m`, `bias[m] = min(lut_f32[m * K .. (m + 1) * K])`.
+/// 2. `max_normalised = max(lut_f32[m, k] - bias[m])` across all `m, k`.
+/// 3. `scale_global = max_normalised / 255.0` (or `0.0` if everything
+///    collapses to the per-sub minima).
+/// 4. `lut4[m * K + k] = round((lut_f32[m, k] - bias[m]) / scale_global)`,
+///    clamped to `[0, 255]`. Degenerate (constant) sub-quantisers get
+///    all-zero codes so the dequantiser recovers `bias[m]` exactly.
+/// 5. `bias_sum = Σ_m bias[m]`, folded into the per-vector constant.
+///
+/// Returns `(lut4_global, scale_global, bias_sum)`:
+///
+/// - `lut4_global.len() == m * K`, each entry in `[0, 255]`.
+/// - `scale_global` is a single non-negative `f32`.
+/// - `bias_sum` is `Σ_m bias[m]` (any sign).
+pub fn quantise_lut_global(lut_f32: &[f32], m: usize) -> (Vec<u8>, f32, f32) {
+    debug_assert_eq!(lut_f32.len(), m * K);
+    let mut bias = vec![0.0_f32; m];
+    let mut max_normalised: f32 = 0.0;
+    for sub in 0..m {
+        let chunk = &lut_f32[sub * K..(sub + 1) * K];
+        let min = chunk.iter().copied().fold(f32::INFINITY, f32::min);
+        bias[sub] = min;
+        for &v in chunk {
+            let normalised = v - min;
+            if normalised > max_normalised {
+                max_normalised = normalised;
+            }
+        }
+    }
+    let scale_global = if max_normalised > 0.0 {
+        max_normalised / 255.0
+    } else {
+        0.0
+    };
+    let mut lut4 = vec![0u8; m * K];
+    if scale_global > 0.0 {
+        for sub in 0..m {
+            for k in 0..K {
+                let v = lut_f32[sub * K + k] - bias[sub];
+                lut4[sub * K + k] = (v / scale_global).round().clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+    let bias_sum: f32 = bias.iter().sum();
+    (lut4, scale_global, bias_sum)
 }
 
 /// Decode the M 4-bit codes for `vec_idx_in_block` out of a single
@@ -258,6 +335,32 @@ pub fn distance_pq_fastscan_u8_scalar(
     apply_metric(metric, l2_sq)
 }
 
+/// Scalar FastScan ADC distance using the **global**-scale u8 LUT.
+///
+/// Mirrors the FAISS-style SIMD pipeline that parts B (#693 AVX2) and
+/// C (#694 NEON) implement: accumulate `Σ_m lut4_global[m * K + code_m]`
+/// in u16, then dequantise once via
+/// `distance = u16_sum as f32 * lut_scale_global + lut_bias_sum`.
+///
+/// The arithmetic here is bit-identical to the SIMD kernels (no
+/// intermediate floats inside the accumulator) so this function serves
+/// as the **correctness anchor** for the SIMD kernels' property tests.
+pub fn distance_pq_fastscan_u8_global_scalar(
+    metric: DistanceMetric,
+    query: &PqFastScanQuery,
+    packed_block: &[u8],
+    vec_idx_in_block: usize,
+) -> f32 {
+    let m = query.params.m as usize;
+    let codes = decode_codes_in_block(packed_block, m, vec_idx_in_block);
+    let mut u16_sum: u32 = 0;
+    for (sub, &code) in codes.iter().enumerate() {
+        u16_sum += query.lut4_global[sub * K + code as usize] as u32;
+    }
+    let l2_sq = u16_sum as f32 * query.lut_scale_global + query.lut_bias_sum;
+    apply_metric(metric, l2_sq)
+}
+
 /// Apply the metric-specific post-processing to the raw L2² sum.
 ///
 /// Same convention as
@@ -266,7 +369,7 @@ pub fn distance_pq_fastscan_u8_scalar(
 /// any other metric returns `f32::INFINITY` to make the searcher's
 /// dispatch fail cleanly.
 #[inline]
-fn apply_metric(metric: DistanceMetric, l2_sq: f32) -> f32 {
+pub(crate) fn apply_metric(metric: DistanceMetric, l2_sq: f32) -> f32 {
     match metric {
         DistanceMetric::Euclidean => l2_sq.max(0.0).sqrt(),
         DistanceMetric::Cosine => (l2_sq * 0.5).clamp(0.0, 2.0),
@@ -555,6 +658,94 @@ mod tests {
             assert!(
                 (kernel - direct).abs() < 1e-3,
                 "vec_idx={vec_idx}: kernel={kernel} direct={direct}"
+            );
+        }
+    }
+
+    #[test]
+    fn quantise_lut_global_round_trip_within_tolerance() {
+        // Build a synthetic LUT with a known per-sub range. The
+        // expected max element-wise error after dequantise is
+        // `scale_global / 2` (round-to-nearest).
+        let m = 4;
+        let mut lut_f32 = vec![0.0_f32; m * K];
+        for sub in 0..m {
+            for i in 0..K {
+                lut_f32[sub * K + i] = (sub as f32) * 20.0 + (i as f32) * (1.0 + sub as f32);
+            }
+        }
+        let (lut4_global, scale_global, bias_sum) = quantise_lut_global(&lut_f32, m);
+
+        // Reconstruct per-sub bias to dequantise: we know
+        // `bias[sub] = min(lut_f32[sub * K..(sub + 1) * K])`.
+        let mut bias = vec![0.0_f32; m];
+        for sub in 0..m {
+            bias[sub] = lut_f32[sub * K..(sub + 1) * K]
+                .iter()
+                .copied()
+                .fold(f32::INFINITY, f32::min);
+        }
+        assert!((bias.iter().sum::<f32>() - bias_sum).abs() < 1e-4);
+
+        let tolerance = scale_global / 2.0 + 1e-5;
+        for sub in 0..m {
+            for i in 0..K {
+                let reconstructed = lut4_global[sub * K + i] as f32 * scale_global + bias[sub];
+                let original = lut_f32[sub * K + i];
+                assert!(
+                    (reconstructed - original).abs() <= tolerance,
+                    "sub={sub} i={i}: |{reconstructed} - {original}| > {tolerance}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn quantise_lut_global_handles_degenerate_lut() {
+        // All-zero LUT collapses to scale_global = 0 and bias_sum = 0.
+        let m = 2;
+        let lut_f32 = vec![0.0_f32; m * K];
+        let (lut4, scale, bias_sum) = quantise_lut_global(&lut_f32, m);
+        assert!(lut4.iter().all(|&c| c == 0));
+        assert_eq!(scale, 0.0);
+        assert_eq!(bias_sum, 0.0);
+    }
+
+    #[test]
+    fn u8_global_scalar_matches_f32_scalar_within_tolerance() {
+        // Codebook + query setup identical to the per-sub property
+        // test above so we can reuse the expectation framework.
+        let m = 4;
+        let sub_dim = 2;
+        let dim = m * sub_dim;
+        let (params, codebook, vectors) = train_small_codebook(m, sub_dim, 256);
+        let query: Vec<f32> = vectors[0].data.to_vec();
+        assert_eq!(query.len(), dim);
+        let q = PqFastScanQuery::prepare(&query, params, &codebook).unwrap();
+
+        // Pack a couple of vectors into one block and walk every
+        // in-block index.
+        let codes: Vec<Vec<u8>> = (0..32)
+            .map(|i| encode_vec(&vectors[i % vectors.len()].data, params, &codebook))
+            .collect();
+        let block = pack_codes_into_blocks(&codes, m);
+
+        let max_error = (m as f32) * q.lut_scale_global / 2.0 + 1e-4;
+        for vec_idx in 0..32 {
+            let f32_val =
+                distance_pq_fastscan_f32_scalar(DistanceMetric::Euclidean, &q, &block, vec_idx);
+            let u8_val = distance_pq_fastscan_u8_global_scalar(
+                DistanceMetric::Euclidean,
+                &q,
+                &block,
+                vec_idx,
+            );
+            // The two are computed in different precision regimes
+            // (sqrt of the L2² sum) so we compare the squared values.
+            let diff_sq = (f32_val.powi(2) - u8_val.powi(2)).abs();
+            assert!(
+                diff_sq <= max_error,
+                "vec {vec_idx}: |{f32_val}² - {u8_val}²| = {diff_sq} > {max_error}"
             );
         }
     }

--- a/laurus/src/vector/index.rs
+++ b/laurus/src/vector/index.rs
@@ -14,6 +14,7 @@ pub mod format;
 pub mod hnsw;
 pub mod io;
 pub mod ivf;
+pub mod pq_fastscan_avx2;
 pub mod pq_fastscan_storage;
 pub mod pq_io;
 pub mod pq_storage;

--- a/laurus/src/vector/index/pq_fastscan_avx2.rs
+++ b/laurus/src/vector/index/pq_fastscan_avx2.rs
@@ -26,10 +26,14 @@
 use std::arch::x86_64::*;
 
 use crate::vector::core::distance::DistanceMetric;
+#[cfg(target_arch = "x86_64")]
+use crate::vector::core::distance_pq_fastscan::apply_metric;
 use crate::vector::core::distance_pq_fastscan::{
-    PqFastScanQuery, apply_metric, distance_pq_fastscan_u8_global_scalar,
+    PqFastScanQuery, distance_pq_fastscan_u8_global_scalar,
 };
-use crate::vector::index::pq_fastscan_storage::{BLOCK_SIZE, BYTES_PER_SUB_PER_BLOCK};
+use crate::vector::index::pq_fastscan_storage::BLOCK_SIZE;
+#[cfg(target_arch = "x86_64")]
+use crate::vector::index::pq_fastscan_storage::BYTES_PER_SUB_PER_BLOCK;
 
 /// Returns `true` when the current x86_64 CPU supports AVX2.
 ///

--- a/laurus/src/vector/index/pq_fastscan_avx2.rs
+++ b/laurus/src/vector/index/pq_fastscan_avx2.rs
@@ -1,0 +1,401 @@
+//! AVX2 SIMD kernel for FastScan PQ ADC distance
+//! (Issue [#693](https://github.com/mosuka/laurus/issues/693), part B
+//! of [#651](https://github.com/mosuka/laurus/issues/651)).
+//!
+//! The kernel processes one 32-vector FastScan block per call:
+//!
+//! 1. For each sub-quantiser `m`, load the 16-byte u8 LUT into an XMM
+//!    register and `vpshufb` the 32 packed nibbles (16 from the low
+//!    half of the byte and 16 from the high half) to gather 32 u8
+//!    distances per sub.
+//! 2. Widen each u8 lane to u16 (`vpunpcklbw` / `vpunpckhbw` with
+//!    zero) and accumulate across all sub-quantisers. With `m ≤ 64`
+//!    and the per-sub u8 cap of 255, the u16 accumulator cannot
+//!    overflow (`255 × 64 = 16320 < 65535`).
+//! 3. Permute the two 256-bit accumulators with `vperm2i128` so the
+//!    output `[u16; 32]` follows the natural `[vec 0, vec 1, …, vec 31]`
+//!    layout, then convert each lane back to f32 via
+//!    `dist = sum * lut_scale_global + lut_bias_sum` (FAISS pq4_fast_scan
+//!    convention).
+//!
+//! The scalar fallback ([`distance_pq_fastscan_block_scalar`]) performs
+//! the same arithmetic and is bit-identical to the AVX2 path; tests
+//! exercise both paths and assert equivalence.
+
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+use crate::vector::core::distance::DistanceMetric;
+use crate::vector::core::distance_pq_fastscan::{
+    PqFastScanQuery, apply_metric, distance_pq_fastscan_u8_global_scalar,
+};
+use crate::vector::index::pq_fastscan_storage::{BLOCK_SIZE, BYTES_PER_SUB_PER_BLOCK};
+
+/// Returns `true` when the current x86_64 CPU supports AVX2.
+///
+/// Always returns `false` on non-x86_64 targets. The result is cached
+/// by `is_x86_feature_detected!` after the first call so subsequent
+/// invocations cost roughly one branch.
+#[inline]
+pub fn is_avx2_supported() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        is_x86_feature_detected!("avx2")
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        false
+    }
+}
+
+/// AVX2 kernel: distances for all `BLOCK_SIZE = 32` vectors of one
+/// packed FastScan block.
+///
+/// # Arguments
+///
+/// * `metric` - Distance metric. Supported: [`DistanceMetric::Euclidean`]
+///   and [`DistanceMetric::Cosine`]; any other variant yields
+///   `f32::INFINITY` per vector (matching the scalar reference).
+/// * `query` - Per-query state built by
+///   [`PqFastScanQuery::prepare`]. Must carry the global-scale LUT
+///   (`lut4_global`, `lut_scale_global`, `lut_bias_sum`).
+/// * `packed_block` - One block's worth of packed codes, i.e. exactly
+///   `query.params.m as usize * BYTES_PER_SUB_PER_BLOCK` bytes.
+///
+/// # Output
+///
+/// `out[v]` is the distance for the `v`-th vector in the block
+/// (`v ∈ [0, BLOCK_SIZE)`). Positions past `n_vectors` in the trailing
+/// partial block contain whatever the padding nibbles decode to; the
+/// caller masks them.
+///
+/// # Safety
+///
+/// Caller must guarantee:
+/// - The CPU supports AVX2. Use [`is_avx2_supported`] before calling.
+/// - `packed_block.len() >= query.params.m as usize * BYTES_PER_SUB_PER_BLOCK`.
+/// - `query.lut4_global.len() == query.params.m as usize * 16`.
+/// - `query.params.m as usize <= 64` so the u16 accumulator cannot
+///   overflow (the dispatcher [`distance_pq_fastscan_block`] enforces
+///   this by routing larger `M` to the scalar fallback).
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+pub unsafe fn distance_pq_fastscan_block_avx2(
+    metric: DistanceMetric,
+    query: &PqFastScanQuery,
+    packed_block: &[u8],
+) -> [f32; BLOCK_SIZE] {
+    // SAFETY: caller contract documented above; intrinsics are sound
+    // when called from a `#[target_feature(enable = "avx2")]` function
+    // on an AVX2-capable CPU.
+    unsafe {
+        let m = query.params.m as usize;
+        let zero = _mm256_setzero_si256();
+        let mask_0f = _mm_set1_epi8(0x0F);
+        let mut u16_acc_lo = zero;
+        let mut u16_acc_hi = zero;
+
+        let lut_ptr = query.lut4_global.as_ptr();
+        let block_ptr = packed_block.as_ptr();
+
+        for m_idx in 0..m {
+            // Load 16-byte LUT for sub `m_idx` (K = 16 u8 entries).
+            let lut_xmm = _mm_loadu_si128(lut_ptr.add(m_idx * 16) as *const __m128i);
+
+            // Load 16 bytes of packed codes for sub `m_idx` (32 nibbles).
+            let codes_xmm =
+                _mm_loadu_si128(block_ptr.add(m_idx * BYTES_PER_SUB_PER_BLOCK) as *const __m128i);
+
+            // Low nibbles → codes for vectors 0..16.
+            let low_nibbles = _mm_and_si128(codes_xmm, mask_0f);
+            // High nibbles → codes for vectors 16..32. Shift right by
+            // 4 within each 16-bit lane (carries one bit between
+            // adjacent low-nibble columns but that bit is masked off
+            // by `mask_0f` immediately).
+            let high_nibbles = _mm_and_si128(_mm_srli_epi16(codes_xmm, 4), mask_0f);
+
+            // `vpshufb` gathers 16 u8 distances from the 16-entry LUT.
+            let dist_lo_xmm = _mm_shuffle_epi8(lut_xmm, low_nibbles);
+            let dist_hi_xmm = _mm_shuffle_epi8(lut_xmm, high_nibbles);
+
+            // Pack into a single ymm register laid out as
+            // `[vec 0..16 u8 | vec 16..32 u8]`.
+            let dist_ymm = _mm256_set_m128i(dist_hi_xmm, dist_lo_xmm);
+
+            // Widen u8 → u16 (`vpunpcklbw` / `vpunpckhbw` operate
+            // per-128-bit lane).
+            let dist_u16_lo = _mm256_unpacklo_epi8(dist_ymm, zero);
+            let dist_u16_hi = _mm256_unpackhi_epi8(dist_ymm, zero);
+
+            u16_acc_lo = _mm256_add_epi16(u16_acc_lo, dist_u16_lo);
+            u16_acc_hi = _mm256_add_epi16(u16_acc_hi, dist_u16_hi);
+        }
+
+        // Reorder so the two YMM accumulators hold:
+        // - `acc_0_to_16`  : u16 sums for vec 0..16
+        // - `acc_16_to_32` : u16 sums for vec 16..32
+        //
+        // Before the permute, the per-lane layout is:
+        //   u16_acc_lo lane 0 = vec  0.. 8
+        //   u16_acc_lo lane 1 = vec 16..24
+        //   u16_acc_hi lane 0 = vec  8..16
+        //   u16_acc_hi lane 1 = vec 24..32
+        let acc_0_to_16 = _mm256_permute2x128_si256(u16_acc_lo, u16_acc_hi, 0x20);
+        let acc_16_to_32 = _mm256_permute2x128_si256(u16_acc_lo, u16_acc_hi, 0x31);
+
+        let mut u16_dists = [0u16; BLOCK_SIZE];
+        _mm256_storeu_si256(u16_dists.as_mut_ptr() as *mut __m256i, acc_0_to_16);
+        _mm256_storeu_si256(u16_dists.as_mut_ptr().add(16) as *mut __m256i, acc_16_to_32);
+
+        let mut out = [0.0_f32; BLOCK_SIZE];
+        for (v, &sum) in u16_dists.iter().enumerate() {
+            let l2_sq = sum as f32 * query.lut_scale_global + query.lut_bias_sum;
+            out[v] = apply_metric(metric, l2_sq);
+        }
+        out
+    }
+}
+
+/// Scalar fallback that mirrors the SIMD kernels' arithmetic exactly.
+///
+/// Computes one distance per vector in the block by reusing
+/// [`distance_pq_fastscan_u8_global_scalar`], which performs the same
+/// `u16` accumulation and `* scale_global + bias_sum` reconstruction
+/// the SIMD path emits.
+pub fn distance_pq_fastscan_block_scalar(
+    metric: DistanceMetric,
+    query: &PqFastScanQuery,
+    packed_block: &[u8],
+) -> [f32; BLOCK_SIZE] {
+    let mut out = [0.0_f32; BLOCK_SIZE];
+    for (v, slot) in out.iter_mut().enumerate() {
+        *slot = distance_pq_fastscan_u8_global_scalar(metric, query, packed_block, v);
+    }
+    out
+}
+
+/// Compute distances for one FastScan block, dispatching to the AVX2
+/// kernel when the CPU supports it (and the validation constraints
+/// hold) and to the scalar fallback otherwise.
+///
+/// This is the production-facing entry point that Part D ([#695])
+/// wires into the HNSW / IVF search hot path.
+///
+/// Currently the AVX2 path requires `query.params.m as usize <= 64` so
+/// the u16 accumulator cannot overflow (`255 × 64 = 16320 < 65535`).
+/// Larger `M` falls back to the scalar path.
+pub fn distance_pq_fastscan_block(
+    metric: DistanceMetric,
+    query: &PqFastScanQuery,
+    packed_block: &[u8],
+) -> [f32; BLOCK_SIZE] {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_avx2_supported() && (query.params.m as usize) <= 64 {
+            // SAFETY: AVX2 is detected at runtime, and the M ≤ 64
+            // guard ensures the u16 accumulator cannot overflow. The
+            // buffer lengths are validated by
+            // `PqFastScanQuery::prepare()` and the pool layout.
+            return unsafe { distance_pq_fastscan_block_avx2(metric, query, packed_block) };
+        }
+    }
+    distance_pq_fastscan_block_scalar(metric, query, packed_block)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vector::core::quantization::{PqParams, pq_encode, pq_train_codebook};
+    use crate::vector::core::vector::Vector;
+    use crate::vector::index::pq_fastscan_storage::{PqFastScanPool, pack_codes_into_blocks};
+
+    /// Deterministic pseudo-random training corpus identical in shape
+    /// to the helper used by the Part A tests, so the resulting
+    /// codebook is well-conditioned (K-means converges to non-degenerate
+    /// centroids).
+    fn train_small_codebook(
+        m: usize,
+        sub_dim: usize,
+        n: usize,
+    ) -> (PqParams, Vec<f32>, Vec<Vector>) {
+        let dim = m * sub_dim;
+        let params = PqParams::new(m as u16, 16, sub_dim as u16).unwrap();
+        let mut vectors = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut v = Vec::with_capacity(dim);
+            for d in 0..dim {
+                let x = ((i * 31 + d * 17) % 257) as f32 - 128.0;
+                let y = ((i.wrapping_mul(d + 1)) % 91) as f32 * 0.1;
+                v.push(x + y);
+            }
+            vectors.push(Vector::new(v));
+        }
+        let codebook = pq_train_codebook(dim, params, &vectors).unwrap();
+        (params, codebook, vectors)
+    }
+
+    /// Helper to build a `PqFastScanPool` from a slice of `Vector`s.
+    fn build_pool(vectors: &[Vector], params: PqParams, codebook: &[f32]) -> PqFastScanPool {
+        let codes: Vec<Vec<u8>> = vectors
+            .iter()
+            .map(|v| pq_encode(&v.data, params, codebook))
+            .collect();
+        let entries = codes
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (i as u64, "f".to_string(), c.clone()));
+        PqFastScanPool::build(params, codebook.to_vec(), entries).unwrap()
+    }
+
+    /// Helper to extract one block's worth of packed codes from a pool.
+    fn block_slice(pool: &PqFastScanPool, block_idx: usize) -> Vec<u8> {
+        let stride = pool.block_stride();
+        let base = block_idx * stride;
+        pool.packed[base..base + stride].to_vec()
+    }
+
+    #[test]
+    fn scalar_and_dispatch_paths_agree_on_random_block() {
+        let (params, codebook, vectors) = train_small_codebook(4, 2, 200);
+        let pool = build_pool(&vectors, params, &codebook);
+        // Use the first training vector as the query so every code
+        // round-trip is non-degenerate.
+        let query = PqFastScanQuery::prepare(&vectors[0].data, params, &codebook).unwrap();
+        let block = block_slice(&pool, 0);
+
+        let scalar = distance_pq_fastscan_block_scalar(DistanceMetric::Euclidean, &query, &block);
+        let dispatch = distance_pq_fastscan_block(DistanceMetric::Euclidean, &query, &block);
+        assert_eq!(scalar, dispatch);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_block_matches_scalar_for_random_codebook() {
+        if !is_avx2_supported() {
+            eprintln!("AVX2 not supported on this CPU; skipping kernel test");
+            return;
+        }
+
+        let (params, codebook, vectors) = train_small_codebook(8, 2, 256);
+        let pool = build_pool(&vectors, params, &codebook);
+        let query = PqFastScanQuery::prepare(&vectors[3].data, params, &codebook).unwrap();
+
+        // Walk every block in the pool and assert kernel equivalence.
+        for block_idx in 0..pool.block_count() {
+            let block = block_slice(&pool, block_idx);
+            let scalar =
+                distance_pq_fastscan_block_scalar(DistanceMetric::Euclidean, &query, &block);
+            // SAFETY: AVX2 supported (checked above); lengths come
+            // from a freshly-built pool.
+            let simd = unsafe {
+                distance_pq_fastscan_block_avx2(DistanceMetric::Euclidean, &query, &block)
+            };
+            for v in 0..BLOCK_SIZE {
+                assert_eq!(
+                    simd[v], scalar[v],
+                    "block {block_idx} vec {v} mismatch (simd={} scalar={})",
+                    simd[v], scalar[v]
+                );
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_matches_scalar_for_cosine_metric() {
+        if !is_avx2_supported() {
+            return;
+        }
+        let (params, codebook, vectors) = train_small_codebook(4, 2, 200);
+        let pool = build_pool(&vectors, params, &codebook);
+        let query = PqFastScanQuery::prepare(&vectors[1].data, params, &codebook).unwrap();
+        let block = block_slice(&pool, 0);
+
+        let scalar = distance_pq_fastscan_block_scalar(DistanceMetric::Cosine, &query, &block);
+        // SAFETY: AVX2 supported; lengths verified by helper above.
+        let simd =
+            unsafe { distance_pq_fastscan_block_avx2(DistanceMetric::Cosine, &query, &block) };
+        assert_eq!(simd, scalar);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_matches_scalar_for_partial_block() {
+        if !is_avx2_supported() {
+            return;
+        }
+        // n = 5 < BLOCK_SIZE → first block has 5 real vectors + 27
+        // padding positions. Both kernels should agree on every lane
+        // (including padding, since `decode_codes_in_block` reads what
+        // the buffer holds).
+        let m = 4;
+        let sub_dim = 2;
+        let params = PqParams::new(m as u16, 16, sub_dim as u16).unwrap();
+        let dim = m * sub_dim;
+        let codebook: Vec<f32> = (0..params.codebook_len())
+            .map(|i| (i as f32) * 0.01)
+            .collect();
+        let codes: Vec<Vec<u8>> = (0..5)
+            .map(|i| (0..m).map(|sub| ((i + sub) % 16) as u8).collect())
+            .collect();
+        let _packed = pack_codes_into_blocks(&codes, m);
+        let pool = PqFastScanPool::build(
+            params,
+            codebook.clone(),
+            codes
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i as u64, "f".to_string(), c.clone())),
+        )
+        .unwrap();
+        let query_vec: Vec<f32> = (0..dim).map(|d| 0.1 * d as f32).collect();
+        let query = PqFastScanQuery::prepare(&query_vec, params, &codebook).unwrap();
+        let block = block_slice(&pool, 0);
+        let scalar = distance_pq_fastscan_block_scalar(DistanceMetric::Euclidean, &query, &block);
+        // SAFETY: AVX2 supported.
+        let simd =
+            unsafe { distance_pq_fastscan_block_avx2(DistanceMetric::Euclidean, &query, &block) };
+        assert_eq!(simd, scalar);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_handles_max_m_64_without_overflow() {
+        if !is_avx2_supported() {
+            return;
+        }
+        let m = 64usize;
+        let sub_dim = 1usize;
+        let params = PqParams::new(m as u16, 16, sub_dim as u16).unwrap();
+        // Maximum u8 LUT value per sub is 255. With M=64 the u16 sum
+        // is at most 16320, well below the u16 ceiling 65535.
+        // Construct a synthetic codebook whose squared-distance LUT
+        // exercises the upper bound: all codes map to entry 0, but
+        // we set every entry to the same value so the sum hits the
+        // dynamic range cap.
+        let codebook: Vec<f32> = (0..params.codebook_len())
+            .map(|i| (i % 16) as f32)
+            .collect();
+        let codes: Vec<Vec<u8>> = (0..BLOCK_SIZE)
+            .map(|i| (0..m).map(|sub| ((i + sub) % 16) as u8).collect())
+            .collect();
+        let pool = PqFastScanPool::build(
+            params,
+            codebook.clone(),
+            codes
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i as u64, "f".to_string(), c.clone())),
+        )
+        .unwrap();
+        let query_vec: Vec<f32> = (0..m * sub_dim).map(|d| d as f32).collect();
+        let query = PqFastScanQuery::prepare(&query_vec, params, &codebook).unwrap();
+        let block = block_slice(&pool, 0);
+
+        let scalar = distance_pq_fastscan_block_scalar(DistanceMetric::Euclidean, &query, &block);
+        // SAFETY: AVX2 supported.
+        let simd =
+            unsafe { distance_pq_fastscan_block_avx2(DistanceMetric::Euclidean, &query, &block) };
+        assert_eq!(simd, scalar);
+    }
+}


### PR DESCRIPTION
## Summary

Part B of [#651](https://github.com/mosuka/laurus/issues/651) (PQ FastScan: 4-bit codes + SIMD LUT distance). Depends on [#692](https://github.com/mosuka/laurus/issues/692) (Part A, merged in #696). This PR lands the **AVX2 SIMD kernel + runtime dispatch + scalar reference for SIMD**; no production hot-path wiring yet.

Subsequent parts:

- Part C ([#694](https://github.com/mosuka/laurus/issues/694)): NEON SIMD kernel for aarch64
- Part D ([#695](https://github.com/mosuka/laurus/issues/695)): writer/reader integration + persistence + benchmark

## Changes

### Phase 1 — scalar global reference (FAISS-compatible quantisation)

- New `quantise_lut_global(lut_f32, m)` builds the FAISS pq4_fast_scan u8 LUT (per-sub bias + single global scale) that the SIMD u8 saturating accumulator pattern requires.
- `PqFastScanQuery` gains three additive fields: `lut4_global`, `lut_scale_global`, `lut_bias_sum`. The Part A per-sub fields stay untouched so the Part A scalar reference tests remain bit-exact.
- New `distance_pq_fastscan_u8_global_scalar` is the bit-identical scalar reference for the SIMD kernels (same u16 accumulation, same `* scale_global + bias_sum` reconstruction).

### Phase 2 — AVX2 kernel + dispatch

New module `laurus/src/vector/index/pq_fastscan_avx2.rs` (+401 lines):

- `is_avx2_supported()` — runtime CPUID check (cached after first call).
- `distance_pq_fastscan_block_avx2()` (unsafe + `#[target_feature(enable = \"avx2\")]`) processes one 32-vector block via `_mm_shuffle_epi8` LUT lookups, `_mm256_unpacklo/hi_epi8` u8→u16 widening, and `_mm256_permute2x128_si256` lane reordering.
- `distance_pq_fastscan_block_scalar()` fallback wrapping the u8_global scalar reference.
- `distance_pq_fastscan_block()` runtime dispatch: AVX2 when supported **and** M ≤ 64 (u16 accumulator cap `255 × 64 = 16320 < 65535`), scalar otherwise.

The M ≤ 64 guard means the kernel can use u16 accumulators directly without periodic flushing — simpler than the FAISS pq4_fast_scan u8-saturating + flush variant while covering HNSW typical M=8/16/32 and beyond.

## Test plan

- [x] `cargo build -p laurus`
- [x] `cargo fmt --check` (formatter idempotent)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` — laurus: **1037 pass** (8 new), 0 regressions; laurus-mcp: 12 pass; laurus-server: 28 pass.
- [x] `markdownlint-cli2 \"docs/src/**/*.md\"` — 154 files, 0 error.

### New unit tests (8)

`vector::core::distance_pq_fastscan::tests` (3):
- `quantise_lut_global_round_trip_within_tolerance` — element-wise error ≤ `scale_global / 2`.
- `quantise_lut_global_handles_degenerate_lut` — all-zero LUT collapses to `scale=0`, `bias_sum=0`.
- `u8_global_scalar_matches_f32_scalar_within_tolerance` — squared-distance difference ≤ `M × scale_global / 2`.

`vector::index::pq_fastscan_avx2::tests` (5):
- `scalar_and_dispatch_paths_agree_on_random_block` — dispatcher routes correctly.
- `avx2_block_matches_scalar_for_random_codebook` — **walks every block of a random K=16 codebook + 256-vector pool and asserts AVX2 == scalar bit-identical**.
- `avx2_matches_scalar_for_cosine_metric` — Cosine post-processing path matches.
- `avx2_matches_scalar_for_partial_block` — n=5 partial block (27 padded positions) still matches.
- `avx2_handles_max_m_64_without_overflow` — M=64 exercises the u16 accumulator ceiling.

The bit-identical equivalence (not just within-tolerance) was deliberate: both kernels widen u8 → u16 and apply the same `* scale_global + bias_sum` at the end, so any deviation would indicate a SIMD wiring bug. This makes the property test a strict correctness anchor for Parts C and D.

Refs #693
Refs #651
Refs #536