### PR TITLE
fix(vector): honor VectorSearchParams.overfetch in VectorStore::search (#675)

### DIFF
--- a/docs/ja/src/concepts/search/vector_search.md
+++ b/docs/ja/src/concepts/search/vector_search.md
@@ -70,7 +70,7 @@ let request = VectorSearchRequestBuilder::new()
 | `limit(n)` | 結果の最大件数（デフォルト: 10） |
 | `score_mode(VectorScoreMode)` | スコア結合モード（`WeightedSum`、`MaxSim`、`LateInteraction`） |
 | `min_score(f32)` | 最小スコア閾値（デフォルト: 0.0） |
-| `overfetch(f32)` | 結果品質向上のためのオーバーフェッチ係数（デフォルト: 1.0） |
+| `overfetch(f32)` | オーバーフェッチ係数（デフォルト: 2.0、#675）。各クエリは `ceil(limit × overfetch)` 件の候補を取得し、融合後に `limit` へ切り詰める。`<= 1.0` で無効化 |
 | `build()` | `VectorSearchRequest` を構築 |
 
 ## マルチフィールド Vector 検索

--- a/laurus/src/vector/search/searcher.rs
+++ b/laurus/src/vector/search/searcher.rs
@@ -457,8 +457,16 @@ fn default_query_limit() -> usize {
     10
 }
 
+/// Default overfetch factor (Issue #675).
+///
+/// `2.0` matches the historical hardcoded behaviour (`top_k = limit * 2`) that
+/// [`VectorStore::search`](crate::vector::store::VectorStore::search) applied
+/// before the factor was honoured, and the documented gRPC default. Keeping the
+/// declared default at `2.0` means callers that do not set `overfetch`
+/// (including the engine, which passes `2.0` explicitly) see no behaviour
+/// change now that the factor drives `top_k`.
 fn default_overfetch() -> f32 {
-    1.0
+    2.0
 }
 
 /// Parameters for vector search operations.
@@ -478,7 +486,13 @@ pub struct VectorSearchParams {
     /// How to combine scores from multiple query vectors.
     #[serde(default)]
     pub score_mode: crate::vector::store::request::VectorScoreMode,
-    /// Overfetch factor for better result quality.
+    /// Overfetch factor for better result quality (Issue #675).
+    ///
+    /// Each per-field index query fetches `ceil(limit * overfetch)` candidates
+    /// (see [`Self::overfetch_top_k`]) so the multi-vector score-mode merge has
+    /// headroom before the final truncation to [`limit`](Self::limit). A factor
+    /// `<= 1.0` (or non-finite) disables overfetch. Defaults to `2.0`
+    /// ([`default_overfetch`]).
     #[serde(default = "default_overfetch")]
     pub overfetch: f32,
     /// Minimum score threshold. Results below this score are filtered out.
@@ -517,6 +531,34 @@ impl Default for VectorSearchParams {
             allowed_ids: None,
             rerank_factor: None,
             ef_search: None,
+        }
+    }
+}
+
+impl VectorSearchParams {
+    /// Resolve the per-field index `top_k` (the overfetch candidate pool) from
+    /// [`limit`](Self::limit) and [`overfetch`](Self::overfetch) (Issue #675).
+    ///
+    /// Overfetching pulls more candidates than `limit` so the multi-vector
+    /// score-mode merge in
+    /// [`VectorStore::search`](crate::vector::store::VectorStore::search) has
+    /// headroom before the final truncation to `limit`. An `overfetch` factor
+    /// `f` yields `ceil(limit * f)` candidates; a factor `<= 1.0` or non-finite
+    /// disables overfetch (`top_k == limit`), and the result never drops below
+    /// `limit`. Before this was honoured a hardcoded `2x` was always used.
+    ///
+    /// # Returns
+    ///
+    /// The number of candidates each per-field index query should request.
+    pub(crate) fn overfetch_top_k(&self) -> usize {
+        if !self.overfetch.is_finite() || self.overfetch <= 1.0 {
+            return self.limit;
+        }
+        let scaled = (self.limit as f32 * self.overfetch).ceil();
+        if scaled >= usize::MAX as f32 {
+            usize::MAX
+        } else {
+            (scaled as usize).max(self.limit)
         }
     }
 }
@@ -619,5 +661,52 @@ mod tests {
             });
             assert!(result.is_err(), "n = {n}");
         }
