### PR TITLE
feat(vector): implement HNSW searcher warmup + Engine/VectorStore hooks (#677)

### DIFF
--- a/docs/ja/src/laurus/engine.md
+++ b/docs/ja/src/laurus/engine.md
@@ -189,6 +189,23 @@ let request = SearchRequestBuilder::new()
 let results = engine.search(request).await?;
 ```
 
+### ウォームアップ
+
+`engine.warmup()`（Issue #677）は Vector searcher を事前に準備し、**初回**の
+Vector / ハイブリッドクエリが one-time のセットアップコストを払わないようにします。
+Engine 構築後、トラフィック処理を始める前に一度呼び出します:
+
+```rust,ignore
+let engine = builder.build()?;
+engine.warmup()?;   // オプション: 初回クエリの latency を起動時に移す
+```
+
+Vector searcher を先行構築・キャッシュし（reader をロード — `InMemory` は
+ファイル→メモリ、`Mmap` はオフセット表）、HNSW の `Mmap` モードではディスク上の
+Vector データを OS page cache に pre-fault します。HNSW グラフは常に eager に
+ロードされるため、warming が必要なのは Vector データのみです。`warmup()` は
+複数回呼んでも安全で、lexical のみのワークロードでは no-op です。
+
 ## SearchRequest
 
 | フィールド | 型 | デフォルト | 説明 |

--- a/docs/src/laurus/engine.md
+++ b/docs/src/laurus/engine.md
@@ -190,6 +190,24 @@ let request = SearchRequestBuilder::new()
 let results = engine.search(request).await?;
 ```
 
+### Warmup
+
+`engine.warmup()` (Issue #677) primes the vector searcher so the **first**
+vector / hybrid query does not pay one-time setup costs. Call it once after
+building the engine, before serving traffic:
+
+```rust,ignore
+let engine = builder.build()?;
+engine.warmup()?;   // optional: move first-query latency to startup
+```
+
+It eagerly builds and caches the vector searcher — loading the reader (file →
+memory for `InMemory`, the offset table for `Mmap`) — and, for HNSW indexes in
+`Mmap` mode, pre-faults the on-disk vector data into the OS page cache. The HNSW
+graph is always loaded eagerly, so only the vector data needs warming.
+`warmup()` is safe to call multiple times and is a no-op for lexical-only
+workloads.
+
 ## SearchRequest
 
 | Field | Type | Default | Description |

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -1128,6 +1128,22 @@ impl Engine {
         Ok((lexical_config, vector_config))
     }
 
+    /// Warm the vector searcher so the first vector / hybrid query does not pay
+    /// the searcher-construction and page-fault cost (Issue #677).
+    ///
+    /// Delegates to [`VectorStore::warmup`](crate::vector::VectorStore::warmup):
+    /// it eagerly builds the cached searcher (loading the reader) and pre-faults
+    /// on-disk vector data into the OS page cache where applicable (HNSW `Mmap`
+    /// mode). Call once after building the engine, before serving traffic.
+    /// Safe to call multiple times; lexical search needs no warming.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if building the vector searcher (reader load) fails.
+    pub fn warmup(&self) -> Result<()> {
+        self.vector.warmup()
+    }
+
     /// Search the index.
     ///
     /// Supports three modes depending on how the

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -374,6 +374,45 @@ impl VectorIndexSearcher for HnswSearcher {
             Ok(self.index_reader.vector_ids()?.len() as u64)
         }
     }
+
+    /// Pre-fault the on-disk vector data into the OS page cache (Issue #677).
+    ///
+    /// Only the [`OnDemand`](crate::vector::index::storage::VectorStorage::OnDemand)
+    /// (`Mmap` / lazy) storage benefits: without warming, the first query pays
+    /// a page fault for every candidate vector it reads. Touching each stored
+    /// vector once moves that cost to startup. The `Owned*` variants are
+    /// already heap-resident after the reader load that
+    /// [`VectorStore::warmup`](crate::vector::VectorStore::warmup) forces, so
+    /// this is a no-op for them. The HNSW graph is always loaded into memory
+    /// eagerly, so only the vector data needs warming.
+    ///
+    /// Individual read failures are skipped rather than aborting startup —
+    /// warming is a best-effort optimisation, and a genuinely unreadable vector
+    /// would surface on the real query regardless.
+    fn warmup(&mut self) -> Result<()> {
+        let Some(reader) = self.index_reader.as_any().downcast_ref::<HnswIndexReader>() else {
+            return Ok(());
+        };
+        if !matches!(
+            reader.vectors(),
+            crate::vector::index::storage::VectorStorage::OnDemand { .. }
+        ) {
+            return Ok(());
+        }
+        // Read every stored vector so its backing page is faulted in. The
+        // accumulator (kept live via `black_box`) stops the loop from being
+        // optimised away as dead code.
+        let mut acc = 0u64;
+        for (doc_id, field) in reader.vector_ids()? {
+            if let Ok(Some(vector)) = reader.get_vector(doc_id, &field)
+                && let Some(first) = vector.data.first()
+            {
+                acc = acc.wrapping_add(first.to_bits() as u64);
+            }
+        }
+        std::hint::black_box(acc);
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -379,6 +379,35 @@ impl VectorStore {
         Ok(parking_lot::RwLockWriteGuard::downgrade(guard))
     }
 
+    /// Warm the cached searcher so the first query does not pay its setup cost
+    /// (Issue #677).
+    ///
+    /// Eagerly builds and caches the index searcher — which loads the reader
+    /// (file → memory for `InMemory`, the offset table for `Mmap`) — and then
+    /// invokes the searcher's
+    /// [`warmup`](crate::vector::search::searcher::VectorIndexSearcher::warmup),
+    /// which pre-faults on-disk vector data into the OS page cache where
+    /// applicable (HNSW `Mmap` mode). This moves the searcher-construction and
+    /// page-fault latency off the first query.
+    ///
+    /// Safe to call multiple times and from any index type (a no-op
+    /// `warmup` for searchers that do not override it). Typically called once
+    /// at startup via [`Engine::warmup`](crate::engine::Engine::warmup).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if building the searcher (reader load) fails.
+    pub fn warmup(&self) -> Result<()> {
+        let mut guard = self.searcher_cache.write();
+        if guard.is_none() {
+            *guard = Some(self.index.searcher()?);
+        }
+        if let Some(searcher) = guard.as_mut() {
+            searcher.warmup()?;
+        }
+        Ok(())
+    }
+
     /// Execute a low-level vector similarity search.
     pub fn search_index(
         &self,

--- a/laurus/tests/vector_warmup_test.rs
+++ b/laurus/tests/vector_warmup_test.rs
@@ -1,0 +1,134 @@
+//! Integration tests for searcher warmup (Issue #677).
+//!
+//! `VectorStore::warmup` eagerly builds the cached searcher and invokes the
+//! searcher's `warmup`, which for HNSW pre-faults on-disk (`Mmap` / `OnDemand`)
+//! vector data into the OS page cache. Warmup must be transparent (results
+//! unchanged), idempotent, and must exercise the HNSW `OnDemand` path without
+//! error. Cold-start *timing* is environment-dependent and intentionally not
+//! asserted.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use laurus::PrecomputedEmbedder;
+use laurus::storage::file::FileStorageConfig;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::vector::core::field::HnswOption;
+use laurus::vector::store::config::VectorFieldConfig;
+use laurus::vector::{
+    DistanceMetric, FieldOption, VectorIndexConfig, VectorSearchRequestBuilder, VectorStore,
+};
+use laurus::{DataValue, Document};
+
+fn hnsw_field(dimension: usize) -> VectorFieldConfig {
+    VectorFieldConfig {
+        vector: Some(FieldOption::Hnsw(HnswOption {
+            dimension,
+            distance: DistanceMetric::Cosine,
+            m: 16,
+            ef_construction: 100,
+            default_ef_search: None,
+            base_weight: 1.0,
+            quantizer: Default::default(),
+            rerank_storage: None,
+            embedder: None,
+        })),
+        lexical: None,
+    }
+}
+
+fn config(dimension: usize) -> VectorIndexConfig {
+    VectorIndexConfig::builder()
+        .embedder(Arc::new(PrecomputedEmbedder::new()))
+        .field("v", hnsw_field(dimension))
+        .build()
+        .unwrap()
+}
+
+async fn add_docs(store: &VectorStore, vectors: Vec<Vec<f32>>) {
+    for (i, vec) in vectors.into_iter().enumerate() {
+        let doc = Document::builder()
+            .add_field("v", DataValue::Vector(vec))
+            .build();
+        store
+            .upsert_document_by_internal_id((i + 1) as u64, doc)
+            .await
+            .unwrap();
+    }
+    store.commit().await.unwrap();
+}
+
+fn search_ids(store: &VectorStore, query: Vec<f32>) -> BTreeSet<u64> {
+    let request = VectorSearchRequestBuilder::new()
+        .add_vector("v", query)
+        .limit(3)
+        .build();
+    store
+        .search(request)
+        .unwrap()
+        .hits
+        .into_iter()
+        .map(|h| h.doc_id)
+        .collect()
+}
+
+/// Warmup is transparent (results unchanged) and idempotent on an in-memory
+/// (Eager) HNSW store — exercises `VectorStore::warmup` and the `Owned*`
+/// early-return in `HnswSearcher::warmup`.
+#[tokio::test(flavor = "multi_thread")]
+async fn warmup_is_transparent_and_idempotent() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let store = VectorStore::new(storage, config(3)).unwrap();
+    add_docs(
+        &store,
+        vec![
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0],
+            vec![1.0, 1.0, 0.0],
+        ],
+    )
+    .await;
+
+    let query = vec![1.0, 0.1, 0.0];
+    let before = search_ids(&store, query.clone());
+    assert!(!before.is_empty(), "baseline search must return hits");
+
+    store.warmup().unwrap();
+    store.warmup().unwrap(); // idempotent
+
+    let after = search_ids(&store, query);
+    assert_eq!(after, before, "warmup must not change search results");
+}
+
+/// Warmup exercises the HNSW `OnDemand` (Mmap) page-fault loop without error
+/// and leaves search working. `use_mmap` is forced on so the storage is `Lazy`
+/// on every platform (the default is platform-specific).
+#[tokio::test(flavor = "multi_thread")]
+async fn warmup_on_demand_hnsw_pre_faults() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut file_config = FileStorageConfig::new(dir.path());
+    file_config.use_mmap = true; // force Lazy / OnDemand on all platforms
+    let storage = StorageFactory::create(StorageConfig::File(file_config)).unwrap();
+    let store = VectorStore::new(storage, config(3)).unwrap();
+    add_docs(
+        &store,
+        vec![
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0],
+        ],
+    )
+    .await;
+
+    // Warmup before any query: builds the cached searcher and runs the
+    // OnDemand page-fault pass.
+    store.warmup().unwrap();
+
+    let hits = search_ids(&store, vec![1.0, 0.1, 0.0]);
+    assert!(
+        !hits.is_empty(),
+        "search after warmup on an OnDemand store must return hits"
+    );
+}


