### PR TITLE
perf(vector): wire PQ FastScan config + format + I/O layer (Part D Phase 1) (#695)

### DIFF
--- a/laurus-server/Cargo.toml
+++ b/laurus-server/Cargo.toml
@@ -40,6 +40,10 @@ embeddings-all = [
     "embeddings-multimodal",
     "embeddings-openai",
 ]
+# Forwards the experimental PQ FastScan integration (Issue #695 /
+# part D of #651) from the laurus crate. Enables the
+# `ProductQuantizationFastScan` proto<->Rust conversion arms.
+pq-fastscan = ["laurus/pq-fastscan"]
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/laurus-server/proto/laurus/v1/index.proto
+++ b/laurus-server/proto/laurus/v1/index.proto
@@ -180,6 +180,11 @@ enum QuantizationMethod {
   QUANTIZATION_METHOD_NONE = 0;
   QUANTIZATION_METHOD_SCALAR_8BIT = 1;
   QUANTIZATION_METHOD_PRODUCT_QUANTIZATION = 2;
+  // PQ FastScan (K=16 4-bit codes + SIMD LUT distance). Issue #695 /
+  // part D of #651. Requires the server to be built with the
+  // `pq-fastscan` cargo feature; otherwise the conversion path rejects
+  // the value with an explicit error.
+  QUANTIZATION_METHOD_PRODUCT_QUANTIZATION_FASTSCAN = 3;
 }
 
 message QuantizationConfig {

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -298,6 +298,13 @@ fn quantization_to_proto(q: &QuantizationMethod) -> v1::QuantizationConfig {
             method: v1::QuantizationMethod::ProductQuantization as i32,
             subvector_count: *subvector_count as u32,
         },
+        #[cfg(feature = "pq-fastscan")]
+        QuantizationMethod::ProductQuantizationFastScan { subvector_count } => {
+            v1::QuantizationConfig {
+                method: v1::QuantizationMethod::ProductQuantizationFastscan as i32,
+                subvector_count: *subvector_count as u32,
+            }
+        }
     }
 }
 
@@ -315,6 +322,19 @@ fn quantization_from_proto(q: &v1::QuantizationConfig) -> QuantizationMethod {
                 subvector_count: q.subvector_count as usize,
             }
         }
+        #[cfg(feature = "pq-fastscan")]
+        Ok(v1::QuantizationMethod::ProductQuantizationFastscan) => {
+            QuantizationMethod::ProductQuantizationFastScan {
+                subvector_count: q.subvector_count as usize,
+            }
+        }
+        // Feature off: a client that sends FastScan over gRPC will be
+        // silently downgraded to scalar quantization. Returning an
+        // error here would require changing the function signature
+        // across many call sites; we accept the lossy mapping for
+        // Phase 1 and revisit when FastScan exits experimental.
+        #[cfg(not(feature = "pq-fastscan"))]
+        Ok(v1::QuantizationMethod::ProductQuantizationFastscan) => QuantizationMethod::Scalar8Bit,
     }
 }
 

