### PR TITLE
perf(lexical/index): drop the .json stored-field mirror, read from .docs (#756)

### DIFF
--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -535,27 +535,8 @@ impl SegmentReader {
 
     /// Load stored documents for this segment.
     fn load_stored_documents(&self) -> Result<()> {
-        // Try JSON format first (for compatibility)
-        let json_file = format!("{}.json", self.info.segment_id);
-        if self.storage.file_exists(&json_file) {
-            let mut input = self.storage.open_input(&json_file)?;
-            let mut json_data = String::new();
-            std::io::Read::read_to_string(&mut input, &mut json_data)?;
-
-            let docs: Vec<Document> = serde_json::from_str(&json_data)
-                .map_err(|e| LaurusError::index(format!("Failed to parse JSON documents: {e}")))?;
-
-            let mut documents = BTreeMap::new();
-            for (idx, doc) in docs.into_iter().enumerate() {
-                let doc_id = self.info.min_doc_id + idx as u64;
-                documents.insert(doc_id, doc);
-            }
-
-            *self.stored_documents.write().unwrap() = Some(documents);
-            return Ok(());
-        }
-
-        // Fallback to binary format with type information
+        // Primary: typed binary `.docs`, which records the real doc_id per
+        // document (correct for non-contiguous ids, e.g. merged segments).
         let docs_file = format!("{}.docs", self.info.segment_id);
         if let Ok(input) = self.storage.open_input(&docs_file) {
             let mut reader = StructReader::new(input)?;
@@ -659,6 +640,29 @@ impl SegmentReader {
                     doc.fields.insert(field_name, field_value);
                 }
 
+                documents.insert(doc_id, doc);
+            }
+
+            *self.stored_documents.write().unwrap() = Some(documents);
+            return Ok(());
+        }
+
+        // Legacy fallback: segments written before the binary `.docs` format
+        // stored fields as a positional JSON mirror (Issue #756 stopped writing
+        // it). Doc ids are assigned positionally — valid only for the
+        // contiguous ids those legacy segments used.
+        let json_file = format!("{}.json", self.info.segment_id);
+        if self.storage.file_exists(&json_file) {
+            let mut input = self.storage.open_input(&json_file)?;
+            let mut json_data = String::new();
+            std::io::Read::read_to_string(&mut input, &mut json_data)?;
+
+            let docs: Vec<Document> = serde_json::from_str(&json_data)
+                .map_err(|e| LaurusError::index(format!("Failed to parse JSON documents: {e}")))?;
+
+            let mut documents = BTreeMap::new();
+            for (idx, doc) in docs.into_iter().enumerate() {
+                let doc_id = self.info.min_doc_id + idx as u64;
                 documents.insert(doc_id, doc);
             }
 

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -696,9 +696,8 @@ impl InvertedIndexWriter {
         self.write_doc_values(segment_name)?;
         self.write_segment_metadata(segment_name)?;
         self.write_bkd_trees(segment_name)?;
-        // COMPATIBILITY: also write documents as JSON for BasicIndexReader
-        // (removed in #756).
-        self.write_json_documents(segment_name)?;
+        // The redundant `.json` stored-field mirror is no longer written
+        // (Issue #756); stored fields are read from the typed `.docs` file.
 
         // Collect every file written under this segment prefix (the BKD step
         // writes one `.{field}.bkd` per numeric/geo field, so enumerate rather
@@ -1142,29 +1141,6 @@ impl InvertedIndexWriter {
         // (Issue #753) passes the merged segment's name so accumulated values
         // land in the right `.dv` file.
         self.doc_values_writer.write_to(segment_name)?;
-        Ok(())
-    }
-
-    /// Write documents as JSON for compatibility with BasicIndexReader.
-    fn write_json_documents(&self, segment_name: &str) -> Result<()> {
-        // Convert analyzed documents back to Document format with preserved types
-        let mut documents = Vec::new();
-        for (_doc_id, analyzed_doc) in &self.buffered_docs {
-            let mut doc = Document::new();
-            for (field_name, field_value) in &analyzed_doc.stored_fields {
-                doc.fields.insert(field_name.clone(), field_value.clone());
-            }
-            documents.push(doc);
-        }
-
-        // Write as JSON
-        let json_file = format!("{segment_name}.json");
-        let mut output = self.storage.create_output(&json_file)?;
-        let segment_data = serde_json::to_string_pretty(&documents)
-            .map_err(|e| LaurusError::index(format!("Failed to serialize segment: {e}")))?;
-        std::io::Write::write_all(&mut output, segment_data.as_bytes())?;
-        output.close()?;
-
         Ok(())
     }
 

--- a/laurus/tests/lexical_json_mirror_test.rs
+++ b/laurus/tests/lexical_json_mirror_test.rs
@@ -1,0 +1,106 @@
+//! Integration test for dropping the `.json` stored-field mirror (Issue #756).
+//!
+//! Stored fields are now written only to the typed binary `.docs` file (no
+//! `.json` mirror), and read from `.docs`. `.docs` records the real per-document
+//! id, so stored-field lookup is correct even for **non-contiguous** doc ids
+//! (e.g. merged segments) — unlike the old `.json` path, which assigned ids
+//! positionally (`min_doc_id + index`).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use laurus::lexical::{LexicalIndexConfig, LexicalSearchRequest, LexicalStore, TermQuery};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::{DataValue, Document};
+
+fn doc(title: &str) -> Document {
+    Document::builder()
+        .add_text("title", title)
+        .add_text("body", "lorem ipsum")
+        .build()
+}
+
+/// Any segment `.json` stored-field mirror present?
+fn has_json_mirror(storage: &Arc<dyn Storage>) -> bool {
+    storage
+        .list_files()
+        .unwrap()
+        .iter()
+        .any(|f| (f.starts_with("segment_") || f.starts_with("merged_")) && f.ends_with(".json"))
+}
+
+fn count_files(storage: &Arc<dyn Storage>, suffix: &str) -> usize {
+    storage
+        .list_files()
+        .unwrap()
+        .iter()
+        .filter(|f| f.ends_with(suffix))
+        .count()
+}
+
+/// Map each hit's doc_id to its stored `title` (via `load_documents`, which
+/// retrieves stored fields by doc_id — the path that differs between `.docs`
+/// and the legacy `.json` mirror).
+fn titles_by_id(store: &LexicalStore) -> BTreeMap<u64, String> {
+    let query = Box::new(TermQuery::new("body", "lorem"));
+    let request = LexicalSearchRequest::new(query).load_documents(true);
+    store
+        .search(request)
+        .unwrap()
+        .hits
+        .into_iter()
+        .map(|h| {
+            let title = h
+                .document
+                .as_ref()
+                .and_then(|d| d.fields.get("title"))
+                .and_then(|v| match v {
+                    DataValue::Text(t) => Some(t.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            (h.doc_id, title)
+        })
+        .collect()
+}
+
+#[test]
+fn drops_json_mirror_and_reads_stored_fields_from_docs() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+
+    // Non-contiguous ids: the old positional `.json` read would map these wrong.
+    store.upsert_document(10, doc("ten")).unwrap();
+    store.upsert_document(20, doc("twenty")).unwrap();
+    store.upsert_document(30, doc("thirty")).unwrap();
+    store.commit().unwrap();
+
+    let expected: BTreeMap<u64, String> = [
+        (10, "ten".to_string()),
+        (20, "twenty".to_string()),
+        (30, "thirty".to_string()),
+    ]
+    .into_iter()
+    .collect();
+
+    // No `.json` mirror is written; `.docs` is.
+    assert!(
+        !has_json_mirror(&storage),
+        "no .json mirror should be written"
+    );
+    assert!(count_files(&storage, ".docs") >= 1, ".docs must be written");
+
+    // Stored fields read back correctly by their real (non-contiguous) ids.
+    assert_eq!(titles_by_id(&store), expected, "stored fields via .docs");
+
+    // After a merge the ids stay non-contiguous in the merged segment's `.docs`;
+    // still no `.json`, still correct.
+    store.optimize().unwrap();
+    assert!(!has_json_mirror(&storage), "merged segment writes no .json");
+    assert_eq!(
+        titles_by_id(&store),
+        expected,
+        "stored fields correct after merge"
+    );
+}


### PR DESCRIPTION
Final core sub-issue of the #538 merge-engine campaign (umbrella #533). Depends on #753 (merged). **Closes #756.**

## Problem

Every segment wrote stored fields **twice**: the typed binary `.docs`
(`write_stored_documents`) and a JSON mirror `.json` (`write_json_documents`),
kept "for compatibility with BasicIndexReader". The mirror doubled per-segment
stored-field disk usage and added a write to every flush.

## What it does

- **Writer**: stop writing `.json` (removed `write_json_documents` and its call
  in `write_segment_files`).
- **Reader**: `load_stored_documents` now reads the typed `.docs` **first**, with
  the `.json` path kept only as a legacy fallback for segments written before
  `.docs` existed.

## Correctness improvement (bonus)

The old `.json` reader assigned doc ids **positionally** (`min_doc_id + index`),
which is wrong for **non-contiguous** doc ids — exactly what merged segments
produce (#753 preserves the original, shard-encoded ids). `.docs` records the
real per-document id (`read_u64`), so reading `.docs` first makes stored-field
lookup correct for merged segments, not just cheaper.

## Compatibility

`.docs` is written for every segment (since #753's `write_segment_files`), so
both existing and new segments read from `.docs`; any pre-`.docs` `.json`-only
segment still reads via the fallback (its ids were contiguous in that era). The
`.docs` on-disk format is unchanged — no version bump.

## Tests

`laurus/tests/lexical_json_mirror_test.rs`: with **non-contiguous ids
(10/20/30)**, after commit there is **no `.json`** mirror (and a `.docs` is
present), and a `load_documents` search retrieves each doc's stored `title` by
its real id (the old positional `.json` read would mismap these). Still correct
and `.json`-free after `optimize()` merges them.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -p laurus --all-targets -- -D warnings`: no warnings
- `cargo test -p laurus --lib lexical`: 425 passed (incl. the #753 merge test
  that reads typed stored fields via `document()` — now through `.docs`)
- Integration: `lexical_json_mirror_test`, `lexical_optimize_test`,
  `lexical_auto_merge_test`, `schema_lexical_test`, `unified_search_test`,
  `unified_engine_test`, `wal_recovery_test` — pass

## Scope

`writer.rs` + `reader.rs` only; no public API, on-disk `.docs` format, or
language-binding changes. No docs reference the `.json` mirror.

With this, the #538 campaign's four core sub-issues (#753/#754/#755/#756) are
complete; the remaining item is follow-up #758 (index-only numeric BKD).

Closes #756
Refs #538 #533