### PR DESCRIPTION
## Summary

`VectorIndexSearcher::warmup` existed as a default no-op and was **never called
anywhere**. This implements it for HNSW and adds the startup hooks that invoke
it, so the **first** vector / hybrid query no longer pays one-time setup costs.

- **`HnswSearcher::warmup`** — for the `OnDemand` (`Mmap` / lazy) storage,
  reads every stored vector once to pre-fault its backing pages into the OS page
  cache. It is an early-return no-op for the heap-resident `Owned*` variants
  (the HNSW graph is always loaded into memory eagerly, so only the vector data
  needs warming). Individual read failures are skipped (best-effort).
- **`VectorStore::warmup`** (new public method) — eagerly builds and caches the
  index searcher, which loads the reader (file → memory for `InMemory`, the
  offset table for `Mmap`), then calls `searcher.warmup()`. This moves both the
  searcher-construction and the page-fault latency off the first query, for
  every index type.
- **`Engine::warmup`** (new public method) — delegates to `VectorStore::warmup`;
  call once after building the engine, before serving traffic.

## Design note

The issue suggested touching the graph too, but the **HNSW graph is always
loaded eagerly** into `Vec<Vec<Vec<u64>>>` at reader load — it is never mmap'd —
so only the vector data (the `OnDemand` int8 pool) benefits from a page-fault
pass. Warmup is scoped accordingly.