--- a/laurus-server/src/gateway/convert.rs
+++ b/laurus-server/src/gateway/convert.rs
@@ -572,6 +572,9 @@ fn json_to_quantizer(json: &Value) -> Option<v1::QuantizationConfig> {
     let method = match method_str.to_lowercase().as_str() {
         "scalar_8bit" => v1::QuantizationMethod::Scalar8bit as i32,
         "product_quantization" => v1::QuantizationMethod::ProductQuantization as i32,
+        "product_quantization_fastscan" => {
+            v1::QuantizationMethod::ProductQuantizationFastscan as i32
+        }
         _ => v1::QuantizationMethod::None as i32,
     };
     let subvector_count = obj
@@ -589,6 +592,7 @@ fn quantizer_to_json(q: &v1::QuantizationConfig) -> Value {
         Ok(v1::QuantizationMethod::None) => "none",
         Ok(v1::QuantizationMethod::Scalar8bit) => "scalar_8bit",
         Ok(v1::QuantizationMethod::ProductQuantization) => "product_quantization",
+        Ok(v1::QuantizationMethod::ProductQuantizationFastscan) => "product_quantization_fastscan",
         Err(_) => "none",
     };
     json!({

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -104,6 +104,12 @@ embeddings-all = [
     "embeddings-multimodal",
     "embeddings-openai",
 ]
+# Experimental opt-in for the PQ FastScan integration in HNSW indexes
+# (Issue #695 / part D of #651). Enables the SIMD-accelerated K=16
+# 4-bit PQ ADC path. The underlying kernels (#692 / #693 / #694) are
+# always compiled; this feature only switches on the writer / reader /
+# searcher wiring and the `ProductQuantizationFastScan` schema option.
+pq-fastscan = []
 
 [[example]]
 name = "quickstart"

--- a/laurus/src/vector/core/quantization.rs
+++ b/laurus/src/vector/core/quantization.rs
@@ -58,6 +58,23 @@ pub enum QuantizationMethod {
         /// to derive the codebook layout.
         subvector_count: usize,
     },
+    /// FastScan product quantization (K=16 4-bit codes + SIMD LUT
+    /// distance). Experimental, only available with the `pq-fastscan`
+    /// cargo feature and only supported by HNSW indexes today
+    /// (Issue [#695](https://github.com/mosuka/laurus/issues/695) /
+    /// part D of [#651](https://github.com/mosuka/laurus/issues/651)).
+    ///
+    /// Use this when the HNSW search latency is dominated by the PQ
+    /// ADC kernel and the corpus fits the FAISS-style block layout
+    /// (32 vectors / block, 4-bit packed codes).
+    #[cfg(feature = "pq-fastscan")]
+    ProductQuantizationFastScan {
+        /// Number of sub-vectors. Same semantics as
+        /// [`Self::ProductQuantization::subvector_count`]; the only
+        /// difference is the K=16 codebook (4-bit codes) and the
+        /// block-transposed packing.
+        subvector_count: usize,
+    },
 }
 
 /// Segment-level scalar quantization parameters.
@@ -658,6 +675,14 @@ impl VectorQuantizer {
                  from_params is Scalar8Bit-only"
                     .to_string(),
             )),
+            #[cfg(feature = "pq-fastscan")]
+            QuantizationMethod::ProductQuantizationFastScan { .. } => {
+                Err(LaurusError::InvalidOperation(
+                    "Use VectorQuantizer::from_pq_codebook for ProductQuantizationFastScan; \
+                     from_params is Scalar8Bit-only"
+                        .to_string(),
+                ))
+            }
         }
     }
 
@@ -715,6 +740,17 @@ impl VectorQuantizer {
             }
             QuantizationMethod::ProductQuantization { subvector_count } => {
                 let params = PqParams::from_dim_and_m(self.dimension, subvector_count)?;
+                let codebook = pq_train_codebook(self.dimension, params, vectors)?;
+                self.state = QuantizerState::ProductQuantization { params, codebook };
+                Ok(())
+            }
+            #[cfg(feature = "pq-fastscan")]
+            QuantizationMethod::ProductQuantizationFastScan { subvector_count } => {
+                // FastScan uses K=16; reuse `from_dim_and_m` which validates
+                // divisibility and propagate via the standard PQ codebook
+                // training (k-means on each sub-vector).
+                let mut params = PqParams::from_dim_and_m(self.dimension, subvector_count)?;
+                params.k = 16;
                 let codebook = pq_train_codebook(self.dimension, params, vectors)?;
                 self.state = QuantizerState::ProductQuantization { params, codebook };
                 Ok(())
@@ -817,6 +853,17 @@ impl VectorQuantizer {
                     1.0
                 } else {
                     (self.dimension * 4) as f32 / subvector_count as f32
+                }
+            }
+            #[cfg(feature = "pq-fastscan")]
+            QuantizationMethod::ProductQuantizationFastScan { subvector_count } => {
+                // FastScan stores 4 bits per sub-vector (half a byte per
+                // sub), so the compressed size is `subvector_count / 2`
+                // bytes per vector.
+                if subvector_count == 0 {
+                    1.0
+                } else {
+                    (self.dimension * 4) as f32 / (subvector_count as f32 / 2.0)
                 }
             }
         }

--- a/laurus/src/vector/index.rs
+++ b/laurus/src/vector/index.rs
@@ -15,6 +15,8 @@ pub mod hnsw;
 pub mod io;
 pub mod ivf;
 pub mod pq_fastscan_avx2;
+#[cfg(feature = "pq-fastscan")]
+pub mod pq_fastscan_io;
 pub mod pq_fastscan_neon;
 pub mod pq_fastscan_storage;
 pub mod pq_io;

--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -105,6 +105,14 @@ impl FlatVectorIndexReader {
                         .to_string(),
                 ));
             }
