### PR TITLE
feat(ruby): expose search_batch method in laurus-ruby (Phase 3d of #648)

### DIFF
--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -25,6 +25,7 @@ Laurus::Index.new(path: nil, schema: nil)
 | `delete_documents(id)` | 指定 ID の全バージョンを削除します。 |
 | `commit` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |
 | `search(query, limit: 10, offset: 0) -> Array<SearchResult>` | 検索クエリを実行します。 |
+| `search_batch(queries, limit: 10, offset: 0) -> Array<Array<SearchResult>>` | 独立した複数の検索を 1 回の呼び出しで実行します。各クエリは内部の tokio ランタイム上で並列に dispatch されます。`results[i]` は `queries[i]` に対応し、入力が空の配列の場合は `[]` を返します。 |
 | `stats -> Hash` | インデックス統計（`"document_count"`、`"vector_fields"`）を返します。 |
 
 ### `search` の query 引数
@@ -35,6 +36,8 @@ Laurus::Index.new(path: nil, schema: nil)
 - **Lexical クエリオブジェクト**（`TermQuery`、`PhraseQuery`、`BooleanQuery` など）
 - **Vector クエリオブジェクト**（`VectorQuery`、`VectorTextQuery`）
 - **`SearchRequest`**（完全な制御が必要な場合）
+
+`search_batch` の `queries` 配列の各要素も同じ種類の値を受け付けます。DSL 文字列・クエリオブジェクト・`SearchRequest` を 1 つのバッチ内で混在させることもできます。
 
 ---
 

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -25,6 +25,7 @@ Laurus::Index.new(path: nil, schema: nil)
 | `delete_documents(id)` | Delete all versions for the given ID. |
 | `commit` | Flush buffered writes and make all pending changes searchable. |
 | `search(query, limit: 10, offset: 0) -> Array<SearchResult>` | Execute a search query. |
+| `search_batch(queries, limit: 10, offset: 0) -> Array<Array<SearchResult>>` | Execute multiple independent searches in one call. Each query is dispatched in parallel on the underlying tokio runtime. `results[i]` corresponds to `queries[i]`. Empty input returns `[]`. |
 | `stats -> Hash` | Return index statistics (`"document_count"`, `"vector_fields"`). |
 
 ### `search` query argument
@@ -35,6 +36,8 @@ The `query` parameter accepts any of the following:
 - A **lexical query object** (`TermQuery`, `PhraseQuery`, `BooleanQuery`, ...)
 - A **vector query object** (`VectorQuery`, `VectorTextQuery`)
 - A **`SearchRequest`** for full control
+
+The same value kinds are accepted as the elements of `search_batch`'s `queries` Array — DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch.
 
 ---
 

--- a/laurus-ruby/src/index.rs
+++ b/laurus-ruby/src/index.rs
@@ -10,7 +10,7 @@ use crate::search::{build_request_from_rb, to_rb_search_result};
 use laurus::{Engine, EngineStats, Storage, StorageConfig, StorageFactory};
 use magnus::prelude::*;
 use magnus::scan_args::{get_kwargs, scan_args};
-use magnus::{Error, RArray, RHash, RModule, Ruby, Value};
+use magnus::{Error, RArray, RHash, RModule, Ruby, TryConvert, Value};
 
 // ---------------------------------------------------------------------------
 // Index
@@ -214,6 +214,77 @@ impl RbIndex {
         Ok(arr)
     }
 
+    /// Execute multiple independent searches in one call.
+    ///
+    /// Each entry in `queries` is dispatched in parallel on the
+    /// underlying tokio runtime via `laurus::Engine::search_batch`.
+    /// The same `limit:` and `offset:` keyword arguments apply to every
+    /// query in the batch. Each entry accepts the same kinds of values
+    /// as `search`: a DSL string, a lexical / vector query object, or
+    /// a `SearchRequest`.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - Positional and keyword arguments:
+    ///   - `queries`: An Array of queries to execute.
+    ///   - `limit:` (Integer, default 10): Maximum number of results per query.
+    ///   - `offset:` (Integer, default 0): Pagination offset per query.
+    ///
+    /// # Returns
+    ///
+    /// An Array of Arrays: `results[i]` is the result Array for
+    /// `queries[i]`. Empty input returns an empty Array without
+    /// invoking the engine.
+    ///
+    /// Issue [#719](https://github.com/mosuka/laurus/issues/719)
+    /// Phase 3d of [#648](https://github.com/mosuka/laurus/issues/648).
+    fn search_batch(&self, args: &[Value]) -> Result<RArray, Error> {
+        let ruby = Ruby::get().expect("called from Ruby thread");
+        let args = scan_args::<(Value,), (), (), (), RHash, ()>(args)?;
+        let (queries,) = args.required;
+        let kwargs = get_kwargs::<_, (), (Option<usize>, Option<usize>), ()>(
+            args.keywords,
+            &[],
+            &["limit", "offset"],
+        )?;
+        let (limit, offset) = kwargs.optional;
+        let limit = limit.unwrap_or(10);
+        let offset = offset.unwrap_or(0);
+
+        let queries_array: RArray = TryConvert::try_convert(queries).map_err(|_| {
+            Error::new(
+                ruby.exception_arg_error(),
+                "search_batch: expected an Array of queries (DSL string, Query object, or SearchRequest)",
+            )
+        })?;
+
+        if queries_array.is_empty() {
+            return Ok(ruby.ary_new());
+        }
+
+        let mut requests = Vec::with_capacity(queries_array.len());
+        for item in queries_array.into_iter() {
+            requests.push(build_request_from_rb(item, limit, offset)?);
+        }
+
+        let engine = self.engine.clone();
+        let batch_results = self
+            .rt
+            .block_on(engine.search_batch(requests))
+            .map_err(laurus_err)?;
+
+        let outer = ruby.ary_new_capa(batch_results.len());
+        for per_query_results in batch_results {
+            let inner = ruby.ary_new_capa(per_query_results.len());
+            for r in per_query_results {
+                let rb_result = to_rb_search_result(r);
+                inner.push(ruby.into_value(rb_result))?;
+            }
+            outer.push(inner)?;
+        }
+        Ok(outer)
+    }
+
     // ── Schema & stats ────────────────────────────────────────────────────
 
     /// Return index statistics.
@@ -294,6 +365,7 @@ pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     )?;
     class.define_method("commit", magnus::method!(RbIndex::commit, 0))?;
     class.define_method("search", magnus::method!(RbIndex::search, -1))?;
