### PR TITLE
perf(engine): add shared LRU embedding cache for query-time embeddings (#678)

### DIFF
--- a/docs/ja/src/laurus/engine.md
+++ b/docs/ja/src/laurus/engine.md
@@ -38,8 +38,9 @@ let schema = Schema::builder()
     .build();
 
 let engine = Engine::builder(storage, schema)
-    .analyzer(my_analyzer)    // オプション: カスタムテキストAnalyzer
-    .embedder(my_embedder)    // オプション: ベクトルEmbedder
+    .analyzer(my_analyzer)            // オプション: カスタムテキストAnalyzer
+    .embedder(my_embedder)            // オプション: ベクトルEmbedder
+    .embedding_cache_capacity(1024)   // オプション: クエリEmbeddingをキャッシュ
     .build()
     .await?;
 ```
@@ -50,7 +51,23 @@ let engine = Engine::builder(storage, schema)
 | :--- | :--- | :--- | :--- |
 | `analyzer()` | `Arc<dyn Analyzer>` | `StandardAnalyzer` | Lexicalフィールド用のテキスト解析パイプライン |
 | `embedder()` | `Arc<dyn Embedder>` | None | Vectorフィールド用のEmbeddingモデル |
+| `embedding_cache_capacity()` | `usize` | None（無効） | 最大 N 件のクエリEmbeddingをLRUキャッシュする |
 | `build()` | -- | -- | Engineを構築（非同期） |
+
+### クエリEmbeddingキャッシュ
+
+`embedding_cache_capacity(n)` は **クエリ時** のEmbeddingに対するLRU
+キャッシュを有効化します（ドキュメント取り込み時のEmbeddingは対象外）。
+Vector / hybrid 検索でクエリペイロードをEmbeddingする際、結果を
+`(field, embedder 名, payload ハッシュ)` をキーにキャッシュし、以降の同一
+クエリで再利用します。DSL パス（例: `content:"cute kitten"`）と事前
+Embedding 済みの `Payloads` パスは同じキャッシュを共有します。
+
+これにより、繰り返しクエリのワークロード（オートコンプリート、ダッシュ
+ボード更新、A/B 評価など）で、ローカル Embedder のモデル推論やリモート
+Embedder のネットワークラウンドトリップを回避できます。デフォルトでは
+無効です。識別可能なクエリの working set に応じてメモリを抑える容量を
+指定してください。
 
 ### Buildライフサイクル
 

--- a/docs/src/laurus/engine.md
+++ b/docs/src/laurus/engine.md
@@ -38,8 +38,9 @@ let schema = Schema::builder()
     .build();
 
 let engine = Engine::builder(storage, schema)
-    .analyzer(my_analyzer)    // optional: custom text analyzer
-    .embedder(my_embedder)    // optional: vector embedder
+    .analyzer(my_analyzer)            // optional: custom text analyzer
+    .embedder(my_embedder)            // optional: vector embedder
+    .embedding_cache_capacity(1024)   // optional: cache query embeddings
     .build()
     .await?;
 ```
@@ -50,7 +51,22 @@ let engine = Engine::builder(storage, schema)
 | :--- | :--- | :--- | :--- |
 | `analyzer()` | `Arc<dyn Analyzer>` | `StandardAnalyzer` | Text analysis pipeline for lexical fields |
 | `embedder()` | `Arc<dyn Embedder>` | None | Embedding model for vector fields |
+| `embedding_cache_capacity()` | `usize` | None (disabled) | Enable an LRU cache of up to N query embeddings |
 | `build()` | -- | -- | Create the Engine (async) |
+
+### Query embedding cache
+
+`embedding_cache_capacity(n)` enables an LRU cache for **query-time**
+embeddings (document-ingestion embedding is unaffected). When a vector or
+hybrid search embeds a query payload, the result is cached keyed by
+`(field, embedder name, payload hash)` and reused on subsequent identical
+queries — both the DSL path (e.g. `content:"cute kitten"`) and the
+pre-embedded `Payloads` path share the same cache.
+
+This avoids repeated model inference for local embedders, or network round
+trips for remote ones, on repeated-query workloads (autocomplete, dashboard
+refreshes, A/B evaluation). It is disabled by default; pick a capacity that
+bounds memory to your working set of distinct queries.
 
 ### Build Lifecycle
 

--- a/laurus/src/embedding.rs
+++ b/laurus/src/embedding.rs
@@ -10,6 +10,10 @@ pub mod embedder;
 // Per-field embedder support (analogous to PerFieldAnalyzer)
 pub mod per_field;
 
+// Query-time embedding cache shared by the engine and the vector query
+// parser (Issue #678).
+pub mod cache;
+
 // Embedder for pre-computed vectors (analogous to NoOpAnalyzer)
 pub mod precomputed;
 

--- a/laurus/src/embedding/cache.rs
+++ b/laurus/src/embedding/cache.rs
@@ -1,0 +1,140 @@
+//! Query-time embedding cache (Issue [#678](https://github.com/mosuka/laurus/issues/678)).
+//!
+//! Vector / hybrid search embeds the query payload before searching. The
+//! same payload (same field, same embedder) produces the same vector, so
+//! re-embedding identical queries wastes work — model inference for local
+//! embedders, or a network round trip for remote ones.
+//!
+//! [`EmbeddingCache`] is a small LRU keyed by [`EmbeddingCacheKey`]. It is
+//! shared (via `Arc`) between the two query-time embedding sites:
+//!
+//! - [`crate::engine::Engine::search`]'s direct `Payloads` resolution, and
+//! - [`crate::vector::query::parser::VectorQueryParser`]'s DSL resolution.
+//!
+//! [`embed_with_cache`] is the single helper both call sites use, so the
+//! cache-lookup / embed / store logic lives in one place.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use lru::LruCache;
+use parking_lot::Mutex;
+
+use crate::embedding::embedder::{EmbedInput, Embedder};
+use crate::embedding::per_field::PerFieldEmbedder;
+use crate::error::Result;
+use crate::vector::core::vector::Vector;
+
+/// Cache key for a query-time embedding.
+///
+/// The payload is stored as a 64-bit hash (see [`hash_embed_input`]) rather
+/// than its full bytes to keep the cache compact. `field` distinguishes
+/// per-field embedders and `embedder` distinguishes different embedder
+/// configurations, so an entry is only reused when the same embedder embeds
+/// the same payload for the same field.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct EmbeddingCacheKey {
+    field: String,
+    embedder: String,
+    payload_hash: u64,
+}
+
+/// Hash an [`EmbedInput`] for use in an [`EmbeddingCacheKey`].
+///
+/// A leading discriminant byte keeps `Text("x")` and `Bytes(b"x", None)`
+/// from colliding.
+fn hash_embed_input(input: &EmbedInput<'_>) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    match input {
+        EmbedInput::Text(t) => {
+            0u8.hash(&mut hasher);
+            t.hash(&mut hasher);
+        }
+        EmbedInput::Bytes(b, mime) => {
+            1u8.hash(&mut hasher);
+            b.hash(&mut hasher);
+            mime.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
+/// A bounded LRU cache of query embeddings.
+///
+/// A `Mutex` (not `RwLock`) is required because [`LruCache::get`] takes
+/// `&mut self` to update recency. Critical sections are tiny (a hash-map
+/// probe); the embedder call always runs outside the lock.
+#[derive(Debug)]
+pub struct EmbeddingCache {
+    inner: Mutex<LruCache<EmbeddingCacheKey, Vector>>,
+}
+
+impl EmbeddingCache {
+    /// Create a cache holding up to `capacity` entries.
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            inner: Mutex::new(LruCache::new(capacity)),
+        }
+    }
+
+    /// Look up a cached embedding, bumping its recency on a hit.
+    fn get(&self, key: &EmbeddingCacheKey) -> Option<Vector> {
+        self.inner.lock().get(key).cloned()
+    }
+
+    /// Insert an embedding, evicting the least-recently-used entry when full.
+    fn put(&self, key: EmbeddingCacheKey, value: Vector) {
+        self.inner.lock().put(key, value);
+    }
+}
+
+/// Embed `input` for `field`, consulting `cache` first when it is `Some`.
+///
+/// On a cache hit the stored [`Vector`] is cloned (an `Arc` bump) and
+/// returned without invoking the embedder. On a miss the embedder runs —
+/// the per-field embedder when `embedder` is a [`PerFieldEmbedder`],
+/// otherwise the default — and the result is stored before being returned.
+/// When `cache` is `None` the embedder always runs.
+///
+/// This is the single embedding entry point shared by the engine's direct
+/// payload path and the vector query parser's DSL path (Issue #678).
+///
+/// # Arguments
+///
+/// * `cache` - The shared embedding cache, or `None` to bypass caching.
+/// * `embedder` - The configured embedder.
+/// * `field` - The vector field the payload targets.
+/// * `input` - The prepared embedding input.
+pub async fn embed_with_cache(
+    cache: Option<&Arc<EmbeddingCache>>,
+    embedder: &Arc<dyn Embedder>,
+    field: &str,
+    input: &EmbedInput<'_>,
+) -> Result<Vector> {
+    let key = cache.map(|_| EmbeddingCacheKey {
+        field: field.to_string(),
+        embedder: embedder.name().to_string(),
+        payload_hash: hash_embed_input(input),
+    });
+
+    if let (Some(cache), Some(key)) = (cache, &key)
+        && let Some(vector) = cache.get(key)
+    {
+        return Ok(vector);
+    }
+
+    let vector = if let Some(pf) = embedder.as_any().downcast_ref::<PerFieldEmbedder>() {
+        pf.embed_field(field, input).await?
+    } else {
+        embedder.embed(input).await?
+    };
+
+    if let (Some(cache), Some(key)) = (cache, key) {
+        cache.put(key, vector.clone());
+    }
+
+    Ok(vector)
+}

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -5,6 +5,7 @@ pub mod type_coercion;
 pub mod type_inference;
 
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -14,6 +15,7 @@ use crate::analysis::analyzer::keyword::KeywordAnalyzer;
 use crate::analysis::analyzer::per_field::PerFieldAnalyzer;
 use crate::analysis::analyzer::standard::StandardAnalyzer;
 use crate::data::Document;