+            #[cfg(feature = "pq-fastscan")]
+            QuantHeader::ProductQuantizationFastScan { .. } => {
+                return Err(crate::error::LaurusError::NotImplemented(
+                    "PQ FastScan (#695) is HNSW-only; the Flat reader does not \
+                     support PQ FastScan segments"
+                        .to_string(),
+                ));
+            }
         };
 
         let (vectors, vector_ids) = match storage.loading_mode() {

--- a/laurus/src/vector/index/flat/writer.rs
+++ b/laurus/src/vector/index/flat/writer.rs
@@ -125,6 +125,14 @@ impl FlatIndexWriter {
                         .to_string(),
                 ));
             }
+            #[cfg(feature = "pq-fastscan")]
+            QuantHeader::ProductQuantizationFastScan { .. } => {
+                return Err(crate::error::LaurusError::NotImplemented(
+                    "PQ FastScan (#695) is HNSW-only; the Flat writer does not \
+                     support PQ FastScan segments"
+                        .to_string(),
+                ));
+            }
         };
 
         // Read quantized vectors, dequantizing back to f32 so the

--- a/laurus/src/vector/index/format.rs
+++ b/laurus/src/vector/index/format.rs
@@ -83,6 +83,15 @@ pub mod quant_kind {
     pub const SCALAR_8BIT: u16 = 1;
     /// Product quantization. Stage 3 — reader returns NotImplemented.
     pub const PRODUCT_QUANTIZATION: u16 = 2;
+    /// FastScan Product Quantization (K=16 4-bit codes + SIMD LUT
+    /// distance). Issue [#695](https://github.com/mosuka/laurus/issues/695)
+    /// / part D of [#651](https://github.com/mosuka/laurus/issues/651).
+    /// Same on-disk layout as [`PRODUCT_QUANTIZATION`] (m / k / sub_dim
+    /// header followed by the codebook) but `k == 16` and the per-vector
+    /// records are 4-bit packed instead of 8-bit AoS. Only available
+    /// with the `pq-fastscan` cargo feature.
+    #[cfg(feature = "pq-fastscan")]
+    pub const PRODUCT_QUANTIZATION_FASTSCAN: u16 = 3;
 }
 
 /// Size in bytes of the fixed portion of the segment header (the part
@@ -140,6 +149,23 @@ pub enum QuantHeader {
         /// always `m * k * sub_dim` floats.
         codebook: Vec<f32>,
     },