+    class.define_method("search_batch", magnus::method!(RbIndex::search_batch, -1))?;
     class.define_method("stats", magnus::method!(RbIndex::stats, 0))?;
     class.define_method("inspect", magnus::method!(RbIndex::inspect, 0))?;
     class.define_method("to_s", magnus::method!(RbIndex::inspect, 0))?;

--- a/laurus-ruby/test/test_search_batch.rb
+++ b/laurus-ruby/test/test_search_batch.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Integration tests for Laurus::Index#search_batch
+# (Phase 3d of #648, issue #719).
+#
+# Covers:
+# - Empty input returns an empty Array without invoking the engine.
+# - Single-query batch matches the single-query #search result.
+# - Multi-query batch preserves input order and returns one result Array
+#   per input query.
+# - DSL strings, Query objects, and SearchRequest are all accepted.
+class TestSearchBatch < Minitest::Test
+  def create_index
+    idx = Laurus::Index.new
+    idx.put_document("doc1", { "title" => "Introduction to Rust", "body" => "Systems programming language." })
+    idx.put_document("doc2", { "title" => "Python for Data Science", "body" => "Data analysis with Python." })
+    idx.put_document("doc3", { "title" => "Distributed Systems", "body" => "Engineering at scale." })
+    idx.commit
+    idx
+  end
+
+  def test_search_batch_empty
+    idx = create_index
+    results = idx.search_batch([])
+    assert_equal [], results
+  end
+
+  def test_search_batch_single_query_matches_search
+    idx = create_index
+    serial = idx.search("title:rust", limit: 5)
+    batch = idx.search_batch(["title:rust"], limit: 5)
+
+    assert_equal 1, batch.length
+    assert_equal serial.length, batch[0].length
+    batch[0].each_with_index do |result, i|
+      assert_equal serial[i].id, result.id
+    end
+  end
+
+  def test_search_batch_multi_query_preserves_order
+    idx = create_index
+    queries = ["title:rust", "body:python", "title:distributed"]
+    expected_top_ids = %w[doc1 doc2 doc3]
+
+    batch = idx.search_batch(queries, limit: 5)
+    assert_equal queries.length, batch.length
+
+    batch.each_with_index do |results, i|
+      assert results.length >= 1, "expected at least 1 hit for query #{queries[i]}"
+      assert_equal expected_top_ids[i], results[0].id
+    end
+  end
+
+  def test_search_batch_with_query_objects
+    idx = create_index
+    queries = [
+      Laurus::TermQuery.new("title", "rust"),
+      Laurus::TermQuery.new("body", "python"),
+    ]
+    batch = idx.search_batch(queries, limit: 5)
+
+    assert_equal 2, batch.length
+    assert_equal "doc1", batch[0][0].id
+    assert_equal "doc2", batch[1][0].id
+  end
+
+  def test_search_batch_with_search_requests
+    idx = create_index
+    requests = [
+      Laurus::SearchRequest.new(lexical_query: Laurus::TermQuery.new("title", "rust"), limit: 5),
+      Laurus::SearchRequest.new(lexical_query: Laurus::TermQuery.new("body", "python"), limit: 5),
+    ]
+    batch = idx.search_batch(requests)
+
+    assert_equal 2, batch.length
+    assert_equal "doc1", batch[0][0].id
+    assert_equal "doc2", batch[1][0].id
+  end
+
+  def test_search_batch_no_match_returns_empty_inner_array
+    idx = create_index
+    queries = ["title:rust", "title:nonexistent_xyz"]
+    batch = idx.search_batch(queries, limit: 5)
+
+    assert_equal 2, batch.length
+    assert batch[0].length >= 1
+    assert_equal [], batch[1]
+  end
+
+  def test_search_batch_limit_per_query
+    idx = create_index
+    queries = ["body:programming OR body:data", "body:programming OR body:data"]
+    batch = idx.search_batch(queries, limit: 1)
+
+    assert_equal 2, batch.length
+    batch.each do |results|
+      assert results.length <= 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 3d of [#648](https://github.com/mosuka/laurus/issues/648) (issue [#719](https://github.com/mosuka/laurus/issues/719)). Exposes the new batched search API in the laurus-ruby binding so Ruby callers can submit B queries in a single call.

## API

```ruby
index.search_batch(
  queries,       # Array of DSL strings, Query objects, or SearchRequest instances
  limit: 10,     # applied per query
  offset: 0      # applied per query
) # => Array<Array<SearchResult>>
```

- Each entry of `queries` accepts the same kinds of values as `Laurus::Index#search`: a DSL string, a lexical / vector query object, or a `SearchRequest`.
- DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch (matches the Python binding's polymorphic input from #717).
- Empty input returns `[]` without invoking the engine.
- `results[i]` is the result `Array<SearchResult>` for `queries[i]` — order is preserved.
- Existing `Laurus::Index#search` is unchanged.

## Internals

The Rust-side implementation uses magnus's `scan_args` to take one positional Array argument plus the `limit:` / `offset:` keyword arguments, mirroring the existing `#search` method. Each entry is converted to a `laurus::SearchRequest` via the existing `build_request_from_rb` helper, then dispatched via `laurus::Engine::search_batch` (added in PR #721 / sub-issue #715). The engine method uses `futures::future::try_join_all` to run each request concurrently on the tokio runtime.

## Tests

New `laurus-ruby/test/test_search_batch.rb` (7 tests, all passing):

- `test_search_batch_empty` — empty Array returns `[]`.
- `test_search_batch_single_query_matches_search` — single-query batch equals `#search`.
- `test_search_batch_multi_query_preserves_order` — three distinct queries, position-preserving output.
- `test_search_batch_with_query_objects` — accepts `TermQuery` etc.
- `test_search_batch_with_search_requests` — accepts pre-built `SearchRequest`.
- `test_search_batch_no_match_returns_empty_inner_array` — no-match query yields `[]`, not a missing entry.
- `test_search_batch_limit_per_query` — `limit:` applies per query.

`rake test` reports **45 tests, 89 assertions, 0 failures** (new 7 + existing 38) — no regression.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-ruby --all-targets -- -D warnings` clean
- [x] `rake compile` builds the native gem
- [x] `rake test` — 45 tests pass
- [x] `npx markdownlint-cli2` on English + Japanese Ruby docs — 0 errors

Closes #719
Refs #714
Refs #648