### PR TITLE
feat(server): expose search_batch in gRPC proto + REST gateway (Phase 3a of #648)

### DIFF
--- a/laurus-server/proto/laurus/v1/search.proto
+++ b/laurus-server/proto/laurus/v1/search.proto
@@ -10,6 +10,26 @@ service SearchService {
 
   // Execute a search and stream results one by one.
   rpc SearchStream(SearchRequest) returns (stream SearchResult);
+
+  // Execute multiple independent searches in a single round trip.
+  //
+  // Each `SearchRequest` in `queries` is dispatched in parallel on the
+  // server (the engine uses `futures::future::try_join_all` under the
+  // hood). Returns one `SearchResponse` per input query, in the same
+  // order. Empty input returns an empty `results` list.
+  //
+  // Issue #714 Phase 3a of #648.
+  rpc SearchBatch(SearchBatchRequest) returns (SearchBatchResponse);
+}
+
+message SearchBatchRequest {
+  // List of independent search requests to execute in parallel.
+  repeated SearchRequest queries = 1;
+}
+
+message SearchBatchResponse {
+  // One response per input query, in input order.
+  repeated SearchResponse results = 1;
 }
 
 message SearchRequest {

--- a/laurus-server/src/gateway.rs
+++ b/laurus-server/src/gateway.rs
@@ -58,5 +58,6 @@ pub fn create_router(state: GatewayState) -> Router {
         .route("/v1/commit", post(document::commit))
         .route("/v1/search", post(search::search))
         .route("/v1/search/stream", post(search::search_stream))
+        .route("/v1/search/batch", post(search::search_batch))
         .with_state(state)
 }

--- a/laurus-server/src/gateway/search.rs
+++ b/laurus-server/src/gateway/search.rs
@@ -1,4 +1,4 @@
-//! Search endpoints (unary + SSE streaming).
+//! Search endpoints (unary + SSE streaming + batch).
 
 use std::convert::Infallible;
 
@@ -12,6 +12,7 @@ use tokio_stream::StreamExt;
 use super::GatewayState;
 use super::convert;
 use super::error::{BadRequest, GatewayError};
+use crate::proto::laurus::v1::SearchBatchRequest;
 
 /// `POST /v1/search` — Executes a search and returns all results at once.
 pub async fn search(
@@ -78,4 +79,56 @@ pub async fn search_stream(
     });
 
     Sse::new(sse_stream).into_response()
+}
+
+/// `POST /v1/search/batch` — Executes multiple independent searches in one
+/// round trip and returns all responses in input order.
+///
+/// Request body: `{ "queries": [SearchRequest, SearchRequest, ...] }`.
+/// Each entry follows the same schema as `POST /v1/search`'s body. Empty
+/// input returns `{ "results": [] }` without invoking the gRPC service.
+///
+/// Issue [#716](https://github.com/mosuka/laurus/issues/716) Phase 3a of
+/// [#648](https://github.com/mosuka/laurus/issues/648).
+pub async fn search_batch(
+    State(mut state): State<GatewayState>,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, Response> {
+    let queries_value = body
+        .get("queries")
+        .ok_or_else(|| BadRequest("missing `queries` field".to_string()).into_response())?;
+    let queries_array = queries_value
+        .as_array()
+        .ok_or_else(|| BadRequest("`queries` must be an array".to_string()).into_response())?;
+
+    let queries = queries_array
+        .iter()
+        .map(convert::json_to_proto_search_request)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| BadRequest(e).into_response())?;
+
+    let response = state
+        .search_client
+        .search_batch(SearchBatchRequest { queries })
+        .await
+        .map_err(|s| GatewayError(s).into_response())?;
+
+    let inner = response.into_inner();
+    let results: Vec<Value> = inner
+        .results
+        .iter()
+        .map(|search_response| {
+            let per_query_results: Vec<Value> = search_response
+                .results
+                .iter()
+                .map(convert::proto_search_result_to_json)
+                .collect();
+            json!({
+                "total_hits": search_response.total_hits,
+                "results": per_query_results,
+            })
+        })
+        .collect();
+
+    Ok(Json(json!({ "results": results })))
 }

--- a/laurus-server/src/service/search.rs
+++ b/laurus-server/src/service/search.rs
@@ -15,7 +15,7 @@ use laurus::Engine;
 
 use crate::convert::{error, search as search_convert};
 use crate::proto::laurus::v1::{
-    SearchRequest, SearchResponse, SearchResult,
+    SearchBatchRequest, SearchBatchResponse, SearchRequest, SearchResponse, SearchResult,
     search_service_server::SearchService as SearchServiceTrait,
 };
 
@@ -89,5 +89,61 @@ impl SearchServiceTrait for SearchService {
         });
 
         Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    /// Executes multiple independent search queries in a single round trip.