+    }
+
+    fn params_with_overfetch(limit: usize, overfetch: f32) -> VectorSearchParams {
+        VectorSearchParams {
+            limit,
+            overfetch,
+            ..Default::default()
+        }
+    }
+
+    /// `overfetch_top_k` scales `limit` by the factor with a ceiling, honouring
+    /// the user-supplied value (Issue #675).
+    #[test]
+    fn overfetch_top_k_scales_limit() {
+        assert_eq!(params_with_overfetch(10, 2.0).overfetch_top_k(), 20);
+        assert_eq!(params_with_overfetch(10, 3.0).overfetch_top_k(), 30);
+        // Non-integer factors round up so the pool never undershoots.
+        assert_eq!(params_with_overfetch(10, 1.5).overfetch_top_k(), 15);
+        assert_eq!(params_with_overfetch(3, 1.5).overfetch_top_k(), 5);
+    }
+
+    /// The default factor (`2.0`) reproduces the historical `limit * 2`
+    /// candidate pool, so callers that never set `overfetch` are unaffected.
+    #[test]
+    fn overfetch_top_k_default_is_2x() {
+        assert_eq!(VectorSearchParams::default().overfetch, 2.0);
+        assert_eq!(
+            params_with_overfetch(7, default_overfetch()).overfetch_top_k(),
+            14
+        );
+    }
+
+    /// Factors `<= 1.0` (and degenerate values) disable overfetch — `top_k`
+    /// equals `limit` and never drops below it.
+    #[test]
+    fn overfetch_top_k_clamps_low_and_degenerate_factors() {
+        assert_eq!(params_with_overfetch(10, 1.0).overfetch_top_k(), 10);
+        assert_eq!(params_with_overfetch(10, 0.5).overfetch_top_k(), 10);
+        assert_eq!(params_with_overfetch(10, 0.0).overfetch_top_k(), 10);
+        assert_eq!(params_with_overfetch(10, -1.0).overfetch_top_k(), 10);
+        assert_eq!(params_with_overfetch(10, f32::NAN).overfetch_top_k(), 10);
+        assert_eq!(
+            params_with_overfetch(10, f32::INFINITY).overfetch_top_k(),
+            10
+        );
+        // limit == 0 stays 0 regardless of factor.
+        assert_eq!(params_with_overfetch(0, 4.0).overfetch_top_k(), 0);
     }
 }

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -412,12 +412,17 @@ impl VectorStore {
     /// resolved against the reader's field names). When neither is set, all
     /// indexed fields are searched (the default).
     ///
-    /// **Note:** The following request fields are currently **ignored** by this
+    /// The per-field candidate pool is widened by
+    /// [`overfetch`](crate::vector::search::searcher::VectorSearchParams::overfetch)
+    /// via
+    /// [`overfetch_top_k`](crate::vector::search::searcher::VectorSearchParams::overfetch_top_k)
+    /// (Issue #675) so the score-mode merge has headroom before the final
+    /// truncation to `limit`.
+    ///
+    /// **Note:** The following request field is currently **ignored** by this
     /// implementation:
     /// - `VectorSearchQuery::Payloads` -- callers must embed payloads into
     ///   vectors before calling this method.
-    /// - [`overfetch`](crate::vector::search::searcher::VectorSearchParams::overfetch)
-    ///   -- a hardcoded 2x overfetch (`limit * 2`) is used instead.
     ///
     /// # Arguments
     ///
@@ -563,7 +568,7 @@ impl VectorStore {
             );
             let make = |field: Option<&str>| {
                 let mut q = VectorIndexQuery::new(qv.vector.clone())
-                    .top_k(request.params.limit.saturating_mul(2));
+                    .top_k(request.params.overfetch_top_k());
                 if let Some(field) = field {
                     q = q.field_name(field.to_string());
                 }

--- a/laurus/tests/vector_overfetch_test.rs
+++ b/laurus/tests/vector_overfetch_test.rs
@@ -1,0 +1,156 @@
+//! Integration test for the `overfetch` factor (Issue #675).
+//!
+//! `VectorStore::search` previously ignored `VectorSearchParams.overfetch` and
+//! always fetched `limit * 2` candidates per query vector. This test proves the
+//! factor is now honoured end-to-end: a document that is only the *second*
+//! nearest to each of two query vectors can only surface in the fused top-`k`
+//! when `overfetch` widens the per-query candidate pool past `limit`.
+//!
+//! A Flat index with the Cosine metric is used so the ranking is exact and
+//! deterministic (unlike the randomised HNSW graph).
+
+use async_trait::async_trait;
+use laurus::lexical::LexicalIndexConfig;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::Vector;
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::field::FlatOption;
+use laurus::vector::store::config::VectorFieldConfig;
+use laurus::vector::store::request::{
+    QueryVector, VectorScoreMode, VectorSearchParams, VectorSearchRequest,
+};
+use laurus::vector::{FieldOption, VectorIndexConfig};
+use laurus::{DataValue, Document};
+use laurus::{EmbedInput, EmbedInputType, Embedder};
+use laurus::{LaurusError, Result};
+use std::any::Any;
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct MockEmbedder {
+    dimension: usize,
+}
+
+#[async_trait]
+impl Embedder for MockEmbedder {
+    async fn embed(&self, input: &EmbedInput<'_>) -> Result<Vector> {
+        match input {
+            EmbedInput::Text(_) => Ok(Vector::new(vec![0.0; self.dimension])),
+            _ => Err(LaurusError::invalid_argument(
+                "this embedder only supports text input",
+            )),
+        }
+    }
+    fn supported_input_types(&self) -> Vec<EmbedInputType> {
+        vec![EmbedInputType::Text]
+    }
+    fn name(&self) -> &str {
+        "mock"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Build a Flat / Cosine store holding three 2-D documents:
+/// - doc 1 = A = (1, 0)
+/// - doc 2 = B = (0, 1)
+/// - doc 3 = D = (1, 1) (the diagonal — second-nearest to both queries below)
+async fn setup_store() -> laurus::vector::VectorStore {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut field_configs = std::collections::HashMap::new();
+    field_configs.insert(
+        "v".to_string(),
+        VectorFieldConfig {
+            vector: Some(FieldOption::Flat(FlatOption {
+                dimension: 2,
+                distance: DistanceMetric::Cosine,
+                ..Default::default()
+            })),
+            lexical: None,
+        },
+    );
+    let config = VectorIndexConfig {
+        fields: field_configs,
+        embedder: Arc::new(MockEmbedder { dimension: 2 }),
+        default_fields: vec!["v".to_string()],
+        metadata: std::collections::HashMap::new(),
+        deletion_config: laurus::DeletionConfig::default(),
+        shard_id: 0,
+        metadata_config: LexicalIndexConfig::default(),
+    };
+    let store = laurus::vector::VectorStore::new(storage, config).unwrap();
+
+    for (id, vec) in [
+        (1u64, vec![1.0, 0.0]),
+        (2, vec![0.0, 1.0]),
+        (3, vec![1.0, 1.0]),
+    ] {
+        let doc = Document::builder()
+            .add_field("v", DataValue::Vector(vec))
+            .build();
+        store.upsert_document_by_internal_id(id, doc).await.unwrap();
+    }
+    store.commit().await.unwrap();
+    store
+}
+
+/// Two query vectors close to A and B respectively. The diagonal D is the
+/// second-nearest to each, so it is excluded from a `top_k = 1` pool but
+/// included from a `top_k = 2` pool.
+fn two_queries() -> Vec<QueryVector> {
+    // ~10 degrees off the x-axis (near A) and ~10 degrees off the y-axis
+    // (near B). Cosine similarities to {A, D, B}: roughly {0.98, 0.82, 0.17}.
+    let q1 = vec![(10f32).to_radians().cos(), (10f32).to_radians().sin()];
+    let q2 = vec![(80f32).to_radians().cos(), (80f32).to_radians().sin()];
+    vec![
+        QueryVector {
+            vector: Vector::new(q1),
+            weight: 1.0,
+            fields: None,
+        },
+        QueryVector {
+            vector: Vector::new(q2),
+            weight: 1.0,
+            fields: None,
+        },
+    ]
+}
+
+fn request(overfetch: f32) -> VectorSearchRequest {
+    VectorSearchRequest {
+        query: laurus::vector::VectorSearchQuery::Vectors(two_queries()),
+        params: VectorSearchParams {
+            limit: 1,
+            score_mode: VectorScoreMode::WeightedSum,
+            overfetch,
+            ..Default::default()
+        },
+    }
+}
+
+/// With `overfetch = 1.0` each query fetches only its single nearest doc
+/// (A for q1, B for q2), so the diagonal D never enters the fused pool and the
+/// top hit is the specialist A. With `overfetch = 2.0` each query also fetches
+/// its second-nearest (D), whose summed score across both queries wins the top
+/// slot. The differing winners prove the factor is honoured.
+#[tokio::test]
+async fn overfetch_controls_fused_candidate_pool() {
+    let store = setup_store().await;
+
+    let narrow = store.search(request(1.0)).unwrap();
+    assert_eq!(narrow.hits.len(), 1, "limit = 1 must return one hit");
+    assert_ne!(
+        narrow.hits[0].doc_id, 3,
+        "with overfetch = 1.0 the diagonal D (doc 3) is outside each query's \
+         top_k = 1 pool and must not surface"
+    );
+
+    let wide = store.search(request(2.0)).unwrap();
+    assert_eq!(wide.hits.len(), 1, "limit = 1 must return one hit");
+    assert_eq!(
+        wide.hits[0].doc_id, 3,
+        "with overfetch = 2.0 the diagonal D (doc 3) enters both queries' \
+         top_k = 2 pool and wins the fused top slot"
+    );
+}


### PR DESCRIPTION
## Summary

`VectorStore::search` hardcoded the per-query candidate pool at `limit * 2` and
silently ignored the user-supplied `VectorSearchParams.overfetch` factor. This
resolves `top_k` through a new `VectorSearchParams::overfetch_top_k()`:

- `ceil(limit * overfetch)`, saturating at `usize::MAX`, never below `limit`;
- `overfetch <= 1.0` or non-finite disables overfetch (`top_k == limit`).

### Why the default changes 1.0 → 2.0 (and why behaviour is unchanged)

`default_overfetch()` was `1.0`, but the runtime always used a hardcoded `2x`,
so the declared default was dead. Raising it to `2.0` aligns the declared
default with the historical effective behaviour and the documented gRPC default.
The engine (`build_vector_request`) already passes `overfetch: 2.0` explicitly,
so:

- engine / server / language bindings: unchanged (engine overrides; bindings do
  not expose `overfetch`);
- direct `VectorStore::search` callers using the default: still `2x`;
- direct callers that explicitly set `overfetch`: now honoured — the fix.

## Scope

The issue's "Where" is `store.rs`, so this fixes `VectorStore::search`. The
engine hardcoding `overfetch: 2.0` (not exposing it to its own callers) and the
gateway's `unwrap_or(0.0)` are separate layers and out of scope here — noted as
possible follow-ups.

## Why overfetch is tested via multi-query fusion

For a single query, `overfetch` only widens a candidate pool that is then
truncated to `limit`, so the top-`limit` results are identical regardless of the
factor — no observable effect. Overfetch matters for **multi-vector fusion**,
where a document that is not any single query's top hit but ranks well across
several can surface only when the per-query pool is widened (this is the "2x
overfetch to improve fusion quality" the engine relies on).

## Tests

- Unit (`overfetch_top_k`): scaling, default-is-2x, and clamping of low /
  non-finite factors.
- Integration (`vector_overfetch_test.rs`, Flat + Cosine, deterministic): docs
  A=(1,0), B=(0,1), D=(1,1); two queries near A and near B; `limit = 1`. With
  `overfetch = 1.0` each query's `top_k = 1` pool excludes the diagonal D, so the
  top hit is the specialist A; with `overfetch = 2.0` the `top_k = 2` pool
  includes D, whose summed score wins the top slot. The differing winners prove
  the factor is honoured end-to-end. Flat is used (not HNSW) for exact,
  deterministic ranking.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -p laurus --all-targets -- -D warnings`: no warnings
- `cargo test -p laurus --lib vector::`: 228 passed (incl. 3 new)
- `cargo test -p laurus --test vector_overfetch_test`: 1 passed
- Regression: `vector_multi_query_test` (3), `vector_field_routing_test` (5),
  `vector_search_batch_test` (4), `unified_filter_test` (3) — all pass
- `markdownlint-cli2` (changed doc): 0 errors

## Docs

- `store.rs` doc note updated (overfetch is now honoured, not ignored).
- `VectorSearchParams.overfetch` field doc + `overfetch_top_k` doc.
- JA concept doc default corrected `1.0 → 2.0` (gRPC docs already said 2.0).

Closes #675
Refs #536
