### PR TITLE
feat(php): expose searchBatch method in laurus-php (Phase 3e of #648)

### DIFF
--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -25,6 +25,7 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null)
 | `deleteDocuments(string $id): void` | 指定 ID の全バージョンを削除します。 |
 | `commit(): void` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |
 | `search(mixed $query, int $limit = 10, int $offset = 0): array` | 検索クエリを実行します。`SearchResult` の配列を返します。 |
+| `searchBatch(array $queries, int $limit = 10, int $offset = 0): array` | 独立した複数の検索を 1 回の呼び出しで実行します。各クエリは内部の tokio ランタイム上で並列に dispatch されます。`results[i]` は `queries[i]` に対応し、`SearchResult` の配列の配列を返します。入力が空の配列の場合は `[]` を返します。 |
 | `stats(): array` | インデックス統計（`"documentCount"`、`"vectorFields"`）を返します。 |
 
 ### `search` の query 引数
@@ -35,6 +36,8 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null)
 - **Lexical クエリオブジェクト**（`TermQuery`、`PhraseQuery`、`BooleanQuery` など）
 - **Vector クエリオブジェクト**（`VectorQuery`、`VectorTextQuery`）
 - **`SearchRequest`**（完全な制御が必要な場合）
+
+`searchBatch` の `$queries` 配列の各要素も同じ種類の値を受け付けます。DSL 文字列・クエリオブジェクト・`SearchRequest` を 1 つのバッチ内で混在させることもできます。
 
 ---
 

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -25,6 +25,7 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null)
 | `deleteDocuments(string $id): void` | Delete all versions for the given ID. |
 | `commit(): void` | Flush buffered writes and make all pending changes searchable. |
 | `search(mixed $query, int $limit = 10, int $offset = 0): array` | Execute a search query. Returns an array of `SearchResult`. |
+| `searchBatch(array $queries, int $limit = 10, int $offset = 0): array` | Execute multiple independent searches in one call. Each query is dispatched in parallel on the underlying tokio runtime. `results[i]` corresponds to `queries[i]`. Returns an array of arrays of `SearchResult`. Empty input returns `[]`. |
 | `stats(): array` | Return index statistics (`"documentCount"`, `"vectorFields"`). |
 
 ### `search` query argument
@@ -35,6 +36,8 @@ The `$query` parameter accepts any of the following:
 - A **lexical query object** (`TermQuery`, `PhraseQuery`, `BooleanQuery`, ...)
 - A **vector query object** (`VectorQuery`, `VectorTextQuery`)
 - A **`SearchRequest`** for full control
+
+The same value kinds are accepted as the elements of `searchBatch`'s `$queries` array — DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch.
 
 ---
 

--- a/laurus-php/src/index.rs
+++ b/laurus-php/src/index.rs
@@ -192,6 +192,72 @@ impl PhpIndex {
         Ok(results.into_iter().map(to_php_search_result).collect())
     }
 
