### PR TITLE
feat(nodejs): expose searchBatch method in laurus-nodejs (Phase 3c of #648)

### DIFF
--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -34,6 +34,7 @@ class Index {
 | `searchVector(field, vector, limit?, offset?)` | 事前計算ベクトルで検索。 |
 | `searchVectorText(field, text, limit?, offset?)` | テキストを自動埋め込みして検索。 |
 | `searchWithRequest(request)` | `SearchRequest` で検索。 |
+| `searchBatch(queries, limit?, offset?)` | 複数の DSL 文字列クエリを並列実行します。`results[i]` は `queries[i]` に対応。戻り値は `Promise<Array<Array<JsSearchResult>>>`。空入力の場合は `[]` を返します。 |
 | `stats()` | インデックス統計（`documentCount`、`vectorFields`）を返す。 |
 
 ドキュメント操作と検索メソッドはすべて非同期で Promise を返します。

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -34,6 +34,7 @@ class Index {
 | `searchVector(field, vector, limit?, offset?)` | Search with a pre-computed vector. |
 | `searchVectorText(field, text, limit?, offset?)` | Search with text (auto-embedded). |
 | `searchWithRequest(request)` | Search with a `SearchRequest`. |
+| `searchBatch(queries, limit?, offset?)` | Execute multiple DSL string queries in parallel. `results[i]` corresponds to `queries[i]`. Returns `Promise<Array<Array<JsSearchResult>>>`. Empty input returns `[]`. |
 | `stats()` | Return index statistics (`documentCount`, `vectorFields`). |
 
 All document methods and search methods are async

--- a/laurus-nodejs/__tests__/search_batch.spec.mjs
+++ b/laurus-nodejs/__tests__/search_batch.spec.mjs
@@ -1,0 +1,93 @@
+/**
+ * Integration tests for `Index.searchBatch` (Phase 3c of #648, issue #718).
+ *
+ * Covers:
+ * - Empty input returns an empty list without invoking the engine.
+ * - Single-query batch matches the single-query `search()` result.
+ * - Multi-query batch preserves input order and returns one result list
+ *   per input query.
+ * - `limit` and `offset` apply per query in the batch.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Index, Schema } from "../index.js";
+
+async function createTextIndex() {
+  const schema = new Schema();
+  schema.addTextField("title");
+  schema.addTextField("body");
+  schema.setDefaultFields(["title", "body"]);
+  const index = await Index.create(null, schema);
+  await index.putDocument("doc1", {
+    title: "Introduction to Rust",
+    body: "Systems programming language.",
+  });
+  await index.putDocument("doc2", {
+    title: "Python for Data Science",
+    body: "Data analysis with Python.",
+  });
+  await index.putDocument("doc3", {
+    title: "Distributed Systems",
+    body: "Engineering at scale.",
+  });
+  await index.commit();
+  return index;
+}
+
+describe("searchBatch", () => {
+  it("returns an empty array for empty input", async () => {
+    const index = await createTextIndex();
+    const results = await index.searchBatch([]);
+    expect(results).toEqual([]);
+  });
+
+  it("single-query batch matches search()", async () => {
+    const index = await createTextIndex();
+    const serial = await index.search("title:rust", 5);
+    const batch = await index.searchBatch(["title:rust"], 5);
+
+    expect(batch.length).toBe(1);
+    expect(batch[0].length).toBe(serial.length);
+    for (let i = 0; i < serial.length; i++) {
+      expect(batch[0][i].id).toBe(serial[i].id);
+    }
+  });
+
+  it("multi-query batch preserves input order", async () => {
+    const index = await createTextIndex();
+    const queries = ["title:rust", "body:python", "title:distributed"];
+    const expectedTopIds = ["doc1", "doc2", "doc3"];
+
+    const batch = await index.searchBatch(queries, 5);
+    expect(batch.length).toBe(queries.length);
+
+    for (let i = 0; i < queries.length; i++) {
+      expect(batch[i].length).toBeGreaterThanOrEqual(1);
+      expect(batch[i][0].id).toBe(expectedTopIds[i]);
+    }
+  });
+
+  it("returns an empty inner list for a no-match query", async () => {
+    const index = await createTextIndex();
+    const queries = ["title:rust", "title:nonexistent_xyz"];
+    const batch = await index.searchBatch(queries, 5);
+
+    expect(batch.length).toBe(2);
+    expect(batch[0].length).toBeGreaterThanOrEqual(1);
+    expect(batch[1]).toEqual([]);
+  });
+
+  it("applies limit per query", async () => {
+    const index = await createTextIndex();
+    const queries = [
+      "body:programming OR body:data",
+      "body:programming OR body:data",
+    ];
+    const batch = await index.searchBatch(queries, 1);
+
+    expect(batch.length).toBe(2);
+    for (const results of batch) {
+      expect(results.length).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/laurus-nodejs/src/index.rs
+++ b/laurus-nodejs/src/index.rs
@@ -310,6 +310,61 @@ impl JsIndex {
         Ok(results.into_iter().map(to_js_search_result).collect())
     }
 
+    /// Execute multiple independent searches in one call.
+    ///
+    /// Each query is dispatched in parallel on the underlying tokio
+    /// runtime via `laurus::Engine::search_batch`. The same `limit`
+    /// and `offset` are applied to every query in the batch.
+    ///
+    /// # Arguments
+    ///
+    /// * `queries` - An array of query DSL strings.
+    /// * `limit` - Maximum number of results per query (default 10).
+    /// * `offset` - Pagination offset applied to each query (default 0).
+    ///
+    /// # Returns
+    ///
+    /// An array of arrays: `results[i]` is the result list for
+    /// `queries[i]`. Empty input returns `[]` without invoking the
+    /// engine.
+    ///
+    /// Issue [#718](https://github.com/mosuka/laurus/issues/718)
+    /// Phase 3c of [#648](https://github.com/mosuka/laurus/issues/648).
+    #[napi]
+    pub async fn search_batch(
+        &self,
+        queries: Vec<String>,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<Vec<Vec<JsSearchResult>>> {
+        if queries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let limit = limit.unwrap_or(10) as usize;
+        let offset = offset.unwrap_or(0) as usize;
+        let requests: Vec<_> = queries
+            .into_iter()
+            .map(|q| build_dsl_request(q, limit, offset))
+            .collect();
+
+        let batch_results = self
+            .engine
+            .search_batch(requests)
+            .await
+            .map_err(laurus_err)?;
+
+        Ok(batch_results
+            .into_iter()
+            .map(|per_query_results| {
+                per_query_results
+                    .into_iter()
+                    .map(to_js_search_result)
+                    .collect()
+            })
+            .collect())
+    }
+
     // ── Stats ─────────────────────────────────────────────────────────────
 
     /// Return index statistics.


### PR DESCRIPTION
## Summary

Phase 3c of [#648](https://github.com/mosuka/laurus/issues/648) (issue [#718](https://github.com/mosuka/laurus/issues/718)). Exposes the new batched search API in the laurus-nodejs binding so Node.js callers can submit B queries in a single call.

## API

```typescript
index.searchBatch(
  queries: Array<string>,                 // DSL string queries
  limit?: number,                         // applied per query (default 10)
  offset?: number,                        // applied per query (default 0)
): Promise<Array<Array<JsSearchResult>>>
```

- Each element of `queries` is a DSL string (e.g. `"title:hello"`, mirroring the existing `index.search()` contract).
- Empty input returns `[]` without invoking the engine.
- `results[i]` is the result list for `queries[i]` — order is preserved.
- Existing `search` / `searchTerm` / `searchVector` / `searchVectorText` / `searchWithRequest` are unchanged.

## Design note: Python parity

The Python binding (#717) accepts polymorphic input — DSL strings, query objects, or `SearchRequest` instances may be mixed in one batch. Node.js follows its existing strict-typed pattern (each query variant has its own method) and accepts only DSL strings here, mirroring `index.search(query: string, …)`. A `searchBatchWithRequests(requests: SearchRequest[])` variant for pre-built `SearchRequest` arrays can be added in a follow-up if a concrete user need emerges.

## Internals

The Rust-side implementation builds one `laurus::SearchRequest` per input string via the existing `build_dsl_request` helper, then dispatches the batch via `laurus::Engine::search_batch` (added in PR #721 / sub-issue #715). The engine method uses `futures::future::try_join_all` to run each request concurrently on the tokio runtime.

## Tests

New `laurus-nodejs/__tests__/search_batch.spec.mjs` (5 tests, all passing):

- empty input returns `[]`
- single-query batch matches `search()`
- multi-query batch preserves input order
- no-match query yields `[]` as the inner list, not a missing entry
- `limit` applies per query

Existing `__tests__/index.spec.mjs` (30 tests) still passes — no regression.

## Notes

- TypeScript declaration (`laurus-nodejs/index.d.ts`) is auto-regenerated by `napi build` and is gitignored, so it is not part of this PR.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-nodejs --all-targets -- -D warnings` clean
- [x] `npm run build:debug` builds the native addon
- [x] `npx vitest run __tests__/search_batch.spec.mjs` — 5 passed
- [x] `npx vitest run __tests__/index.spec.mjs` — 30 passed (regression check)
- [x] `npx markdownlint-cli2` on English + Japanese Node.js docs — 0 errors

Closes #718
Refs #714
Refs #648