### PR TITLE
feat(engine): add Engine::search_batch async parallel API (Phase 3 prerequisite of #648)

### DIFF
--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -1516,6 +1516,54 @@ impl Engine {
 
         Ok(results)
     }
+
+    /// Execute multiple independent search requests in parallel.
+    ///
+    /// Batched form of [`Self::search`] that runs each request
+    /// concurrently on the tokio runtime via
+    /// [`futures::future::try_join_all`]. Internal vector-search work
+    /// additionally parallelises per-request via rayon (Phase 1 of
+    /// issue [#648](https://github.com/mosuka/laurus/issues/648), PR
+    /// [#711](https://github.com/mosuka/laurus/pull/711)), so a batch
+    /// of `B` requests benefits from two-level parallelism: `B`
+    /// requests in parallel on tokio, each request's multi-vector
+    /// path in parallel on rayon.
+    ///
+    /// External callers (gRPC service, REST gateway, language
+    /// bindings) invoke this method to amortise IPC and serialisation
+    /// overhead across multiple queries, in addition to the per-query
+    /// parallelism already provided by Phases 1 and 2 of
+    /// [#648](https://github.com/mosuka/laurus/issues/648).
+    ///
+    /// # Parameters
+    ///
+    /// - `requests` - The list of independent search requests. Order
+    ///   is preserved in the output.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<Vec<SearchResult>>` where `results[i]` is the result of
+    /// `requests[i]`. Empty input returns an empty `Vec` without
+    /// invoking [`Self::search`] at all.
+    ///
+    /// # Errors
+    ///
+    /// Short-circuits with the first error encountered; the other
+    /// in-flight requests are dropped per
+    /// [`futures::future::try_join_all`] semantics.
+    ///
+    /// Issue [#715](https://github.com/mosuka/laurus/issues/715)
+    /// (Phase 3 prerequisite of
+    /// [#648](https://github.com/mosuka/laurus/issues/648)).
+    pub async fn search_batch(
+        &self,
+        requests: Vec<self::search::SearchRequest>,
+    ) -> Result<Vec<Vec<self::search::SearchResult>>> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+        futures::future::try_join_all(requests.into_iter().map(|r| self.search(r))).await
+    }
 }
 
 /// Builder for constructing an [`Engine`] with custom configuration.

