### PR TITLE
fix(lexical/index): preserve BKD points for index-only numeric fields on merge (#758)

### DIFF
--- a/laurus/src/lexical/index/inverted/segment/merge_engine.rs
+++ b/laurus/src/lexical/index/inverted/segment/merge_engine.rs
@@ -3,7 +3,6 @@
 //! This module provides the core functionality for merging multiple segments
 //! into a single optimized segment with proper handling of deletions and updates.
 
-use crate::lexical::core::field::FieldValue;
 use std::sync::Arc;
 
 use ahash::{AHashMap, AHashSet};
@@ -16,6 +15,8 @@ use crate::lexical::index::inverted::segment::manager::{
     ManagedSegmentInfo, MergeCandidate, MergeStrategy,
 };
 use crate::lexical::index::inverted::writer::{InvertedIndexWriter, InvertedIndexWriterConfig};
+use crate::lexical::index::structures::aabb::AABB;
+use crate::lexical::index::structures::visitor::{CellRelation, IntersectVisitor};
 use crate::lexical::reader::LexicalIndexReader;
 use crate::storage::Storage;
 
@@ -291,7 +292,12 @@ impl MergeEngine {
         for segment in segments {
             let reader = SegmentReader::open(segment.segment_info.clone(), self.storage.clone())?;
             let deleted = self.load_deleted_docs(&segment.segment_info)?;
-            let reconstructed = Self::reconstruct_segment(&reader, &deleted, &mut store_positions)?;
+            let reconstructed = self.reconstruct_segment(
+                &reader,
+                &segment.segment_info.segment_id,
+                &deleted,
+                &mut store_positions,
+            )?;
             stats.deleted_docs_removed += deleted.len() as u64;
             for (doc_id, analyzed) in reconstructed {
                 if docs.insert(doc_id, analyzed).is_none() {
@@ -406,14 +412,18 @@ impl MergeEngine {
     ///
     /// `field_terms` are rebuilt from the segment's postings (the authoritative
     /// source for the inverted index, so index-only fields survive);
-    /// `stored_fields` from the stored documents; `point_values` are re-derived
-    /// from the stored numeric / geo / datetime fields; `field_lengths` are read
-    /// back from the segment. Deleted docs are excluded.
+    /// `stored_fields` from the stored documents; `point_values` (BKD entries)
+    /// are read back from the segment's BKD trees — the authoritative source
+    /// for numeric/geo points, so index-only (`stored=false`) and multi-valued
+    /// numeric fields are preserved (Issue #758); `field_lengths` are read back
+    /// from the segment. Deleted docs are excluded.
     ///
     /// `store_positions` is set from the first posting seen (whether the source
     /// stored term positions) so the merged segment matches.
     fn reconstruct_segment(
+        &self,
         reader: &SegmentReader,
+        segment_id: &str,
         deleted: &AHashSet<u64>,
         store_positions: &mut Option<bool>,
     ) -> Result<Vec<(u64, AnalyzedDocument)>> {
@@ -466,6 +476,37 @@ impl MergeEngine {
             }
         }
 
+        // Collect BKD points per (doc, field) straight from the segment's BKD
+        // trees — the authoritative source for numeric/geo points. This keeps
+        // index-only (`stored=false`) and multi-valued numeric fields, which a
+        // stored-field derivation would miss (Issue #758).
+        let mut points: AHashMap<u64, AHashMap<String, Vec<Vec<f64>>>> = AHashMap::new();
+        let bkd_prefix = format!("{segment_id}.");
+        let bkd_suffix = ".bkd";
+        for file in self.storage.list_files()? {
+            let Some(field) = file
+                .strip_prefix(&bkd_prefix)
+                .and_then(|rest| rest.strip_suffix(bkd_suffix))
+            else {
+                continue;
+            };
+            if let Some(tree) = reader.get_bkd_tree(field)? {
+                let mut visitor = CollectPointsVisitor::default();
+                tree.intersect(&mut visitor)?;
+                for (doc_id, point) in visitor.entries {
+                    if deleted.contains(&doc_id) {
+                        continue;
+                    }
+                    points
+                        .entry(doc_id)
+                        .or_default()
+                        .entry(field.to_string())
+                        .or_default()
+                        .push(point);
+                }
+            }
+        }
+
         // Pass 2: assemble each live document.
         let mut out = Vec::new();
         for doc_id in reader.doc_ids()? {
@@ -478,16 +519,12 @@ impl MergeEngine {
 
             let mut analyzed = AnalyzedDocument::new();
             analyzed.field_terms = field_terms.remove(&doc_id).unwrap_or_default();
+            analyzed.point_values = points.remove(&doc_id).unwrap_or_default();
 
             for (field_name, value) in &stored.fields {
                 analyzed
                     .stored_fields
                     .insert(field_name.clone(), value.clone());
-                if let Some(point) = Self::data_value_point(value) {
-                    analyzed
-                        .point_values
-                        .insert(field_name.clone(), vec![point]);
-                }
             }
 
             // Field lengths are read back from the segment so BM25 length
@@ -504,21 +541,6 @@ impl MergeEngine {
         }
 
         Ok(out)
-    }
-
-    /// Re-derive the BKD point for a numeric / geo / datetime field value,
-    /// mirroring the analyzer's point extraction. Returns `None` for field
-    /// types that do not contribute a point (text, bool, bytes, vector, null,
-    /// arrays).
-    fn data_value_point(value: &FieldValue) -> Option<Vec<f64>> {
-        match value {
-            FieldValue::Int64(n) => Some(vec![*n as f64]),
-            FieldValue::Float64(f) => Some(vec![*f]),
-            FieldValue::DateTime(dt) => Some(vec![dt.timestamp() as f64]),
-            FieldValue::Geo(p) => Some(vec![p.lat, p.lon]),
-            FieldValue::GeoEcef(p) => Some(vec![p.x, p.y, p.z]),
-            _ => None,
-        }
     }
 
     /// Verify the integrity of a merged segment.
@@ -542,6 +564,34 @@ impl MergeEngine {
     /// Get merge configuration.
     pub fn get_config(&self) -> &MergeConfig {
         &self.config
+    }
+}
+
+/// BKD visitor that enumerates **every** `(doc_id, point)` entry in a tree.
+///
+/// Used by the merge to read back all stored points (Issue #758). `compare`
+/// always returns [`CellRelation::Crosses`] so the traversal descends to every
+/// leaf and yields each point through `visit` (a `CellRelation::Inside` verdict
+/// would report doc ids via `visit_inside` *without* the point coordinates,
+/// which the merge needs). `visit_inside` is therefore never called.
+#[derive(Default)]
+struct CollectPointsVisitor {
+    entries: Vec<(u64, Vec<f64>)>,
+}
+
+impl IntersectVisitor for CollectPointsVisitor {
+    fn compare(&self, _cell: &AABB) -> CellRelation {
+        // Force a full descent so every point is reported via `visit`.
+        CellRelation::Crosses
+    }
+
+    fn visit_inside(&mut self, _doc_id: u64) {
+        // Unreachable: `compare` never returns `Inside`. Points (not just doc
+        // ids) are required, so all entries must arrive through `visit`.
+    }
+
+    fn visit(&mut self, doc_id: u64, point: &[f64]) {
+        self.entries.push((doc_id, point.to_vec()));
     }
 }
 

--- a/laurus/tests/lexical_merge_bkd_test.rs
+++ b/laurus/tests/lexical_merge_bkd_test.rs
@@ -1,0 +1,84 @@
+//! Integration test for preserving BKD points of index-only numeric fields
+//! across a merge (Issue #758, follow-up of #753).
+//!
+//! A numeric field configured `indexed = true, stored = false` lives only in
+//! the BKD tree (not in the stored `.docs`). The merge must reconstruct point
+//! values from the source segments' BKD trees — not from stored fields — or
+//! range queries on such a field stop matching after a merge.
+
+use std::sync::Arc;
+
+use laurus::DataValue;
+use laurus::Document;
+use laurus::lexical::core::field::{FieldOption, IntegerOption};
+use laurus::lexical::query::NumericRangeQuery;
+use laurus::lexical::{LexicalIndexConfig, LexicalSearchRequest, LexicalStore};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+fn price_doc(price: i64) -> Document {
+    Document::builder()
+        .add_field("price", DataValue::Int64(price))
+        .build()
+}
+
+fn count_in_range(store: &LexicalStore, lower: i64, upper: i64) -> usize {
+    let query = Box::new(NumericRangeQuery::i64_range(
+        "price",
+        Some(lower),
+        Some(upper),
+    ));
+    store
+        .search(LexicalSearchRequest::new(query))
+        .unwrap()
+        .hits
+        .len()
+}
+
+#[test]
+fn merge_preserves_bkd_points_for_index_only_numeric_field() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    // `price` is indexed (BKD) but NOT stored — so its points exist only in the
+    // BKD tree, the case the old stored-field-derived merge dropped.
+    let config = LexicalIndexConfig::builder()
+        .add_field(
+            "price",
+            FieldOption::Integer(IntegerOption {
+                indexed: true,
+                stored: false,
+                multi_valued: false,
+            }),
+        )
+        .build();
+    let store = LexicalStore::new(storage, config).unwrap();
+
+    // Two segments (two commits).
+    store.upsert_document(1, price_doc(10)).unwrap();
+    store.upsert_document(2, price_doc(20)).unwrap();
+    store.commit().unwrap();
+    store.upsert_document(3, price_doc(30)).unwrap();
+    store.commit().unwrap();
+
+    // Sanity: range query works before merge (per-segment BKD).
+    assert_eq!(
+        count_in_range(&store, 0, 100),
+        3,
+        "all docs in range pre-merge"
+    );
+
+    // Merge: the index-only field's BKD points must survive (#758). With the
+    // old stored-field derivation these were lost (stored=false), so the merged
+    // segment had no BKD and this returned 0.
+    store.optimize().unwrap();
+    assert_eq!(
+        count_in_range(&store, 0, 100),
+        3,
+        "all BKD points survive the merge for a stored=false field"
+    );
+    // The actual values survive, not just the count: only price=20 is in [15,25].
+    assert_eq!(
+        count_in_range(&store, 15, 25),
+        1,
+        "merged BKD holds the real point values"
+    );
+}


### PR DESCRIPTION
Follow-up of #753, part of the #538 merge-engine campaign (umbrella #533). **Closes #758.**

## Problem

`MergeEngine::reconstruct_segment` rebuilt each document's `point_values` (BKD
entries) by **re-deriving them from the stored fields**. A numeric/geo field
configured `indexed = true, stored = false` (index-only) has no stored value, so
its points were dropped on merge — **range queries on such a field returned
nothing after a merge**. Multi-valued numeric fields were likewise not fully
reconstructed.

## Fix

Read point values straight from each source segment's **BKD tree**, the
authoritative and complete source (it holds every numeric/geo point, stored or
not):

- `CollectPointsVisitor` — an `IntersectVisitor` whose `compare` always returns
  `CellRelation::Crosses`, forcing a full descent so every `(doc_id, point)` is
  reported through `visit` (a `CellRelation::Inside` verdict would report doc ids
  via `visit_inside` *without* the point coordinates).
- `reconstruct_segment` enumerates the segment's `{segment_id}.{field}.bkd`
  files, runs the visitor per field, and buckets the live `(doc_id, point)`
  pairs into `point_values`.
- Removes the stored-field-derived `data_value_point`.

This covers index-only and multi-valued numeric fields uniformly; stored numeric
fields are unaffected (they're in the BKD too).

## Tests

`laurus/tests/lexical_merge_bkd_test.rs`: a `price` field set
`indexed = true, stored = false` across two segments. Before merge a range query
`[0,100]` returns all 3 docs; after `optimize()` it still returns 3 (the old
code returned 0), and `[15,25]` returns exactly 1 (`price = 20`) — proving the
real point values survived, not just the count.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -p laurus --all-targets -- -D warnings`: no warnings
- `cargo test -p laurus --lib lexical`: 425 passed (incl. the #753 typed-merge
  test, whose `Int64` field now sources points from the BKD)
- Integration: `lexical_merge_bkd_test`, `lexical_optimize_test`,
  `lexical_auto_merge_test`, `lexical_json_mirror_test` — pass

## Scope

`merge_engine.rs` only; no public API, on-disk format, or language-binding
changes. This closes the last #538 follow-up — the merge now preserves postings,
typed stored fields, and all BKD points (including index-only and multi-valued).

Closes #758
Refs #538 #533
