### PR TITLE
perf(lexical/search): add snapshot-scoped filter/query result cache (LRU + Roaring)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,6 +2597,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.3",
  "rkyv",
+ "roaring",
  "serde",
  "serde_json",
  "tempfile",
@@ -4541,6 +4542,16 @@ dependencies = [
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
 ]
 
 [[package]]

--- a/docs/ja/src/concepts/search/lexical_search.md
+++ b/docs/ja/src/concepts/search/lexical_search.md
@@ -316,6 +316,39 @@ let query = parser.parse("year:[2020 TO 2024]")?;
 
 完全な構文リファレンスは [Query DSL](../query_dsl.md) を参照してください。
 
+## フィルタ結果キャッシュ（Filter Result Cache）
+
+テナント・カテゴリ・ステータスフラグなどの filter 句は、多数のリクエストで繰り返し
+再利用されます。毎回ゼロから評価すると同じ posting list を何度も走査することになります。
+laurus は filter がマッチする**ドキュメント ID の集合**をメモ化し、繰り返しの filter を
+posting 走査ではなく単一のルックアップで済ませます。
+
+- **スナップショット連動・自己無効化（snapshot-scoped, self-invalidating）。**
+  キャッシュは reader 上に存在し、reader は `commit()` / `optimize()` / `refresh()` の
+  たびに再構築されます。各 reader は point-in-time スナップショットなので、手動の無効化は
+  不要です。インデックス変更後の次の検索は空のキャッシュから始まり、常にコミット済みの
+  データを反映します。
+- **スコア非依存（score-independent）。** filter は relevance に影響せずドキュメントを
+  選別するだけなので、キャッシュ値は単なる doc-id 集合（Roaring ビットマップ）です。
+  [ハイブリッド検索 / フィルタ検索](hybrid_search.md) の `filter_query` に使われ、
+  lexical 側・vector 側の両方に供給されます。
+- **構造的に安全（safe by construction）。** canonical なキーを持つクエリのみキャッシュ
+  されます。Term・Phrase・Prefix・Wildcard・Regexp・Fuzzy・Range・Geo・Geo3d クエリは
+  キャッシュ可能で、キャッシュ可能な句のみで構成され、かつ少なくとも 1 つの正句
+  （Must / Should / Filter）を持つ BooleanQuery も同様です。正句のない BooleanQuery・
+  Span クエリ・マルチフィールドクエリは毎回新規評価され（キャッシュされず）、結果は常に
+  正しくなります。
+
+キャッシュはデフォルトで有効です。インデックス設定で調整・無効化できます。
+
+```rust
+use laurus::lexical::store::config::LexicalIndexConfig;
+
+let config = LexicalIndexConfig::builder()
+    .query_filter_cache_capacity(4096) // スナップショットあたりのエントリ数。0 で無効化
+    .build();
+```
+
 ## 次のステップ
 
 - 意味的類似性検索: [Vector 検索](vector_search.md)

--- a/docs/src/concepts/search/lexical_search.md
+++ b/docs/src/concepts/search/lexical_search.md
@@ -317,6 +317,40 @@ let query = parser.parse("year:[2020 TO 2024]")?;
 
 See [Query DSL](../query_dsl.md) for the complete syntax reference.
 
+## Filter Result Cache
+
+Filter clauses — tenancy, category, status flags, and similar — are frequently
+reused across many requests. Re-evaluating them from scratch every time re-walks
+the same posting lists. Laurus memoises the **set of document ids** a filter
+matches so a repeated filter becomes a single lookup instead of a full posting
+walk.
+
+- **Snapshot-scoped, self-invalidating.** The cache lives on the reader, which
+  is rebuilt on every `commit()` / `optimize()` / `refresh()`. Each reader is a
+  point-in-time snapshot, so the cache needs no manual invalidation: after the
+  index changes, the next search starts from a fresh, empty cache and always
+  reflects committed data.
+- **Score-independent.** A filter selects documents without affecting relevance,
+  so the cached value is a plain doc-id set (a Roaring bitmap). It is used for
+  the `filter_query` of a [hybrid / filtered search](hybrid_search.md) and feeds
+  both the lexical and vector sides.
+- **Safe by construction.** Only queries with a canonical key are cached. Term,
+  phrase, prefix, wildcard, regexp, fuzzy, range, geo, and geo3d queries are
+  cacheable, as are boolean queries composed entirely of cacheable clauses with
+  at least one positive (Must / Should / Filter) clause. Boolean queries with no
+  positive clause, span queries, and multi-field queries are evaluated fresh
+  (never cached), so results are always correct.
+
+The cache is enabled by default. Tune or disable it via the index config:
+
+```rust
+use laurus::lexical::store::config::LexicalIndexConfig;
+
+let config = LexicalIndexConfig::builder()
+    .query_filter_cache_capacity(4096) // entries per snapshot; 0 disables the cache
+    .build();
+```
+
 ## Next Steps
 
 - Semantic similarity search: [Vector Search](vector_search.md)

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -42,6 +42,7 @@ pest_derive = "2.8.6"
 rand = "0.10.1"
 regex = "1.12.3"
 rkyv = { version = "0.8.16", features = ["std"] }