## API / compatibility

Additive only: `Engine::warmup` and `VectorStore::warmup` are new inherent
methods, and `HnswSearcher` overrides the **existing** `warmup` trait method.
No trait signature changes, so there is no language-binding break. Exposing
`warmup` through the gRPC server / language bindings is left as an optional
follow-up.

## Tests (`laurus/tests/vector_warmup_test.rs`)

Cold-start *timing* is environment-dependent and intentionally not asserted;
behaviour is verified instead:

- `warmup_is_transparent_and_idempotent` (MemoryStorage / Eager HNSW): warmup
  does not change search results and is safe to call twice — covers
  `VectorStore::warmup` and the `Owned*` early-return.
- `warmup_on_demand_hnsw_pre_faults` (FileStorage `use_mmap = true` / Lazy
  HNSW): warmup runs the `OnDemand` page-fault loop without error and search
  still works. `use_mmap` is forced on so the storage is `Lazy` on every
  platform.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -p laurus --all-targets -- -D warnings`: no warnings
- `cargo test -p laurus --test vector_warmup_test`: 2 passed
- Regression: `mmap_test` (2), HNSW searcher lib (8), vector store lib (3) — pass
- `markdownlint-cli2` (changed docs): 0 errors

## Docs

`docs/{src,ja/src}/laurus/engine.md` gain a "Warmup" section describing
`engine.warmup()` and when to call it.

Closes #677
Refs #536