+use crate::embedding::cache::{EmbeddingCache, embed_with_cache};
 use crate::embedding::embedder::Embedder;
 use crate::error::Result;
 use crate::lexical::store::LexicalStore;
@@ -54,6 +56,14 @@ pub struct Engine {
     /// per-field analyzer references. See
     /// [`EngineBuilder::register_runtime_analyzer`].
     runtime_analyzers: HashMap<String, Arc<dyn Analyzer>>,
+    /// Optional LRU cache for query-time embeddings (Issue #678).
+    ///
+    /// `None` when the cache is disabled (the default); enabled via
+    /// [`EngineBuilder::embedding_cache_capacity`]. Shared (via `Arc`) with
+    /// the [`VectorQueryParser`](crate::vector::query::parser::VectorQueryParser)
+    /// built in [`Self::unified_query_parser`], so both the direct
+    /// `Payloads` path and the DSL path hit the same cache.
+    embedding_cache: Option<Arc<EmbeddingCache>>,
 }
 
 use crate::engine::search::{FusionAlgorithm, SearchResult};
@@ -566,6 +576,11 @@ impl Engine {
         let mut vector_parser = crate::vector::query::parser::VectorQueryParser::new(embedder);
         if !vector_fields.is_empty() {
             vector_parser = vector_parser.with_default_fields(vector_fields);
+        }
+        if let Some(cache) = &self.embedding_cache {
+            // Share the engine's cache so DSL queries hit the same entries
+            // as the direct Payloads path (Issue #678).
+            vector_parser = vector_parser.with_embedding_cache(cache.clone());
         }
 
         Ok(
@@ -1299,7 +1314,6 @@ impl Engine {
             {
                 use crate::data::DataValue;
                 use crate::embedding::embedder::EmbedInput;
-                use crate::embedding::per_field::PerFieldEmbedder;
                 use crate::vector::store::request::QueryVector;
 
                 let embedder = self.vector.embedder();
@@ -1318,12 +1332,13 @@ impl Engine {
                     } else {
                         unreachable!()
                     };
-                    let vector =
-                        if let Some(pf) = embedder.as_any().downcast_ref::<PerFieldEmbedder>() {
-                            pf.embed_field(&field_name, &input).await?
-                        } else {
-                            embedder.embed(&input).await?
-                        };
+                    let vector = embed_with_cache(
+                        self.embedding_cache.as_ref(),
+                        &embedder,
+                        &field_name,
+                        &input,
+                    )
+                    .await?;
                     query_vectors.push(QueryVector {
                         vector,
                         weight: payload.weight,
@@ -1594,6 +1609,7 @@ pub struct EngineBuilder {
     analyzer: Option<Arc<dyn Analyzer>>,
     embedder: Option<Arc<dyn Embedder>>,
     runtime_analyzers: HashMap<String, Arc<dyn Analyzer>>,
+    embedding_cache_capacity: Option<usize>,
 }
 
 impl EngineBuilder {
@@ -1605,6 +1621,7 @@ impl EngineBuilder {
             analyzer: None,
             embedder: None,
             runtime_analyzers: HashMap::new(),
+            embedding_cache_capacity: None,
         }
     }
 
@@ -1655,6 +1672,22 @@ impl EngineBuilder {
         self
     }
 
+    /// Enable an LRU cache for query-time embeddings, holding up to
+    /// `capacity` entries (Issue #678).
+    ///
+    /// When set, identical query payloads embedded by the same field /
+    /// embedder are produced only once and reused on subsequent searches,
+    /// avoiding repeated model inference (or network round trips for remote
+    /// embedders). Disabled by default; `capacity = 0` is treated as
+    /// disabled.
+    ///
+    /// The cache only affects query-time embedding in [`Engine::search`];
+    /// document-ingestion embedding is unaffected.
+    pub fn embedding_cache_capacity(mut self, capacity: usize) -> Self {
+        self.embedding_cache_capacity = Some(capacity);
+        self
+    }
+
     /// Build the [`Engine`].
     ///
     /// Creates the lexical store, vector store, and document log (WAL),
@@ -1688,12 +1721,18 @@ impl EngineBuilder {
             document_storage,
         )?);
 
+        let embedding_cache = self
+            .embedding_cache_capacity
+            .and_then(NonZeroUsize::new)
+            .map(|cap| Arc::new(EmbeddingCache::new(cap)));
+
         let engine = Engine {
             schema: RwLock::new(self.schema),
             lexical,
             vector,
             log,
             runtime_analyzers: self.runtime_analyzers,
+            embedding_cache,
         };
 
         engine.recover().await?;

--- a/laurus/src/vector/query/parser.rs
+++ b/laurus/src/vector/query/parser.rs
@@ -12,7 +12,6 @@ use pest_derive::Parser;
 
 use crate::data::DataValue;
 use crate::embedding::embedder::{EmbedInput, Embedder};
-use crate::embedding::per_field::PerFieldEmbedder;
 use crate::error::{LaurusError, Result};
 use crate::vector::core::vector::Vector;
 use crate::vector::store::request::{
@@ -55,6 +54,10 @@ struct VectorQueryStringParser;
 pub struct VectorQueryParser {
     embedder: Arc<dyn Embedder>,
     default_fields: Vec<String>,
+    /// Optional query-time embedding cache, shared with the engine so DSL
+    /// queries reuse embeddings produced by the direct payload path
+    /// (Issue #678). `None` disables caching.
+    embedding_cache: Option<Arc<crate::embedding::cache::EmbeddingCache>>,
 }
 
 impl VectorQueryParser {
@@ -66,7 +69,21 @@ impl VectorQueryParser {
         Self {
             embedder,
             default_fields: Vec::new(),
+            embedding_cache: None,
         }
+    }
+
+    /// Attach a shared query-time embedding cache (Issue #678).
+    ///
+    /// When set, identical query payloads embedded by the same field /
+    /// embedder are produced only once. The cache is normally shared with
+    /// the owning [`Engine`](crate::engine::Engine).
+    pub fn with_embedding_cache(
+        mut self,
+        cache: Arc<crate::embedding::cache::EmbeddingCache>,
+    ) -> Self {
+        self.embedding_cache = Some(cache);
+        self
     }
 
     /// Set a single default field for queries without explicit field prefix.
@@ -132,13 +149,17 @@ impl VectorQueryParser {
         })
     }
 
-    /// Embed input for a specific field, using PerFieldEmbedder if available.
+    /// Embed input for a specific field, consulting the shared embedding
+    /// cache when configured (Issue #678) and using `PerFieldEmbedder`
+    /// routing when the embedder supports it.
     async fn embed_for_field(&self, field: &str, input: &EmbedInput<'_>) -> Result<Vector> {
-        if let Some(pf) = self.embedder.as_any().downcast_ref::<PerFieldEmbedder>() {
-            pf.embed_field(field, input).await
-        } else {
-            self.embedder.embed(input).await
-        }
+        crate::embedding::cache::embed_with_cache(
+            self.embedding_cache.as_ref(),
+            &self.embedder,
+            field,
+            input,
+        )
+        .await
     }
 
     /// Parse a single vector clause (e.g., `content:"cute kitten"^0.8` or `content:python`).

--- a/laurus/tests/engine_embedding_cache_test.rs
+++ b/laurus/tests/engine_embedding_cache_test.rs
@@ -1,0 +1,257 @@
+//! Integration tests for the query-time embedding cache (issue #678).
+//!
+//! These tests use a `CountingEmbedder` that records how many times `embed`
+//! is called. Documents are indexed with pre-computed vectors (so document
+//! ingestion does not embed), leaving the query path as the only source of
+//! `embed` calls. The tests then assert the cache collapses repeated
+//! identical query embeddings into a single `embed` call.
+
+use async_trait::async_trait;
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use laurus::Engine;
+use laurus::LaurusError;
+use laurus::SearchRequestBuilder;
+use laurus::storage::memory::MemoryStorage;
+use laurus::vector::FlatOption;
+use laurus::vector::Vector;
+use laurus::{DataValue, Document};
+use laurus::{EmbedInput, EmbedInputType, Embedder};
+use laurus::{FieldOption, Schema};
+
+/// Embedder that maps known texts to vectors and counts `embed` calls.
+#[derive(Debug)]
+struct CountingEmbedder {
+    vectors: Mutex<HashMap<String, Vec<f32>>>,
+    calls: AtomicUsize,
+}
+
+impl CountingEmbedder {
+    fn new() -> Self {
+        Self {
+            vectors: Mutex::new(HashMap::new()),
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn add(&self, text: &str, vector: Vec<f32>) {
+        self.vectors
+            .lock()
+            .unwrap()
+            .insert(text.to_string(), vector);
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+}
+
+#[async_trait]
+impl Embedder for CountingEmbedder {
+    async fn embed(&self, input: &EmbedInput<'_>) -> std::result::Result<Vector, LaurusError> {
+        match input {
+            EmbedInput::Text(text) => {
+                self.calls.fetch_add(1, Ordering::Relaxed);
+                let map = self.vectors.lock().unwrap();
+                map.get(*text)
+                    .map(|v| Vector::new(v.clone()))
+                    .ok_or_else(|| {
+                        LaurusError::invalid_argument(format!(
+                            "CountingEmbedder: unknown text '{text}'"
+                        ))
+                    })
+            }
+            _ => Err(LaurusError::invalid_argument(
+                "CountingEmbedder only supports text",
+            )),
+        }
+    }
+
+    fn supported_input_types(&self) -> Vec<EmbedInputType> {
+        vec![EmbedInputType::Text]
+    }
+
+    fn supports_text(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> &str {
+        "counting"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+fn schema() -> Schema {
+    Schema::builder()
+        .add_field(
+            "embedding",
+            FieldOption::Flat(FlatOption::default().dimension(3)),
+        )
+        .build()
+}
+
+async fn index_corpus(engine: &Engine) {
+    // Pre-computed vectors → no ingestion embedding, so the only embed calls
+    // come from queries.
+    engine
+        .put_document(
+            "doc1",
+            Document::builder()
+                .add_field("embedding", DataValue::Vector(vec![1.0, 0.0, 0.0]))
+                .build(),
+        )
+        .await
+        .unwrap();
+    engine
+        .put_document(
+            "doc2",
+            Document::builder()
+                .add_field("embedding", DataValue::Vector(vec![0.0, 1.0, 0.0]))
+                .build(),
+        )
+        .await
+        .unwrap();
+    engine.commit().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cache_disabled_by_default() {
+    let storage = Arc::new(MemoryStorage::new(Default::default()));
+    let embedder = Arc::new(CountingEmbedder::new());
+    embedder.add("apple", vec![1.0, 0.0, 0.0]);
+
+    // `Engine::new` (no builder knob) → cache disabled.
+    let engine = Engine::builder(storage, schema())
+        .embedder(embedder.clone())
+        .build()
+        .await
+        .unwrap();
+    index_corpus(&engine).await;
+
+    let base = embedder.call_count();
+    for _ in 0..3 {
+        engine
+            .search(
+                SearchRequestBuilder::new()
+                    .query_dsl("embedding:\"apple\"")
+                    .build(),
+            )
+            .await
+            .unwrap();
+    }
+    // No cache → one embed per search.
+    assert_eq!(embedder.call_count() - base, 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cache_hit_avoids_reembed() {
+    let storage = Arc::new(MemoryStorage::new(Default::default()));
+    let embedder = Arc::new(CountingEmbedder::new());
+    embedder.add("apple", vec![1.0, 0.0, 0.0]);
+
+    let engine = Engine::builder(storage, schema())
+        .embedder(embedder.clone())
+        .embedding_cache_capacity(16)
+        .build()
+        .await
+        .unwrap();
+    index_corpus(&engine).await;
+
+    let base = embedder.call_count();
+    for _ in 0..5 {
+        engine
+            .search(
+                SearchRequestBuilder::new()
+                    .query_dsl("embedding:\"apple\"")
+                    .build(),
+            )
+            .await
+            .unwrap();
+    }
+    // Cache → identical query embedded only once.
+    assert_eq!(embedder.call_count() - base, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cache_distinguishes_payload() {
+    let storage = Arc::new(MemoryStorage::new(Default::default()));
+    let embedder = Arc::new(CountingEmbedder::new());
+    embedder.add("apple", vec![1.0, 0.0, 0.0]);
+    embedder.add("banana", vec![0.0, 1.0, 0.0]);
+
+    let engine = Engine::builder(storage, schema())
+        .embedder(embedder.clone())
+        .embedding_cache_capacity(16)
+        .build()
+        .await
+        .unwrap();
+    index_corpus(&engine).await;
+
+    let base = embedder.call_count();
+    // Two distinct payloads, each searched twice → two embeds total.
+    for _ in 0..2 {
+        engine
+            .search(
+                SearchRequestBuilder::new()
+                    .query_dsl("embedding:\"apple\"")
+                    .build(),
+            )
+            .await
+            .unwrap();
+        engine
+            .search(
+                SearchRequestBuilder::new()
+                    .query_dsl("embedding:\"banana\"")
+                    .build(),
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(embedder.call_count() - base, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cache_hit_returns_correct_results() {
+    let storage = Arc::new(MemoryStorage::new(Default::default()));
+    let embedder = Arc::new(CountingEmbedder::new());
+    embedder.add("apple", vec![1.0, 0.0, 0.0]);
+
+    let engine = Engine::builder(storage, schema())
+        .embedder(embedder.clone())
+        .embedding_cache_capacity(16)
+        .build()
+        .await
+        .unwrap();
+    index_corpus(&engine).await;
+
+    // First search populates the cache; second hits it. Both must return
+    // doc1 (closest to [1,0,0]) as the top result.
+    let first = engine
+        .search(
+            SearchRequestBuilder::new()
+                .query_dsl("embedding:\"apple\"")
+                .build(),
+        )
+        .await
+        .unwrap();
+    let second = engine
+        .search(
+            SearchRequestBuilder::new()
+                .query_dsl("embedding:\"apple\"")
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    assert!(!first.is_empty());
+    assert_eq!(first[0].id, "doc1");
+    assert_eq!(first.len(), second.len());
+    assert_eq!(first[0].id, second[0].id);
+}


### PR DESCRIPTION
## Summary

Round-3 sub-issue #678 (umbrella #536). Vector / hybrid search embeds the query payload on every call, re-running model inference (or a network round trip for remote embedders) for identical queries. This adds an **opt-in LRU cache** for query-time embeddings.

## Key design decision: shared cache across both embed paths

There are **two** query-time embedding sites, and a correct cache must cover both:

1. `Engine::search`'s direct `Payloads` resolution (`engine.rs`).
2. `VectorQueryParser`'s DSL resolution — e.g. `content:"cute kitten"` (`vector/query/parser.rs`). **This is the typical user path.**

So the cache is shared, not engine-local:

- New `embedding::cache` module holds `EmbeddingCache` (a `Mutex<LruCache>` — `LruCache::get` takes `&mut self` to update recency) and a single `embed_with_cache` helper.
- Both sites call `embed_with_cache`, so the lookup / embed / store logic — including `PerFieldEmbedder` routing — lives in one place.
- The engine stores `Option<Arc<EmbeddingCache>>` and shares the `Arc` with the `VectorQueryParser` it builds in `unified_query_parser`, so DSL and `Payloads` queries hit the same entries.

## Cache key

`(field, embedder.name(), payload_hash)`:

- `field` distinguishes per-field embedders.
- `embedder.name()` distinguishes embedder configurations.
- `payload_hash` is a 64-bit hash of the `EmbedInput` (text or bytes + MIME), with a discriminant byte so `Text("x")` and `Bytes(b"x")` don't collide. Storing a hash (not the full payload) keeps the cache compact.

## Configuration

`EngineBuilder::embedding_cache_capacity(n)` enables an LRU of up to `n` entries. **Disabled by default** — `Engine::new` and existing callers are unchanged. Document-ingestion embedding is unaffected (query-time only).

## Tests

New `laurus/tests/engine_embedding_cache_test.rs` (4 tests, `CountingEmbedder` records `embed` calls; documents use pre-computed vectors so only the query path embeds):

- `test_cache_disabled_by_default` — 3 searches → 3 embeds (no cache).
- `test_cache_hit_avoids_reembed` — 5 identical searches → **1 embed**.
- `test_cache_distinguishes_payload` — two payloads × 2 → 2 embeds.
- `test_cache_hit_returns_correct_results` — cache hit returns the same top result as the miss.

These exercise the **DSL path** (`query_dsl("embedding:\"apple\"")`), confirming the shared-cache wiring works end to end.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` clean
- [x] `cargo test -p laurus --test engine_embedding_cache_test` — 4 passed
- [x] `cargo test -p laurus --test hybrid_unification_test --test unified_search_test --test engine_search_batch_test` — no regression
- [x] `npx markdownlint-cli2` on English + Japanese engine docs — 0 errors

Refs #536
Closes #678