+    /// Execute multiple independent searches in one call.
+    ///
+    /// Each entry of `queries` is dispatched in parallel on the
+    /// underlying tokio runtime via `laurus::Engine::search_batch`.
+    /// The same `limit` and `offset` are applied to every query in the
+    /// batch. Each entry accepts the same kinds of values as `search`:
+    /// a DSL string, a lexical / vector query object, or a
+    /// `SearchRequest`.
+    ///
+    /// # Arguments
+    ///
+    /// * `queries` - An array of queries to execute.
+    /// * `limit` - Maximum number of results per query (default: 10).
+    /// * `offset` - Pagination offset per query (default: 0).
+    ///
+    /// # Returns
+    ///
+    /// An array of arrays: `results[i]` is the result array for
+    /// `queries[i]`. Empty input returns an empty array without
+    /// invoking the engine.
+    ///
+    /// Issue [#720](https://github.com/mosuka/laurus/issues/720)
+    /// Phase 3e of [#648](https://github.com/mosuka/laurus/issues/648).
+    #[php(defaults(limit = 10, offset = 0))]
+    pub fn search_batch(
+        &self,
+        queries: &Zval,
+        limit: i64,
+        offset: i64,
+    ) -> PhpResult<Vec<Vec<PhpSearchResult>>> {
+        let arr = queries.array().ok_or_else(|| {
+            PhpException::from(
+                "search_batch: expected an array of queries (DSL string, Query object, or SearchRequest)".to_string(),
+            )
+        })?;
+
+        if arr.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut requests = Vec::with_capacity(arr.len());
+        for (_, value) in arr.iter() {
+            requests.push(build_request_from_php(
+                value,
+                limit as usize,
+                offset as usize,
+            )?);
+        }
+
+        let engine = self.engine.clone();
+        let batch_results = self
+            .rt
+            .block_on(engine.search_batch(requests))
+            .map_err(laurus_err)?;
+
+        Ok(batch_results
+            .into_iter()
+            .map(|per_query_results| {
+                per_query_results
+                    .into_iter()
+                    .map(to_php_search_result)
+                    .collect()
+            })
+            .collect())
+    }
+
     // ── Schema & stats ────────────────────────────────────────────────────
 
     /// Return index statistics as an associative array.

--- a/laurus-php/tests/LaurusTest.php
+++ b/laurus-php/tests/LaurusTest.php
@@ -463,4 +463,96 @@ class LaurusTest extends TestCase
         $this->assertStringContainsString("SearchResult(", $str);
         $this->assertStringContainsString("doc1", $str);
     }