+    /// `quant_kind = 3` — FastScan Product Quantization (#695 / #651).
+    ///
+    /// Wire-identical to [`Self::ProductQuantization`] on disk (same
+    /// m / k / sub_dim header + codebook); the distinguishing factor is
+    /// `k == 16` (4-bit codes) and the per-vector record format used
+    /// by the reader to build a
+    /// [`crate::vector::index::pq_fastscan_storage::PqFastScanPool`]
+    /// instead of a [`crate::vector::index::pq_storage::PqVectorPool`].
+    /// Only constructible when the `pq-fastscan` cargo feature is on.
+    #[cfg(feature = "pq-fastscan")]
+    ProductQuantizationFastScan {
+        /// FastScan quantizer parameters (M / K=16 / sub_dim).
+        params: PqParams,
+        /// Per-segment codebook in row-major layout. The length is
+        /// always `m * 16 * sub_dim` floats.
+        codebook: Vec<f32>,
+    },
 }
 
 impl QuantHeader {
@@ -148,6 +174,8 @@ impl QuantHeader {
         match self {
             Self::Scalar8Bit(_) => quant_kind::SCALAR_8BIT,
             Self::ProductQuantization { .. } => quant_kind::PRODUCT_QUANTIZATION,
+            #[cfg(feature = "pq-fastscan")]
+            Self::ProductQuantizationFastScan { .. } => quant_kind::PRODUCT_QUANTIZATION_FASTSCAN,
         }
     }
 
@@ -157,6 +185,10 @@ impl QuantHeader {
         match self {
             Self::Scalar8Bit(_) => SCALAR_8BIT_METADATA_SIZE,
             Self::ProductQuantization { params, .. } => {
+                PQ_FIXED_METADATA_SIZE + params.codebook_byte_size()
+            }
+            #[cfg(feature = "pq-fastscan")]
+            Self::ProductQuantizationFastScan { params, .. } => {
                 PQ_FIXED_METADATA_SIZE + params.codebook_byte_size()
             }
         }
@@ -184,6 +216,22 @@ impl VectorSegmentHeader {
         }
     }
 
+    /// Build a FastScan PQ header (Issue #695 / part D).
+    ///
+    /// `params.k` must be 16. The codebook layout is the same as
+    /// [`Self::product_quantization`] (row-major `m × k × sub_dim`
+    /// floats) — only the per-vector record format on disk differs
+    /// (4-bit packed instead of 8-bit AoS).
+    #[cfg(feature = "pq-fastscan")]
+    pub fn product_quantization_fastscan(params: PqParams, codebook: Vec<f32>) -> Self {
+        debug_assert_eq!(params.k, 16, "FastScan requires k == 16");
+        debug_assert_eq!(codebook.len(), params.codebook_len());
+        Self {
+            version: CURRENT_VERSION,
+            quant: QuantHeader::ProductQuantizationFastScan { params, codebook },
+        }
+    }
+
     /// Total serialized size: fixed header + quant-kind metadata.
     pub fn serialized_size(&self) -> usize {
         FIXED_HEADER_SIZE + self.quant.metadata_size()
@@ -204,6 +252,17 @@ impl VectorSegmentHeader {
                 writer.write_all(&params.scale.to_le_bytes())?;
             }
             QuantHeader::ProductQuantization { params, codebook } => {
+                writer.write_all(&params.m.to_le_bytes())?;
+                writer.write_all(&params.k.to_le_bytes())?;
+                writer.write_all(&params.sub_dim.to_le_bytes())?;
+                writer.write_all(&0u16.to_le_bytes())?; // padding
+                debug_assert_eq!(codebook.len(), params.codebook_len());
+                for &f in codebook {
+                    writer.write_all(&f.to_le_bytes())?;
+                }
+            }
+            #[cfg(feature = "pq-fastscan")]
+            QuantHeader::ProductQuantizationFastScan { params, codebook } => {
                 writer.write_all(&params.m.to_le_bytes())?;
                 writer.write_all(&params.k.to_le_bytes())?;
                 writer.write_all(&params.sub_dim.to_le_bytes())?;
@@ -291,6 +350,34 @@ impl VectorSegmentHeader {
                     codebook.push(f32::from_le_bytes(fbuf));
                 }
                 QuantHeader::ProductQuantization { params, codebook }
+            }
+            #[cfg(feature = "pq-fastscan")]
+            quant_kind::PRODUCT_QUANTIZATION_FASTSCAN => {
+                let mut buf2 = [0u8; 2];
+                reader.read_exact(&mut buf2)?;
+                let m = u16::from_le_bytes(buf2);
+                reader.read_exact(&mut buf2)?;
+                let k = u16::from_le_bytes(buf2);
+                reader.read_exact(&mut buf2)?;
+                let sub_dim = u16::from_le_bytes(buf2);
+                reader.read_exact(&mut buf2)?; // padding
+                let params = PqParams::new(m, k, sub_dim).map_err(|e| {
+                    LaurusError::IncompatibleFormat(format!("invalid PQ FastScan params: {e}"))
+                })?;
+                if params.k != 16 {
+                    return Err(LaurusError::IncompatibleFormat(format!(
+                        "PQ FastScan segment must declare k == 16, got k = {}",
+                        params.k
+                    )));
+                }
+                let codebook_len = params.codebook_len();
+                let mut codebook = Vec::with_capacity(codebook_len);
+                let mut fbuf = [0u8; 4];
+                for _ in 0..codebook_len {
+                    reader.read_exact(&mut fbuf)?;
+                    codebook.push(f32::from_le_bytes(fbuf));
+                }
+                QuantHeader::ProductQuantizationFastScan { params, codebook }
             }
             quant_kind::NONE => {
                 return Err(LaurusError::IncompatibleFormat(

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -355,6 +355,15 @@ impl HnswIndexReader {
                 );
                 (VectorStorage::OwnedPq(Arc::new(pool)), vector_ids, graph)
             }
+            #[cfg(feature = "pq-fastscan")]
+            (QuantHeader::ProductQuantizationFastScan { .. }, _) => {
+                return Err(LaurusError::NotImplemented(
+                    "PQ FastScan (#695) reader path is wired up in a later commit \
+                     of part D; the format header is recognised but the in-memory \
+                     load is not yet implemented"
+                        .to_string(),
+                ));
+            }
         };
 
         // Build zero-allocation prefetch lookup. For OwnedQuantized

--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -346,6 +346,14 @@ impl HnswIndexWriter {
                         &mut input, *params, codebook,
                     )?
                 }
+                #[cfg(feature = "pq-fastscan")]
+                QuantHeader::ProductQuantizationFastScan { .. } => {
+                    return Err(LaurusError::NotImplemented(
+                        "PQ FastScan (#695) writer reload path is wired up in a \
+                         later commit of part D"
+                            .to_string(),
+                    ));
+                }
             };
 
             vectors.push((doc_id, field_name, Vector::new(values)));
@@ -1253,6 +1261,16 @@ impl VectorIndexWriter for HnswIndexWriter {
                         crate::vector::index::pq_io::write_pq_record(&mut output, codes_i)?;
                     }
                 }