+roaring = "0.11.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -1246,18 +1246,17 @@ impl Engine {
 
         // 0b. Pre-process Filter
         let (allowed_ids, lexical_query_override) = if let Some(filter_query) = &request_filter {
-            let req = crate::lexical::search::searcher::LexicalSearchRequest::new(
-                filter_query.clone_box(),
-            )
-            .limit(1_000_000)
-            .load_documents(false);
+            // Evaluate the filter through the snapshot-scoped query/filter cache
+            // (Issue #578): a repeated filter is served as a cached doc-id set
+            // instead of re-walking posting lists. Unlike the previous path,
+            // this is not capped at 1M matches.
+            let allowed = self.lexical.matching_doc_ids(filter_query.clone_box())?;
 
-            let filter_hits = self.lexical.search(req)?.hits;
-            let ids: Vec<u64> = filter_hits.into_iter().map(|h| h.doc_id).collect();
-
-            if ids.is_empty() {
+            if allowed.is_empty() {
                 return Ok(Vec::new());
             }
+
+            let ids: Vec<u64> = allowed.iter().collect();
 
             let new_lexical_query: Option<Box<dyn crate::lexical::query::Query>> =
                 if let Some(lex_req) = &lexical_search_request {

--- a/laurus/src/lexical/index/config.rs
+++ b/laurus/src/lexical/index/config.rs
@@ -73,10 +73,23 @@ pub struct InvertedIndexConfig {
     /// If empty, all fields are indexed with default options (schema-less).
     #[serde(default)]
     pub fields: HashMap<String, FieldOption>,
+
+    /// Maximum number of entries in the snapshot-scoped query / filter result
+    /// cache (Issue #578).
+    ///
+    /// Repeated filter clauses (tenancy, category, status, …) are memoised as
+    /// document-id sets so they are evaluated once per reader snapshot instead
+    /// of on every request. `0` disables the cache. Defaults to `1024`.
+    #[serde(default = "default_query_filter_cache_capacity")]
+    pub query_filter_cache_capacity: usize,
 }
 
 fn default_analyzer() -> Arc<dyn Analyzer> {
     Arc::new(StandardAnalyzer::new().expect("StandardAnalyzer should be creatable"))
+}
+
+fn default_query_filter_cache_capacity() -> usize {
+    1024
 }
 
 impl Default for InvertedIndexConfig {
@@ -95,6 +108,7 @@ impl Default for InvertedIndexConfig {
             default_fields: Vec::new(),
             shard_id: 0,
             fields: HashMap::new(),
+            query_filter_cache_capacity: default_query_filter_cache_capacity(),
         }
     }
 }
@@ -110,6 +124,10 @@ impl std::fmt::Debug for InvertedIndexConfig {
             .field("max_segments", &self.max_segments)
             .field("analyzer", &self.analyzer.name())
             .field("default_fields", &self.default_fields)
+            .field(
+                "query_filter_cache_capacity",
+                &self.query_filter_cache_capacity,
+            )
             .finish()
     }
 }

--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -36,6 +36,7 @@ pub(crate) mod bmw;
 pub mod core;
 pub mod maintenance;
 pub(crate) mod per_segment_view;
+pub mod query_cache;
 pub mod reader;
 pub mod searcher;
 pub mod segment;
@@ -498,9 +499,12 @@ impl LexicalIndex for InvertedIndex {
 
         let segments = self.load_segments()?;
 
-        // Use analyzer from index config
+        // Use analyzer from index config. The query/filter cache capacity must
+        // be set explicitly here: `InvertedIndexReaderConfig::default()` would
+        // otherwise mask the value configured on the index (Issue #578).
         let reader_config = InvertedIndexReaderConfig {
             analyzer: self.config.analyzer.clone(),
+            query_filter_cache_capacity: self.config.query_filter_cache_capacity,
             ..InvertedIndexReaderConfig::default()
         };
 

--- a/laurus/src/lexical/index/inverted/query_cache.rs
+++ b/laurus/src/lexical/index/inverted/query_cache.rs
@@ -1,0 +1,231 @@
+//! Snapshot-scoped query / filter result cache (Issue
+//! [#578](https://github.com/mosuka/laurus/issues/578)).
+//!
+//! Filter clauses (tenancy, category, status flags, …) are frequently reused
+//! across many search requests, yet each request re-decodes every posting list
+//! to re-evaluate them. [`QueryFilterCache`] memoises the **set of document
+//! ids** a query matches so a repeated filter becomes a single map probe plus
+//! an [`Arc`] clone instead of a full posting walk.
+//!
+//! # Lifetime and invalidation
+//!
+//! The cache lives on
+//! [`InvertedIndexReader`](crate::lexical::index::inverted::reader::InvertedIndexReader),
+//! which is rebuilt on every `commit()` / `optimize()` / `refresh()` (the
+//! cached searcher in [`LexicalStore`](crate::lexical::store::LexicalStore) is
+//! dropped). Each reader is therefore a point-in-time snapshot and its cache
+//! requires **no explicit invalidation** — when the index changes, a fresh
+//! reader starts with an empty cache. This mirrors Lucene's per-reader cache
+//! model.
+//!
+//! # What is safe to cache
+//!
+//! Entries are keyed by [`Query::cache_key`](crate::lexical::query::Query::cache_key),
+//! which returns `Some(key)` only for queries whose matched set is canonically
+//! identified by the key (and `None` otherwise, bypassing the cache). The
+//! cached set is **score-independent**, so it is sound for filters and counts.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use lru::LruCache;
+use parking_lot::Mutex;
+use roaring::RoaringTreemap;
+
+use crate::error::Result;
+use crate::lexical::query::matcher::Matcher;
+
+/// Drain a fully-constructed matcher into a [`RoaringTreemap`] of document ids.
+///
+/// Shared by the reader's cache-backed
+/// [`matching_doc_ids`](crate::lexical::index::inverted::reader::InvertedIndexReader::matching_doc_ids)
+/// and the searcher's uncached fallback so the matcher-iteration protocol lives
+/// in one place. Mirrors the searcher's scoring loop: the matcher is
+/// pre-positioned at its first match, so `doc_id` is read before each `next`,
+/// and `u64::MAX` marks exhaustion. Deleted documents are already filtered at
+/// the posting-iterator level, so they never appear here.
+///
+/// # Arguments
+///
+/// * `matcher` - A matcher positioned at its first match (as returned by
+///   [`Query::matcher`](crate::lexical::query::Query::matcher)).
+///
+/// # Returns
+///
+/// The set of document ids the matcher yields.
+pub(crate) fn drain_matcher(mut matcher: Box<dyn Matcher>) -> Result<RoaringTreemap> {
+    let mut bitmap = RoaringTreemap::new();
+    while !matcher.is_exhausted() {
+        let doc_id = matcher.doc_id();
+        if doc_id == u64::MAX {
+            break;
+        }
+        bitmap.insert(doc_id);
+        if !matcher.next()? {
+            break;
+        }
+    }
+    Ok(bitmap)
+}
+
+/// A bounded LRU cache mapping a query's canonical cache key to the set of
+/// document ids it matches within one reader snapshot.
+///
+/// A [`Mutex`] (not an `RwLock`) guards the map because [`LruCache::get`] takes
+/// `&mut self` to update recency; critical sections are a single map probe plus
+/// an [`Arc`] clone. When the configured capacity is zero the cache is disabled
+/// and every operation is a no-op.
+#[derive(Debug)]
+pub struct QueryFilterCache {
+    /// The LRU map, or `None` when caching is disabled (capacity 0).
+    inner: Option<Mutex<LruCache<String, Arc<RoaringTreemap>>>>,
+    /// Number of lookups that returned a cached set.
+    hits: AtomicU64,
+    /// Number of lookups that missed (including lookups while disabled).
+    misses: AtomicU64,
+}
+
+impl QueryFilterCache {
+    /// Create a cache holding up to `capacity` entries.
+    ///
+    /// A `capacity` of `0` disables the cache: [`get`](Self::get) always misses
+    /// and [`put`](Self::put) is a no-op, so callers always compute fresh.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - Maximum number of `(query key, doc-id set)` entries to
+    ///   retain. The least-recently-used entry is evicted when full.
+    pub fn new(capacity: usize) -> Self {
+        let inner = NonZeroUsize::new(capacity).map(|c| Mutex::new(LruCache::new(c)));
+        QueryFilterCache {
+            inner,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// Returns `true` if caching is enabled (capacity was non-zero).
+    pub fn is_enabled(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Look up the doc-id set cached for `key`, bumping its recency on a hit.
+    ///
+    /// Records a hit or miss in the cache statistics. Returns `None` when the
+    /// key is absent or the cache is disabled; the cloned [`Arc`] on a hit is a
+    /// refcount bump, not a copy of the bitmap.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The query's canonical cache key.
+    ///
+    /// # Returns
+    ///
+    /// `Some(set)` on a hit, `None` on a miss.
+    pub fn get(&self, key: &str) -> Option<Arc<RoaringTreemap>> {
+        let hit = self
+            .inner
+            .as_ref()
+            .and_then(|inner| inner.lock().get(key).cloned());
+        if hit.is_some() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        hit
+    }
+
+    /// Insert a doc-id set for `key`, evicting the least-recently-used entry
+    /// when full. A no-op when the cache is disabled.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The query's canonical cache key.
+    /// * `value` - The set of matching document ids for this snapshot.
+    pub fn put(&self, key: String, value: Arc<RoaringTreemap>) {
+        if let Some(inner) = self.inner.as_ref() {
+            inner.lock().put(key, value);
+        }
+    }
+
+    /// Number of entries currently cached (0 when disabled).
+    pub fn len(&self) -> usize {
+        self.inner.as_ref().map_or(0, |inner| inner.lock().len())
+    }
+
+    /// Returns `true` if the cache holds no entries (or is disabled).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Snapshot of the cache hit / miss counters.
+    pub fn stats(&self) -> QueryFilterCacheStats {
+        QueryFilterCacheStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Hit / miss counters for a [`QueryFilterCache`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryFilterCacheStats {
+    /// Number of lookups served from the cache.
+    pub hits: u64,
+    /// Number of lookups that had to compute the result.
+    pub misses: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(ids: &[u64]) -> Arc<RoaringTreemap> {
+        Arc::new(ids.iter().copied().collect())
+    }
+
+    #[test]
+    fn put_then_get_returns_same_set() {
+        let cache = QueryFilterCache::new(4);
+        cache.put("k".to_string(), set(&[1, 2, 3]));
+
+        let got = cache.get("k").expect("entry should be present");
+        assert_eq!(got.iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(cache.stats().hits, 1);
+        assert_eq!(cache.stats().misses, 0);
+    }
+
+    #[test]
+    fn miss_increments_miss_counter() {
+        let cache = QueryFilterCache::new(4);
+        assert!(cache.get("absent").is_none());
+        assert_eq!(cache.stats().misses, 1);
+        assert_eq!(cache.stats().hits, 0);
+    }
+
+    #[test]
+    fn capacity_zero_disables_cache() {
+        let cache = QueryFilterCache::new(0);
+        assert!(!cache.is_enabled());
+        cache.put("k".to_string(), set(&[1]));
+        // Disabled cache never retains anything.
+        assert!(cache.get("k").is_none());
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn lru_evicts_least_recently_used() {
+        let cache = QueryFilterCache::new(2);
+        cache.put("a".to_string(), set(&[1]));
+        cache.put("b".to_string(), set(&[2]));
+        // Touch "a" so "b" becomes the LRU victim.
+        assert!(cache.get("a").is_some());
+        cache.put("c".to_string(), set(&[3]));
+
+        assert!(cache.get("a").is_some(), "a was recently used");
+        assert!(cache.get("c").is_some(), "c was just inserted");
+        assert!(cache.get("b").is_none(), "b should have been evicted");
+        assert_eq!(cache.len(), 2);
+    }
+}

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 use ahash::AHashMap;
+use roaring::RoaringTreemap;
 
 use crate::analysis::analyzer::analyzer::Analyzer;
 use crate::analysis::analyzer::standard::StandardAnalyzer;
@@ -19,11 +20,13 @@ use crate::lexical::index::inverted::core::posting::{DecodedPostingList, Posting
 use crate::lexical::index::inverted::core::terms::{
     InvertedIndexTerms, MergedInvertedIndexTerms, TermDictionaryAccess, Terms,
 };
+use crate::lexical::index::inverted::query_cache::QueryFilterCache;
 use crate::lexical::index::inverted::segment::SegmentInfo;
 use crate::lexical::index::structures::bkd_tree::{BKDReader, BKDTree};
 use crate::lexical::index::structures::dictionary::BlockTermDictionary;
 use crate::lexical::index::structures::dictionary::TermInfo;
 use crate::lexical::index::structures::doc_values::DocValuesReader;
+use crate::lexical::query::Query;
 use crate::lexical::reader::FieldStats;
 use crate::lexical::reader::PostingIterator;
 use crate::maintenance::deletion::DeletionBitmap;
@@ -48,6 +51,11 @@ pub struct InvertedIndexReaderConfig {
     /// Maximum number of cached terms per field.
     pub max_cached_terms_per_field: usize,
 
+    /// Maximum number of entries in the snapshot-scoped query / filter result
+    /// cache (Issue #578). `0` disables the cache. See
+    /// [`QueryFilterCache`](crate::lexical::index::inverted::query_cache::QueryFilterCache).
+    pub query_filter_cache_capacity: usize,
+
     /// Analyzer for query term analysis.
     pub analyzer: Arc<dyn Analyzer>,
 }
@@ -63,6 +71,10 @@ impl std::fmt::Debug for InvertedIndexReaderConfig {
                 "max_cached_terms_per_field",
                 &self.max_cached_terms_per_field,
             )
+            .field(
+                "query_filter_cache_capacity",
+                &self.query_filter_cache_capacity,
+            )
             .field("analyzer", &self.analyzer.name())
             .finish()
     }
@@ -76,6 +88,7 @@ impl Default for InvertedIndexReaderConfig {
             enable_posting_cache: true,
             preload_segments: false,
             max_cached_terms_per_field: 10000,
+            query_filter_cache_capacity: 1024,
             analyzer: Arc::new(
                 StandardAnalyzer::new().expect("StandardAnalyzer should be creatable"),
             ),
@@ -1504,6 +1517,14 @@ pub struct InvertedIndexReader {
     /// Cache manager.
     cache_manager: Arc<CacheManager>,
 
+    /// Snapshot-scoped query / filter result cache (Issue #578).
+    ///
+    /// `Arc` so that `#[derive(Clone)]` shares a single cache across clones of
+    /// this reader rather than deep-cloning an empty one. The cache is bound to
+    /// this reader's snapshot and is dropped when a new reader is built after a
+    /// commit / optimize / refresh.
+    query_cache: Arc<QueryFilterCache>,
+
     /// Reader configuration.
     config: InvertedIndexReaderConfig,
 
@@ -1522,6 +1543,7 @@ impl InvertedIndexReader {
         config: InvertedIndexReaderConfig,
     ) -> Result<Self> {
         let cache_manager = Arc::new(CacheManager::new(config.max_cache_memory));
+        let query_cache = Arc::new(QueryFilterCache::new(config.query_filter_cache_capacity));
         let mut segment_readers = Vec::new();
         let mut total_doc_count = 0;
 
@@ -1540,6 +1562,7 @@ impl InvertedIndexReader {
             segment_readers,
             segment_infos: segments,
             cache_manager,
+            query_cache,
             config,
             closed: Arc::new(AtomicBool::new(false)),
             total_doc_count,
@@ -1549,6 +1572,53 @@ impl InvertedIndexReader {
     /// Get cache statistics.
     pub fn cache_stats(&self) -> CacheStats {
         self.cache_manager.stats()
+    }
+
+    /// Snapshot of the query / filter result cache hit / miss counters (Issue
+    /// #578).
+    pub fn query_cache_stats(
+        &self,
+    ) -> crate::lexical::index::inverted::query_cache::QueryFilterCacheStats {
+        self.query_cache.stats()
+    }
+
+    /// Return the set of document ids matching `query` within this reader
+    /// snapshot, consulting the snapshot-scoped query / filter cache (Issue
+    /// [#578](https://github.com/mosuka/laurus/issues/578)).
+    ///
+    /// On a cache hit the stored [`RoaringTreemap`] is returned as a refcount
+    /// bump. On a miss — or for an uncacheable query, i.e. one whose
+    /// [`Query::cache_key`] is `None` — the query's matcher is drained into a
+    /// fresh bitmap; cacheable results are then stored for reuse. The returned
+    /// set is **score-independent** and excludes deleted documents (deletions
+    /// are filtered at the posting-iterator level, so a posting-derived matcher
+    /// never emits them).
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query whose matching document set is requested.
+    ///
+    /// # Returns
+    ///
+    /// An `Arc<RoaringTreemap>` of matching document ids, shared with the cache
+    /// when the query is cacheable.
+    pub fn matching_doc_ids(&self, query: &dyn Query) -> Result<Arc<RoaringTreemap>> {
+        if let Some(key) = query.cache_key() {
+            if let Some(cached) = self.query_cache.get(&key) {
+                return Ok(cached);
+            }
+            let bitmap = Arc::new(self.drain_matching(query)?);
+            self.query_cache.put(key, Arc::clone(&bitmap));
+            Ok(bitmap)
+        } else {
+            Ok(Arc::new(self.drain_matching(query)?))
+        }
+    }
+
+    /// Drain `query`'s matcher over this reader into a [`RoaringTreemap`].
+    fn drain_matching(&self, query: &dyn Query) -> Result<RoaringTreemap> {
+        let matcher = query.matcher(self)?;
+        crate::lexical::index::inverted::query_cache::drain_matcher(matcher)
     }
 
     /// Get the analyzer from configuration.

--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -908,6 +908,21 @@ impl crate::lexical::search::searcher::LexicalSearcher for InvertedIndexSearcher
     ) -> Result<u64> {
         InvertedIndexSearcher::count(self, request)
     }
+
+    fn matching_doc_ids(&self, query: Box<dyn Query>) -> Result<Arc<roaring::RoaringTreemap>> {
+        // The common case: the reader is an `InvertedIndexReader`, which owns
+        // the snapshot-scoped query/filter cache (Issue #578) and serves
+        // cacheable queries without re-walking posting lists.
+        if let Some(inverted_reader) = self.reader.as_any().downcast_ref::<InvertedIndexReader>() {
+            return inverted_reader.matching_doc_ids(query.as_ref());
+        }
+        // Fallback for a non-inverted reader (e.g. a transient
+        // `PerSegmentReaderView`): no snapshot cache is available, so drain the
+        // matcher directly using the shared helper.
+        let matcher = query.matcher(self.reader.as_ref())?;
+        let bitmap = crate::lexical::index::inverted::query_cache::drain_matcher(matcher)?;
+        Ok(Arc::new(bitmap))
+    }
 }
 
 #[cfg(test)]
@@ -1384,5 +1399,223 @@ mod tests {
         );
         let count = store.count(LexicalSearchRequest::new(query)).unwrap();
         assert!(count > 0, "count query on multi-seg corpus must hit");
+    }
+
+    // ----- Issue #578: query / filter result cache -----
+
+    /// `matching_doc_ids` must return exactly the doc-id set that an unbounded
+    /// `search` produces, for both a term filter and a boolean filter. The
+    /// cache is score-independent, so only the *set* (not scores) is compared.
+    #[test]
+    fn matching_doc_ids_matches_search_hit_set() {
+        use crate::lexical::query::boolean::BooleanQueryBuilder;
+        use std::collections::BTreeSet;
+
+        let store = build_skewed_store_with_segments(1);
+
+        let cases: Vec<Box<dyn Query>> = vec![
+            Box::new(TermQuery::new("body", "alpha")),
+            Box::new(
+                BooleanQueryBuilder::new()
+                    .must(Box::new(TermQuery::new("body", "alpha")))
+                    .should(Box::new(TermQuery::new("body", "beta")))
+                    .build(),
+            ),
+        ];
+
+        for query in cases {
+            let bitmap = store.matching_doc_ids(query.clone_box()).unwrap();
+            let cached_set: BTreeSet<u64> = bitmap.iter().collect();
+
+            let search_set: BTreeSet<u64> = store
+                .search(
+                    LexicalSearchRequest::new(query.clone_box())
+                        .limit(usize::MAX)
+                        .load_documents(false),
+                )
+                .unwrap()
+                .hits
+                .into_iter()
+                .map(|h| h.doc_id)
+                .collect();
+
+            assert_eq!(
+                cached_set,
+                search_set,
+                "matching_doc_ids must equal the search hit set for {}",
+                query.description()
+            );
+            assert!(!cached_set.is_empty(), "corpus should match the query");
+        }
+    }
+
+    /// A repeated cacheable lookup against the same reader snapshot is served
+    /// from the cache: it returns the very same `Arc` and bumps the hit
+    /// counter.
+    #[test]
+    fn matching_doc_ids_cache_hit_returns_shared_arc() {
+        let store = build_skewed_store_with_segments(1);
+        let reader = store.reader_for_tests().unwrap();
+        let inverted = reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .expect("memory store yields an InvertedIndexReader");
+
+        let query: Box<dyn Query> = Box::new(TermQuery::new("body", "alpha"));
+
+        let first = inverted.matching_doc_ids(query.as_ref()).unwrap();
+        let second = inverted.matching_doc_ids(query.as_ref()).unwrap();
+
+        assert_eq!(first, second, "cache hit must return the same set");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "second lookup should be served from the cache (same Arc)"
+        );
+
+        let stats = inverted.query_cache_stats();
+        assert_eq!(stats.misses, 1, "first lookup is a miss");
+        assert_eq!(stats.hits, 1, "second lookup is a hit");
+    }
+
+    /// Deleted documents must not appear in a cached filter set (deletions are
+    /// filtered at the posting-iterator level, before the matcher).
+    #[test]
+    fn matching_doc_ids_excludes_deleted_docs() {
+        use crate::Document;
+        use crate::lexical::store::LexicalStore;
+        use crate::lexical::store::config::LexicalIndexConfig;
+
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let store = LexicalStore::new(storage, LexicalIndexConfig::default()).unwrap();
+        for id in 0..10u64 {
+            let doc = Document::builder().add_text("body", "shared term").build();
+            store.upsert_document(id, doc).unwrap();
+        }
+        store.commit().unwrap();
+
+        let query = || -> Box<dyn Query> { Box::new(TermQuery::new("body", "shared")) };
+        let before = store.matching_doc_ids(query()).unwrap();
+        assert_eq!(before.len(), 10);
+
+        store.delete_document_by_internal_id(3).unwrap();
+        store.commit().unwrap();
+
+        let after = store.matching_doc_ids(query()).unwrap();
+        assert_eq!(after.len(), 9, "deleted doc must be excluded");
+        assert!(!after.contains(3), "doc 3 was deleted");
+    }
+
+    /// `commit` drops the cached searcher (and its reader's cache), so the next
+    /// lookup recomputes against the new snapshot and sees freshly added docs.
+    #[test]
+    fn commit_invalidates_query_filter_cache() {
+        use crate::Document;
+        use crate::lexical::store::LexicalStore;
+        use crate::lexical::store::config::LexicalIndexConfig;
+
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let store = LexicalStore::new(storage, LexicalIndexConfig::default()).unwrap();
+        for id in 0..5u64 {
+            let doc = Document::builder().add_text("body", "rust").build();
+            store.upsert_document(id, doc).unwrap();
+        }
+        store.commit().unwrap();
+
+        let query = || -> Box<dyn Query> { Box::new(TermQuery::new("body", "rust")) };
+        let before = store.matching_doc_ids(query()).unwrap();
+        assert_eq!(before.len(), 5);
+
+        // Add a matching doc and commit; the cached searcher is invalidated.
+        store
+            .upsert_document(99, Document::builder().add_text("body", "rust").build())
+            .unwrap();
+        store.commit().unwrap();
+
+        let after = store.matching_doc_ids(query()).unwrap();
+        assert_eq!(
+            after.len(),
+            6,
+            "post-commit lookup must see the new doc (cache invalidated)"
+        );
+        assert!(after.contains(99));
+    }
+
+    /// A query whose `cache_key` is `None` (here a MustNot-only boolean, R1)
+    /// must never touch the cache: it recomputes each call (distinct `Arc`) and
+    /// leaves the hit/miss counters untouched, while still returning a stable,
+    /// correct set.
+    #[test]
+    fn uncacheable_query_bypasses_cache() {
+        use crate::lexical::query::boolean::BooleanQueryBuilder;
+
+        let store = build_skewed_store_with_segments(1);
+        let reader = store.reader_for_tests().unwrap();
+        let inverted = reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .unwrap();
+
+        let make = || -> Box<dyn Query> {
+            Box::new(
+                BooleanQueryBuilder::new()
+                    .must_not(Box::new(TermQuery::new("body", "alpha")))
+                    .build(),
+            )
+        };
+        assert!(
+            make().cache_key().is_none(),
+            "MustNot-only boolean must be uncacheable"
+        );
+
+        let first = inverted.matching_doc_ids(make().as_ref()).unwrap();
+        let second = inverted.matching_doc_ids(make().as_ref()).unwrap();
+
+        assert_eq!(
+            first, second,
+            "uncacheable query still returns a stable set"
+        );
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "uncacheable query must recompute (a distinct Arc each call)"
+        );
+        let stats = inverted.query_cache_stats();
+        assert_eq!(stats.hits, 0, "uncacheable query never hits the cache");
+        assert_eq!(stats.misses, 0, "uncacheable query never probes the cache");
+    }
+
+    /// Many threads hammering the same cached filter must not deadlock or race
+    /// on the cache `Mutex`, and every thread must observe the same set.
+    #[test]
+    fn concurrent_matching_doc_ids_is_consistent() {
+        use std::collections::BTreeSet;
+        use std::thread;
+
+        let store = Arc::new(build_skewed_store_with_segments(1));
+        // Prime the cached searcher so all threads share one reader + cache.
+        let expected: BTreeSet<u64> = store
+            .matching_doc_ids(Box::new(TermQuery::new("body", "alpha")))
+            .unwrap()
+            .iter()
+            .collect();
+        assert!(!expected.is_empty());
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let store = Arc::clone(&store);
+            let expected = expected.clone();
+            handles.push(thread::spawn(move || {
+                for _ in 0..50 {
+                    let set: BTreeSet<u64> = store
+                        .matching_doc_ids(Box::new(TermQuery::new("body", "alpha")))
+                        .unwrap()
+                        .iter()
+                        .collect();
+                    assert_eq!(set, expected, "every thread sees the same cached set");
+                }
+            }));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
     }
 }

--- a/laurus/src/lexical/query.rs
+++ b/laurus/src/lexical/query.rs
@@ -188,4 +188,34 @@ pub trait Query: Send + Sync + Debug {
             self.set_boost(self.boost() * b);
         }
     }
+
+    /// Return a stable, canonical cache key identifying the **set of documents**
+    /// this query matches within a reader snapshot, or `None` if the query must
+    /// not be cached.
+    ///
+    /// This key backs the snapshot-scoped filter/doc-id result cache
+    /// (see [`QueryFilterCache`](crate::lexical::index::inverted::query_cache::QueryFilterCache)).
+    /// It is **score-independent**: two queries that match the same document set
+    /// must produce the same key, and the query's boost — which only scales
+    /// scores, never changes membership — is deliberately excluded.
+    ///
+    /// # Correctness contract
+    ///
+    /// Returning `Some(key)` is a promise that the key is *canonical*: any two
+    /// query instances that would match different document sets MUST yield
+    /// different keys. Implementors that cannot guarantee this (e.g. a key built
+    /// from a non-deterministic `HashMap` iteration order, or one that omits a
+    /// membership-affecting parameter) MUST return `None` so the query bypasses
+    /// the cache and is evaluated fresh. The default is `None` (not cacheable),
+    /// which is always safe.
+    ///
+    /// Keys are namespaced with a per-type tag (e.g. `"term|…"`) so that two
+    /// different query types can never collide in the shared cache map.
+    ///
+    /// # Returns
+    ///
+    /// `Some(canonical_key)` if this query may be cached, `None` otherwise.
+    fn cache_key(&self) -> Option<String> {
+        None
+    }
 }

--- a/laurus/src/lexical/query/boolean.rs
+++ b/laurus/src/lexical/query/boolean.rs
@@ -459,6 +459,42 @@ impl Query for BooleanQuery {
             }
         }
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // R1 safety: a boolean with no positive (Must/Should/Filter) clause is
+        // realised as `AllMatcher` / `NotMatcher` over the entire
+        // `[0, max_doc)` doc-id space (see `matcher` above), which includes
+        // deleted and never-assigned ids. That set is not a canonical "live
+        // document" set, so refuse to cache it.
+        let has_positive = self
+            .clauses
+            .iter()
+            .any(|c| matches!(c.occur, Occur::Must | Occur::Should | Occur::Filter));
+        if !has_positive {
+            return None;
+        }
+
+        // Compose from each clause's own `cache_key`. If any child is
+        // uncacheable, the whole boolean is uncacheable — a non-canonical
+        // child would make the composite key non-canonical (the `?` below
+        // short-circuits to `None`). Clause order is preserved: the matched
+        // set is order-independent, so order only affects cache fragmentation,
+        // never correctness. `minimum_should_match` affects membership and is
+        // included; boost is score-only and excluded. Each child key is
+        // `{:?}`-escaped so the concatenation is unambiguous.
+        let mut key = format!("bool|msm={}|", self.minimum_should_match);
+        for clause in &self.clauses {
+            let tag = match clause.occur {
+                Occur::Must => 'M',
+                Occur::Should => 'S',
+                Occur::MustNot => 'N',
+                Occur::Filter => 'F',
+            };
+            let child = clause.query.cache_key()?;
+            key.push_str(&format!("{tag}{child:?};"));
+        }
+        Some(key)
+    }
 }
 
 /// Builder for creating boolean queries.
@@ -653,5 +689,75 @@ mod tests {
 
         let matcher = query.matcher(&reader).unwrap();
         assert!(matcher.is_exhausted());
+    }
+
+    // ----- Issue #578: cache_key composition rules -----
+
+    /// `cache_key` composes children and excludes boost (which scales scores,
+    /// not membership); a different child term yields a different key.
+    #[test]
+    fn cache_key_composes_and_excludes_boost() {
+        let base = BooleanQueryBuilder::new()
+            .must(Box::new(TermQuery::new("f", "a")))
+            .should(Box::new(TermQuery::new("g", "b")))
+            .build();
+        let key = base
+            .cache_key()
+            .expect("a boolean over cacheable children is cacheable");
+
+        let mut boosted = BooleanQueryBuilder::new()
+            .must(Box::new(TermQuery::new("f", "a")))
+            .should(Box::new(TermQuery::new("g", "b")))
+            .build();
+        boosted.set_boost(3.5);
+        assert_eq!(
+            boosted.cache_key().unwrap(),
+            key,
+            "boost must not change the cache key"
+        );
+
+        let other = BooleanQueryBuilder::new()
+            .must(Box::new(TermQuery::new("f", "z")))
+            .should(Box::new(TermQuery::new("g", "b")))
+            .build();
+        assert_ne!(
+            other.cache_key().unwrap(),
+            key,
+            "a different child term must change the key"
+        );
+    }
+
+    /// A boolean with no positive (Must/Should/Filter) clause is realised over
+    /// the whole doc-id space (R1) and must be uncacheable.
+    #[test]
+    fn cache_key_none_for_mustnot_only() {
+        let q = BooleanQueryBuilder::new()
+            .must_not(Box::new(TermQuery::new("f", "a")))
+            .build();
+        assert!(
+            q.cache_key().is_none(),
+            "a MustNot-only boolean has no positive clause and must be uncacheable"
+        );
+    }
+
+    /// An uncacheable child (here a span query, whose key is `None`) must make
+    /// the whole boolean uncacheable.
+    #[test]
+    fn cache_key_none_when_child_uncacheable() {
+        use crate::lexical::query::span::{SpanQueryWrapper, SpanTermQuery};
+
+        let span: Box<dyn Query> = Box::new(SpanQueryWrapper::new(Box::new(SpanTermQuery::new(
+            "f", "a",
+        ))));
+        assert!(span.cache_key().is_none(), "span queries are not cacheable");
+
+        let q = BooleanQueryBuilder::new()
+            .must(span)
+            .should(Box::new(TermQuery::new("g", "b")))
+            .build();
+        assert!(
+            q.cache_key().is_none(),
+            "an uncacheable child must make the whole boolean uncacheable"
+        );
     }
 }

--- a/laurus/src/lexical/query/fuzzy.rs
+++ b/laurus/src/lexical/query/fuzzy.rs
@@ -223,6 +223,23 @@ impl Query for FuzzyQuery {
     fn field(&self) -> Option<&str> {
         Some(&self.field)
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Every field below affects which terms (and therefore which
+        // documents) match: edit distance, the untouched prefix length,
+        // transposition support, the expansion cap, and the rewrite method.
+        // Boost is score-only and excluded.
+        Some(format!(
+            "fuzzy|{:?}|{:?}|{}|{}|{}|{}|{:?}",
+            self.field,
+            self.term,
+            self.max_edits,
+            self.prefix_length,
+            self.transpositions,
+            self.max_expansions,
+            self.rewrite_method
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/laurus/src/lexical/query/geo.rs
+++ b/laurus/src/lexical/query/geo.rs
@@ -434,6 +434,16 @@ impl Query for GeoDistanceQuery {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + center + radius determine the matched set; boost is
+        // score-only and excluded. `{:?}` renders the f64 coordinates
+        // deterministically.
+        Some(format!(
+            "geodist|{:?}|{:?}|{:?}",
+            self.field, self.center, self.distance_m
+        ))
+    }
 }
 
 /// A geographical bounding box query.
@@ -786,6 +796,12 @@ impl Query for GeoBoundingBoxQuery {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + bounding box determine the matched set; boost is score-only
+        // and excluded.
+        Some(format!("geobbox|{:?}|{:?}", self.field, self.bounding_box))
     }
 }
 

--- a/laurus/src/lexical/query/geo3d.rs
+++ b/laurus/src/lexical/query/geo3d.rs
@@ -402,6 +402,15 @@ impl Query for Geo3dDistanceQuery {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + center + radius determine the matched set; boost is
+        // score-only and excluded.
+        Some(format!(
+            "geo3ddist|{:?}|{:?}|{:?}",
+            self.field, self.center, self.distance_m
+        ))
+    }
 }
 
 /// A 3D bounding-box query against an ECEF-typed field.
@@ -559,6 +568,15 @@ impl Query for Geo3dBoundingBoxQuery {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + min/max corners determine the matched set; boost is
+        // score-only and excluded.
+        Some(format!(
+            "geo3dbbox|{:?}|{:?}|{:?}",
+            self.field, self.min, self.max
+        ))
     }
 }
 
@@ -880,6 +898,16 @@ impl Query for Geo3dNearestQuery {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + center + k + the radius schedule fully determine which k
+        // documents are returned within a snapshot; boost is score-only and
+        // excluded.
+        Some(format!(
+            "geo3dnear|{:?}|{:?}|{}|{:?}|{:?}",
+            self.field, self.center, self.k, self.initial_radius_m, self.max_radius_m
+        ))
     }
 }
 

--- a/laurus/src/lexical/query/phrase.rs
+++ b/laurus/src/lexical/query/phrase.rs
@@ -521,6 +521,15 @@ impl Query for PhraseQuery {
     fn field(&self) -> Option<&str> {
         Some(&self.field)
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + ordered terms + slop determine the matched set; boost is
+        // score-only and excluded. `{:?}` on the term vector is unambiguous.
+        Some(format!(
+            "phrase|{:?}|{:?}|{}",
+            self.field, self.terms, self.slop
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/laurus/src/lexical/query/prefix.rs
+++ b/laurus/src/lexical/query/prefix.rs
@@ -164,6 +164,16 @@ impl Query for PrefixQuery {
     fn field(&self) -> Option<&str> {
         Some(&self.field)
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + prefix + rewrite method determine the matched set (the
+        // rewrite method can cap term expansion, which affects membership);
+        // boost is score-only and excluded.
+        Some(format!(
+            "prefix|{:?}|{:?}|{:?}",
+            self.field, self.prefix, self.rewrite_method
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/laurus/src/lexical/query/range.rs
+++ b/laurus/src/lexical/query/range.rs
@@ -188,6 +188,15 @@ impl Query for RangeQuery {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + both bounds (inclusivity is encoded in the `Bound` variant)
+        // determine the matched set; boost is score-only and excluded.
+        Some(format!(
+            "range|{:?}|{:?}|{:?}",
+            self.field, self.lower_bound, self.upper_bound
+        ))
+    }
 }
 
 /// Matcher for range queries.
@@ -690,6 +699,20 @@ impl Query for NumericRangeQuery {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + numeric type + both byte-encoded bounds + inclusivity flags
+        // determine the matched set; boost is score-only and excluded.
+        Some(format!(
+            "nrange|{:?}|{:?}|{:?}|{:?}|{}|{}",
+            self.field,
+            self.numeric_type,
+            self.lower_bound,
+            self.upper_bound,
+            self.lower_inclusive,
+            self.upper_inclusive
+        ))
+    }
 }
 
 /// Optimized matcher for numeric range queries.
@@ -1065,6 +1088,19 @@ impl Query for DateTimeRangeQuery {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + both timestamp bounds + inclusivity flags determine the
+        // matched set; boost is score-only and excluded.
+        Some(format!(
+            "dtrange|{:?}|{:?}|{:?}|{}|{}",
+            self.field,
+            self.lower_bound,
+            self.upper_bound,
+            self.lower_inclusive,
+            self.upper_inclusive
+        ))
     }
 }
 

--- a/laurus/src/lexical/query/regexp.rs
+++ b/laurus/src/lexical/query/regexp.rs
@@ -159,6 +159,16 @@ impl Query for RegexpQuery {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + pattern + rewrite method determine the matched set; boost is
+        // score-only and excluded. The compiled automaton is derived from the
+        // pattern, so it need not appear in the key.
+        Some(format!(
+            "regexp|{:?}|{:?}|{:?}",
+            self.field, self.pattern, self.rewrite_method
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/laurus/src/lexical/query/term.rs
+++ b/laurus/src/lexical/query/term.rs
@@ -146,6 +146,13 @@ impl Query for TermQuery {
     fn field(&self) -> Option<&str> {
         Some(&self.field)
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + term fully determine the matched document set; boost only
+        // scales scores, so it is excluded. `{:?}` escapes each string so the
+        // concatenation is unambiguous regardless of the contents.
+        Some(format!("term|{:?}|{:?}", self.field, self.term))
+    }
 }
 
 #[cfg(test)]

--- a/laurus/src/lexical/query/wildcard.rs
+++ b/laurus/src/lexical/query/wildcard.rs
@@ -242,6 +242,16 @@ impl Query for WildcardQuery {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn cache_key(&self) -> Option<String> {
+        // Field + pattern + rewrite method determine the matched set; boost is
+        // score-only and excluded. The compiled regex is derived from the
+        // pattern, so it need not appear in the key.
+        Some(format!(
+            "wildcard|{:?}|{:?}|{:?}",
+            self.field, self.pattern, self.rewrite_method
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/laurus/src/lexical/search/searcher.rs
+++ b/laurus/src/lexical/search/searcher.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use roaring::RoaringTreemap;
+
 use crate::error::Result;
 use crate::lexical::query::{LexicalSearchResults, Query};
 
@@ -240,4 +242,37 @@ pub trait LexicalSearcher: Send + Sync + std::fmt::Debug {
     /// Returns the number of documents that match the given search request,
     /// applying the min_score threshold if specified in the request parameters.
     fn count(&self, request: LexicalSearchRequest) -> Result<u64>;
+
+    /// Return the set of document ids matching `query`, ignoring score
+    /// thresholds (Issue [#578](https://github.com/mosuka/laurus/issues/578)).
+    ///
+    /// This powers filter evaluation: a filter selects documents without
+    /// affecting relevance, so the result is a score-independent doc-id set.
+    /// Implementations backed by a snapshot-scoped cache (notably
+    /// [`InvertedIndexSearcher`](crate::lexical::index::inverted::searcher::InvertedIndexSearcher))
+    /// memoise the set so repeated filters are served without re-walking
+    /// posting lists.
+    ///
+    /// The default implementation drains an unbounded [`search`](Self::search)
+    /// and collects the matching doc ids — correct for any searcher but
+    /// uncached. The returned set excludes deleted documents.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query whose matching document set is requested.
+    ///
+    /// # Returns
+    ///
+    /// An `Arc<RoaringTreemap>` of matching document ids.
+    fn matching_doc_ids(&self, query: Box<dyn Query>) -> Result<Arc<RoaringTreemap>> {
+        let request = LexicalSearchRequest::new(query)
+            .limit(usize::MAX)
+            .load_documents(false);
+        let results = self.search(request)?;
+        let mut bitmap = RoaringTreemap::new();
+        for hit in results.hits {
+            bitmap.insert(hit.doc_id);
+        }
+        Ok(Arc::new(bitmap))
+    }
 }

--- a/laurus/src/lexical/store.rs
+++ b/laurus/src/lexical/store.rs
@@ -13,6 +13,7 @@ use crate::lexical::index::LexicalIndex;
 use crate::lexical::index::factory::LexicalIndexFactory;
 use crate::lexical::index::inverted::InvertedIndexStats;
 use crate::lexical::query::LexicalSearchResults;
+use crate::lexical::query::Query;
 #[cfg(test)]
 use crate::lexical::reader::LexicalIndexReader;
 use crate::lexical::search::searcher::{LexicalSearchRequest, LexicalSearcher};
@@ -526,6 +527,41 @@ impl LexicalStore {
         }
         let guard = parking_lot::RwLockWriteGuard::downgrade(guard);
         guard.as_ref().unwrap().count(request)
+    }
+
+    /// Return the set of document ids matching `query`, ignoring score
+    /// thresholds, via the snapshot-scoped query / filter cache (Issue
+    /// [#578](https://github.com/mosuka/laurus/issues/578)).
+    ///
+    /// Filters select documents without affecting relevance, so the result is a
+    /// score-independent doc-id set. This goes through the cached searcher (and
+    /// thus the reader's filter cache), so a repeated filter is served without
+    /// re-walking posting lists. The cache is invalidated automatically by
+    /// `commit()` / `optimize()` / `refresh()`, which drop the cached searcher.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query whose matching document set is requested.
+    ///
+    /// # Returns
+    ///
+    /// An `Arc<roaring::RoaringTreemap>` of matching document ids.
+    pub fn matching_doc_ids(&self, query: Box<dyn Query>) -> Result<Arc<roaring::RoaringTreemap>> {
+        // Fast path: read lock, cache hit.
+        {
+            let guard = self.searcher_cache.read();
+            if let Some(ref searcher) = *guard {
+                return searcher.matching_doc_ids(query);
+            }
+        }
+
+        // Slow path: populate under write lock, then downgrade to read lock.
+        let mut guard = self.searcher_cache.write();
+        if guard.is_none() {
+            *guard = Some(self.index.searcher()?);
+        }
+        let guard = parking_lot::RwLockWriteGuard::downgrade(guard);
+        guard.as_ref().unwrap().matching_doc_ids(query)
     }
 
     /// Close the search engine and release resources.

--- a/laurus/src/lexical/store/config.rs
+++ b/laurus/src/lexical/store/config.rs
@@ -139,6 +139,7 @@ pub struct LexicalIndexConfigBuilder {
     max_segments: Option<u32>,
     default_fields: Vec<String>,
     fields: HashMap<String, FieldOption>,
+    query_filter_cache_capacity: Option<usize>,
 }
 
 use crate::lexical::core::field::FieldOption;
@@ -162,6 +163,7 @@ impl LexicalIndexConfigBuilder {
             max_segments: None,
             default_fields: Vec::new(),
             fields: HashMap::new(),
+            query_filter_cache_capacity: None,
         }
     }
 
@@ -278,6 +280,17 @@ impl LexicalIndexConfigBuilder {
         self
     }
 
+    /// Set the maximum number of entries in the snapshot-scoped query / filter
+    /// result cache (Issue #578).
+    ///
+    /// Repeated filter clauses are memoised as document-id sets and reused
+    /// within a reader snapshot. `0` disables the cache.
+    /// Default: 1024
+    pub fn query_filter_cache_capacity(mut self, capacity: usize) -> Self {
+        self.query_filter_cache_capacity = Some(capacity);
+        self
+    }
+
     /// Add a field-specific configuration.
     pub fn add_field(mut self, name: impl Into<String>, option: FieldOption) -> Self {
         self.fields.insert(name.into(), option);
@@ -317,6 +330,9 @@ impl LexicalIndexConfigBuilder {
         }
         if !self.fields.is_empty() {
             config.fields = self.fields;
+        }
+        if let Some(capacity) = self.query_filter_cache_capacity {
+            config.query_filter_cache_capacity = capacity;
         }
 
         LexicalIndexConfig::Inverted(config)


### PR DESCRIPTION
Closes #578 (Round-3 audit task LS-01 — the single biggest scaling gap vs Lucene/Tantivy).

## Problem

The engine's `filter_query` path re-evaluated every filter clause from scratch on **every** request, re-walking each posting list. Reused filters (tenancy, category, status flags) had no doc-set memoisation.

## Change

A **snapshot-scoped doc-id result cache** so a repeated filter becomes a map probe + `Arc` clone instead of a full posting walk.

- **`QueryFilterCache`** (`parking_lot::Mutex<LruCache<String, Arc<RoaringTreemap>>>`) lives on `InvertedIndexReader`. The reader is rebuilt on every `commit()` / `optimize()` / `refresh()` (the cached searcher is dropped), so the cache is a point-in-time snapshot and is **auto-invalidated** — no manual bookkeeping. This is the Lucene per-reader cache model.
- **`RoaringTreemap`** (u64) because doc ids are user-assigned and sparse.
- **`Query::cache_key()`** — new trait method, default `None` (not cacheable, always safe). Opt-in canonical key for `term`/`phrase`/`prefix`/`wildcard`/`regexp`/`fuzzy`/`range`/`geo`/`geo3d`/`boolean`. Keys are type-tag-prefixed and exclude boost (score-independent → same matched set).
- **`LexicalSearcher::matching_doc_ids()`** added with a **non-breaking default body**; `InvertedIndexSearcher` delegates to the reader's cache; `LexicalStore` passthrough mirrors `search()`'s read/write-lock-downgrade strategy.
- Engine `filter_query` path wired to `matching_doc_ids()`.
- Capacity configurable via `LexicalIndexConfig::builder().query_filter_cache_capacity(n)` (default 1024; `0` disables).

## Correctness

- Deletions are filtered at the posting-iterator level, so a posting-derived matcher never emits deleted docs.
- A boolean with no positive (Must/Should/Filter) clause is realised over `[0, max_doc)` (`AllMatcher`/`NotMatcher`) and would include deleted/never-assigned ids → such queries return `cache_key None` and bypass the cache.
- `SpanQueryWrapper`, `MultiFieldQuery`, `AdvancedQuery` have lossy/non-deterministic descriptions → left uncacheable (`None`).

## ⚠️ Behavior change

The previous filter path capped matches at `limit = 1_000_000`; `matching_doc_ids` is uncapped, so a filter matching **>1M docs now returns the full set**. This is a bugfix (the cap silently truncated filters) but is a visible change.

## Verification

- `cargo build` (full workspace + all language bindings) ✅
- `cargo clippy --all-targets -- -D warnings` — zero warnings ✅
- `cargo fmt --check` — clean ✅
- `cargo test` (full workspace) — exit 0, 51 test binaries, laurus lib 1074 tests ✅
- New tests: equivalence vs `search`, cache-hit (shared `Arc` + stats), deletion exclusion, commit invalidation, uncacheable bypass, 8-thread concurrency, `cache_key` composition ✅
- `markdownlint-cli2` (en + ja, 77 files each) — 0 errors; docs updated in both languages ✅

Bindings: the trait addition is non-breaking (default method), so no binding signature changes are required.

## Follow-ups (out of scope)

- `Occur::Filter` clause-level caching inside `BooleanQuery` (LS-10)
- Parsed-DSL query cache (LS-13)
- Wire the posting cache (LS-16)
- Carry `Arc<RoaringTreemap>` into vector-search `allowed_ids` (Roaring `contains` on the vector side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)