### PR TITLE
perf(lexical/index): wire optimize() to force-merge all segments (#754)

### DIFF
--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -261,7 +261,11 @@ impl InvertedIndex {
         let mut segments = Vec::new();
 
         for file in &files {
-            if file.starts_with("segment_") && file.ends_with(".meta") {
+            // Both freshly flushed segments (`segment_*`) and segments produced
+            // by a merge (`merged_*`, Issue #754) are discovered here.
+            if (file.starts_with("segment_") || file.starts_with("merged_"))
+                && file.ends_with(".meta")
+            {
                 let mut input = self.storage.open_input(file)?;
                 let mut data = Vec::new();
                 Read::read_to_end(&mut input, &mut data)?;
@@ -276,6 +280,114 @@ impl InvertedIndex {
 
         segments.sort_by_key(|s| s.generation);
         Ok(segments)
+    }
+
+    /// Force-merge every current segment into a single new segment (Issue
+    /// #754), the classic `optimize()` / force-merge semantics.
+    ///
+    /// Discovers the current segments, merges them with the (correct, typed)
+    /// [`MergeEngine`](self::segment::merge_engine::MergeEngine), rewrites the
+    /// merged segment's metadata generation so it sorts as the newest segment,
+    /// and deletes the now-merged source segments' files so segment discovery
+    /// ([`Self::load_segments`]) sees only the merged result. A no-op when
+    /// fewer than two segments exist.
+    fn force_merge_all(&self) -> Result<()> {
+        use self::segment::manager::{ManagedSegmentInfo, MergeCandidate, MergeStrategy};
+        use self::segment::merge_engine::{MergeConfig, MergeEngine};
+
+        let segments = self.load_segments()?;
+        if segments.len() < 2 {
+            // Zero or one segment: nothing to compact.
+            return Ok(());
+        }
+
+        // The merged segment must sort as the newest, so its generation is one
+        // past the highest source generation.
+        let next_generation = segments.iter().map(|s| s.generation).max().unwrap_or(0) + 1;
+
+        let managed: Vec<ManagedSegmentInfo> = segments
+            .iter()
+            .map(|info| {
+                let mut mi = ManagedSegmentInfo::new(info.clone());
+                mi.size_bytes = self.segment_size_bytes(&info.segment_id);
+                mi
+            })
+            .collect();
+        let candidate = MergeCandidate {
+            segments: segments.iter().map(|s| s.segment_id.clone()).collect(),
+            priority: 1.0,
+            estimated_size: 0,
+            strategy: MergeStrategy::SizeBased,
+        };
+
+        let engine = MergeEngine::new(MergeConfig::default(), self.storage.clone());
+        let result = engine.merge_segments(&candidate, &managed, next_generation)?;
+        let merged_id = result.new_segment.segment_info.segment_id.clone();
+
+        // The merged segment's `.meta` was written with the merge writer's own
+        // generation (0); rewrite it with `next_generation` so it is the newest.
+        self.set_segment_generation(&merged_id, next_generation)?;
+
+        // Remove the now-merged source segments so discovery sees only the
+        // merged result. Delete every source's `.meta` first: discovery keys
+        // on `.meta`, so this drops the sources out of the searchable set
+        // before their (now-orphaned, harmless) data files are removed,
+        // minimizing the window in which a doc could be seen in both a source
+        // and the merged segment.
+        for info in &segments {
+            let meta = format!("{}.meta", info.segment_id);
+            if self.storage.file_exists(&meta) {
+                self.storage.delete_file(&meta)?;
+            }
+        }
+        for info in &segments {
+            self.delete_segment_files(&info.segment_id)?;
+        }
+
+        Ok(())
+    }
+
+    /// Sum the on-disk size of every file belonging to `segment_id`.
+    fn segment_size_bytes(&self, segment_id: &str) -> u64 {
+        let prefix = format!("{segment_id}.");
+        self.storage
+            .list_files()
+            .map(|files| {
+                files
+                    .iter()
+                    .filter(|f| f.starts_with(&prefix))
+                    .map(|f| self.storage.metadata(f).map(|m| m.size).unwrap_or(0))
+                    .sum()
+            })
+            .unwrap_or(0)
+    }
+
+    /// Rewrite a segment's `.meta` with an updated generation.
+    fn set_segment_generation(&self, segment_id: &str, generation: u64) -> Result<()> {
+        let meta_file = format!("{segment_id}.meta");
+        let mut input = self.storage.open_input(&meta_file)?;
+        let mut data = Vec::new();
+        Read::read_to_end(&mut input, &mut data)?;
+        let mut info: SegmentInfo = serde_json::from_slice(&data)
+            .map_err(|e| LaurusError::index(format!("Failed to parse segment metadata: {e}")))?;
+        info.generation = generation;
+        let json = serde_json::to_string_pretty(&info).map_err(|e| {
+            LaurusError::index(format!("Failed to serialize segment metadata: {e}"))
+        })?;
+        let mut output = self.storage.create_output(&meta_file)?;
+        std::io::Write::write_all(&mut output, json.as_bytes())?;
+        output.close()?;
+        Ok(())
+    }
+
+    /// Delete every file belonging to `segment_id`.
+    fn delete_segment_files(&self, segment_id: &str) -> Result<()> {
+        let prefix = format!("{segment_id}.");
+        let files = self.storage.list_files()?;
+        for file in files.iter().filter(|f| f.starts_with(&prefix)) {
+            self.storage.delete_file(file)?;
+        }
+        Ok(())
     }
 
     /// Check if an index exists in the given directory.
@@ -406,6 +518,7 @@ impl LexicalIndex for InvertedIndex {
 
     fn optimize(&self) -> Result<()> {
         self.check_closed()?;
+        self.force_merge_all()?;
         self.update_metadata()?;
         Ok(())
     }

--- a/laurus/src/lexical/store.rs
+++ b/laurus/src/lexical/store.rs
@@ -270,13 +270,17 @@ impl LexicalStore {
         Ok(())
     }
 
-    /// Optimize the index.
+    /// Optimize the index by force-merging all segments into one (Issue #754).
     ///
     /// This method delegates to [`LexicalIndex::optimize()`], which for the default
     /// [`InvertedIndex`](crate::lexical::index::inverted::InvertedIndex) implementation
-    /// updates the index metadata (e.g., the `modified` timestamp) and persists it to storage.
+    /// force-merges every current segment into a single new segment (the classic
+    /// `optimize` / force-merge semantics): it rewrites the live documents into one
+    /// segment, reclaiming logically deleted documents and removing the source
+    /// segment files. This bounds the per-query cost that otherwise grows with the
+    /// number of commits. It is a no-op when fewer than two segments exist.
     /// After optimization, the searcher cache is invalidated so subsequent searches
-    /// reflect the updated state.
+    /// reflect the merged state.
     ///
     /// # Returns
     ///

--- a/laurus/tests/lexical_optimize_test.rs
+++ b/laurus/tests/lexical_optimize_test.rs
@@ -1,0 +1,87 @@
+//! Integration test for `LexicalStore::optimize()` force-merging segments
+//! (Issue #754 — wiring the merge engine into production).
+//!
+//! Before #754 `optimize()` was a no-op, so committing repeatedly grew the
+//! segment count without bound. This verifies that optimize now compacts every
+//! segment into one, deletes the source segments, and leaves search results
+//! unchanged — and is idempotent.
+
+use std::sync::Arc;
+
+use laurus::Document;
+use laurus::lexical::{LexicalIndexConfig, LexicalSearchRequest, LexicalStore, TermQuery};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+fn doc(title: &str) -> Document {
+    Document::builder()
+        .add_text("title", title)
+        .add_text("body", "lorem ipsum")
+        .build()
+}
+
+/// Count discovered segment metadata files (`segment_*` flushed + `merged_*`).
+fn segment_count(storage: &Arc<dyn Storage>) -> usize {
+    storage
+        .list_files()
+        .unwrap()
+        .iter()
+        .filter(|f| (f.starts_with("segment_") || f.starts_with("merged_")) && f.ends_with(".meta"))
+        .count()
+}
+
+fn hits(store: &LexicalStore, field: &str, term: &str) -> usize {
+    let query = Box::new(TermQuery::new(field, term));
+    store
+        .search(LexicalSearchRequest::new(query))
+        .unwrap()
+        .hits
+        .len()
+}
+
+#[test]
+fn optimize_force_merges_segments_into_one() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+
+    // Three commits -> three segments.
+    store.upsert_document(1, doc("alpha")).unwrap();
+    store.upsert_document(2, doc("bravo")).unwrap();
+    store.commit().unwrap();
+    store.upsert_document(3, doc("charlie")).unwrap();
+    store.commit().unwrap();
+    store.upsert_document(4, doc("delta")).unwrap();
+    store.commit().unwrap();
+
+    assert_eq!(
+        segment_count(&storage),
+        3,
+        "three commits => three segments"
+    );
+    let before = hits(&store, "body", "lorem");
+    assert_eq!(before, 4, "all four docs match body:lorem before optimize");
+
+    store.optimize().unwrap();
+
+    assert_eq!(
+        segment_count(&storage),
+        1,
+        "optimize must force-merge into a single segment"
+    );
+    let leftover_sources = storage
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .filter(|f| f.starts_with("segment_"))
+        .count();
+    assert_eq!(leftover_sources, 0, "source segment files must be deleted");
+
+    // Search results are unchanged after the merge.
+    assert_eq!(hits(&store, "body", "lorem"), before);
+    assert_eq!(hits(&store, "title", "charlie"), 1, "per-doc term survives");
+
+    // Idempotent: re-optimizing a single-segment index is a no-op.
+    store.optimize().unwrap();
+    assert_eq!(segment_count(&storage), 1, "re-optimize is a no-op");
+    assert_eq!(hits(&store, "body", "lorem"), before);
+}


### PR DESCRIPTION
Part of the #538 merge-engine campaign (umbrella #533). Depends on #753 (merged). **Closes #754.**

## Problem

`InvertedIndex::optimize()` was a no-op (it only bumped the metadata
timestamp). Combined with the fact that nothing else invoked merging in
production (`BackgroundScheduler` isn't started), this meant **segments grew
unbounded** — every `commit()` adds a segment, query cost grows with the commit
count, and logically deleted documents were never reclaimed.

#753 made the merge engine produce correct, typed segments. This PR wires it
into production.

## What it does

`optimize()` now **force-merges every segment into one** (classic
`optimize` / `forceMerge(1)` semantics):

1. Discover the current segments (`load_segments`); **no-op if fewer than two**.
2. `next_generation = max(source generations) + 1`.
3. Run `MergeEngine::merge_segments` over all segments → writes `merged_{next_generation}.*`.
4. Rewrite the merged segment's `.meta` generation to `next_generation` (the
   merge writer records its own generation `0`, which would sort as the oldest).
5. Delete the source segments' files — **`.meta` first** so they drop out of
   file-scan discovery before their (now-orphaned, harmless) data files are
   removed, minimizing any window where a document could be seen in both a
   source and the merged segment.

`load_segments()` now also discovers `merged_*` segments. `LexicalStore::optimize()`
already invalidates the searcher cache, so subsequent searches see the merged result.

## Tests

New `laurus/tests/lexical_optimize_test.rs`: three commits → three segments;
`optimize()` → exactly one segment, all `segment_*` files deleted, search hit
counts unchanged before/after, a per-doc term (`title:charlie`) still found, and
re-`optimize()` is a no-op (idempotent).

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -p laurus --all-targets -- -D warnings`: no warnings
- `cargo test -p laurus --lib lexical`: 425 passed
- Integration: `lexical_optimize_test`, `schema_lexical_test`, `unified_search_test`,
  `unified_engine_test` — pass

## Scope / notes

- Public API is unchanged (`LexicalStore::optimize()` already existed; its
  behaviour changes from no-op to force-merge). The unified `Engine` facade does
  not expose `optimize()`, so bindings need no changes.
- **Automatic** compaction (a post-commit `maybeMerge` hook) and policy-driven
  selective merges are #755; this PR is explicit `optimize()` = force-merge-all.
- Known non-atomicity: `InvertedIndex` discovers segments by scanning `*.meta`
  files (not a manifest), so a `delete_file` I/O failure mid-cleanup could leave
  a source segment behind. It does not occur on `MemoryStorage` and is rare on
  `FileStorage`; fully atomic segment swap (manifest-based) is out of scope.

Closes #754
Refs #538 #533
