### PR TITLE
perf(vector): wire PQ FastScan HNSW writer + reader (Phase 2 of #695) (#701)

### DIFF
--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -311,6 +311,10 @@ impl VectorIndexReader for FlatVectorIndexReader {
             VectorStorage::Owned(vectors) => vectors.len() * (8 + self.dimension * 4),
             VectorStorage::OwnedQuantized(pool) => pool.data.len(),
             VectorStorage::OwnedPq(pool) => pool.data.len() + pool.codebook.len() * 4,
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(_) => {
+                unreachable!("Flat reader rejects PQ FastScan at the segment header (HNSW-only)")
+            }
             VectorStorage::OnDemand { offsets, .. } => {
                 // Estimate memory for offsets map + ID list
                 offsets.len() * (8 + 32 + 8) // Key + Valid + Offset roughly
@@ -331,6 +335,10 @@ impl VectorIndexReader for FlatVectorIndexReader {
             }
             VectorStorage::OwnedQuantized(pool) => pool.contains(doc_id, field_name),
             VectorStorage::OwnedPq(pool) => pool.contains(doc_id, field_name),
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(_) => {
+                unreachable!("Flat reader rejects PQ FastScan at the segment header (HNSW-only)")
+            }
             VectorStorage::OnDemand { offsets, .. } => {
                 offsets.contains_key(&(doc_id, field_name.to_string()))
             }
@@ -463,6 +471,10 @@ impl VectorIndexReader for FlatVectorIndexReader {
                      the trained codebook which is bounded by construction)"
                         .to_string(),
                 );
+            }
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(_) => {
+                unreachable!("Flat reader rejects PQ FastScan at the segment header (HNSW-only)")
             }
             VectorStorage::OnDemand { offsets, .. } => {
                 for (id, field) in &self.vector_ids {

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -356,13 +356,52 @@ impl HnswIndexReader {
                 (VectorStorage::OwnedPq(Arc::new(pool)), vector_ids, graph)
             }
             #[cfg(feature = "pq-fastscan")]
-            (QuantHeader::ProductQuantizationFastScan { .. }, _) => {
-                return Err(LaurusError::NotImplemented(
-                    "PQ FastScan (#695) reader path is wired up in a later commit \
-                     of part D; the format header is recognised but the in-memory \
-                     load is not yet implemented"
-                        .to_string(),
-                ));
+            (
+                QuantHeader::ProductQuantizationFastScan {
+                    params: pq_params,
+                    codebook,
+                },
+                _loading_mode,
+            ) => {
+                // Mirror the K=256 PQ load path but read 4-bit packed
+                // codes via `pq_fastscan_io::read_pq_fastscan_record`
+                // and build a `PqFastScanPool` for the SIMD-friendly
+                // block-transposed in-memory layout.
+                let mut vector_ids = Vec::with_capacity(num_vectors);
+                let mut records: Vec<(u64, String, Vec<u8>)> = Vec::with_capacity(num_vectors);
+
+                for _ in 0..num_vectors {
+                    let mut doc_id_buf = [0u8; 8];
+                    input.read_exact(&mut doc_id_buf)?;
+                    let doc_id = u64::from_le_bytes(doc_id_buf);
+
+                    let mut field_name_len_buf = [0u8; 4];
+                    input.read_exact(&mut field_name_len_buf)?;
+                    let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                    let mut field_name_buf = vec![0u8; field_name_len];
+                    input.read_exact(&mut field_name_buf)?;
+                    let field_name = String::from_utf8(field_name_buf).map_err(|e| {
+                        LaurusError::InvalidOperation(format!("Invalid UTF-8 in field name: {}", e))
+                    })?;
+
+                    let codes = crate::vector::index::pq_fastscan_io::read_pq_fastscan_record(
+                        &mut input, *pq_params,
+                    )?;
+
+                    vector_ids.push((doc_id, field_name.clone()));
+                    records.push((doc_id, field_name, codes));
+                }
+                let graph = read_graph(&mut input)?;
+                let pool = crate::vector::index::pq_fastscan_storage::PqFastScanPool::build(
+                    *pq_params,
+                    codebook.clone(),
+                    records,
+                )?;
+                (
+                    VectorStorage::OwnedPqFastScan(Arc::new(pool)),
+                    vector_ids,
+                    graph,
+                )
             }
         };
 
@@ -403,6 +442,14 @@ impl HnswIndexReader {
                 // PQ records are M bytes each (8-32 bytes) — small
                 // enough that prefetching adds no benefit; the LUT is
                 // the more important cache occupant.
+                HashMap::new()
+            }
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(_) => {
+                // FastScan uses 4-bit packed codes; the SIMD kernel
+                // streams entire 32-vector blocks (~16M bytes/block
+                // for typical M) so per-vector prefetch hints add
+                // nothing on top of the natural sequential access.
                 HashMap::new()
             }
             VectorStorage::OnDemand { .. } => HashMap::new(),
@@ -597,6 +644,8 @@ impl VectorIndexReader for HnswIndexReader {
             VectorStorage::Owned(vectors) => vectors.len() * (8 + self.dimension * 4),
             VectorStorage::OwnedQuantized(pool) => pool.data.len(),
             VectorStorage::OwnedPq(pool) => pool.data.len() + pool.codebook.len() * 4,
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(pool) => pool.packed.len() + pool.codebook.len() * 4,
             VectorStorage::OnDemand { offsets, .. } => {
                 // Estimate memory for offsets map + ID list
                 offsets.len() * (8 + 32 + 8) // Key + Valid + Offset roughly
@@ -618,6 +667,8 @@ impl VectorIndexReader for HnswIndexReader {
             }
             VectorStorage::OwnedQuantized(pool) => pool.contains(doc_id, field_name),
             VectorStorage::OwnedPq(pool) => pool.contains(doc_id, field_name),
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(pool) => pool.contains(doc_id, field_name),
             VectorStorage::OnDemand { offsets, .. } => {
                 offsets.contains_key(&(doc_id, field_name.to_string()))
             }
@@ -748,6 +799,22 @@ impl VectorIndexReader for HnswIndexReader {
                 warnings.push(
                     "OwnedPq mode: dimension / NaN checks skipped (codes index into \
                      the trained codebook which is bounded by construction)"
+                        .to_string(),
+                );
+            }
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(pool) => {
+                for (id, field) in &self.vector_ids {
+                    if !pool.contains(*id, field) {
+                        errors.push(format!(
+                            "Vector {}:{} found in keys but missing in PQ FastScan pool",
+                            id, field
+                        ));
+                    }
+                }
+                warnings.push(
+                    "OwnedPqFastScan mode: dimension / NaN checks skipped (4-bit codes \
+                     index into the trained K=16 codebook which is bounded by construction)"
                         .to_string(),
                 );
             }

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+#[cfg(feature = "pq-fastscan")]
+use crate::error::LaurusError;
 use crate::error::Result;
 use crate::vector::core::distance::DistanceMetric;
 use crate::vector::core::distance_quantized::{
@@ -392,6 +394,21 @@ impl HnswSearcher {
         // Other storage kinds (`OnDemand`, `Owned`) fall through to
         // the f32 reference path in `calc_dist`.
         let metric = reader.distance_metric();
+        // Phase 2 of #695 lets HNSW writer/reader build a
+        // `VectorStorage::OwnedPqFastScan`, but the searcher does not
+        // yet route through the FastScan SIMD kernel (#702 wires it up
+        // in Phase 3). Fail loudly here so users that opt into the
+        // experimental feature do not silently fall back to the f32
+        // reference path on every query.
+        #[cfg(feature = "pq-fastscan")]
+        if reader.vectors().pq_fastscan_pool().is_some() {
+            return Err(LaurusError::NotImplemented(
+                "PQ FastScan searcher integration is part of #702 (Phase 3 of #695); \
+                 Phase 2 only wires the writer and reader"
+                    .to_string(),
+            ));
+        }
+
         let quant_ctx: Option<QuantizedSearchCtx> =
             if let Some(pool) = reader.vectors().quantized_pool() {
                 pool.field_position_index(field_name).map(|field_idx| {

--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -347,12 +347,10 @@ impl HnswIndexWriter {
                     )?
                 }
                 #[cfg(feature = "pq-fastscan")]
-                QuantHeader::ProductQuantizationFastScan { .. } => {
-                    return Err(LaurusError::NotImplemented(
-                        "PQ FastScan (#695) writer reload path is wired up in a \
-                         later commit of part D"
-                            .to_string(),
-                    ));
+                QuantHeader::ProductQuantizationFastScan { params, codebook } => {
+                    crate::vector::index::pq_fastscan_io::read_dequantized_pq_fastscan_vector(
+                        &mut input, *params, codebook,
+                    )?
                 }
             };
 
@@ -1264,13 +1262,44 @@ impl VectorIndexWriter for HnswIndexWriter {
             }
             #[cfg(feature = "pq-fastscan")]
             crate::vector::core::quantization::QuantizationMethod::ProductQuantizationFastScan {
-                ..
+                subvector_count,
             } => {
-                return Err(LaurusError::NotImplemented(
-                    "PQ FastScan (#695) writer path is wired up in a later commit \
-                     of part D; Phase 1 only lands the format / config plumbing"
-                        .to_string(),
-                ));
+                if f32_vectors.is_empty() {
+                    // Empty segment: emit a well-formed LVS1 header with a
+                    // minimal zero-centroid K=16 codebook so the reader can
+                    // dispatch on quant_kind. Mirrors the PQ-256 empty path.
+                    let m = subvector_count.max(1);
+                    let sub_dim = self.index_config.dimension / m;
+                    let params = crate::vector::core::quantization::PqParams::new(
+                        m as u16,
+                        16,
+                        sub_dim as u16,
+                    )?;
+                    let codebook = vec![0.0_f32; params.codebook_len()];
+                    VectorSegmentHeader::product_quantization_fastscan(params, codebook)
+                        .write_to(&mut output)?;
+                } else {
+                    let (params, codebook, codes) =
+                        crate::vector::index::pq_fastscan_io::quantize_segment_pq_fastscan(
+                            &f32_vectors,
+                            self.index_config.dimension,
+                            subvector_count,
+                        )?;
+                    VectorSegmentHeader::product_quantization_fastscan(params, codebook)
+                        .write_to(&mut output)?;
+                    for ((doc_id, field_name, _), codes_i) in
+                        sorted_vectors.iter().zip(codes.iter())
+                    {
+                        output.write_all(&doc_id.to_le_bytes())?;
+                        let field_name_bytes = field_name.as_bytes();
+                        output.write_all(&(field_name_bytes.len() as u32).to_le_bytes())?;
+                        output.write_all(field_name_bytes)?;
+                        crate::vector::index::pq_fastscan_io::write_pq_fastscan_record(
+                            &mut output,
+                            codes_i,
+                        )?;
+                    }
+                }
             }
         }
 

--- a/laurus/src/vector/index/ivf/reader.rs
+++ b/laurus/src/vector/index/ivf/reader.rs
@@ -514,6 +514,10 @@ impl VectorIndexReader for IvfIndexReader {
                         .to_string(),
                 );
             }
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(_) => {
+                unreachable!("IVF reader rejects PQ FastScan at the segment header (HNSW-only)")
+            }
             VectorStorage::OnDemand { offsets, .. } => {
                 for (id, field) in &self.vector_ids {
                     if !offsets.contains_key(&(*id, field.clone())) {

--- a/laurus/src/vector/index/pq_fastscan_io.rs
+++ b/laurus/src/vector/index/pq_fastscan_io.rs
@@ -1,8 +1,3 @@
-// Phase 1 of part D (#695) lands the FastScan I/O helpers ahead of
-// their writer / reader call sites; Phase 2 wires them in and these
-// `allow(dead_code)` attributes go away.
-#![allow(dead_code)]
-
 //! Writer / reader helpers for the HNSW PQ FastScan segment payload
 //! (Issue [#695](https://github.com/mosuka/laurus/issues/695) / part D
 //! of [#651](https://github.com/mosuka/laurus/issues/651)).
@@ -33,12 +28,17 @@
 use std::io::{Read, Write};
 
 use crate::error::{LaurusError, Result};
-use crate::vector::core::quantization::{PqParams, QuantizationMethod, VectorQuantizer};
+use crate::vector::core::quantization::{PqParams, QuantizationMethod, VectorQuantizer, pq_decode};
 use crate::vector::core::vector::Vector;
 
 /// Bytes consumed by the per-vector codes section (everything after
 /// the field_name string ends), i.e. `ceil(m / 2)`.
+///
+/// Currently only used by in-module round-trip tests; the writer and
+/// reader inline `m.div_ceil(2)` since they already have `params.m`
+/// in scope.
 #[inline]
+#[cfg(test)]
 pub(super) const fn pq_fastscan_record_payload_size(m: u16) -> usize {
     (m as usize).div_ceil(2)
 }
@@ -155,6 +155,21 @@ pub(super) fn read_pq_fastscan_record<R: Read>(input: &mut R, params: PqParams) 
     let mut packed = vec![0u8; packed_len];
     input.read_exact(&mut packed)?;
     Ok(unpack_one_record(&packed, m))
+}
+
+/// Read the 4-bit packed codes tail of one FastScan record and
+/// reconstruct it back to a `Vec<f32>` of length `params.original_dim()`
+/// via the codebook. Used by HNSW writer's load path that keeps the
+/// in-memory representation as f32 on rebuild — mirrors
+/// [`crate::vector::index::pq_io::read_dequantized_pq_vector`] for the
+/// 8-bit PQ variant.
+pub(super) fn read_dequantized_pq_fastscan_vector<R: Read>(
+    input: &mut R,
+    params: PqParams,
+    codebook: &[f32],
+) -> Result<Vec<f32>> {
+    let codes = read_pq_fastscan_record(input, params)?;
+    Ok(pq_decode(&codes, params, codebook))
 }
 
 #[cfg(test)]

--- a/laurus/src/vector/index/pq_fastscan_storage.rs
+++ b/laurus/src/vector/index/pq_fastscan_storage.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 
 use crate::error::{LaurusError, Result};
 use crate::vector::core::quantization::PqParams;
+use crate::vector::core::vector::Vector;
 
 /// Number of vectors packed into one FastScan block.
 ///
@@ -189,6 +190,51 @@ impl PqFastScanPool {
             *slot = (byte >> shift) & 0x0F;
         }
         out
+    }
+
+    /// Total vector count held by this pool. Alias for [`Self::n_vectors`]
+    /// so callers can use the same accessor name as
+    /// [`crate::vector::index::pq_storage::PqVectorPool::vector_count`].
+    #[inline]
+    pub fn vector_count(&self) -> usize {
+        self.n_vectors
+    }
+
+    /// Whether the pool contains the given `(doc_id, field)` key.
+    #[inline]
+    pub fn contains(&self, doc_id: u64, field: &str) -> bool {
+        self.field_index
+            .get(field)
+            .is_some_and(|m| m.contains_key(&doc_id))
+    }
+
+    /// Iterate over `(doc_id, field_name)` pairs in this pool. The
+    /// returned list is sorted by doc_id so callers get a stable
+    /// ordering across runs (mirrors the K=256 PqVectorPool API).
+    pub fn keys(&self) -> Vec<(u64, String)> {
+        let mut keys: Vec<(u64, String)> = self
+            .field_index
+            .iter()
+            .flat_map(|(field, map)| map.keys().map(move |id| (*id, field.clone())))
+            .collect();
+        keys.sort_by_key(|(id, _)| *id);
+        keys
+    }
+
+    /// Reconstruct an approximate f32 vector for `(doc_id, field)` by
+    /// decoding the 4-bit codes through the per-segment codebook.
+    /// Used by the legacy
+    /// [`crate::vector::reader::VectorIndexReader::get_vector`] API
+    /// path; the search hot loop never calls this and goes through the
+    /// SIMD kernels via
+    /// [`crate::vector::index::pq_fastscan_avx2::distance_pq_fastscan_block`]
+    /// instead.
+    pub fn dequantize_to_vector(&self, doc_id: u64, field: &str) -> Option<Vector> {
+        let pos = *self.field_index.get(field)?.get(&doc_id)?;
+        let codes = self.codes_at(pos as usize);
+        let data =
+            crate::vector::core::quantization::pq_decode(&codes, self.params, &self.codebook);
+        Some(Vector::new(data))
     }
 }
 

--- a/laurus/src/vector/index/storage.rs
+++ b/laurus/src/vector/index/storage.rs
@@ -6,6 +6,8 @@ use crate::error::{LaurusError, Result};
 use crate::storage::{Storage, StorageInput};
 use crate::vector::core::quantization::{QuantizedVectorMeta, ScalarQuantParams};
 use crate::vector::core::vector::Vector;
+#[cfg(feature = "pq-fastscan")]
+use crate::vector::index::pq_fastscan_storage::PqFastScanPool;
 use crate::vector::index::pq_storage::PqVectorPool;
 use crate::vector::index::quantized_storage::QuantizedVectorPool;
 
@@ -37,6 +39,15 @@ pub enum VectorStorage {
     /// via [`Self::pq_pool`] and feeds codes + the per-query LUT to
     /// [`crate::vector::core::distance_quantized::distance_pq_adc`].
     OwnedPq(Arc<PqVectorPool>),
+    /// All vectors are loaded into memory as 4-bit packed FastScan
+    /// codes plus the per-segment K=16 codebook (Issue #695 / part D
+    /// of #651, HNSW only, experimental). The search hot loop walks
+    /// the inner [`PqFastScanPool`] directly through
+    /// [`crate::vector::index::pq_fastscan_avx2::distance_pq_fastscan_block`]
+    /// which dispatches to AVX2 / NEON / scalar by CPU. Available only
+    /// when the crate is built with the `pq-fastscan` cargo feature.
+    #[cfg(feature = "pq-fastscan")]
+    OwnedPqFastScan(Arc<PqFastScanPool>),
     /// Vectors are read from disk on demand.
     ///
     /// Each [`get`](Self::get) call opens a fresh [`StorageInput`](crate::storage::StorageInput)
@@ -99,12 +110,28 @@ impl VectorStorage {
         }
     }
 
+    /// If this storage is the in-memory PQ FastScan variant (Issue
+    /// #695 / part D of #651), return the underlying
+    /// [`PqFastScanPool`] so the search hot loop can walk the
+    /// block-transposed 4-bit packed codes directly and dispatch to
+    /// the AVX2 / NEON / scalar FastScan kernel via
+    /// [`crate::vector::index::pq_fastscan_avx2::distance_pq_fastscan_block`].
+    #[cfg(feature = "pq-fastscan")]
+    pub fn pq_fastscan_pool(&self) -> Option<&Arc<PqFastScanPool>> {
+        match self {
+            VectorStorage::OwnedPqFastScan(pool) => Some(pool),
+            _ => None,
+        }
+    }
+
     /// Returns all keys stored in this vector storage.
     pub fn keys(&self) -> Vec<(u64, String)> {
         match self {
             VectorStorage::Owned(map) => map.keys().cloned().collect(),
             VectorStorage::OwnedQuantized(pool) => pool.keys(),
             VectorStorage::OwnedPq(pool) => pool.keys(),
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(pool) => pool.keys(),
             VectorStorage::OnDemand { offsets, .. } => offsets.keys().cloned().collect(),
         }
     }
@@ -115,6 +142,8 @@ impl VectorStorage {
             VectorStorage::Owned(map) => map.len(),
             VectorStorage::OwnedQuantized(pool) => pool.vector_count,
             VectorStorage::OwnedPq(pool) => pool.vector_count,
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(pool) => pool.vector_count(),
             VectorStorage::OnDemand { offsets, .. } => offsets.len(),
         }
     }
@@ -134,6 +163,8 @@ impl VectorStorage {
             VectorStorage::Owned(map) => map.contains_key(key),
             VectorStorage::OwnedQuantized(pool) => pool.contains(key.0, &key.1),
             VectorStorage::OwnedPq(pool) => pool.contains(key.0, &key.1),
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(pool) => pool.contains(key.0, &key.1),
             VectorStorage::OnDemand { offsets, .. } => offsets.contains_key(key),
         }
     }
@@ -162,6 +193,8 @@ impl VectorStorage {
             VectorStorage::Owned(map) => Ok(map.get(key).cloned()),
             VectorStorage::OwnedQuantized(pool) => Ok(pool.dequantize_to_vector(key.0, &key.1)),
             VectorStorage::OwnedPq(pool) => Ok(pool.dequantize_to_vector(key.0, &key.1)),
+            #[cfg(feature = "pq-fastscan")]
+            VectorStorage::OwnedPqFastScan(pool) => Ok(pool.dequantize_to_vector(key.0, &key.1)),
             VectorStorage::OnDemand {
                 storage,
                 file_name,

--- a/laurus/tests/pq_fastscan_writer_reader_test.rs
+++ b/laurus/tests/pq_fastscan_writer_reader_test.rs
@@ -1,0 +1,165 @@
+//! End-to-end writer → reader round-trip test for the PQ FastScan
+//! HNSW integration introduced by Issue #701 (Part D Phase 2 of #695).
+//!
+//! Persists a small PQ-FastScan-encoded HNSW segment through the
+//! `HnswIndexWriter`, reloads it via `HnswIndexReader`, and asserts
+//! that the reader rebuilds an equivalent `PqFastScanPool` (same
+//! `n_vectors` / `field_index` keys, same per-vector decoded codes,
+//! identical `codebook` and `packed` buffers).
+//!
+//! The search-time integration (`QuantizedSearchCtx::PqFastScan`)
+//! lands in [#702](https://github.com/mosuka/laurus/issues/702), so
+//! this test exercises the persistence + load path only.
+
+#![cfg(feature = "pq-fastscan")]
+
+use laurus::storage::memory::MemoryStorageConfig;
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::quantization::QuantizationMethod;
+use laurus::vector::core::vector::Vector;
+use laurus::vector::index::VectorIndex;
+use laurus::vector::index::config::HnswIndexConfig;
+use laurus::vector::index::hnsw::HnswIndex;
+use laurus::vector::index::storage::VectorStorage;
+
+#[test]
+fn writer_reader_round_trip_preserves_pq_fastscan_codes() {
+    // 32 vectors of dimension 8 = m=4 sub-quantisers × sub_dim=2.
+    let dim = 8usize;
+    let m = 4usize;
+    let n = 32usize;
+
+    let vectors: Vec<(u64, String, Vector)> = (0..n)
+        .map(|i| {
+            let values: Vec<f32> = (0..dim)
+                .map(|d| ((i * 7 + d * 3) % 31) as f32 - 15.0)
+                .collect();
+            (i as u64, "v".to_string(), Vector::new(values))
+        })
+        .collect();
+
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+        .expect("memory storage");
+    let config = HnswIndexConfig {
+        dimension: dim,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantizationFastScan { subvector_count: m },
+        ..Default::default()
+    };
+    let index = HnswIndex::create(storage.clone(), "fastscan_round_trip", config)
+        .expect("create HNSW index");
+
+    {
+        let mut writer = index.writer().expect("writer");
+        writer.add_vectors(vectors.clone()).expect("add vectors");
+        writer.finalize().expect("finalize");
+        writer.write().expect("write");
+    }
+
+    // Reload through a fresh reader and verify the in-memory pool
+    // matches the written codes.
+    let reader = index.reader().expect("reader");
+    let stats = reader.stats();
+    assert_eq!(stats.vector_count, n);
+    assert_eq!(stats.dimension, dim);
+
+    // Cast to the concrete HNSW reader to inspect the VectorStorage
+    // variant.
+    let hnsw_reader = reader
+        .as_any()
+        .downcast_ref::<laurus::vector::index::hnsw::reader::HnswIndexReader>()
+        .expect("HnswIndexReader");
+    let vectors_storage = hnsw_reader.vectors();
+    let pool = match vectors_storage {
+        VectorStorage::OwnedPqFastScan(pool) => pool.clone(),
+        other => panic!(
+            "expected OwnedPqFastScan, got {:?}",
+            std::mem::discriminant(other)
+        ),
+    };
+
+    assert_eq!(pool.n_vectors, n, "n_vectors mismatch");
+    assert_eq!(pool.params.m as usize, m);
+    assert_eq!(pool.params.k, 16);
+    assert_eq!(pool.codebook.len(), pool.params.codebook_len());
+
+    let field_map = pool.field_index.get("v").expect("v field present in pool");
+    for (doc_id, _, _) in &vectors {
+        assert!(
+            field_map.contains_key(doc_id),
+            "doc_id {doc_id} missing from field index"
+        );
+    }
+
+    // Verify the reader's `keys()` view agrees with the writer's input.
+    let mut keys: Vec<(u64, String)> = vectors_storage.keys();
+    keys.sort();
+    let mut expected: Vec<(u64, String)> =
+        vectors.iter().map(|(id, f, _)| (*id, f.clone())).collect();
+    expected.sort();
+    assert_eq!(keys, expected);
+}
+
+#[test]
+fn writer_reader_round_trip_handles_partial_block() {
+    // n = 5 < BLOCK_SIZE (32) exercises the trailing-block zero-padding
+    // path that PqFastScanPool::build emits when fewer than 32 vectors
+    // are written.
+    let dim = 4usize;
+    let m = 2usize;
+    let n = 5usize;
+
+    let vectors: Vec<(u64, String, Vector)> = (0..n)
+        .map(|i| {
+            let values: Vec<f32> = (0..dim)
+                .map(|d| ((i * 11 + d * 5) % 23) as f32 - 11.0)
+                .collect();
+            (i as u64, "v".to_string(), Vector::new(values))
+        })
+        .collect();
+
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))
+        .expect("memory storage");
+    let config = HnswIndexConfig {
+        dimension: dim,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantizationFastScan { subvector_count: m },
+        ..Default::default()
+    };
+    let index = HnswIndex::create(storage.clone(), "fastscan_partial_block", config)
+        .expect("create HNSW index");
+
+    {
+        let mut writer = index.writer().expect("writer");
+        writer.add_vectors(vectors.clone()).expect("add vectors");
+        writer.finalize().expect("finalize");
+        writer.write().expect("write");
+    }
+
+    let reader = index.reader().expect("reader");
+    let hnsw_reader = reader
+        .as_any()
+        .downcast_ref::<laurus::vector::index::hnsw::reader::HnswIndexReader>()
+        .expect("HnswIndexReader");
+    let pool = match hnsw_reader.vectors() {
+        VectorStorage::OwnedPqFastScan(pool) => pool.clone(),
+        other => panic!(
+            "expected OwnedPqFastScan, got {:?}",
+            std::mem::discriminant(other)
+        ),
+    };
+    assert_eq!(pool.n_vectors, n);
+    assert_eq!(pool.block_count(), 1, "n=5 spans a single block");
+    // Trailing padding positions (5..32) have all-zero codes — the
+    // codebook lookups for those slots return centroid 0 of every
+    // sub-quantiser, which is fine because the searcher masks them
+    // by `n_vectors` at query time.
+    for vec_idx in n..32 {
+        let codes = pool.codes_at(vec_idx);
+        assert!(
+            codes.iter().all(|&c| c == 0),
+            "padding slot {vec_idx} should be all-zero codes (got {codes:?})"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of [#695](https://github.com/mosuka/laurus/issues/695) (PQ FastScan Part D umbrella), closes [#701](https://github.com/mosuka/laurus/issues/701). Builds on Phase 1 ([#700](https://github.com/mosuka/laurus/pull/700)).

Replaces the Phase 1 `NotImplemented` stubs in the HNSW writer and reader with real wiring. A schema that opts into `ProductQuantizationFastScan` now **persists a 4-bit packed segment and reloads it into a `VectorStorage::OwnedPqFastScan` pool**. Search-time integration is the next sub-issue ([#702](https://github.com/mosuka/laurus/issues/702)), so this PR adds a `NotImplemented` short-circuit in the searcher so users who run a query against a FastScan segment in Phase 2 see a clear error rather than a silent f32 fallback.

All FastScan additions stay gated behind the `pq-fastscan` cargo feature.

## Part D phase progress

| Phase | Issue | PR | Status |
|---|---|---|---|
| 1 | #695 | [#700](https://github.com/mosuka/laurus/pull/700) | ✅ Merged |
| **2 (this PR)** | [#701](https://github.com/mosuka/laurus/issues/701) | this PR | ⏳ Open |
| 3 | [#702](https://github.com/mosuka/laurus/issues/702) | _(pending)_ | Open |
| 4 | [#703](https://github.com/mosuka/laurus/issues/703) | _(pending)_ | Open |

## Changes

- **`PqFastScanPool` API parity**: add `vector_count` / `contains` / `keys` / `dequantize_to_vector` so the pool mirrors the K=256 `PqVectorPool` surface.
- **`VectorStorage::OwnedPqFastScan(Arc<PqFastScanPool>)`** variant with a matching `pq_fastscan_pool()` accessor and arms in `keys` / `len` / `contains_key` / `get`. Mirror the new variant through the Flat / IVF reader / writer match sites (HNSW-only rejection `unreachable!`s — segments never reach those paths because the format readers reject the kind code earlier) and through the HNSW reader's `stats`, `contains_vector`, and `validate` paths.
- **HNSW writer**: replace the Phase 1 stub with the full encode pipeline
  (`pq_fastscan_io::quantize_segment_pq_fastscan` → `VectorSegmentHeader::product_quantization_fastscan` → `pq_fastscan_io::write_pq_fastscan_record`), plus an empty-segment branch that emits a zero-centroid K=16 codebook so the reader can still dispatch on `quant_kind`. Replace the writer's load-path stub with `pq_fastscan_io::read_dequantized_pq_fastscan_vector` (added in this PR) so rebuild cycles materialise FastScan codes back to f32.
- **HNSW reader**: replace the Phase 1 stub with the real load path mirroring the K=256 PQ branch — reads each `(doc_id, field_name, codes)` record via `pq_fastscan_io::read_pq_fastscan_record`, validates `k == 16`, then builds a `PqFastScanPool` and stores it as `VectorStorage::OwnedPqFastScan(Arc::new(pool))`.
- **HNSW searcher**: `LaurusError::NotImplemented` short-circuit when the segment is FastScan-backed. Phase 3 ([#702](https://github.com/mosuka/laurus/issues/702)) replaces it with the real `QuantizedSearchCtx::PqFastScan` arm.
- **`pq_fastscan_io.rs` cleanup**: drop the `#![allow(dead_code)]` module attribute (every helper now has a call site) and gate the test-only `pq_fastscan_record_payload_size` with `#[cfg(test)]` so the feature-on non-test build stays warning-free.

## Test plan

- [x] `cargo build -p laurus` (feature off)
- [x] `cargo build -p laurus --features pq-fastscan`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (feature off)
- [x] `cargo clippy --workspace --all-targets --features pq-fastscan -- -D warnings`
- [x] `cargo clippy --target aarch64-unknown-linux-gnu -p laurus --features pq-fastscan --all-targets -- -D warnings`
- [x] `cargo clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings`
- [x] `cargo test --workspace --lib` — laurus: **1038 pass** (feature off, unchanged), **1043 pass** (feature on, unchanged), 0 regressions
- [x] `cargo test --features pq-fastscan --test pq_fastscan_writer_reader_test` (x86_64) — **2 pass**
- [x] `cargo test --target aarch64-unknown-linux-gnu --features pq-fastscan --test pq_fastscan_writer_reader_test` (QEMU) — **2 pass**
- [x] `markdownlint-cli2 \"docs/src/**/*.md\"` — 154 files, 0 error

### New integration tests (2, feature-gated)

`tests/pq_fastscan_writer_reader_test.rs`:

- `writer_reader_round_trip_preserves_pq_fastscan_codes` — full-block (n=32, m=4, dim=8) round trip; asserts the reloaded pool has matching `n_vectors`, `params.k == 16`, codebook length, and per-field doc-id keys.
- `writer_reader_round_trip_handles_partial_block` — partial-block (n=5, m=2) round trip; asserts the trailing 27 padding slots decode to all-zero codes per the `PqFastScanPool::build` zero-padding contract.

## Merge plan

Per `lessons.md` (2026-05-24 #698 lesson), wait for **all** `Test laurus*` jobs to complete before merging. No `--auto`.

Refs #701
Refs #695
Refs #651
Refs #536