### PR TITLE
perf(vector): add SIFT bench for PQ FastScan (Phase 4 of #695) (#703)

### DIFF
--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -1185,6 +1185,134 @@ fn bench_hnsw_graph_search_pq_rerank_real_data(c: &mut Criterion) {
     group.finish();
 }
 
+/// PQ FastScan + F32 rerank real-data benchmark on SIFT1M
+/// (Issue [#703](https://github.com/mosuka/laurus/issues/703), Phase 4
+/// of #695). Mirrors [`bench_hnsw_graph_search_pq_rerank_real_data`]
+/// exactly — same SIFT1M 50k corpus + 200 queries + L2-normalised
+/// Cosine + `m=16` HNSW + `ef_construction=200` + `ef_search=200` +
+/// `rerank_factor=10` + `subvector_count=32` — and swaps only the
+/// `quantization_method` to `ProductQuantizationFastScan`. The
+/// resulting wall-clock ratio (this bench / the K=256 PQ bench) is
+/// the acceptance gate the umbrella [#695](https://github.com/mosuka/laurus/issues/695)
+/// uses to decide whether FastScan ships as the default PQ
+/// implementation or stays behind the `pq-fastscan` cargo feature.
+///
+/// Opt-in via `LAURUS_REAL_BENCHMARK=1` and the `pq-fastscan` feature
+/// flag (`cargo bench --features pq-fastscan ...`). The corpus is
+/// taken from `.cache/sift/sift/sift_*.fvecs`; run
+/// `./scripts/fetch-sift.sh --large` once to populate it.
+#[cfg(feature = "pq-fastscan")]
+fn bench_hnsw_graph_search_pq_fastscan_real_data(c: &mut Criterion) {
+    if std::env::var("LAURUS_REAL_BENCHMARK").as_deref() != Ok("1") {
+        return;
+    }
+    let base_path = common::sift_cache_dir()
+        .join("sift")
+        .join("sift_base.fvecs");
+    let query_path = common::sift_cache_dir()
+        .join("sift")
+        .join("sift_query.fvecs");
+    if !base_path.exists() || !query_path.exists() {
+        eprintln!(
+            "skipping Issue #703 FastScan real-data speed bench: SIFT1M \
+             fixture not found at {}. Run ./scripts/fetch-sift.sh --large.",
+            base_path.display()
+        );
+        return;
+    }
+
+    let dim: usize = 128;
+    let n_corpus: usize = 50_000;
+    let n_queries: usize = 200;
+    // Match the K=256 PQ bench parameters one-to-one so the ratio is
+    // taken at the same operating point.
+    let ef_search: usize = 200;
+    let rerank_factor: usize = 10;
+    let subvector_count: usize = 32;
+    let m: usize = 16;
+    let ef_construction: usize = 200;
+
+    let mut queries =
+        common::load_fvecs(&query_path, dim, Some(n_queries)).expect("load sift_query.fvecs");
+    for v in queries.iter_mut() {
+        common::l2_normalise(v);
+    }
+
+    let config = HnswIndexConfig {
+        dimension: dim,
+        m,
+        ef_construction,
+        distance_metric: DistanceMetric::Cosine,
+        quantization_method:
+            laurus::vector::core::quantization::QuantizationMethod::ProductQuantizationFastScan {
+                subvector_count,
+            },
+        rerank_storage: Some(RerankStorageKind::F32),
+        ..Default::default()
+    };
+    let base_size = std::fs::metadata(&base_path)
+        .map(|m| m.len())
+        .unwrap_or_default();
+    // Distinct cache slot from the K=256 PQ bench so both flavours can
+    // coexist in the bench cache. The "pqfs" prefix keeps the slot
+    // human-readable for `du -sh target/laurus_bench_index_cache/`.
+    let slot = format!(
+        "hnsw_sift_n{n_corpus}_dim{dim}_m{m}_efc{ef_construction}_pqfs{subvector_count}_rerankF32_size{base_size}",
+    );
+    let reader = cached_vector_reader(&slot, VectorIndexTypeConfig::HNSW(config), || {
+        let mut corpus =
+            common::load_fvecs(&base_path, dim, Some(n_corpus)).expect("load sift_base.fvecs");
+        for v in corpus.iter_mut() {
+            common::l2_normalise(v);
+        }
+        corpus
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| (i as u64, "field".to_string(), Vector::new(v)))
+            .collect()
+    });
+    let mut searcher = HnswSearcher::new(reader).unwrap();
+    searcher.set_ef_search(ef_search);
+
+    // Sanity check: the FastScan + rerank path must engage on real data.
+    let probe = searcher
+        .search(
+            &VectorIndexQuery::new(Vector::new(queries[0].clone()))
+                .top_k(10)
+                .field_name("field".to_string())
+                .rerank_factor(rerank_factor),
+        )
+        .unwrap();
+    assert!(
+        !probe.results.is_empty(),
+        "Issue #703 FastScan SIFT probe must return at least one hit"
+    );
+
+    let mut group = c.benchmark_group("HNSW Graph Search PQ FastScan Rerank Real");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+    group.throughput(Throughput::Elements(n_corpus as u64));
+
+    let mut iter_idx: usize = 0;
+    group.bench_function(BenchmarkId::new("top10_pqfs_rerank10", "sift50000"), |b| {
+        b.iter(|| {
+            let q = &queries[iter_idx % queries.len()];
+            iter_idx = iter_idx.wrapping_add(1);
+            let request = VectorIndexQuery::new(Vector::new(q.clone()))
+                .top_k(10)
+                .field_name("field".to_string())
+                .rerank_factor(rerank_factor);
+            searcher.search(&request).unwrap()
+        });
+    });
+    group.finish();
+}
+
+#[cfg(not(feature = "pq-fastscan"))]
+fn bench_hnsw_graph_search_pq_fastscan_real_data(_c: &mut Criterion) {
+    // No-op without the `pq-fastscan` feature so the criterion_group
+    // macro can reference this symbol unconditionally.
+}
+
 criterion_group!(
     benches,
     bench_flat_construction,
@@ -1197,6 +1325,7 @@ criterion_group!(
     bench_hnsw_graph_search_rerank,
     bench_hnsw_graph_search_rerank_real_data,
     bench_hnsw_graph_search_pq_rerank_real_data,
+    bench_hnsw_graph_search_pq_fastscan_real_data,
     bench_hnsw_ef_search_sweep,
     bench_hnsw_multi_field_search,
     bench_flat_multi_field_search,


### PR DESCRIPTION
## Summary

Phase 4 of [#695](https://github.com/mosuka/laurus/issues/695) (PQ FastScan Part D umbrella), closes [#703](https://github.com/mosuka/laurus/issues/703). Builds on Phase 3 ([#705](https://github.com/mosuka/laurus/pull/705)).

Adds `bench_hnsw_graph_search_pq_fastscan_real_data`, the PQ FastScan counterpart to the K=256 PQ + F32 rerank SIFT bench. Mirrors the K=256 setup one-to-one so the resulting per-query latency ratio is taken at the same operating point. The ratio is the acceptance gate for the experimental `pq-fastscan` cargo feature.

## Local measurement on this machine

Two runs of `LAURUS_REAL_BENCHMARK=1 cargo bench --features pq-fastscan --bench vector_search_bench -- "PQ Rerank Real|PQ FastScan Rerank Real"`:

| Variant | Median per-query | 95% CI |
|---|---|---|
| PQ-256 (`top10_pq_rerank20/sift50000`) | **253.85 µs** | 249.52 - 258.01 µs |
| PQ FastScan (`top10_pqfs_rerank10/sift50000`) | **237.30 µs** | 236.23 - 238.42 µs |

**Speedup ≈ 1.07× (≈ 7 %).**

The umbrella's **≥ 1.5× gate is not met**, so the `pq-fastscan` feature stays opt-in (default off) per the umbrella's experimental-fallback policy. The gap is structural rather than noise (`SAMPLE_SIZE_SLOW=30`, IQR < 2 µs on both sides). Two structural hypotheses, attribution + fix tracked in follow-up [#706](https://github.com/mosuka/laurus/issues/706):

1. **F32 rerank dominates the end-to-end wall clock.** The bench runs with `rerank_storage = F32` and `rerank_factor = 10`, so the rerank pass evaluates 100 exact f32 distances per query regardless of which PQ kernel generated the candidates. Phase 0 micro-experiment in #706 will measure `rerank_factor = 1` (no rerank) to isolate the kernel cost.
2. **Per-doc `distance(doc_id)` arm wastes 31/32 of the SIMD block compute.** `QuantizedSearchCtx::PqFastScan::distance` (#705) evaluates a full 32-vector packed block via `distance_pq_fastscan_block` and returns the in-block offset's distance, discarding 31 lanes. A batched neighbour-list API would recover most of the SIMD throughput.

## Part D phase progress

| Phase | Issue | PR | Status |
|---|---|---|---|
| 1 | #695 | [#700](https://github.com/mosuka/laurus/pull/700) | ✅ Merged |
| 2 | [#701](https://github.com/mosuka/laurus/issues/701) | [#704](https://github.com/mosuka/laurus/pull/704) | ✅ Merged |
| 3 | [#702](https://github.com/mosuka/laurus/issues/702) | [#705](https://github.com/mosuka/laurus/pull/705) | ✅ Merged |
| **4 (this PR)** | [#703](https://github.com/mosuka/laurus/issues/703) | this PR | ⏳ Open |

After this merges, #695 can be closed with the acceptance outcome recorded (feature stays gated, follow-up #706 tracks the gap).

## Changes

- `laurus/benches/vector_search_bench.rs`: new `bench_hnsw_graph_search_pq_fastscan_real_data`, feature-gated behind `pq-fastscan`. Same SIFT1M 50k / 200-query / `ef_search=200` / `rerank_factor=10` / `m=16` / `ef_construction=200` setup as the existing PQ-256 bench, just with `quantization_method = ProductQuantizationFastScan { subvector_count: 32 }`. Uses a separate cache slot (`pqfs` prefix in the key) so both flavours coexist.
- No-op `#[cfg(not(feature = "pq-fastscan"))]` stub for the bench function so the `criterion_group!` macro stays well-formed when the feature is off.

## Test plan

- [x] `cargo bench --bench vector_search_bench --no-run` (default features)
- [x] `cargo bench --bench vector_search_bench --features pq-fastscan --no-run`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (feature off)
- [x] `cargo clippy --workspace --all-targets --features pq-fastscan -- -D warnings`
- [x] `cargo clippy --target aarch64-unknown-linux-gnu -p laurus --features pq-fastscan --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --features pq-fastscan` — 1043 lib tests pass, 0 regressions
- [x] `markdownlint-cli2 \"docs/src/**/*.md\"` — 154 files, 0 error
- [x] `LAURUS_REAL_BENCHMARK=1 cargo bench --features pq-fastscan -- "PQ Rerank Real|PQ FastScan Rerank Real"` — both groups complete, measurement table above

## Merge plan

Per `lessons.md` (2026-05-24 #698 lesson), wait for **all** `Test laurus*` jobs to complete before merging. No `--auto`. CI does not run the SIFT bench (opt-in only on machines with the corpus), so the bench delta is verified locally.

Refs #703
Refs #695
Refs #651
Refs #536