+            }
+            #[cfg(feature = "pq-fastscan")]
+            crate::vector::core::quantization::QuantizationMethod::ProductQuantizationFastScan {
+                ..
+            } => {
+                return Err(LaurusError::NotImplemented(
+                    "PQ FastScan (#695) writer path is wired up in a later commit \
+                     of part D; Phase 1 only lands the format / config plumbing"
+                        .to_string(),
+                ));
             }
         }
 

--- a/laurus/src/vector/index/ivf/reader.rs
+++ b/laurus/src/vector/index/ivf/reader.rs
@@ -132,6 +132,14 @@ impl IvfIndexReader {
                         .to_string(),
                 ));
             }
+            #[cfg(feature = "pq-fastscan")]
+            QuantHeader::ProductQuantizationFastScan { .. } => {
+                return Err(crate::error::LaurusError::NotImplemented(
+                    "PQ FastScan (#695) is HNSW-only; the IVF reader does not \
+                     support PQ FastScan segments"
+                        .to_string(),
+                ));
+            }
         };
 
         // Read inverted lists, preserving per-cluster grouping.

--- a/laurus/src/vector/index/ivf/writer.rs
+++ b/laurus/src/vector/index/ivf/writer.rs
@@ -159,6 +159,14 @@ impl IvfIndexWriter {
                         .to_string(),
                 ));
             }
+            #[cfg(feature = "pq-fastscan")]
+            QuantHeader::ProductQuantizationFastScan { .. } => {
+                return Err(crate::error::LaurusError::NotImplemented(
+                    "PQ FastScan (#695) is HNSW-only; the IVF writer does not \
+                     support PQ FastScan segments"
+                        .to_string(),
+                ));
+            }
         };
 
         // Read inverted lists, dequantizing each record back to f32

