### PR TITLE
fix(vector): honor configured n_probe in IVF search (#741)

### DIFF
--- a/laurus/src/vector/index/ivf.rs
+++ b/laurus/src/vector/index/ivf.rs
@@ -259,7 +259,13 @@ impl VectorIndex for IvfIndex {
     fn searcher(&self) -> Result<Box<dyn VectorIndexSearcher>> {
         self.check_closed()?;
         let reader = self.reader()?;
-        Ok(Box::new(IvfSearcher::new(reader)?))
+        // Thread the schema-level `n_probe` from the config into the searcher
+        // so IVF search probes the configured number of clusters instead of
+        // the hard-coded single nearest cluster (Issue #741).
+        Ok(Box::new(IvfSearcher::with_n_probe(
+            reader,
+            self.config.n_probe,
+        )?))
     }
 
     fn embedder(&self) -> Arc<dyn Embedder> {

--- a/laurus/src/vector/index/ivf/searcher.rs
+++ b/laurus/src/vector/index/ivf/searcher.rs
@@ -8,6 +8,16 @@ use crate::vector::reader::VectorIndexReader;
 use crate::vector::search::searcher::VectorIndexSearcher;
 use crate::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryResults};
 
+/// Fallback `n_probe` used when no schema-level value is supplied.
+///
+/// Matches the
+/// [`IvfIndexConfig`](crate::vector::index::config::IvfIndexConfig) default,
+/// so a searcher built via [`IvfSearcher::new`] probes only the single
+/// nearest cluster. Callers that go through the index
+/// [`searcher()`](crate::vector::index::VectorIndex::searcher) factory
+/// instead receive the configured `n_probe` via [`IvfSearcher::with_n_probe`].
+const IVF_DEFAULT_N_PROBE: usize = 1;
+
 /// IVF (Inverted File) vector searcher that performs approximate search by
 /// restricting distance computations to vectors in the `n_probe` nearest
 /// clusters.
@@ -19,7 +29,15 @@ pub struct IvfSearcher {
 }
 
 impl IvfSearcher {
-    /// Create a new IVF searcher with `n_probe = 1`.
+    /// Create a new IVF searcher with the built-in fallback `n_probe`
+    /// ([`IVF_DEFAULT_N_PROBE`] = 1).
+    ///
+    /// Most callers should construct the searcher through the index
+    /// [`searcher()`](crate::vector::index::VectorIndex::searcher) factory,
+    /// which threads the schema-level
+    /// [`IvfIndexConfig::n_probe`](crate::vector::index::config::IvfIndexConfig::n_probe)
+    /// in via [`Self::with_n_probe`]. The number of probed clusters can still
+    /// be adjusted afterwards with [`Self::set_n_probe`].
     ///
     /// # Arguments
     ///
@@ -30,7 +48,32 @@ impl IvfSearcher {
     ///
     /// A new `IvfSearcher` instance.
     pub fn new(index_reader: Arc<dyn VectorIndexReader>) -> Result<Self> {
-        let n_probe = 1;
+        Self::with_n_probe(index_reader, IVF_DEFAULT_N_PROBE)
+    }
+
+    /// Create a new IVF searcher that probes the configured number of
+    /// nearest clusters.
+    ///
+    /// This is the constructor used by the index
+    /// [`searcher()`](crate::vector::index::VectorIndex::searcher) factory so
+    /// the schema-level
+    /// [`IvfIndexConfig::n_probe`](crate::vector::index::config::IvfIndexConfig::n_probe)
+    /// is honoured at search time (Issue
+    /// [#741](https://github.com/mosuka/laurus/issues/741)). Before this, the
+    /// searcher always probed a single cluster regardless of configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `index_reader` - The underlying vector index reader (must be an
+    ///   [`IvfIndexReader`](super::reader::IvfIndexReader)).
+    /// * `n_probe` - Number of nearest clusters to probe during search.
+    ///   Higher values improve recall at the cost of query latency. The
+    ///   effective count is capped at the number of available clusters.
+    ///
+    /// # Returns
+    ///
+    /// A new `IvfSearcher` instance.
+    pub fn with_n_probe(index_reader: Arc<dyn VectorIndexReader>, n_probe: usize) -> Result<Self> {
         Ok(Self {
             index_reader,
             n_probe,
@@ -134,10 +177,12 @@ impl VectorIndexSearcher for IvfSearcher {
         let start = Timer::now();
         let mut results = VectorIndexQueryResults::new();
 
-        // Probe only the n_probe nearest clusters
-        let n_probe = self.n_probe.min(10);
+        // Probe the configured number of nearest clusters (Issue #741).
+        // `probe_clusters` already caps the effective count at the number of
+        // available centroids via `take`, so no artificial upper clamp is
+        // applied here.
         let vector_ids =
-            self.probe_clusters(&request.query, n_probe, request.field_name.as_deref())?;
+            self.probe_clusters(&request.query, self.n_probe, request.field_name.as_deref())?;
 
         // Calculate distances for vectors in the probed clusters.
         // Cache the query-side norm once per search (#414); for Cosine /

--- a/laurus/src/vector/index/ivf/tests.rs
+++ b/laurus/src/vector/index/ivf/tests.rs
@@ -171,3 +171,136 @@ fn test_ivf_optimizer_integration() {
     // So cluster count should change.
     assert_ne!(stats_before.len(), stats_after.len());
 }
+
+/// Build 12 well-separated singleton clusters so that the number of vectors
+/// examined during a search equals the number of probed clusters.
+///
+/// Returns the configured writer plus the storage backing it.
+fn build_singleton_cluster_index(name: &str) -> Arc<MemoryStorage> {
+    let storage = Arc::new(MemoryStorage::default());
+    let config = IvfIndexConfig {
+        dimension: 2,
+        distance_metric: DistanceMetric::Euclidean,
+        n_clusters: 12,
+        // Persisted n_probe; overridden per-test for the direct-searcher path.
+        n_probe: 1,
+        normalize_vectors: false,
+        ..IvfIndexConfig::default()
+    };
+    let mut writer = IvfIndexWriter::with_storage(
+        config,
+        VectorIndexWriterConfig::default(),
+        name,
+        storage.clone(),
+    )
+    .unwrap();
+
+    // One vector per cluster, spaced 1000 units apart so k-means++ assigns
+    // exactly one vector to each of the 12 centroids.
+    let vectors: Vec<(u64, String, Vector)> = (0..12)
+        .map(|i| {
+            (
+                i as u64,
+                "f".to_string(),
+                Vector::new(vec![(i as f32 + 1.0) * 1000.0, 0.0]),
+            )
+        })
+        .collect();
+
+    writer.build(vectors).unwrap();
+    writer.finalize().unwrap();
+    writer.write().unwrap();
+
+    storage
+}
+
+/// The IVF searcher must probe the configured number of clusters, not the
+/// hard-coded single nearest cluster, and must not silently cap `n_probe`
+/// at 10 (Issue #741).
+#[test]
+fn test_ivf_searcher_honors_n_probe() {
+    use crate::vector::index::ivf::reader::IvfIndexReader;
+    use crate::vector::index::ivf::searcher::IvfSearcher;
+    use crate::vector::search::searcher::{VectorIndexQuery, VectorIndexSearcher};
+
+    let storage = build_singleton_cluster_index("test_ivf_honors_n_probe");
+
+    let reader: Arc<dyn crate::vector::reader::VectorIndexReader> = Arc::new(
+        IvfIndexReader::load(
+            storage,
+            "test_ivf_honors_n_probe",
+            DistanceMetric::Euclidean,
+        )
+        .unwrap(),
+    );
+
+    // Sanity: k-means produced one centroid per input vector.
+    let n_centroids = reader
+        .as_any()
+        .downcast_ref::<IvfIndexReader>()
+        .unwrap()
+        .centroids()
+        .len();
+    assert_eq!(n_centroids, 12, "expected one centroid per input vector");
+
+    // Query coincides with the first vector, so the nearest cluster is its
+    // singleton cluster. With singleton clusters, `candidates_examined` is a
+    // direct read-out of the effective `n_probe`. The `n_probe = 11` case also
+    // proves the former `.min(10)` cap is gone.
+    let query = Vector::new(vec![1000.0, 0.0]);
+    for (n_probe, expected) in [(1usize, 1usize), (5, 5), (11, 11), (12, 12)] {
+        let searcher = IvfSearcher::with_n_probe(reader.clone(), n_probe).unwrap();
+        let request = VectorIndexQuery::new(query.clone()).top_k(12);
+        let results = searcher.search(&request).unwrap();
+        assert_eq!(
+            results.candidates_examined, expected,
+            "n_probe = {n_probe} should probe {expected} singleton clusters"
+        );
+    }
+}
+
+/// `IvfIndex::searcher()` must inherit `IvfIndexConfig::n_probe` so that
+/// configured recall is actually applied at search time (Issue #741).
+#[test]
+fn test_ivf_index_searcher_uses_configured_n_probe() {
+    use crate::vector::index::VectorIndex;
+    use crate::vector::index::ivf::IvfIndex;
+    use crate::vector::search::searcher::VectorIndexQuery;
+
+    let storage = Arc::new(MemoryStorage::default());
+    let config = IvfIndexConfig {
+        dimension: 2,
+        distance_metric: DistanceMetric::Euclidean,
+        n_clusters: 12,
+        n_probe: 5,
+        normalize_vectors: false,
+        ..IvfIndexConfig::default()
+    };
+
+    let index = IvfIndex::create(storage, "test_ivf_factory_n_probe", config).unwrap();
+
+    let mut writer = index.writer().unwrap();
+    let vectors: Vec<(u64, String, Vector)> = (0..12)
+        .map(|i| {
+            (
+                i as u64,
+                "f".to_string(),
+                Vector::new(vec![(i as f32 + 1.0) * 1000.0, 0.0]),
+            )
+        })
+        .collect();
+    writer.build(vectors).unwrap();
+    writer.finalize().unwrap();
+    writer.write().unwrap();
+
+    // Before the fix the factory dropped the configured n_probe and always
+    // probed a single cluster (candidates_examined == 1).
+    let searcher = index.searcher().unwrap();
+    let query = Vector::new(vec![1000.0, 0.0]);
+    let request = VectorIndexQuery::new(query).top_k(12);
+    let results = searcher.search(&request).unwrap();
+    assert_eq!(
+        results.candidates_examined, 5,
+        "IvfIndex::searcher() should probe the configured n_probe (5) clusters"
+    );
+}


### PR DESCRIPTION
## Summary

`IvfSearcher` hard-coded `n_probe = 1` and the `IvfIndex` searcher factory never threaded `IvfIndexConfig.n_probe`, so every IVF search probed only the single nearest cluster regardless of the schema's `n_probe`, capping recall. `search()` also silently clamped `n_probe` at 10 (`.min(10)`), so values above 10 could never take effect.

## Changes

- Add `IvfSearcher::with_n_probe(reader, n_probe)` constructor (symmetric with HNSW's `with_default_ef_search`). `new()` now delegates with the `IVF_DEFAULT_N_PROBE = 1` fallback.
- Wire `self.config.n_probe` through the `IvfIndex::searcher()` factory so the configured value is honored at search time.
- Remove the hidden `.min(10)` cap in `search()` — `probe_clusters` already bounds the effective count at the number of available centroids via `take`.

No public API signature changes (`new()` is unchanged). `n_probe` is already passed through the existing schema (`IvfOption.n_probe`), so there is no proto / server / bindings impact — this change simply makes that value take effect.

## Tests

Both tests build 12 well-separated singleton clusters (one vector each), so `candidates_examined` is a direct read-out of the number of probed clusters:

- `test_ivf_searcher_honors_n_probe`: `n_probe = 1/5/11/12` → `candidates_examined = 1/5/11/12`. The `n_probe = 11` case proves the former `.min(10)` cap is gone.
- `test_ivf_index_searcher_uses_configured_n_probe`: an `IvfIndex` built with `config.n_probe = 5` searched via `index.searcher()` → `candidates_examined = 5` (was `1` before the fix). Regression test for the factory wiring.

```
cargo test -p laurus --lib vector::index::ivf  → 13 passed; 0 failed
cargo test -p laurus --lib vector::store       → 3 passed; 0 failed
cargo fmt --check -p laurus                    → OK
cargo clippy -p laurus --lib --tests           → 0 warnings
```

## Acceptance criteria

- [x] The IVF searcher is initialised with the configured `n_probe` (schema / `IvfIndexConfig`).
- [x] Test: a store configured with `n_probe = k` probes k clusters (asserted via `candidates_examined`).
- [x] No change when `n_probe = 1`.

Closes #741