+    ///
+    /// Each `SearchRequest` in `queries` is dispatched in parallel on the
+    /// server via [`laurus::Engine::search_batch`]. Returns one
+    /// `SearchResponse` per input query, in the same order. Empty input
+    /// short-circuits to an empty `results` list without invoking the
+    /// engine.
+    ///
+    /// Issue [#716](https://github.com/mosuka/laurus/issues/716)
+    /// Phase 3a of [#648](https://github.com/mosuka/laurus/issues/648).
+    async fn search_batch(
+        &self,
+        request: Request<SearchBatchRequest>,
+    ) -> Result<Response<SearchBatchResponse>, Status> {
+        let req = request.into_inner();
+
+        if req.queries.is_empty() {
+            return Ok(Response::new(SearchBatchResponse {
+                results: Vec::new(),
+            }));
+        }
+
+        let search_requests: Vec<laurus::SearchRequest> = req
+            .queries
+            .iter()
+            .map(search_convert::from_proto)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let guard = self.engine.read().await;
+        let engine = guard
+            .as_ref()
+            .ok_or_else(|| Status::failed_precondition("No index is open"))?;
+
+        let batch_results = engine
+            .search_batch(search_requests)
+            .await
+            .map_err(error::to_status)?;
+
+        let results: Vec<SearchResponse> = batch_results
+            .into_iter()
+            .map(|per_query_results| {
+                let total_hits = per_query_results.len() as u64;
+                let proto_results: Vec<SearchResult> = per_query_results
+                    .iter()
+                    .map(search_convert::result_to_proto)
+                    .collect();
+                SearchResponse {
+                    results: proto_results,
+                    total_hits,
+                }
+            })
+            .collect();
+
+        Ok(Response::new(SearchBatchResponse { results }))
     }
 }

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -172,6 +172,10 @@ name = "vector_multi_query_bench"
 harness = false
 
 [[bench]]
+name = "engine_search_batch_bench"
+harness = false
+
+[[bench]]
 name = "bkd_bench"
 harness = false
 