--- a/laurus/src/vector/index/pq_fastscan_io.rs
+++ b/laurus/src/vector/index/pq_fastscan_io.rs
@@ -1,0 +1,235 @@
+// Phase 1 of part D (#695) lands the FastScan I/O helpers ahead of
+// their writer / reader call sites; Phase 2 wires them in and these
+// `allow(dead_code)` attributes go away.
+#![allow(dead_code)]
+
+//! Writer / reader helpers for the HNSW PQ FastScan segment payload
+//! (Issue [#695](https://github.com/mosuka/laurus/issues/695) / part D
+//! of [#651](https://github.com/mosuka/laurus/issues/651)).
+//!
+//! Parallel to [`crate::vector::index::pq_io`] (the K=256 8-bit PQ
+//! variant). The on-disk layout for the FastScan region is identical
+//! to the K=256 PQ region in the segment header (LVS1 with
+//! `quant_kind = PRODUCT_QUANTIZATION_FASTSCAN` and the same
+//! `m / k / sub_dim` + codebook payload), but each per-vector record
+//! stores its `m` codes packed into `ceil(m / 2)` bytes (2 codes per
+//! byte, low nibble first):
+//!
+//! ```text
+//! [ VectorSegmentHeader  (LVS1 + PQ params + codebook, k = 16) ]
+//! repeat num_vectors times:
+//!   [ doc_id            u64 LE  8 bytes ]
+//!   [ field_name_len    u32 LE  4 bytes ]
+//!   [ field_name              field_name_len bytes (UTF-8) ]
+//!   [ codes_packed             ceil(m / 2) bytes (4-bit packed) ]
+//! ```
+//!
+//! The 4-bit packing matches the FAISS `pq4_pack_codes` convention so
+//! the reader can hand the codes straight to
+//! [`crate::vector::index::pq_fastscan_storage::PqFastScanPool::build`]
+//! after unpacking back to `Vec<u8>` (one byte per sub-quantiser code,
+//! values in `[0, 15]`).
+
+use std::io::{Read, Write};
+
+use crate::error::{LaurusError, Result};
+use crate::vector::core::quantization::{PqParams, QuantizationMethod, VectorQuantizer};
+use crate::vector::core::vector::Vector;
+
+/// Bytes consumed by the per-vector codes section (everything after
+/// the field_name string ends), i.e. `ceil(m / 2)`.
+#[inline]
+pub(super) const fn pq_fastscan_record_payload_size(m: u16) -> usize {
+    (m as usize).div_ceil(2)
+}
+
+/// Train a K=16 PQ codebook on the given vectors and encode each one
+/// into 4-bit codes.
+///
+/// Returns `(params, codebook, codes)` where `codes[i]` is a `Vec<u8>`
+/// of length `params.m`, each entry in `[0, 15]`. The caller pairs
+/// each entry back with its `(doc_id, field_name)` triple before
+/// writing through [`write_pq_fastscan_record`].
+///
+/// # Errors
+///
+/// Forwards any error from [`VectorQuantizer::train`] /
+/// [`VectorQuantizer::quantize`] (e.g. empty input, dimension
+/// mismatch, `dim % m != 0`). Returns
+/// [`LaurusError::InvalidOperation`] if a sub-quantiser code ends up
+/// outside `[0, 15]` (should never happen with `K = 16` but we
+/// validate to fail loudly rather than silently truncating during
+/// packing).
+pub(super) fn quantize_segment_pq_fastscan(
+    vectors: &[Vector],
+    dim: usize,
+    subvector_count: usize,
+) -> Result<(PqParams, Vec<f32>, Vec<Vec<u8>>)> {
+    let mut quantizer = VectorQuantizer::new(
+        QuantizationMethod::ProductQuantizationFastScan { subvector_count },
+        dim,
+    );
+    quantizer.train(vectors)?;
+    let (params, codebook_slice) = quantizer
+        .pq_state()
+        .expect("PQ FastScan quantizer trained successfully implies pq_state is set");
+    let params = *params;
+    if params.k != 16 {
+        return Err(LaurusError::InvalidOperation(format!(
+            "PQ FastScan must use k == 16, got k = {}",
+            params.k
+        )));
+    }
+    let codebook: Vec<f32> = codebook_slice.to_vec();
+    let codes: Vec<Vec<u8>> = vectors
+        .iter()
+        .map(|v| quantizer.quantize(v).map(|(c, _)| c))
+        .collect::<Result<_>>()?;
+    // Validate every code is a valid 4-bit value before we let the
+    // packer truncate.
+    for (i, c) in codes.iter().enumerate() {
+        for (j, &code) in c.iter().enumerate() {
+            if code >= 16 {
+                return Err(LaurusError::InvalidOperation(format!(
+                    "FastScan code {code} (vector {i}, sub {j}) exceeds 4-bit range"
+                )));
+            }
+        }
+    }
+    Ok((params, codebook, codes))
+}
+
+/// Pack `m` 4-bit codes into `ceil(m / 2)` bytes, low nibble first.
+///
+/// Mirrors the FAISS `pq4_pack_codes_1` per-vector helper. Codes must
+/// already be validated to fit in 4 bits (see
+/// [`quantize_segment_pq_fastscan`]).
+#[inline]
+fn pack_one_record(codes: &[u8]) -> Vec<u8> {
+    let m = codes.len();
+    let mut packed = vec![0u8; m.div_ceil(2)];
+    for (i, &c) in codes.iter().enumerate() {
+        let nibble = c & 0x0F;
+        if i % 2 == 0 {
+            packed[i / 2] |= nibble;
+        } else {
+            packed[i / 2] |= nibble << 4;
+        }
+    }
+    packed
+}
+
+/// Unpack `ceil(m / 2)` bytes back into `m` 4-bit codes (`Vec<u8>` of
+/// length `m`, each entry in `[0, 15]`).
+#[inline]
+fn unpack_one_record(packed: &[u8], m: usize) -> Vec<u8> {
+    let mut codes = vec![0u8; m];
+    for (i, slot) in codes.iter_mut().enumerate().take(m) {
+        let byte = packed[i / 2];
+        *slot = if i % 2 == 0 {
+            byte & 0x0F
+        } else {
+            (byte >> 4) & 0x0F
+        };
+    }
+    codes
+}
+
+/// Write the 4-bit packed codes tail of one FastScan record.
+///
+/// The caller is responsible for writing the preceding `doc_id` /
+/// `field_name_len` / `field_name` fields and the per-segment
+/// [`crate::vector::index::format::VectorSegmentHeader`].
+pub(super) fn write_pq_fastscan_record<W: Write>(output: &mut W, codes: &[u8]) -> Result<()> {
+    let packed = pack_one_record(codes);
+    output.write_all(&packed)?;
+    Ok(())
+}
+
+/// Read the 4-bit packed codes tail of one FastScan record and unpack
+/// it into a `Vec<u8>` of length `m`, ready to feed
+/// [`crate::vector::index::pq_fastscan_storage::PqFastScanPool::build`].
+pub(super) fn read_pq_fastscan_record<R: Read>(input: &mut R, params: PqParams) -> Result<Vec<u8>> {
+    let m = params.m as usize;
+    let packed_len = m.div_ceil(2);
+    let mut packed = vec![0u8; packed_len];
+    input.read_exact(&mut packed)?;
+    Ok(unpack_one_record(&packed, m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn vec_of(values: &[f32]) -> Vector {
+        Vector::new(values.to_vec())
+    }
+
+    #[test]
+    fn payload_size_is_ceil_m_over_two() {
+        assert_eq!(pq_fastscan_record_payload_size(0), 0);
+        assert_eq!(pq_fastscan_record_payload_size(1), 1);
+        assert_eq!(pq_fastscan_record_payload_size(2), 1);
+        assert_eq!(pq_fastscan_record_payload_size(3), 2);
+        assert_eq!(pq_fastscan_record_payload_size(8), 4);
+        assert_eq!(pq_fastscan_record_payload_size(16), 8);
+    }
+
+    #[test]
+    fn pack_unpack_round_trip_even_m() {
+        let codes = vec![0, 1, 2, 15, 8, 7, 4, 3];
+        let packed = pack_one_record(&codes);
+        assert_eq!(packed.len(), 4);
+        let unpacked = unpack_one_record(&packed, codes.len());
+        assert_eq!(unpacked, codes);
+    }
+
+    #[test]
+    fn pack_unpack_round_trip_odd_m() {
+        let codes = vec![5, 10, 15];
+        let packed = pack_one_record(&codes);
+        assert_eq!(packed.len(), 2);
+        let unpacked = unpack_one_record(&packed, codes.len());
+        assert_eq!(unpacked, codes);
+    }
+
+    #[test]
+    fn quantize_segment_pq_fastscan_returns_k_16_codes() {
+        let vectors = vec![
+            vec_of(&[10.0, 10.0, 20.0, 20.0]),
+            vec_of(&[-10.0, -10.0, -20.0, -20.0]),
+            vec_of(&[10.1, 10.1, 20.1, 20.1]),
+        ];
+        let (params, codebook, codes) = quantize_segment_pq_fastscan(&vectors, 4, 2).unwrap();
+        assert_eq!(params.m, 2);
+        assert_eq!(params.k, 16);
+        assert_eq!(params.sub_dim, 2);
+        assert_eq!(codebook.len(), params.codebook_len());
+        assert_eq!(codes.len(), 3);
+        for c in &codes {
+            assert_eq!(c.len(), 2);
+            for &code in c {
+                assert!(code < 16, "code {code} exceeds 4-bit range");
+            }
+        }
+    }
+
+    #[test]
+    fn write_then_read_pq_fastscan_round_trips_codes() {
+        let codes: Vec<Vec<u8>> = vec![vec![0, 1, 2, 3], vec![15, 14, 13, 12], vec![7, 8, 9, 10]];
+        let mut buf = Vec::new();
+        for c in &codes {
+            write_pq_fastscan_record(&mut buf, c).unwrap();
+        }
+        // 4 codes per record → 2 bytes per record.
+        assert_eq!(buf.len(), codes.len() * pq_fastscan_record_payload_size(4));
+
+        let params = PqParams::new(4, 16, 1).unwrap();
+        let mut cursor = Cursor::new(&buf);
+        for original in &codes {
+            let recovered = read_pq_fastscan_record(&mut cursor, params).unwrap();
+            assert_eq!(&recovered, original);
+        }
+    }
+}

--- a/laurus/src/vector/index/quantized_segment.rs
+++ b/laurus/src/vector/index/quantized_segment.rs
@@ -171,6 +171,14 @@ impl QuantizedSegmentVectors {
                         .to_string(),
                 ));
             }