--- a/laurus/tests/engine_search_batch_test.rs
+++ b/laurus/tests/engine_search_batch_test.rs
@@ -1,0 +1,149 @@
+//! Integration tests for [`laurus::Engine::search_batch`]
+//! (issue [#715](https://github.com/mosuka/laurus/issues/715) — Phase 3
+//! prerequisite of [#648](https://github.com/mosuka/laurus/issues/648)).
+//!
+//! These tests verify the engine-level batched search API:
+//!
+//! - Empty input returns an empty `Vec` without invoking `search`.
+//! - Single-request batch produces the same result as
+//!   `Engine::search` invoked directly.
+//! - Multi-request batch preserves input order and returns one result
+//!   list per query.
+//! - Existing `Engine::search` behaviour is unchanged.
+
+use tempfile::TempDir;
+
+use laurus::Engine;
+use laurus::SearchRequestBuilder;
+use laurus::lexical::Query;
+use laurus::lexical::TermQuery;
+use laurus::storage::file::FileStorageConfig;
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::{DataValue, Document};
+use laurus::{FieldOption, LexicalSearchQuery, Schema};
+
+async fn build_engine_with_corpus() -> laurus::Result<Engine> {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_config = StorageConfig::File(FileStorageConfig::new(temp_dir.path()));
+    let storage = StorageFactory::create(storage_config)?;
+
+    let config = Schema::builder()
+        .add_field("title", FieldOption::Text(Default::default()))
+        .build();
+
+    let engine = Engine::new(storage, config).await?;
+
+    engine
+        .put_document(
+            "doc1",
+            Document::builder()
+                .add_field("title", DataValue::Text("Rust Programming".into()))
+                .build(),
+        )
+        .await?;
+    engine
+        .put_document(
+            "doc2",
+            Document::builder()
+                .add_field("title", DataValue::Text("Vector Search".into()))
+                .build(),
+        )
+        .await?;
+    engine
+        .put_document(
+            "doc3",
+            Document::builder()
+                .add_field("title", DataValue::Text("Distributed Systems".into()))
+                .build(),
+        )
+        .await?;
+    engine.commit().await?;
+
+    // Persist `_temp_dir` for the engine lifetime by leaking it intentionally
+    // in this test helper. The OS reclaims the directory on process exit.
+    std::mem::forget(temp_dir);
+
+    Ok(engine)
+}
+
+fn term_request(term: &str) -> laurus::SearchRequest {
+    let q = Box::new(TermQuery::new("title", term)) as Box<dyn Query>;
+    SearchRequestBuilder::new()
+        .lexical_query(LexicalSearchQuery::Obj(q))
+        .build()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_batch_empty_input_returns_empty() -> laurus::Result<()> {
+    let engine = build_engine_with_corpus().await?;
+    let results = engine.search_batch(Vec::new()).await?;
+    assert!(results.is_empty(), "empty input must return empty output");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_batch_single_request_matches_search() -> laurus::Result<()> {
+    let engine = build_engine_with_corpus().await?;
+
+    let req = term_request("rust");
+    let serial = engine.search(req).await?;
+
+    let req = term_request("rust");
+    let batch = engine.search_batch(vec![req]).await?;
+
+    assert_eq!(
+        batch.len(),
+        1,
+        "single-request batch should yield exactly one result list"
+    );
+    assert_eq!(
+        batch[0].len(),
+        serial.len(),
+        "single-request batch result count must match Engine::search",
+    );
+    for (b, s) in batch[0].iter().zip(serial.iter()) {
+        assert_eq!(b.id, s.id, "doc_id must match");
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_batch_multi_request_preserves_order() -> laurus::Result<()> {
+    let engine = build_engine_with_corpus().await?;
+
+    let queries = ["rust", "vector", "distributed"];
+    let requests: Vec<_> = queries.iter().map(|t| term_request(t)).collect();
+
+    let batch = engine.search_batch(requests).await?;
+    assert_eq!(batch.len(), queries.len());
+
+    // Each query targets exactly one document; verify position-preserving result.
+    for (i, term) in queries.iter().enumerate() {
+        let serial = engine.search(term_request(term)).await?;
+        assert_eq!(
+            batch[i].len(),
+            serial.len(),
+            "result list length must match for query[{i}] = {term}",
+        );
+        for (b, s) in batch[i].iter().zip(serial.iter()) {
+            assert_eq!(b.id, s.id, "doc_id must match for query[{i}] = {term}");
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_batch_existing_search_unchanged() -> laurus::Result<()> {
+    let engine = build_engine_with_corpus().await?;
+
+    // Sanity check that the existing single-request `Engine::search` still
+    // returns the expected document for an ad-hoc query that the batch tests
+    // also exercise.
+    let req = term_request("rust");
+    let results = engine.search(req).await?;
+    assert!(
+        results.iter().any(|r| r.id == "doc1"),
+        "Engine::search must still find doc1 for term 'rust' — batch refactor must not regress"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Phase 3 prerequisite for [#648](https://github.com/mosuka/laurus/issues/648) (issue [#715](https://github.com/mosuka/laurus/issues/715)). Adds `Engine::search_batch` — the single Rust-level method that all upcoming Phase 3 sub-issues (#716–#720, optional #714 sub-issue 3f for MCP) will dispatch through.

## Signature

```rust
pub async fn search_batch(
    &self,
    requests: Vec<SearchRequest>,
) -> Result<Vec<Vec<SearchResult>>>
```

- `results[i]` corresponds to `requests[i]` (order is preserved).
- Empty input short-circuits to `Ok(Vec::new())` without invoking `search`.
- One failure aborts the whole batch (`futures::future::try_join_all` semantics).

## Implementation

```rust
if requests.is_empty() {
    return Ok(Vec::new());
}
futures::future::try_join_all(requests.into_iter().map(|r| self.search(r))).await
```

Each request runs the existing `Engine::search` machinery in parallel on the tokio runtime. The internal vector path additionally parallelises via rayon (Phase 1 PR #711 → Phase 2 PR #713), so a batch of B requests benefits from **two-level parallelism**:

1. B requests in parallel on tokio (this PR).
2. Each request's multi-vector search in parallel on rayon (Phases 1+2).

External API surface is otherwise unchanged.

## Tests

New `laurus/tests/engine_search_batch_test.rs` (4 tests):

- `test_search_batch_empty_input_returns_empty` — `Ok(vec![])` short-circuit.
- `test_search_batch_single_request_matches_search` — `search_batch(vec![req])` agrees with `search(req)`.
- `test_search_batch_multi_request_preserves_order` — 3 distinct queries, position-preserving result.
- `test_search_batch_existing_search_unchanged` — sanity check that `Engine::search` still works on the same engine.

## Out of scope (separate sub-issues under umbrella #714)

- gRPC proto + REST gateway exposure — #716.
- Python binding — #717.
- Node.js binding — #718.
- Ruby binding — #719.
- PHP binding — #720.
- MCP server tool (optional) — to be filed if needed.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` clean
- [x] `cargo test -p laurus --test engine_search_batch_test` — 4 tests passed
- [x] `cargo test -p laurus --test unified_search_test` — existing tests still pass (no regression)

Closes #715
Refs #714
Refs #648