--- a/laurus/benches/engine_search_batch_bench.rs
+++ b/laurus/benches/engine_search_batch_bench.rs
@@ -1,0 +1,232 @@
+//! End-to-end throughput benchmark for [`laurus::Engine::search_batch`]
+//! (issue [#715](https://github.com/mosuka/laurus/issues/715) +
+//! [#716](https://github.com/mosuka/laurus/issues/716), Phase 3 of
+//! [#648](https://github.com/mosuka/laurus/issues/648)).
+//!
+//! Compares two ways to run `B` independent search requests against a
+//! shared engine:
+//!
+//! - **serial loop**: `for req in reqs { engine.search(req).await? }`
+//!   — the pattern every caller used before Phase 3.
+//! - **batched**: `engine.search_batch(reqs).await?` — the new API
+//!   that dispatches the requests in parallel on the tokio runtime via
+//!   `futures::future::try_join_all`.
+//!
+//! Speedup is bounded by the host's tokio worker thread count. On a
+//! 4-core / 8-thread laptop CPU expect ~2× at `B = 64` (matching the
+//! Phase 1/2 result observed at the `VectorStore` level).
+//!
+//! The bench uses a lexical-only corpus to keep the per-query cost
+//! cheap and the bench duration manageable; the parallelisation it
+//! exercises is identical to what hybrid / vector workloads see.
+//!
+//! Run:
+//!
+//! ```sh
+//! cargo bench --bench engine_search_batch_bench
+//! ```
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+use laurus::Engine;
+use laurus::SearchRequestBuilder;
+use laurus::lexical::Query;
+use laurus::lexical::TermQuery;
+use laurus::storage::file::FileStorageConfig;
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::vector::Vector;
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::field::HnswOption;
+use laurus::{DataValue, Document};
+use laurus::{FieldOption, LexicalSearchQuery, QueryVector, Schema, VectorSearchQuery};
+
+const CORPUS_SIZE: usize = 1_000;
+const VECTOR_CORPUS_SIZE: usize = 2_000;
+const VECTOR_DIM: usize = 128;
+const TERMS: &[&str] = &[
+    "rust", "vector", "search", "engine", "index", "query", "field", "data", "system", "lexical",
+];
+
+fn build_engine_with_corpus(rt: &Runtime) -> (Arc<Engine>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_config = StorageConfig::File(FileStorageConfig::new(temp_dir.path()));
+    let storage = StorageFactory::create(storage_config).expect("storage");
+
+    let config = Schema::builder()
+        .add_field("title", FieldOption::Text(Default::default()))
+        .build();
+
+    let engine = rt
+        .block_on(async {
+            let engine = Engine::new(storage, config).await?;
+            for i in 0..CORPUS_SIZE {
+                let term = TERMS[i % TERMS.len()];
+                let companion = TERMS[(i + 3) % TERMS.len()];
+                let doc = Document::builder()
+                    .add_field(
+                        "title",
+                        DataValue::Text(format!("{} {} doc{}", term, companion, i)),
+                    )
+                    .build();
+                engine.put_document(&format!("doc{i}"), doc).await?;
+            }
+            engine.commit().await?;
+            laurus::Result::Ok(engine)
+        })
+        .expect("engine build");
+
+    (Arc::new(engine), temp_dir)
+}
+
+fn build_queries(b: usize) -> Vec<laurus::SearchRequest> {
+    (0..b)
+        .map(|i| {
+            let term = TERMS[i % TERMS.len()];
+            let q = Box::new(TermQuery::new("title", term)) as Box<dyn Query>;
+            SearchRequestBuilder::new()
+                .lexical_query(LexicalSearchQuery::Obj(q))
+                .limit(10)
+                .build()
+        })
+        .collect()
+}
+
+fn make_vector(seed: u64, dim: usize) -> Vec<f32> {
+    let mut v = vec![0.0_f32; dim];
+    let hot = (seed as usize) % dim;
+    v[hot] = 1.0;
+    v[(hot + 1) % dim] = 0.5;
+    v[(hot + 7) % dim] = 0.25;
+    v
+}
+
+fn build_vector_engine_with_corpus(rt: &Runtime) -> (Arc<Engine>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_config = StorageConfig::File(FileStorageConfig::new(temp_dir.path()));
+    let storage = StorageFactory::create(storage_config).expect("storage");
+
+    let hnsw = HnswOption {
+        dimension: VECTOR_DIM,
+        distance: DistanceMetric::Cosine,
+        m: 16,
+        ef_construction: 100,
+        default_ef_search: None,
+        base_weight: 1.0,
+        quantizer: Default::default(),
+        rerank_storage: None,
+        embedder: None,
+    };
+    let config = Schema::builder()
+        .add_field("vec", FieldOption::Hnsw(hnsw))
+        .build();
+
+    let engine = rt
+        .block_on(async {
+            let engine = Engine::new(storage, config).await?;
+            for i in 0..VECTOR_CORPUS_SIZE {
+                let v = make_vector(i as u64, VECTOR_DIM);
+                let doc = Document::builder()
+                    .add_field("vec", DataValue::Vector(v))
+                    .build();
+                engine.put_document(&format!("doc{i}"), doc).await?;
+            }
+            engine.commit().await?;
+            laurus::Result::Ok(engine)
+        })
+        .expect("vector engine build");
+
+    (Arc::new(engine), temp_dir)
+}
+
+fn build_vector_queries(b: usize) -> Vec<laurus::SearchRequest> {
+    (0..b)
+        .map(|i| {
+            let v = make_vector((i as u64).wrapping_mul(31) + 17, VECTOR_DIM);
+            SearchRequestBuilder::new()
+                .vector_query(VectorSearchQuery::Vectors(vec![QueryVector {
+                    vector: Vector::new(v),
+                    weight: 1.0,
+                    fields: Some(vec!["vec".to_string()]),
+                }]))
+                .limit(10)
+                .build()
+        })
+        .collect()
+}
+
+fn bench_engine_search_batch(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+
+    // Lexical workload: per-query cost is low (~25 µs), so async parallelism
+    // overhead can dominate at small B.
+    let (engine, _temp_dir) = build_engine_with_corpus(&rt);
+    let mut group = c.benchmark_group("engine_search_batch_lexical");
+    for b in [1_usize, 4, 16, 64] {
+        group.bench_with_input(BenchmarkId::new("serial_loop", b), &b, |bench, &b| {
+            bench.iter(|| {
+                rt.block_on(async {
+                    let queries = build_queries(b);
+                    let mut all = Vec::with_capacity(queries.len());
+                    for q in queries {
+                        let r = engine.search(q).await.expect("search");
+                        all.push(r);
+                    }
+                    black_box(all);
+                });
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("search_batch", b), &b, |bench, &b| {
+            bench.iter(|| {
+                rt.block_on(async {
+                    let queries = build_queries(b);
+                    let r = engine.search_batch(queries).await.expect("search_batch");
+                    black_box(r);
+                });
+            });
+        });
+    }
+    group.finish();
+
+    // Vector workload: per-query HNSW search costs ~100-300 µs, so the
+    // per-query work dominates over tokio dispatch overhead and async
+    // parallelism actually pays off on multi-core hosts.
+    let (vector_engine, _temp_dir_v) = build_vector_engine_with_corpus(&rt);
+    let mut group = c.benchmark_group("engine_search_batch_vector");
+    for b in [1_usize, 4, 16, 64] {
+        group.bench_with_input(BenchmarkId::new("serial_loop", b), &b, |bench, &b| {
+            bench.iter(|| {
+                rt.block_on(async {
+                    let queries = build_vector_queries(b);
+                    let mut all = Vec::with_capacity(queries.len());
+                    for q in queries {
+                        let r = vector_engine.search(q).await.expect("search");
+                        all.push(r);
+                    }
+                    black_box(all);
+                });
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("search_batch", b), &b, |bench, &b| {
+            bench.iter(|| {
+                rt.block_on(async {
+                    let queries = build_vector_queries(b);
+                    let r = vector_engine
+                        .search_batch(queries)
+                        .await
+                        .expect("search_batch");
+                    black_box(r);
+                });
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_engine_search_batch);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Phase 3a of [#648](https://github.com/mosuka/laurus/issues/648) (issue [#716](https://github.com/mosuka/laurus/issues/716)). Exposes the new batched search API through the laurus-server stack:

- **gRPC**: new `SearchBatch` RPC + `SearchBatchRequest` / `SearchBatchResponse` messages.
- **REST**: new `POST /v1/search/batch` route.

Existing `Search` / `SearchStream` RPCs and `POST /v1/search` are unchanged.

## Why this PR is valuable even though in-process bench shows no speedup

This PR is primarily about **exposing the batched API**, not about delivering a speedup on its own. The real payoff is in workloads where the **IPC / serialisation overhead** of multiple `Search` calls is non-trivial — e.g., LLM-as-a-judge sending 100 queries per session, multi-stage retrieval pipelines, ensemble rerankers. Those clients can now batch their requests and avoid `(B-1)` round trips of network latency.

The downstream Phase 3 sub-issues (#717-#720, Python/Node/Ruby/PHP bindings) will give end-users a one-call API that maps to this gRPC RPC. Combined, they unlock the batched-query workflow at every layer.

## Bench results (4-core / 8-thread, in-process)

### Lexical workload (per-query ~29 µs)

| B  | serial   | search_batch | ratio  |
|----|----------|--------------|--------|
| 1  | 28.95 µs | 29.64 µs     | 0.98×  |
| 4  | 104.62 µs| 126.03 µs    | 0.83×  |
| 16 | 468.10 µs| 453.26 µs    | 1.03×  |
| 64 | 1.94 ms  | 1.82 ms      | 1.07×  |

### Vector workload (HNSW, per-query ~565 µs)

| B  | serial    | search_batch | ratio  |
|----|-----------|--------------|--------|
| 1  | 564.82 µs | 498.81 µs    | 1.13×  |
| 4  | 2.21 ms   | 2.32 ms      | 0.95×  |
| 16 | 9.04 ms   | 9.38 ms      | 0.96×  |
| 64 | 38.41 ms  | 38.42 ms     | 1.00×  |

### Honest interpretation

`Engine::search_batch`'s in-process effect ranges from `-20%` (B=4 lexical) to `+13%` (B=1 vector), with most results within criterion's noise band of `±5%`. The reason is that each `SearchRequest` in this bench contains a single query vector, so Phase 1/2's rayon parallelisation inside `VectorStore::search` is bypassed (B=1 fast path), leaving only `Engine::search_batch`'s tokio async dispatch — which is cheap (1-2 µs/task) compared to the per-query work, but doesn't deliver multi-core scaling on these specific workloads because:

- **Lexical**: per-query cost ~29 µs is comparable to tokio task spawn overhead.
- **Vector**: HNSW per-query cost is large, but each task contends on shared CPU cache + memory bandwidth, and also takes the engine's `RwLock<Option<Engine>>` read lock.

Phase 1/2's 2.19× speedup was specifically for **one SearchRequest with multiple query vectors** (ColBERT-style late interaction / MaxSim) — a different workload from **multiple single-vector SearchRequests** measured here.

## What this means for Phase 3

The API expose is still valuable for three reasons that this in-process bench does NOT measure:

1. **Client-server IPC overhead**: when this RPC is called from a remote gRPC or REST client, batching B queries into 1 round trip avoids `B-1` round trips of network latency.
2. **Bindings (#717-#720)**: Python / Node / Ruby / PHP users will submit a list of queries in a single FFI call, avoiding `B-1` FFI overheads.
3. **API surface convergence**: bindings now have a one-call batch method matching internal Phase 1/2 capabilities, simplifying user code.

A follow-up "client-server bench" issue can measure the real-world payoff.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p laurus-server` — 28 unit tests pass (regression check)
- [x] `cargo test -p laurus --test engine_search_batch_test --test unified_search_test --test vector_multi_query_test` all pass
- [x] `cargo bench -p laurus --bench engine_search_batch_bench` compiles and runs end-to-end on both lexical and vector groups
- [x] protobuf regenerated (build.rs auto-runs)

Closes #716
Refs #714
Refs #648