### PR TITLE
feat(python): expose search_batch method in laurus-python (Phase 3b of #648)

### DIFF
--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -26,6 +26,7 @@ class Index:
 | `delete_documents(id)` | 指定 ID の全バージョンを削除します。 |
 | `commit()` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |
 | `search(query, *, limit=10, offset=0) -> list[SearchResult]` | 検索クエリを実行します。 |
+| `search_batch(queries, *, limit=10, offset=0) -> list[list[SearchResult]]` | 独立した複数の検索を 1 回の呼び出しで実行します。各クエリは内部の tokio ランタイム上で並列に dispatch されます。`results[i]` は `queries[i]` に対応し、入力が空のリストの場合は `[]` を返します。 |
 | `stats() -> dict` | インデックス統計（`document_count`、`vector_fields`）を返します。 |
 
 ### `search` の query 引数
@@ -36,6 +37,8 @@ class Index:
 - **Lexical クエリオブジェクト**（`TermQuery`、`PhraseQuery`、`BooleanQuery` など）
 - **Vector クエリオブジェクト**（`VectorQuery`、`VectorTextQuery`）
 - **`SearchRequest`**（完全な制御が必要な場合）
+
+`search_batch` の `queries` リストの各要素も同じ種類の値を受け付けます。DSL 文字列・クエリオブジェクト・`SearchRequest` を 1 つのバッチ内で混在させることもできます。
 
 ---
 

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -26,6 +26,7 @@ class Index:
 | `delete_documents(id)` | Delete all versions for the given ID. |
 | `commit()` | Flush buffered writes and make all pending changes searchable. |
 | `search(query, *, limit=10, offset=0) -> list[SearchResult]` | Execute a search query. |
+| `search_batch(queries, *, limit=10, offset=0) -> list[list[SearchResult]]` | Execute multiple independent searches in one call. Each query is dispatched in parallel on the underlying tokio runtime. `results[i]` corresponds to `queries[i]`. Empty input returns `[]`. |
 | `stats() -> dict` | Return index statistics (`document_count`, `vector_fields`). |
 
 ### `search` query argument
@@ -36,6 +37,8 @@ The `query` parameter accepts any of the following:
 - A **lexical query object** (`TermQuery`, `PhraseQuery`, `BooleanQuery`, …)
 - A **vector query object** (`VectorQuery`, `VectorTextQuery`)
 - A **`SearchRequest`** for full control
+
+The same value kinds are accepted as the elements of `search_batch`'s `queries` list — DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch.
 
 ---
 

--- a/laurus-python/src/index.rs
+++ b/laurus-python/src/index.rs
@@ -199,6 +199,70 @@ impl PyIndex {
             .collect()
     }
 
+    /// Execute multiple independent searches in one call.
+    ///
+    /// Each query in `queries` is dispatched in parallel on the underlying
+    /// tokio runtime via `laurus::Engine::search_batch`. Each entry can
+    /// be the same kind of value `search()` accepts: a DSL string, a
+    /// `LexicalQuery` / `VectorQuery` / `VectorTextQuery` object, or a
+    /// `SearchRequest`. The same `limit` and `offset` are applied to
+    /// every query in the batch.
+    ///
+    /// Args:
+    ///     queries: A list of queries to execute. Order is preserved in
+    ///         the output.
+    ///     limit: Maximum number of results to return per query
+    ///         (default 10).
+    ///     offset: Pagination offset applied to each query (default 0).
+    ///
+    /// Returns:
+    ///     A list of lists: `results[i]` is the result list for
+    ///     `queries[i]`. Empty input returns an empty list without
+    ///     invoking the engine.
+    ///
+    /// Issue [#717](https://github.com/mosuka/laurus/issues/717)
+    /// Phase 3b of [#648](https://github.com/mosuka/laurus/issues/648).
+    #[pyo3(signature = (queries, *, limit=10, offset=0))]
+    pub fn search_batch(
+        &self,
+        py: Python,
+        queries: &Bound<PyAny>,
+        limit: usize,
+        offset: usize,
+    ) -> PyResult<Vec<Vec<PySearchResult>>> {
+        let queries_seq = queries.try_iter().map_err(|_| {
+            PyRuntimeError::new_err(
+                "search_batch: expected an iterable of queries (DSL string, Query object, or SearchRequest)",
+            )
+        })?;
+
+        let mut requests = Vec::new();
+        for item in queries_seq {
+            let item = item?;
+            requests.push(build_request_from_py(py, &item, limit, offset)?);
+        }
+
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let engine = self.engine.clone();
+        let batch_results = self
+            .rt
+            .block_on(engine.search_batch(requests))
+            .map_err(laurus_err)?;
+
+        batch_results
+            .into_iter()
+            .map(|per_query_results| {
+                per_query_results
+                    .into_iter()
+                    .map(|r| to_py_search_result(py, r))
+                    .collect::<PyResult<Vec<_>>>()
+            })
+            .collect()
+    }
+
     // ── Schema & stats ────────────────────────────────────────────────────
 
     /// Return index statistics.

--- a/laurus-python/tests/test_search_batch.py
+++ b/laurus-python/tests/test_search_batch.py
@@ -1,0 +1,95 @@
+"""Integration tests for ``Index.search_batch`` (Phase 3b of #648, issue #717).
+
+These tests cover the Python-facing batched search API:
+
+- Empty input returns an empty list without invoking the engine.
+- Single-query batch matches the single-query ``search()`` result.
+- Multi-query batch preserves input order and returns one result list
+  per input query.
+- DSL strings, ``Query`` objects, and ``SearchRequest`` are all accepted.
+"""
+
+import pytest
+import laurus
+
+
+@pytest.fixture
+def index():
+    """Return a fresh in-memory index with three indexed documents."""
+    idx = laurus.Index()
+    idx.put_document("doc1", {"title": "Introduction to Rust", "body": "Systems programming language."})
+    idx.put_document("doc2", {"title": "Python for Data Science", "body": "Data analysis with Python."})
+    idx.put_document("doc3", {"title": "Distributed Systems", "body": "Engineering at scale."})
+    idx.commit()
+    return idx
+
+
+def test_search_batch_empty(index):
+    """Empty list returns empty list."""
+    results = index.search_batch([])
+    assert results == []
+
+
+def test_search_batch_single_query_matches_search(index):
+    """search_batch([q]) should match search(q) for an equivalent query."""
+    serial = index.search("title:rust", limit=5)
+    batch = index.search_batch(["title:rust"], limit=5)
+    assert len(batch) == 1
+    assert len(batch[0]) == len(serial)
+    for b, s in zip(batch[0], serial):
+        assert b.id == s.id
+
+
+def test_search_batch_multi_query_preserves_order(index):
+    """Multi-query batch returns one list per input, in input order."""
+    queries = ["title:rust", "body:python", "title:distributed"]
+    expected_top_ids = ["doc1", "doc2", "doc3"]
+
+    batch = index.search_batch(queries, limit=5)
+    assert len(batch) == len(queries)
+
+    for results, expected_id in zip(batch, expected_top_ids):
+        assert len(results) >= 1, f"expected at least 1 hit for query targeting {expected_id}"
+        assert results[0].id == expected_id
+
+
+def test_search_batch_with_query_objects(index):
+    """search_batch accepts ``Query`` objects, not just DSL strings."""
+    queries = [
+        laurus.TermQuery("title", "rust"),
+        laurus.TermQuery("body", "python"),
+    ]
+    batch = index.search_batch(queries, limit=5)
+    assert len(batch) == 2
+    assert batch[0][0].id == "doc1"
+    assert batch[1][0].id == "doc2"
+
+
+def test_search_batch_with_search_requests(index):
+    """search_batch accepts pre-built ``SearchRequest`` instances."""
+    requests = [
+        laurus.SearchRequest(lexical_query=laurus.TermQuery("title", "rust"), limit=5),
+        laurus.SearchRequest(lexical_query=laurus.TermQuery("body", "python"), limit=5),
+    ]
+    batch = index.search_batch(requests)
+    assert len(batch) == 2
+    assert batch[0][0].id == "doc1"
+    assert batch[1][0].id == "doc2"
+
+
+def test_search_batch_no_match_returns_empty_inner_list(index):
+    """A query with no matches yields an empty inner list, not a missing entry."""
+    queries = ["title:rust", "title:nonexistent_xyz"]
+    batch = index.search_batch(queries, limit=5)
+    assert len(batch) == 2
+    assert len(batch[0]) >= 1
+    assert batch[1] == []
+
+
+def test_search_batch_limit_per_query(index):
+    """``limit`` applies to each query independently."""
+    queries = ["body:programming OR body:data", "body:programming OR body:data"]
+    batch = index.search_batch(queries, limit=1)
+    assert len(batch) == 2
+    for results in batch:
+        assert len(results) <= 1


### PR DESCRIPTION
## Summary

Phase 3b of [#648](https://github.com/mosuka/laurus/issues/648) (issue [#717](https://github.com/mosuka/laurus/issues/717)). Exposes the new batched search API in the laurus-python binding so Python callers can submit B queries in a single call.

## API

```python
index.search_batch(
    queries,        # list of DSL strings, Query objects, or SearchRequest instances
    *,
    limit=10,       # applied per query
    offset=0,       # applied per query
) -> list[list[SearchResult]]
```

- Each element of `queries` accepts the same value kinds as `Index.search()`: a DSL string, a lexical / vector query object, or a `SearchRequest`.
- DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch.
- Empty input returns `[]` without invoking the engine.
- `results[i]` is the result list for `queries[i]` — order is preserved.
- Existing `Index.search` is unchanged.

## Internals

The Rust-side implementation builds one `laurus::SearchRequest` per input via the existing `build_request_from_py` helper, then dispatches the batch via `laurus::Engine::search_batch` (added in PR #721 / sub-issue #715). The engine method uses `futures::future::try_join_all` to run each request concurrently on the tokio runtime.

## Tests

New `laurus-python/tests/test_search_batch.py` (7 tests, all passing):

- `test_search_batch_empty` — empty list returns `[]`.
- `test_search_batch_single_query_matches_search` — single-query batch equals `search()`.
- `test_search_batch_multi_query_preserves_order` — three distinct queries, position-preserving output.
- `test_search_batch_with_query_objects` — accepts `TermQuery` etc.
- `test_search_batch_with_search_requests` — accepts pre-built `SearchRequest`.
- `test_search_batch_no_match_returns_empty_inner_list` — no-match query yields `[]`, not a missing entry.
- `test_search_batch_limit_per_query` — `limit` applies per query.

Existing `tests/test_index.py` (30 tests) still passes — no regression.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-python --all-targets -- -D warnings` clean
- [x] `maturin develop --release` builds the wheel
- [x] `pytest tests/test_search_batch.py` — 7 passed
- [x] `pytest tests/test_index.py` — 30 passed (regression check)
- [x] `npx markdownlint-cli2` on English + Japanese Python docs — 0 errors

Closes #717
Refs #714
Refs #648