### PR TITLE
perf(lexical): O(1) TermQuery::count via doc frequency (#610)

### DIFF
--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -26,6 +26,7 @@ use crate::lexical::query::collector::{
     Collector, CountCollector, TopDocsCollector, TopFieldCollector,
 };
 use crate::lexical::query::parser::LexicalQueryParser;
+use crate::lexical::query::term::TermQuery;
 use crate::lexical::query::{LexicalSearchResults, SearchHit};
 use crate::lexical::reader::LexicalIndexReader;
 use crate::lexical::search::searcher::{
@@ -857,6 +858,30 @@ impl InvertedIndexSearcher {
         // Check if query is empty
         if query.is_empty(self.reader.as_ref())? {
             return Ok(0);
+        }
+
+        // O(1) fast path (Issue #610): a bare `TermQuery` with no score
+        // threshold over a reader with no deletions equals the term's document
+        // frequency, which is already stored in the term dictionary — so the
+        // full posting-list walk the slow path performs is unnecessary.
+        //
+        // All three guards are required for correctness; if any fails we fall
+        // through to the slow path, so the fast path can never miscount:
+        // - `min_score <= 0.0`: with a positive threshold each doc's score must
+        //   be computed, so a count cannot come from `doc_freq` alone.
+        // - `doc_count() == max_doc()`: the term dictionary's `doc_freq` counts
+        //   raw postings, including deleted docs, whereas the slow path filters
+        //   deletions out. The equality holds iff the index has no deletions,
+        //   in which case the two agree. (Conservative: any inequality, for any
+        //   reason, just keeps the slow path.)
+        // - the query is exactly a `TermQuery` (not a Boolean/phrase/etc.).
+        if request.params.min_score <= 0.0
+            && self.reader.doc_count() == self.reader.max_doc()
+            && let Some(term_query) = query.as_any().downcast_ref::<TermQuery>()
+        {
+            return self
+                .reader
+                .term_doc_freq(term_query.field(), term_query.term());
         }
 
         // Use count collector with min_score if specified

--- a/laurus/src/lexical/store.rs
+++ b/laurus/src/lexical/store.rs
@@ -866,6 +866,109 @@ mod tests {
         assert_eq!(count, 0);
     }
 
+    /// Helper: a `LexicalStore` over file storage with `titles` indexed (one
+    /// document per title, internal id = index + 1), committed.
+    fn store_with_titles(temp_dir: &TempDir, titles: &[&str]) -> LexicalStore {
+        let storage = Arc::new(
+            FileStorage::new(temp_dir.path(), FileStorageConfig::new(temp_dir.path())).unwrap(),
+        );
+        let store = LexicalStore::new(storage, LexicalIndexConfig::default()).unwrap();
+        for (i, title) in titles.iter().enumerate() {
+            store
+                .upsert_document(
+                    (i + 1) as u64,
+                    create_test_document(title, "shared body text"),
+                )
+                .unwrap();
+        }
+        store.commit().unwrap();
+        store
+    }
+
+    fn term_count(store: &LexicalStore, field: &str, term: &str) -> u64 {
+        let q = Box::new(TermQuery::new(field, term)) as Box<dyn Query>;
+        store.count(LexicalSearchRequest::new(q)).unwrap()
+    }
+
+    /// Issue #610: `TermQuery::count` over an index with no deletions returns
+    /// the term's document frequency (the O(1) fast path), matching the true
+    /// number of matching documents.
+    #[test]
+    fn test_count_term_query_o1_no_deletions() {
+        let temp_dir = TempDir::new().unwrap();
+        // "world" appears in 3 titles, "hello" in 1.
+        let store = store_with_titles(&temp_dir, &["Hello World", "Goodbye World", "Big World"]);
+        assert_eq!(term_count(&store, "title", "world"), 3);
+        assert_eq!(term_count(&store, "title", "hello"), 1);
+    }
+
+    /// Issue #610: with deletions present the fast path must NOT fire — the
+    /// raw `doc_freq` still counts the deleted posting, so the count must come
+    /// from the deletion-aware slow path. Deleting one of three "world"
+    /// documents yields a count of 2, not 3.
+    #[test]
+    fn test_count_term_query_excludes_deleted() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = store_with_titles(&temp_dir, &["Hello World", "Goodbye World", "Big World"]);
+        assert_eq!(term_count(&store, "title", "world"), 3);
+
+        store.delete_document_by_internal_id(2).unwrap();
+        store.commit().unwrap();
+
+        assert_eq!(
+            term_count(&store, "title", "world"),
+            2,
+            "deleted document must not be counted"
+        );
+    }
+
+    /// Issue #610: a non-`TermQuery` (here a Boolean AND) bypasses the fast
+    /// path and is counted correctly by the slow path.
+    #[test]
+    fn test_count_boolean_query_falls_back() {
+        use crate::lexical::query::boolean::BooleanQueryBuilder;
+
+        let temp_dir = TempDir::new().unwrap();
+        let store = store_with_titles(&temp_dir, &["Hello World", "Goodbye World", "Big World"]);
+
+        // title:world AND title:hello → only "Hello World".
+        let q = Box::new(
+            BooleanQueryBuilder::new()
+                .must(Box::new(TermQuery::new("title", "world")))
+                .must(Box::new(TermQuery::new("title", "hello")))
+                .build(),
+        ) as Box<dyn Query>;
+        let count = store.count(LexicalSearchRequest::new(q)).unwrap();
+        assert_eq!(count, 1);
+    }
+
+    /// Issue #610: a positive `min_score` forces the scoring slow path (the
+    /// fast path cannot honour a score threshold). An unreachable threshold
+    /// yields zero; a zero threshold counts every match.
+    #[test]
+    fn test_count_with_min_score_falls_back() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = store_with_titles(&temp_dir, &["Hello World", "Goodbye World", "Big World"]);
+
+        let all = term_count(&store, "title", "world");
+        assert_eq!(all, 3);
+
+        let q = Box::new(TermQuery::new("title", "world")) as Box<dyn Query>;
+        let thresholded = store
+            .count(LexicalSearchRequest::new(q).min_score(f32::MAX))
+            .unwrap();
+        assert_eq!(thresholded, 0, "no document scores above f32::MAX");
+    }
+
+    /// Issue #610: a term absent from the index counts as zero (handled by the
+    /// `is_empty` guard before the fast path).
+    #[test]
+    fn test_count_nonexistent_term() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = store_with_titles(&temp_dir, &["Hello World"]);
+        assert_eq!(term_count(&store, "title", "nonexistent"), 0);
+    }
+
     #[test]
     fn test_engine_refresh() {
         let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

`InvertedIndexSearcher::count` always built a `CountCollector` and walked **every** matching document — even for a bare `TermQuery`, whose document frequency is already stored in the term dictionary. This adds an O(1) fast path returning `term_doc_freq` directly, matching Lucene's `IndexReader::docFreq(Term)`.

## Changes

- **`lexical/index/inverted/searcher.rs`** — `count` now short-circuits to `reader.term_doc_freq(field, term)` when three guards all hold. If any fails it falls through to the existing collector walk, so the count can never be wrong (the gate is conservative — it only fires when the answer is provably `doc_freq`):
  - `min_score <= 0.0` — a positive threshold needs each doc's score, which `doc_freq` cannot provide.
  - `doc_count() == max_doc()` — true iff the index has no deletions. The raw `doc_freq` counts deleted postings; the slow path filters them out via `filter_deleted_soa`. The two agree only when there are no deletions.
  - the query downcasts to exactly a `TermQuery`.
- **`lexical/store.rs`** — 5 tests through the public `LexicalStore::count`.

No behavior change: counts over an index with deletions, with a `min_score`, or for a non-term query take the unchanged slow path.

## Test plan

- [x] `test_count_term_query_o1_no_deletions` — fast path returns the true count (world×3, hello×1)
- [x] `test_count_term_query_excludes_deleted` — after deleting one of three matches, count is **2** (gate disables the fast path; slow path excludes the deleted doc). **Verified this fails (returns 3) if the deletion gate is removed.**
- [x] `test_count_boolean_query_falls_back` — Boolean AND counted correctly (1)
- [x] `test_count_with_min_score_falls_back` — `min_score = f32::MAX` → 0 (scoring slow path)
- [x] `test_count_nonexistent_term` — 0
- [x] Regression: existing searcher tests (14)
- [x] `cargo fmt --check`, `cargo clippy -p laurus --all-targets -- -D warnings`, wasm `clippy --target wasm32-unknown-unknown -- -D warnings`

## Follow-up

- Boolean-of-all-Filter `count` optimisation (intersection size can't come from `doc_freq` alone, so the win is narrower) — tracked separately if pursued.

Refs #534
Closes #610