### PR TITLE
fix(ci): remove aarch64 QEMU runner from repo cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,9 +3,16 @@
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
 
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-runner = "qemu-aarch64-static -L /usr/aarch64-linux-gnu"
+# NOTE: For local aarch64 cross-compile + QEMU testing (Issue #694
+# Part C), set these in your user-level config (`~/.cargo/config.toml`)
+# or via environment variables — NOT here. The `runner` setting in
+# this repo-wide file is applied even when the host itself is aarch64,
+# which breaks the native `ubuntu-24.04-arm` CI runner that does not
+# have qemu installed:
+#
+#     [target.aarch64-unknown-linux-gnu]
+#     linker = "aarch64-linux-gnu-gcc"
+#     runner = "qemu-aarch64-static -L /usr/aarch64-linux-gnu"
 
 # Environment variables exported to cargo, build scripts, and rustc.
 #


### PR DESCRIPTION
## Summary

Hotfix for the aarch64 CI failure introduced by #698 (PQ FastScan Part C).

## What broke

PR #698 added the following to `.cargo/config.toml`:

\`\`\`toml
[target.aarch64-unknown-linux-gnu]
linker = \"aarch64-linux-gnu-gcc\"
runner = \"qemu-aarch64-static -L /usr/aarch64-linux-gnu\"
\`\`\`

cargo applies the `runner` setting **whenever the target matches**, regardless of whether the host architecture matches. On the native aarch64 CI runner (`ubuntu-24.04-arm`) cargo therefore tries to launch the test binary through qemu even though the host can execute it directly, and the runner image has no qemu installed:

\`\`\`
could not execute process \`qemu-aarch64-static -L /usr/aarch64-linux-gnu /home/runner/work/laurus/laurus/target/aarch64-unknown-linux-gnu/debug/deps/laurus-2033cadfbe6d9267\` (never executed)

Caused by:
  No such file or directory (os error 2)
\`\`\`

See [the failing main run](https://github.com/mosuka/laurus/actions/runs/26357170097/job/77586007297).

## Fix

- Remove the `[target.aarch64-unknown-linux-gnu]` section from the repo's `.cargo/config.toml`.
- Replace it with a comment block explaining the trap and pointing future contributors at user-level config (`~/.cargo/config.toml`) for local QEMU cross-testing.
- The Part C NEON kernel itself is **untouched** — only the broken project-wide cross-test runner is removed.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` (x86_64) — OK
- [x] `cargo clippy --target aarch64-unknown-linux-gnu -p laurus --all-targets -- -D warnings` — OK
- [x] `cargo test --target aarch64-unknown-linux-gnu -p laurus --lib vector::index::pq_fastscan_neon` (local QEMU with user-level config) — **5 pass**
- [ ] CI must wait for `Test laurus (ubuntu-24.04-arm)` to complete before merge (the previous merge raced ahead of this job — lesson learned).

Refs #698
Refs #694