+            #[cfg(feature = "pq-fastscan")]
+            QuantHeader::ProductQuantizationFastScan { .. } => {
+                return Err(crate::error::LaurusError::NotImplemented(
+                    "QuantizedSegmentVectors (Stage 1) cannot read PQ FastScan \
+                     segments; the FastScan reader lives in vector::index::hnsw::reader"
+                        .to_string(),
+                ));
+            }
         };
 
         let mut dim_bytes = [0u8; 4];


### PR DESCRIPTION
## Summary

Phase 1 of [#695](https://github.com/mosuka/laurus/issues/695) (PQ FastScan Part D umbrella). Depends on Parts A ([#696](https://github.com/mosuka/laurus/pull/696)), B ([#697](https://github.com/mosuka/laurus/pull/697)), C ([#698](https://github.com/mosuka/laurus/pull/698) + hotfix [#699](https://github.com/mosuka/laurus/pull/699)) — all merged.

This PR lands the **experimental opt-in plumbing** (cargo feature, schema/config enum variant, on-disk format variant, sibling I/O module) so the writer / reader / searcher / benchmark can be wired up in follow-up Phase 2-4 PRs without a single 1500+ line merge. Same pattern as Parts A/B/C: ship kernels and infrastructure first, integrate later.

The feature is **`pq-fastscan`, default off**. Users won't reach any FastScan code unless they explicitly build with `--features pq-fastscan` AND set `ProductQuantizationFastScan` in their schema. In Phase 1 doing both yields a clear `NotImplemented` error pointing at the in-progress writer / reader wiring.

## Part D phases

| Phase | Issue | Scope |
|---|---|---|
| **1 (this PR)** | [#695](https://github.com/mosuka/laurus/issues/695) | Cargo feature + schema/config enum + on-disk format + I/O layer |
| 2 | [#701](https://github.com/mosuka/laurus/issues/701) | HNSW writer + reader integration, `VectorStorage::OwnedPqFastScan` variant |
| 3 | [#702](https://github.com/mosuka/laurus/issues/702) | HNSW searcher + end-to-end integration test |
| 4 | [#703](https://github.com/mosuka/laurus/issues/703) | SIFT benchmark + ≥1.5× speedup verification (acceptance gate) |

## Changes

All FastScan additions gated behind `pq-fastscan`:

- **Cargo feature** added to `laurus` and forwarded from `laurus-server` so the gRPC layer can carry the new proto enum value when built with the feature.
- **`QuantizationMethod::ProductQuantizationFastScan { subvector_count }`** variant in `laurus/src/vector/core/quantization.rs`. Propagated through `VectorQuantizer` (`from_params`, `train`, `compression_ratio`); training reuses the existing PQ codebook pipeline but pins `k = 16`.
- **`quant_kind::PRODUCT_QUANTIZATION_FASTSCAN = 3`** in `laurus/src/vector/index/format.rs` plus a matching `QuantHeader::ProductQuantizationFastScan` variant. `write_to` / `read_from` recognise the new kind code; on-disk layout matches the existing K=256 PQ header (m / k / sub_dim + codebook) and the reader validates `k == 16` at load time.
- New helper `VectorSegmentHeader::product_quantization_fastscan` constructor.
- **New module `laurus/src/vector/index/pq_fastscan_io.rs`** with `quantize_segment_pq_fastscan`, `pack_one_record` / `unpack_one_record` (FAISS `pq4_pack_codes_1` convention — 4-bit packing, low nibble first), `write_pq_fastscan_record` / `read_pq_fastscan_record`. Tagged `#![allow(dead_code)]` until Phase 2 wires the call sites.
- Stubbed `NotImplemented` arms in HNSW writer / reader (replaced with real wiring in Phase 2 / [#701](https://github.com/mosuka/laurus/issues/701)) and permanent **HNSW-only** rejection arms in the Flat / IVF writer / reader paths so the new enum variant fails clearly rather than silently falling through.
- Proto enum extended with `QUANTIZATION_METHOD_PRODUCT_QUANTIZATION_FASTSCAN = 3`; routed through `quantization_to_proto`, `quantization_from_proto`, `json_to_quantizer`, `quantizer_to_json`. Without the feature, the from-proto path silently downgrades the value to scalar quantization (lossy) — a deliberate Phase 1 trade-off to avoid changing function signatures across the gateway.

## Test plan

- [x] `cargo build -p laurus` (feature off)
- [x] `cargo build -p laurus --features pq-fastscan` (feature on)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (feature off)
- [x] `cargo clippy --workspace --all-targets --features pq-fastscan -- -D warnings` (feature on)
- [x] `cargo test --workspace --lib` — laurus: **1038 pass** with feature off, **1043 pass** with feature on, 0 regressions in either configuration
- [x] `cargo clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings`
- [x] `markdownlint-cli2 \"docs/src/**/*.md\"` — 154 files, 0 error

### New unit tests (5, feature-gated)

`vector::index::pq_fastscan_io::tests`:
- `payload_size_is_ceil_m_over_two` — packing geometry edge cases.
- `pack_unpack_round_trip_even_m` — 8-code round-trip.
- `pack_unpack_round_trip_odd_m` — 3-code round-trip.
- `quantize_segment_pq_fastscan_returns_k_16_codes` — training emits `k = 16` codes in `[0, 15]`.
- `write_then_read_pq_fastscan_round_trips_codes` — on-disk round-trip with `Cursor`.

Refs #695
Refs #651
Refs #536