### PR TITLE
perf(server): set TCP_NODELAY on SearchBatch bench's accepted sockets (#732)

### DIFF
--- a/laurus-server/benches/search_batch_grpc_bench.rs
+++ b/laurus-server/benches/search_batch_grpc_bench.rs
@@ -73,13 +73,28 @@ async fn build_engine() -> Engine {
 
 /// Boot the gRPC `SearchService` on an ephemeral loopback port and return
 /// the bound address.
+///
+/// Each accepted connection has `TCP_NODELAY` enabled. tonic sets this
+/// automatically on the sockets it accepts via `serve(addr)`, but
+/// `serve_with_incoming` hands tonic a caller-supplied stream, so the
+/// option must be applied here. Without it, small HTTP/2 frames hit
+/// Nagle's algorithm + delayed-ACK and every RPC pays a ~40ms penalty,
+/// which would otherwise dwarf the actual per-query work and distort the
+/// batching comparison (issue #732).
 async fn start_server(engine: Arc<RwLock<Option<Engine>>>) -> SocketAddr {
+    use tokio_stream::StreamExt;
+
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind");
     let addr = listener.local_addr().expect("local_addr");
     let svc = SearchService { engine };
-    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener).map(|conn| {
+        if let Ok(ref stream) = conn {
+            let _ = stream.set_nodelay(true);
+        }
+        conn
+    });
     tokio::spawn(async move {
         Server::builder()
             .add_service(SearchServiceServer::new(svc))


### PR DESCRIPTION
## Summary

Investigates and fixes the ~41ms per-RPC latency surfaced by the #727 client-server bench (issue #732).

**Conclusion: it was a bench artifact, not a production issue.**

## Root cause

The bench from PR #729 boots the server with `Server::builder().serve_with_incoming(TcpListenerStream)`. tonic only applies its default `TCP_NODELAY` to sockets it accepts itself via `serve(addr)`; when handed a caller-supplied incoming stream, the accepted `TcpStream`s keep Nagle's algorithm enabled. Small HTTP/2 frames then hit the 40ms delayed-ACK timeout, so every RPC paid ~41ms (vs ~29µs for the in-process `engine.search`).

The **production** server path (`laurus-server/src/server.rs`, `serve_with_shutdown(addr)`) lets tonic accept the sockets, so `TCP_NODELAY` is already applied — production is unaffected.

## Fix

Enable `set_nodelay(true)` on each accepted connection in the bench's incoming stream.

## Before / after (loopback, 1000-doc corpus)

| B | per-RPC before | per-RPC after |
|---|---|---|
| 1 | 41.06 ms | **0.43 ms** (95× faster) |

Corrected batching comparison after the fix:

| B | `search_loop` | `search_batch` | speedup |
|---|---|---|---|
| 1 | 432 µs | 425 µs | 1.02× |
| 4 | 1.72 ms | 1.53 ms | 1.13× |
| 16 | 8.37 ms | 5.14 ms | 1.63× |
| 64 | 29.82 ms | 19.45 ms | **1.53×** |

## ⚠️ Correction to PR #729

The "45.6× @ B=64" reported in PR #729 was **inflated by the Nagle penalty** (per-RTT was artificially ~41ms). The realistic loopback figure is **~1.5× @ B=64**. The qualitative advantage — collapsing B round trips into 1 — still holds, and grows on real networks where per-RTT cost is in the millisecond range (there the 45.6×-style gap reappears, but driven by genuine network latency rather than a local Nagle stall).

## Test plan

- [x] `cargo bench -p laurus-server --bench search_batch_grpc_bench --no-run` compiles
- [x] `cargo bench -p laurus-server --bench search_batch_grpc_bench` runs (tables above)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus-server --all-targets -- -D warnings` clean

Closes #732