### PR TITLE
perf(vector): batch query-payload embedding in Engine and parser (#671)

### DIFF
--- a/docs/ja/src/laurus/engine.md
+++ b/docs/ja/src/laurus/engine.md
@@ -69,6 +69,11 @@ Embedder のネットワークラウンドトリップを回避できます。�
 無効です。識別可能なクエリの working set に応じてメモリを抑える容量を
 指定してください。
 
+1 つのクエリ内では、その全 payload を 1 回の `Embedder::embed_batch`
+呼び出しでEmbedding します（キャッシュミスのみ、`PerFieldEmbedder` では
+field ごとにグルーピング）。これにより、バッチ対応 Embedder ではマルチ
+ベクトルクエリでも payload ごとではなく 1 往復で済みます（Issue #671）。
+
 ### Buildライフサイクル
 
 `build()` が呼び出されると、以下の処理が実行されます。

--- a/docs/src/laurus/engine.md
+++ b/docs/src/laurus/engine.md
@@ -68,6 +68,11 @@ trips for remote ones, on repeated-query workloads (autocomplete, dashboard
 refreshes, A/B evaluation). It is disabled by default; pick a capacity that
 bounds memory to your working set of distinct queries.
 
+Within a single query, all of its payloads are embedded in one
+`Embedder::embed_batch` call (cache misses only, grouped per field for
+`PerFieldEmbedder`), so a batch-capable embedder pays one round trip for a
+multi-vector query instead of one per payload (Issue #671).
+
 ### Build Lifecycle
 
 When `build()` is called, the following steps occur:

--- a/laurus/src/embedding/cache.rs
+++ b/laurus/src/embedding/cache.rs
@@ -11,8 +11,11 @@
 //! - [`crate::engine::Engine::search`]'s direct `Payloads` resolution, and
 //! - [`crate::vector::query::parser::VectorQueryParser`]'s DSL resolution.
 //!
-//! [`embed_with_cache`] is the single helper both call sites use, so the
-//! cache-lookup / embed / store logic lives in one place.
+//! [`embed_with_cache`] is the single-input helper and
+//! [`embed_batch_with_cache`] its batch counterpart (Issue #671); both call
+//! sites embed all of a query's payloads through the batch helper so the
+//! cache-lookup / embed / store logic lives in one place and a batch-capable
+//! embedder pays one round trip instead of one per payload.
 
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -137,4 +140,283 @@ pub async fn embed_with_cache(
     }
 
     Ok(vector)
+}
+
+/// Batch variant of [`embed_with_cache`] (Issue #671).
+///
+/// Embeds many `(field, input)` pairs together so an embedder with a real
+/// batch API (e.g. a remote model that serves many inputs per request, like
+/// [`OpenAIEmbedder`](crate::embedding::openai_embedder::OpenAIEmbedder)) pays
+/// one round trip instead of one per payload. Replaces the per-payload
+/// `embed_with_cache` loops in the engine's `Payloads` fallback and the
+/// vector query parser.
+///
+/// Cache semantics match [`embed_with_cache`] exactly: each item is looked up
+/// by `(field, embedder.name(), hash(input))`, only misses are embedded, and
+/// fresh embeddings are stored. Per-field routing is preserved: when
+/// `embedder` is a [`PerFieldEmbedder`] the misses are grouped by field and
+/// each group is dispatched to that field's embedder before calling
+/// [`Embedder::embed_batch`]; otherwise all misses are embedded in one call.
+///
+/// # Arguments
+///
+/// * `cache` - The shared embedding cache, or `None` to bypass caching.
+/// * `embedder` - The configured embedder.
+/// * `items` - The `(field, input)` pairs to embed.
+///
+/// # Returns
+///
+/// One [`Vector`] per item, in the same order as `items`.
+///
+/// # Errors
+///
+/// Returns an error if any underlying [`Embedder::embed_batch`] call fails, or
+/// (defensively) if an embedder returns fewer vectors than inputs.
+pub async fn embed_batch_with_cache(
+    cache: Option<&Arc<EmbeddingCache>>,
+    embedder: &Arc<dyn Embedder>,
+    items: &[(String, EmbedInput<'_>)],
+) -> Result<Vec<Vector>> {
+    // Per-item cache keys (`None` when caching is disabled). Computed once and
+    // reused for both the lookup and the store so the keying matches
+    // `embed_with_cache`.
+    let keys: Vec<Option<EmbeddingCacheKey>> = items
+        .iter()
+        .map(|(field, input)| {
+            cache.map(|_| EmbeddingCacheKey {
+                field: field.clone(),
+                embedder: embedder.name().to_string(),
+                payload_hash: hash_embed_input(input),
+            })
+        })
+        .collect();
+
+    // Fill cache hits immediately; collect the indices that still need work.
+    let mut out: Vec<Option<Vector>> = vec![None; items.len()];
+    let mut misses: Vec<usize> = Vec::new();
+    for (i, key) in keys.iter().enumerate() {
+        if let (Some(cache), Some(key)) = (cache, key)
+            && let Some(vector) = cache.get(key)
+        {
+            out[i] = Some(vector);
+        } else {
+            misses.push(i);
+        }
+    }
+
+    // Group misses so each batch call goes to the right embedder. Field only
+    // affects routing for a `PerFieldEmbedder`; a field-agnostic embedder
+    // takes every miss in a single batch. Grouping is order-stable so the
+    // first occurrence of each field keeps its position.
+    let per_field = embedder.as_any().downcast_ref::<PerFieldEmbedder>();
+    let mut groups: Vec<(String, Vec<usize>)> = Vec::new();
+    if per_field.is_some() {
+        for &i in &misses {
+            let field = &items[i].0;
+            if let Some((_, idxs)) = groups.iter_mut().find(|(f, _)| f == field) {
+                idxs.push(i);
+            } else {
+                groups.push((field.clone(), vec![i]));
+            }
+        }
+    } else if !misses.is_empty() {
+        groups.push((String::new(), misses));
+    }
+
+    for (field, idxs) in groups {
+        let inputs: Vec<EmbedInput<'_>> = idxs.iter().map(|&i| items[i].1.clone()).collect();
+        let group_embedder = match per_field {
+            Some(pf) => pf.get_embedder(&field),
+            None => embedder.clone(),
+        };
+        let vectors = group_embedder.embed_batch(&inputs).await?;
+        for (&i, vector) in idxs.iter().zip(vectors) {
+            if let (Some(cache), Some(key)) = (cache, &keys[i]) {
+                cache.put(key.clone(), vector.clone());
+            }
+            out[i] = Some(vector);
+        }
+    }
+
+    // Every slot is filled by construction; the error guards against an
+    // embedder returning fewer vectors than inputs rather than panicking.
+    out.into_iter()
+        .map(|v| {
+            v.ok_or_else(|| {
+                crate::error::LaurusError::internal(
+                    "embed_batch_with_cache: embedder returned fewer vectors than inputs",
+                )
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embedding::embedder::EmbedInputType;
+    use async_trait::async_trait;
+    use std::any::Any;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Encode an input as a single deterministic scalar so a returned vector
+    /// can be traced back to the input that produced it (order assertions).
+    fn seed(input: &EmbedInput<'_>) -> f32 {
+        match input {
+            EmbedInput::Text(t) => t.bytes().map(|b| b as u32).sum::<u32>() as f32,
+            EmbedInput::Bytes(b, _) => b.iter().map(|x| *x as u32).sum::<u32>() as f32,
+        }
+    }
+
+    /// Embedder that counts `embed` / `embed_batch` calls and how many inputs
+    /// the batch path saw, so tests can assert batching and routing.
+    #[derive(Debug)]
+    struct CountingEmbedder {
+        name: String,
+        embed_calls: AtomicUsize,
+        embed_batch_calls: AtomicUsize,
+        inputs_seen: AtomicUsize,
+    }
+
+    impl CountingEmbedder {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                embed_calls: AtomicUsize::new(0),
+                embed_batch_calls: AtomicUsize::new(0),
+                inputs_seen: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Embedder for CountingEmbedder {
+        async fn embed(&self, input: &EmbedInput<'_>) -> Result<Vector> {
+            self.embed_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Vector::new(vec![seed(input)]))
+        }
+        async fn embed_batch(&self, inputs: &[EmbedInput<'_>]) -> Result<Vec<Vector>> {
+            self.embed_batch_calls.fetch_add(1, Ordering::SeqCst);
+            self.inputs_seen.fetch_add(inputs.len(), Ordering::SeqCst);
+            Ok(inputs.iter().map(|i| Vector::new(vec![seed(i)])).collect())
+        }
+        fn supported_input_types(&self) -> Vec<EmbedInputType> {
+            vec![EmbedInputType::Text]
+        }
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    fn cache(cap: usize) -> Arc<EmbeddingCache> {
+        Arc::new(EmbeddingCache::new(NonZeroUsize::new(cap).unwrap()))
+    }
+
+    fn item(field: &str, text: &'static str) -> (String, EmbedInput<'static>) {
+        (field.to_string(), EmbedInput::Text(text))
+    }
+
+    /// One `embed_batch` call replaces the per-item `embed` loop, and results
+    /// come back in input order.
+    #[tokio::test]
+    async fn batches_in_one_call_and_preserves_order() {
+        let counter = Arc::new(CountingEmbedder::new("m"));
+        let embedder: Arc<dyn Embedder> = counter.clone();
+        let items = [item("f", "a"), item("f", "bb"), item("f", "ccc")];
+
+        let got = embed_batch_with_cache(None, &embedder, &items)
+            .await
+            .unwrap();
+
+        assert_eq!(counter.embed_batch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.embed_calls.load(Ordering::SeqCst), 0);
+        let expected: Vec<f32> = items.iter().map(|(_, i)| seed(i)).collect();
+        let actual: Vec<f32> = got.iter().map(|v| v.data[0]).collect();
+        assert_eq!(actual, expected, "results must be in input order");
+    }
+
+    /// Cached items are not re-embedded; only fresh items reach `embed_batch`.
+    #[tokio::test]
+    async fn reuses_cached_and_only_embeds_misses() {
+        let counter = Arc::new(CountingEmbedder::new("m"));
+        let embedder: Arc<dyn Embedder> = counter.clone();
+        let cache = cache(16);
+
+        let first = [item("f", "a"), item("f", "b")];
+        embed_batch_with_cache(Some(&cache), &embedder, &first)
+            .await
+            .unwrap();
+        assert_eq!(counter.embed_batch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.inputs_seen.load(Ordering::SeqCst), 2);
+
+        // Identical second call: all hits, no new embedding.
+        embed_batch_with_cache(Some(&cache), &embedder, &first)
+            .await
+            .unwrap();
+        assert_eq!(counter.embed_batch_calls.load(Ordering::SeqCst), 1);
+
+        // Mixed: "a" hits, "x" misses -> one more batch call over just "x".
+        let mixed = [item("f", "a"), item("f", "x")];
+        let got = embed_batch_with_cache(Some(&cache), &embedder, &mixed)
+            .await
+            .unwrap();
+        assert_eq!(counter.embed_batch_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            counter.inputs_seen.load(Ordering::SeqCst),
+            3,
+            "only the miss is embedded"
+        );
+        assert_eq!(got[0].data[0], seed(&EmbedInput::Text("a")));
+        assert_eq!(got[1].data[0], seed(&EmbedInput::Text("x")));
+    }
+
+    /// A `PerFieldEmbedder` routes each field's misses to that field's embedder
+    /// (grouped into one batch call per field), never the default.
+    #[tokio::test]
+    async fn routes_misses_per_field() {
+        let title = Arc::new(CountingEmbedder::new("title"));
+        let body = Arc::new(CountingEmbedder::new("body"));
+        let default = Arc::new(CountingEmbedder::new("default"));
+
+        let pf = PerFieldEmbedder::new(default.clone() as Arc<dyn Embedder>);
+        pf.add_embedder("title", title.clone() as Arc<dyn Embedder>);
+        pf.add_embedder("body", body.clone() as Arc<dyn Embedder>);
+        let embedder: Arc<dyn Embedder> = Arc::new(pf);
+
+        // Interleaved fields exercise the order-stable grouping.
+        let items = [item("title", "a"), item("body", "b"), item("title", "c")];
+        let got = embed_batch_with_cache(None, &embedder, &items)
+            .await
+            .unwrap();
+
+        assert_eq!(title.embed_batch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            title.inputs_seen.load(Ordering::SeqCst),
+            2,
+            "title got a + c"
+        );
+        assert_eq!(body.embed_batch_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(body.inputs_seen.load(Ordering::SeqCst), 1, "body got b");
+        assert_eq!(default.embed_batch_calls.load(Ordering::SeqCst), 0);
+
+        let expected: Vec<f32> = items.iter().map(|(_, i)| seed(i)).collect();
+        let actual: Vec<f32> = got.iter().map(|v| v.data[0]).collect();
+        assert_eq!(
+            actual, expected,
+            "results stay in original interleaved order"
+        );
+    }
+
+    /// No items -> no embedding, empty result.
+    #[tokio::test]
+    async fn empty_items_is_a_noop() {
+        let counter = Arc::new(CountingEmbedder::new("m"));
+        let embedder: Arc<dyn Embedder> = counter.clone();
+        let got = embed_batch_with_cache(None, &embedder, &[]).await.unwrap();
+        assert!(got.is_empty());
+        assert_eq!(counter.embed_batch_calls.load(Ordering::SeqCst), 0);
+    }
 }

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -15,7 +15,7 @@ use crate::analysis::analyzer::keyword::KeywordAnalyzer;
 use crate::analysis::analyzer::per_field::PerFieldAnalyzer;
 use crate::analysis::analyzer::standard::StandardAnalyzer;
 use crate::data::Document;
-use crate::embedding::cache::{EmbeddingCache, embed_with_cache};
+use crate::embedding::cache::{EmbeddingCache, embed_batch_with_cache};
 use crate::embedding::embedder::Embedder;
 use crate::error::Result;
 use crate::lexical::store::LexicalStore;
@@ -1316,35 +1316,51 @@ impl Engine {
                 use crate::embedding::embedder::EmbedInput;
                 use crate::vector::store::request::QueryVector;
 
-                let embedder = self.vector.embedder();
-                let mut query_vectors = Vec::new();
+                // Owned payload data for the embeddable (Text / Bytes) payloads,
+                // keeping each one's field and weight. Non-text / non-bytes
+                // payloads are skipped, as before. Owned buffers must outlive the
+                // borrowed `EmbedInput`s handed to the batch call below.
+                enum Owned {
+                    Text(String),
+                    Bytes(Vec<u8>, Option<String>),
+                }
+                let mut owned: Vec<(String, f32, Owned)> = Vec::new();
                 for payload in payloads {
-                    let (text_owned, bytes_owned, mime_owned) = match &payload.payload {
-                        DataValue::Text(t) => (Some(t.clone()), None, None),
-                        DataValue::Bytes(b, m) => (None, Some(b.clone()), m.clone()),
+                    let data = match &payload.payload {
+                        DataValue::Text(t) => Owned::Text(t.clone()),
+                        DataValue::Bytes(b, m) => Owned::Bytes(b.clone(), m.clone()),
                         _ => continue,
                     };
-                    let field_name = payload.field.clone();
-                    let input = if let Some(ref text) = text_owned {
-                        EmbedInput::Text(text)
-                    } else if let Some(ref bytes) = bytes_owned {
-                        EmbedInput::Bytes(bytes, mime_owned.as_deref())
-                    } else {
-                        unreachable!()
-                    };
-                    let vector = embed_with_cache(
-                        self.embedding_cache.as_ref(),
-                        &embedder,
-                        &field_name,
-                        &input,
-                    )
-                    .await?;
-                    query_vectors.push(QueryVector {
-                        vector,
-                        weight: payload.weight,
-                        fields: Some(vec![payload.field.clone()]),
-                    });
+                    owned.push((payload.field.clone(), payload.weight, data));
                 }
+
+                // Embed every payload in one batch (Issue #671) so a
+                // batch-capable embedder pays one round trip instead of one per
+                // payload, while preserving cache and per-field routing.
+                let items: Vec<(String, EmbedInput<'_>)> = owned
+                    .iter()
+                    .map(|(field, _, data)| {
+                        let input = match data {
+                            Owned::Text(t) => EmbedInput::Text(t),
+                            Owned::Bytes(b, m) => EmbedInput::Bytes(b, m.as_deref()),
+                        };
+                        (field.clone(), input)
+                    })
+                    .collect();
+                let embedder = self.vector.embedder();
+                let vectors =
+                    embed_batch_with_cache(self.embedding_cache.as_ref(), &embedder, &items)
+                        .await?;
+
+                let query_vectors: Vec<QueryVector> = owned
+                    .iter()
+                    .zip(vectors)
+                    .map(|((field, weight, _), vector)| QueryVector {
+                        vector,
+                        weight: *weight,
+                        fields: Some(vec![field.clone()]),
+                    })
+                    .collect();
                 vreq.query =
                     crate::vector::search::searcher::VectorSearchQuery::Vectors(query_vectors);
             }

--- a/laurus/src/vector/query/parser.rs
+++ b/laurus/src/vector/query/parser.rs
@@ -13,7 +13,6 @@ use pest_derive::Parser;
 use crate::data::DataValue;
 use crate::embedding::embedder::{EmbedInput, Embedder};
 use crate::error::{LaurusError, Result};
-use crate::vector::core::vector::Vector;
 use crate::vector::store::request::{
     QueryPayload, QueryVector, VectorSearchQuery, VectorSearchRequest,
 };
@@ -127,39 +126,41 @@ impl VectorQueryParser {
             ));
         }
 
-        // Embed each text payload into a query vector.
-        let mut query_vectors = Vec::new();
-        for payload in payloads {
+        // Embed every clause's payload in one batch (Issue #671) so a
+        // batch-capable embedder pays one round trip instead of one per clause,
+        // while preserving the shared embedding cache (#678) and per-field
+        // routing. Non-text / non-bytes payloads are skipped, as before.
+        let mut kept: Vec<&QueryPayload> = Vec::new();
+        let mut items: Vec<(String, EmbedInput<'_>)> = Vec::new();
+        for payload in &payloads {
             let input = match &payload.payload {
                 DataValue::Text(t) => EmbedInput::Text(t),
                 DataValue::Bytes(b, m) => EmbedInput::Bytes(b, m.as_deref()),
                 _ => continue,
             };
-            let vector = self.embed_for_field(&payload.field, &input).await?;
-            query_vectors.push(QueryVector {
+            items.push((payload.field.clone(), input));
+            kept.push(payload);
+        }
+        let vectors = crate::embedding::cache::embed_batch_with_cache(
+            self.embedding_cache.as_ref(),
+            &self.embedder,
+            &items,
+        )
+        .await?;
+        let query_vectors: Vec<QueryVector> = kept
+            .into_iter()
+            .zip(vectors)
+            .map(|(payload, vector)| QueryVector {
                 vector,
                 weight: payload.weight,
-                fields: Some(vec![payload.field]),
-            });
-        }
+                fields: Some(vec![payload.field.clone()]),
+            })
+            .collect();
 
         Ok(VectorSearchRequest {
             query: VectorSearchQuery::Vectors(query_vectors),
             params: Default::default(),
         })
-    }
-
-    /// Embed input for a specific field, consulting the shared embedding
-    /// cache when configured (Issue #678) and using `PerFieldEmbedder`
-    /// routing when the embedder supports it.
-    async fn embed_for_field(&self, field: &str, input: &EmbedInput<'_>) -> Result<Vector> {
-        crate::embedding::cache::embed_with_cache(
-            self.embedding_cache.as_ref(),
-            &self.embedder,
-            field,
-            input,
-        )
-        .await
     }
 
     /// Parse a single vector clause (e.g., `content:"cute kitten"^0.8` or `content:python`).
@@ -238,6 +239,7 @@ mod tests {
 
     use super::*;
     use crate::embedding::embedder::EmbedInputType;
+    use crate::vector::core::vector::Vector;
 
     /// Mock embedder that returns a zero vector of the configured dimension.
     #[derive(Debug)]


### PR DESCRIPTION
## Summary

Vector / hybrid query embedding ran **one `embed()` per payload** inside an
async loop, so a query with `B` payloads cost `B` model calls — or `B` network
round trips for a remote embedder.

This adds `embed_batch_with_cache()` (the batch counterpart of the existing
`embed_with_cache()`) and routes **both** query-time embedding sites through it:

- `Engine::search`'s `Payloads` fallback (for `VectorSearchRequestBuilder` users), and
- the DSL `VectorQueryParser` (the common path, which embeds at parse time).

Cache misses are embedded in a single `Embedder::embed_batch()` call, so a
batch-capable embedder pays **one round trip instead of `B`** for a multi-vector
query. `OpenAIEmbedder` already overrides `embed_batch()` with one batched
request, so the win is immediate there.

The `Embedder` trait already had `embed_batch()` (default = sequential), so
**there is no public API change and no language-binding change.**

## Correctness preserved

`embed_batch_with_cache()` matches `embed_with_cache()` semantics exactly:

- **Cache** (#678): same key `(field, embedder.name(), hash(input))`; only misses
  are embedded; fresh embeddings are stored.
- **Per-field routing**: when the embedder is a `PerFieldEmbedder`, misses are
  grouped by field and each group is dispatched to that field's embedder; a
  field-agnostic embedder embeds all misses in one call.
- **Order**: results are returned in input order (filled via index, with a
  defensive error if an embedder returns fewer vectors than inputs — no
  `unwrap`/`expect`).

## Tests

New unit tests in `embedding/cache.rs` (batch-counting mock embedder):

- one `embed_batch` call replaces the per-item loop; results in input order;
- cached items are not re-embedded — only fresh items reach `embed_batch`;
- `PerFieldEmbedder` routes each field's misses to that field's embedder
  (grouped, never the default), preserving interleaved order;
- empty input is a no-op.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -p laurus --all-targets -- -D warnings`: no warnings
- `cargo test -p laurus --lib embedding::cache`: 4 passed
- Regression: `vector::query::parser` (14), `embedding::` (28),
  `engine_embedding_cache_test` (4), `unified_search_test` (2),
  `hybrid_unification_test` (1) — all pass
- `markdownlint-cli2` (changed docs): 0 errors

## Docs

`docs/{src,ja/src}/laurus/engine.md` "Query embedding cache" section notes the
single-batch-per-query behaviour; `cache.rs` module doc updated.

## Notes

The payoff materialises for embedders that override `embed_batch` (e.g.
`OpenAIEmbedder`); default-impl embedders behave as before (sequential) but now
benefit automatically once they override it.

Closes #671
Refs #536