+
+    // ── searchBatch (Phase 3e of #648, issue #720) ───────────────────────
+
+    /**
+     * Return a fresh in-memory index with three indexed documents — used
+     * specifically by the searchBatch tests to provide three distinct
+     * query targets.
+     */
+    private function createBatchIndex(): Laurus\Index
+    {
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+        $schema->addTextField("body");
+        $idx = new Laurus\Index(null, $schema);
+        $idx->putDocument("doc1", ["title" => "Introduction to Rust", "body" => "Systems programming language."]);
+        $idx->putDocument("doc2", ["title" => "Python for Data Science", "body" => "Data analysis with Python."]);
+        $idx->putDocument("doc3", ["title" => "Distributed Systems", "body" => "Engineering at scale."]);
+        $idx->commit();
+        return $idx;
+    }
+
+    public function testSearchBatchEmpty(): void
+    {
+        $idx = $this->createBatchIndex();
+        $results = $idx->searchBatch([]);
+        $this->assertSame([], $results);
+    }
+
+    public function testSearchBatchSingleQueryMatchesSearch(): void
+    {
+        $idx = $this->createBatchIndex();
+        $serial = $idx->search("title:rust", 5);
+        $batch = $idx->searchBatch(["title:rust"], 5);
+
+        $this->assertCount(1, $batch);
+        $this->assertCount(count($serial), $batch[0]);
+        foreach ($serial as $i => $s) {
+            $this->assertEquals($s->getId(), $batch[0][$i]->getId());
+        }
+    }
+
+    public function testSearchBatchMultiQueryPreservesOrder(): void
+    {
+        $idx = $this->createBatchIndex();
+        $queries = ["title:rust", "body:python", "title:distributed"];
+        $expectedTopIds = ["doc1", "doc2", "doc3"];
+
+        $batch = $idx->searchBatch($queries, 5);
+        $this->assertCount(count($queries), $batch);
+
+        foreach ($queries as $i => $q) {
+            $this->assertGreaterThanOrEqual(1, count($batch[$i]), "expected at least 1 hit for $q");
+            $this->assertEquals($expectedTopIds[$i], $batch[$i][0]->getId());
+        }
+    }
+
+    public function testSearchBatchWithQueryObjects(): void
+    {
+        $idx = $this->createBatchIndex();
+        $queries = [
+            new Laurus\TermQuery("title", "rust"),
+            new Laurus\TermQuery("body", "python"),
+        ];
+        $batch = $idx->searchBatch($queries, 5);
+
+        $this->assertCount(2, $batch);
+        $this->assertEquals("doc1", $batch[0][0]->getId());
+        $this->assertEquals("doc2", $batch[1][0]->getId());
+    }
+
+    public function testSearchBatchNoMatchReturnsEmptyInnerArray(): void
+    {
+        $idx = $this->createBatchIndex();
+        $queries = ["title:rust", "title:nonexistent_xyz"];
+        $batch = $idx->searchBatch($queries, 5);
+
+        $this->assertCount(2, $batch);
+        $this->assertGreaterThanOrEqual(1, count($batch[0]));
+        $this->assertSame([], $batch[1]);
+    }
+
+    public function testSearchBatchLimitPerQuery(): void
+    {
+        $idx = $this->createBatchIndex();
+        $queries = ["body:programming OR body:data", "body:programming OR body:data"];
+        $batch = $idx->searchBatch($queries, 1);
+
+        $this->assertCount(2, $batch);
+        foreach ($batch as $results) {
+            $this->assertLessThanOrEqual(1, count($results));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Phase 3e of [#648](https://github.com/mosuka/laurus/issues/648) (issue [#720](https://github.com/mosuka/laurus/issues/720)). Exposes the new batched search API in the laurus-php binding so PHP callers can submit B queries in a single call.

This is the **final** binding sub-issue under umbrella [#714](https://github.com/mosuka/laurus/issues/714).

## API

```php
$index->searchBatch(
    array $queries,       // DSL strings, Query objects, or SearchRequest instances
    int $limit = 10,      // applied per query
    int $offset = 0       // applied per query
): array  // array of arrays of SearchResult
```

- Each entry of `$queries` accepts the same kinds of values as `Laurus\Index::search`: a DSL string, a lexical / vector query object, or a `SearchRequest`.
- DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch (matches Python #717 and Ruby #719 polymorphic input).
- Empty input returns `[]` without invoking the engine.
- `results[i]` is the result array for `queries[i]` — order is preserved.
- Existing `Laurus\Index::search` is unchanged.

## Internals

The Rust-side implementation extracts the input PHP array via `Zval::array()`, iterates each entry through the existing `build_request_from_php` helper to build `Vec<laurus::SearchRequest>`, then dispatches via `laurus::Engine::search_batch` (added in PR #721 / sub-issue #715).

## Tests

New `searchBatch` test methods inline in `laurus-php/tests/LaurusTest.php` (6 tests, all passing):

- `testSearchBatchEmpty` — empty array returns `[]`.
- `testSearchBatchSingleQueryMatchesSearch` — single-query batch equals `search()`.
- `testSearchBatchMultiQueryPreservesOrder` — three distinct queries, position-preserving output.
- `testSearchBatchWithQueryObjects` — accepts `TermQuery` etc.
- `testSearchBatchNoMatchReturnsEmptyInnerArray` — no-match query yields `[]`, not a missing entry.
- `testSearchBatchLimitPerQuery` — `$limit` applies per query.

`phpunit tests/LaurusTest.php` reports **42 tests, 86 assertions, 0 failures** (new 6 + existing 36) — no regression.

### Note on test file location

The tests are inlined into `tests/LaurusTest.php` rather than added as a separate `tests/LaurusSearchBatchTest.php` file. The reason: the CI workflow (`.github/workflows/regression.yml:624`) currently runs `phpunit tests/LaurusTest.php` with an explicit file argument, so a separate test file would not be picked up. Moving the laurus-php test invocation to `phpunit tests/` is a separate concern and can be addressed in a follow-up.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-php --all-targets -- -D warnings` clean
- [x] `cargo build --release` builds the extension
- [x] `phpunit tests/LaurusTest.php` — 42 tests, 86 assertions pass
- [x] `npx markdownlint-cli2` on English + Japanese PHP docs — 0 errors

Closes #720
Refs #714
Refs #648