### PR TITLE
perf(server): add client-server gRPC bench for SearchBatch (#727)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "criterion",
  "laurus",
  "prost",
  "serde",

--- a/laurus-server/Cargo.toml
+++ b/laurus-server/Cargo.toml
@@ -48,3 +48,13 @@ pq-fastscan = ["laurus/pq-fastscan"]
 [build-dependencies]
 tonic-build = { workspace = true }
 tonic-prost-build = { workspace = true }
+
+[dev-dependencies]
+criterion = { version = "0.8.2", features = ["async_tokio"] }
+# `net` feature provides `TcpListenerStream`, used by the client-server
+# bench to serve the gRPC service on an ephemeral port (#727).
+tokio-stream = { workspace = true, features = ["net"] }
+
+[[bench]]
+name = "search_batch_grpc_bench"
+harness = false

--- a/laurus-server/benches/search_batch_grpc_bench.rs
+++ b/laurus-server/benches/search_batch_grpc_bench.rs
@@ -1,0 +1,151 @@
+//! Client-server gRPC benchmark for the `SearchBatch` RPC
+//! (issue [#727](https://github.com/mosuka/laurus/issues/727), follow-up to
+//! Phase 3 of [#648](https://github.com/mosuka/laurus/issues/648)).
+//!
+//! The in-process bench added in PR #722
+//! (`laurus/benches/engine_search_batch_bench.rs`) could not observe the
+//! IPC / serialisation savings of batching, because it called the engine
+//! directly. This bench boots the gRPC `SearchService` on an ephemeral
+//! loopback port and compares, from a real `tonic` client:
+//!
+//! - **`search_loop/B`**: `B` sequential `Search` RPCs (B round trips).
+//! - **`search_batch/B`**: one `SearchBatch` RPC carrying `B` queries (1 round trip).
+//!
+//! The difference isolates the per-round-trip fixed cost (HTTP/2 framing +
+//! protobuf encode/decode + request dispatch) that batching amortises.
+//! Over loopback the per-RTT cost is small but measurable; over a real
+//! network it grows with link latency, so the gap widens.
+//!
+//! Run:
+//!
+//! ```sh
+//! cargo bench -p laurus-server --bench search_batch_grpc_bench
+//! ```
+
+use std::hint::black_box;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+use tokio::sync::RwLock;
+use tonic::transport::{Channel, Server};
+
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::{DataValue, Document};
+use laurus::{Engine, FieldOption, Schema};
+
+use laurus_server::proto::laurus::v1::search_service_client::SearchServiceClient;
+use laurus_server::proto::laurus::v1::search_service_server::SearchServiceServer;
+use laurus_server::proto::laurus::v1::{SearchBatchRequest, SearchRequest};
+use laurus_server::service::search::SearchService;
+
+const CORPUS_SIZE: usize = 1_000;
+const TERMS: &[&str] = &[
+    "rust", "vector", "search", "engine", "index", "query", "field", "data", "system", "lexical",
+];
+
+async fn build_engine() -> Engine {
+    let storage =
+        StorageFactory::create(StorageConfig::Memory(Default::default())).expect("storage");
+    let schema = Schema::builder()
+        .add_field("title", FieldOption::Text(Default::default()))
+        .build();
+    let engine = Engine::new(storage, schema).await.expect("engine");
+
+    for i in 0..CORPUS_SIZE {
+        let term = TERMS[i % TERMS.len()];
+        let companion = TERMS[(i + 3) % TERMS.len()];
+        let doc = Document::builder()
+            .add_field(
+                "title",
+                DataValue::Text(format!("{term} {companion} doc{i}")),
+            )
+            .build();
+        engine
+            .put_document(&format!("doc{i}"), doc)
+            .await
+            .expect("put_document");
+    }
+    engine.commit().await.expect("commit");
+    engine
+}
+
+/// Boot the gRPC `SearchService` on an ephemeral loopback port and return
+/// the bound address.
+async fn start_server(engine: Arc<RwLock<Option<Engine>>>) -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let svc = SearchService { engine };
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(SearchServiceServer::new(svc))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("serve");
+    });
+    addr
+}
+
+fn make_query(i: usize) -> SearchRequest {
+    SearchRequest {
+        query: format!("title:{}", TERMS[i % TERMS.len()]),
+        limit: 10,
+        ..Default::default()
+    }
+}
+
+fn bench_search_batch_grpc(c: &mut Criterion) {
+    let rt = Runtime::new().expect("tokio runtime");
+
+    let client = rt.block_on(async {
+        let engine = Arc::new(RwLock::new(Some(build_engine().await)));
+        let addr = start_server(engine).await;
+        // `connect().await` waits until the server is accepting connections,
+        // avoiding a race between spawn and the first RPC.
+        let channel = Channel::from_shared(format!("http://{addr}"))
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        SearchServiceClient::new(channel)
+    });
+
+    let mut group = c.benchmark_group("search_batch_grpc");
+    for b in [1_usize, 4, 16, 64] {
+        group.bench_with_input(BenchmarkId::new("search_loop", b), &b, |bench, &b| {
+            bench.to_async(&rt).iter(|| {
+                let mut client = client.clone();
+                async move {
+                    let mut all = Vec::with_capacity(b);
+                    for i in 0..b {
+                        let resp = client.search(make_query(i)).await.expect("search");
+                        all.push(resp);
+                    }
+                    black_box(all);
+                }
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("search_batch", b), &b, |bench, &b| {
+            bench.to_async(&rt).iter(|| {
+                let mut client = client.clone();
+                async move {
+                    let queries = (0..b).map(make_query).collect();
+                    let resp = client
+                        .search_batch(SearchBatchRequest { queries })
+                        .await
+                        .expect("search_batch");
+                    black_box(resp);
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_search_batch_grpc);
+criterion_main!(benches);

--- a/laurus-server/src/lib.rs
+++ b/laurus-server/src/lib.rs
@@ -16,7 +16,7 @@ mod context;
 pub mod convert;
 pub mod gateway;
 pub mod server;
-mod service;
+pub mod service;
 
 /// Generated protobuf/gRPC code.
 pub mod proto {


### PR DESCRIPTION
## Summary

Follow-up to Phase 3 of the batched-search work (#714 / #648, both closed). Adds a client-server gRPC benchmark that measures the IPC / round-trip amortisation of `SearchBatch` — something the in-process bench from #722 could not observe.

The bench boots `SearchService` on an ephemeral loopback port and, from a real `tonic` client, compares:

- **`search_loop/B`**: `B` sequential `Search` RPCs (B round trips).
- **`search_batch/B`**: one `SearchBatch` RPC carrying `B` queries (1 round trip).

## Results (4-core / 8-thread, loopback, 1000-doc corpus)

| B | `search_loop` (B round trips) | `search_batch` (1 round trip) | speedup |
|---|---|---|---|
| 1 | 41.06 ms | 41.32 ms | 0.99× |
| 4 | 165.14 ms | 42.03 ms | **3.93×** |
| 16 | 659.91 ms | 45.20 ms | **14.6×** |
| 64 | 2642.3 ms | 57.88 ms | **45.6×** |

`search_loop` scales linearly with B (B × per-RTT); `search_batch` stays nearly flat. This **confirms the Phase 3 payoff**: in a client-server topology, batching B queries into one round trip is dramatically faster, in stark contrast to the ~1.0× of the in-process bench (#722) where there is no transport layer to amortise.

### Where the #648 series lands

| Workload | Phase that helps | Measured |
|---|---|---|
| 1 SearchRequest × many query vectors (ColBERT / MaxSim) | Phase 1/2 (VectorStore rayon) | 2.19× @ B=64 |
| Many SearchRequests × 1 vector each, **same process** | (none — shown by #722) | ~1.0× |
| Many SearchRequests × 1 vector each, **client-server** | **Phase 3 (batched API)** | **45.6× @ B=64** |

## ⚠️ Side finding: ~41ms per-RPC latency

A single RPC takes ~41ms on loopback, while the in-process `engine.search` is ~29µs (#722). The 41ms figure matches the classic **Nagle's algorithm + delayed-ACK (40ms)** signature, suggesting `TCP_NODELAY` may not be set on the tonic server/client transport. If so, this is a separate per-RPC latency concern worth investigating (independent of batching).

Caveat: because per-RTT here is inflated by the 40ms delay, the **absolute** speedup is exaggerated. With `TCP_NODELAY` enabled, per-RTT would drop to the hundreds-of-µs range and the absolute numbers would shrink — but the **qualitative** advantage (B round trips → 1) holds in any environment. I recommend filing a follow-up issue to confirm/fix `TCP_NODELAY`.

## Changes

- `laurus-server/benches/search_batch_grpc_bench.rs` (new) — the bench harness.
- `laurus-server/Cargo.toml` — `criterion` (`async_tokio`) + `tokio-stream` `net` feature as dev-deps; `[[bench]]` entry.
- `laurus-server/src/lib.rs` — `mod service` → `pub mod service` so the bench (a separate crate) can construct `SearchService`. Backward-compatible visibility widening; no logic change.

## Test plan

- [x] `cargo bench -p laurus-server --bench search_batch_grpc_bench --no-run` compiles
- [x] `cargo bench -p laurus-server --bench search_batch_grpc_bench` runs (table above)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-server --all-targets -- -D warnings` clean
- [x] `cargo test -p laurus-server` — 28 tests pass (no regression)

Closes #727