### PR TITLE
perf(lexical/search): reuse the snapshot filter cache for Occur::Filter clauses inside BooleanQuery

### DIFF
--- a/docs/ja/src/concepts/search/lexical_search.md
+++ b/docs/ja/src/concepts/search/lexical_search.md
@@ -332,6 +332,9 @@ posting 走査ではなく単一のルックアップで済ませます。
   選別するだけなので、キャッシュ値は単なる doc-id 集合（Roaring ビットマップ）です。
   [ハイブリッド検索 / フィルタ検索](hybrid_search.md) の `filter_query` に使われ、
   lexical 側・vector 側の両方に供給されます。
+- **BooleanQuery 内でも再利用。** `BooleanQuery` 内の `Occur::Filter` 句
+  （例: `must(user_query).filter(tenant_filter)`）も、posting 再走査ではなくキャッシュから
+  マッチ集合を取得します。マルチセグメント時の per-segment fanout 経路でも有効です。
 - **構造的に安全（safe by construction）。** canonical なキーを持つクエリのみキャッシュ
   されます。Term・Phrase・Prefix・Wildcard・Regexp・Fuzzy・Range・Geo・Geo3d クエリは
   キャッシュ可能で、キャッシュ可能な句のみで構成され、かつ少なくとも 1 つの正句

--- a/docs/src/concepts/search/lexical_search.md
+++ b/docs/src/concepts/search/lexical_search.md
@@ -334,6 +334,10 @@ walk.
   so the cached value is a plain doc-id set (a Roaring bitmap). It is used for
   the `filter_query` of a [hybrid / filtered search](hybrid_search.md) and feeds
   both the lexical and vector sides.
+- **Reused inside boolean queries.** An `Occur::Filter` clause within a
+  `BooleanQuery` (e.g. `must(user_query).filter(tenant_filter)`) also draws its
+  matched set from the cache instead of re-walking postings — including the
+  per-segment fan-out path on multi-segment indexes.
 - **Safe by construction.** Only queries with a canonical key are cached. Term,
   phrase, prefix, wildcard, regexp, fuzzy, range, geo, and geo3d queries are
   cacheable, as are boolean queries composed entirely of cacheable clauses with

--- a/laurus/src/lexical/index/inverted/per_segment_view.rs
+++ b/laurus/src/lexical/index/inverted/per_segment_view.rs
@@ -34,10 +34,13 @@
 use std::any::Any;
 use std::sync::{Arc, RwLock};
 
+use roaring::RoaringTreemap;
+
 use crate::error::Result;
 use crate::lexical::core::document::Document;
 use crate::lexical::index::inverted::reader::SegmentReader;
 use crate::lexical::index::structures::bkd_tree::BKDTree;
+use crate::lexical::query::Query;
 use crate::lexical::reader::{FieldStats, LexicalIndexReader, PostingIterator, ReaderTermInfo};
 
 /// Cross-segment term-info lookup function. Returns the **global**
@@ -46,6 +49,14 @@ use crate::lexical::reader::{FieldStats, LexicalIndexReader, PostingIterator, Re
 /// signals that no segment has the term — the per-segment view will
 /// then also report `None` from its `term_info`.
 type GlobalTermInfoFn = dyn Fn(&str, &str) -> Result<Option<ReaderTermInfo>> + Send + Sync;
+
+/// Cross-segment matching-doc-ids lookup function (#764). Resolves a query's
+/// matched document set against the **cross-segment** reader's snapshot-scoped
+/// query/filter cache, so a filter clause evaluated under this per-segment
+/// fanout view reuses the same cache as the top-level reader. Doc ids are
+/// global, so the returned set intersects correctly with this segment's local
+/// matchers.
+type GlobalMatchingDocIdsFn = dyn Fn(&dyn Query) -> Result<Arc<RoaringTreemap>> + Send + Sync;
 
 /// Adapter that exposes a single [`SegmentReader`] as a
 /// [`LexicalIndexReader`] backed by per-segment posting / field data
@@ -61,24 +72,48 @@ pub(crate) struct PerSegmentReaderView {
     global_doc_count: u64,
     global_max_doc: u64,
     global_term_info_fn: Arc<GlobalTermInfoFn>,
+    global_matching_doc_ids_fn: Arc<GlobalMatchingDocIdsFn>,
 }
 
 impl PerSegmentReaderView {
     /// Create a view over `segment` that reports the supplied global
-    /// `doc_count` / `max_doc` and looks up cross-segment term-info via
-    /// `global_term_info_fn`.
+    /// `doc_count` / `max_doc`, looks up cross-segment term-info via
+    /// `global_term_info_fn`, and resolves cached filter doc-id sets via
+    /// `global_matching_doc_ids_fn` (#764).
     pub fn new(
         segment: Arc<RwLock<SegmentReader>>,
         global_doc_count: u64,
         global_max_doc: u64,
         global_term_info_fn: Arc<GlobalTermInfoFn>,
+        global_matching_doc_ids_fn: Arc<GlobalMatchingDocIdsFn>,
     ) -> Self {
         PerSegmentReaderView {
             segment,
             global_doc_count,
             global_max_doc,
             global_term_info_fn,
+            global_matching_doc_ids_fn,
         }
+    }
+
+    /// Resolve the cross-segment cached doc-id set for `query` (#764).
+    ///
+    /// Delegates to the cross-segment reader's
+    /// [`matching_doc_ids`](crate::lexical::index::inverted::reader::InvertedIndexReader::matching_doc_ids),
+    /// so a filter clause evaluated under this per-segment fanout view reuses
+    /// the same snapshot-scoped cache as the top-level reader. The returned
+    /// set uses global doc ids and therefore intersects correctly with this
+    /// segment's local matchers.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The (cacheable) filter query whose doc-id set is requested.
+    ///
+    /// # Returns
+    ///
+    /// An `Arc<RoaringTreemap>` of matching global document ids.
+    pub fn matching_doc_ids(&self, query: &dyn Query) -> Result<Arc<RoaringTreemap>> {
+        (self.global_matching_doc_ids_fn)(query)
     }
 
     /// Per-segment field length for `(doc_id, field)`. Mirrors

--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -329,6 +329,30 @@ impl InvertedIndexSearcher {
             )
         };
 
+        // Build a cross-segment matching-doc-ids closure (#764) so each
+        // PerSegmentReaderView can resolve a cacheable filter clause against the
+        // cross-segment snapshot cache rather than re-walking postings per
+        // segment. The fanout is only entered when `self.reader` is an
+        // InvertedIndexReader (dispatch gate), so the downcast succeeds; the
+        // defensive branch drains the matcher uncached.
+        let global_matching_doc_ids_fn = {
+            let reader_arc = self.reader.clone();
+            std::sync::Arc::new(
+                move |query: &dyn Query| -> Result<Arc<roaring::RoaringTreemap>> {
+                    if let Some(inverted) =
+                        reader_arc.as_any().downcast_ref::<InvertedIndexReader>()
+                    {
+                        inverted.matching_doc_ids(query)
+                    } else {
+                        let matcher = query.matcher(reader_arc.as_ref())?;
+                        Ok(Arc::new(
+                            crate::lexical::index::inverted::query_cache::drain_matcher(matcher)?,
+                        ))
+                    }
+                },
+            )
+        };
+
         // Per-segment K. The collector wants `top_k` hits globally;
         // each segment returns up to `top_k` so the merge has the
         // headroom to pick any combination of per-segment hits.
@@ -348,6 +372,7 @@ impl InvertedIndexSearcher {
                     global_doc_count,
                     global_max_doc,
                     global_term_info_fn.clone(),
+                    global_matching_doc_ids_fn.clone(),
                 );
                 let view_reader: Arc<dyn LexicalIndexReader> = Arc::new(view);
                 let temp_searcher = InvertedIndexSearcher::from_arc(view_reader);
@@ -1617,5 +1642,119 @@ mod tests {
         for handle in handles {
             handle.join().unwrap();
         }
+    }
+
+    // ----- Issue #764: Occur::Filter clause reuses the filter cache -----
+
+    /// A repeated `must(...).filter(...)` search must serve the `Occur::Filter`
+    /// clause from `QueryFilterCache` (single-segment / non-fanout path).
+    #[test]
+    fn filter_clause_reuses_cache_single_segment() {
+        use crate::lexical::query::boolean::BooleanQueryBuilder;
+
+        let store = build_skewed_store_with_segments(1);
+        let reader = store.reader_for_tests().unwrap();
+        let searcher = InvertedIndexSearcher::from_arc(reader.clone());
+
+        let make = || -> Box<dyn Query> {
+            Box::new(
+                BooleanQueryBuilder::new()
+                    .must(Box::new(TermQuery::new("body", "alpha")))
+                    .filter(Box::new(TermQuery::new("body", "beta")))
+                    .build(),
+            )
+        };
+
+        // First search populates the filter-clause set; second reuses it.
+        let _ = searcher
+            .search_with_collector(make(), TopDocsCollector::new(10))
+            .unwrap();
+        let _ = searcher
+            .search_with_collector(make(), TopDocsCollector::new(10))
+            .unwrap();
+
+        let inverted = reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .unwrap();
+        let stats = inverted.query_cache_stats();
+        assert!(
+            stats.hits >= 1,
+            "the Occur::Filter clause must hit the cache on the repeat search (stats: {stats:?})"
+        );
+    }
+
+    /// Cache-on must produce exactly the same result set as cache-off for a
+    /// filtered boolean across a multi-segment index (exercises the fanout
+    /// path through `PerSegmentReaderView::matching_doc_ids`).
+    #[test]
+    fn filter_clause_cache_matches_uncached_multi_segment() {
+        use crate::Document;
+        use crate::lexical::query::boolean::BooleanQueryBuilder;
+        use crate::lexical::store::LexicalStore;
+        use crate::lexical::store::config::LexicalIndexConfig;
+        use std::collections::BTreeSet;
+
+        // Build a 4-segment store with the given cache capacity. alpha = even
+        // ids, beta = multiples of 3, so must(alpha) ∩ filter(beta) = ids % 6.
+        let build = |capacity: usize| -> LexicalStore {
+            let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+            let config = LexicalIndexConfig::builder()
+                .query_filter_cache_capacity(capacity)
+                .build();
+            let store = LexicalStore::new(storage, config).unwrap();
+            for id in 0..400u64 {
+                let mut body = String::new();
+                if id % 2 == 0 {
+                    body.push_str("alpha ");
+                }
+                if id % 3 == 0 {
+                    body.push_str("beta ");
+                }
+                body.push_str("filler");
+                let doc = Document::builder().add_text("body", &body).build();
+                store.upsert_document(id, doc).unwrap();
+                if id % 100 == 99 {
+                    store.commit().unwrap();
+                }
+            }
+            store.commit().unwrap();
+            store
+        };
+
+        let make = || -> Box<dyn Query> {
+            Box::new(
+                BooleanQueryBuilder::new()
+                    .must(Box::new(TermQuery::new("body", "alpha")))
+                    .filter(Box::new(TermQuery::new("body", "beta")))
+                    .build(),
+            )
+        };
+        let run = |store: &LexicalStore| -> BTreeSet<u64> {
+            store
+                .search(
+                    LexicalSearchRequest::new(make())
+                        .limit(usize::MAX)
+                        .load_documents(false),
+                )
+                .unwrap()
+                .hits
+                .into_iter()
+                .map(|h| h.doc_id)
+                .collect()
+        };
+
+        let cached_set = run(&build(1024));
+        let uncached_set = run(&build(0));
+
+        assert_eq!(
+            cached_set, uncached_set,
+            "cache-on must equal cache-off for a filtered boolean (fanout path)"
+        );
+        assert!(!cached_set.is_empty(), "filter should match some docs");
+        assert!(
+            cached_set.iter().all(|&d| d % 6 == 0),
+            "must(alpha=even) ∩ filter(beta=%3) == ids divisible by 6"
+        );
     }
 }

--- a/laurus/src/lexical/query/boolean.rs
+++ b/laurus/src/lexical/query/boolean.rs
@@ -2,11 +2,15 @@
 
 use std::sync::Arc;
 
+use roaring::RoaringTreemap;
+
 use crate::error::Result;
+use crate::lexical::index::inverted::per_segment_view::PerSegmentReaderView;
+use crate::lexical::index::inverted::reader::InvertedIndexReader;
 use crate::lexical::query::Query;
 use crate::lexical::query::matcher::{
     AllMatcher, ConjunctionMatcher, ConjunctionNotMatcher, DisjunctionMatcher, EmptyMatcher,
-    Matcher, NotMatcher,
+    Matcher, NotMatcher, PreComputedMatcher,
 };
 use crate::lexical::query::scorer::{BM25Scorer, Scorer};
 use crate::lexical::reader::LexicalIndexReader;
@@ -170,6 +174,50 @@ impl Clone for BooleanQuery {
     }
 }
 
+/// Resolve the cached doc-id set for `query` when `reader` exposes a snapshot
+/// query/filter cache (#578/#764).
+///
+/// Reachable on the cross-segment [`InvertedIndexReader`] and on the
+/// per-segment fanout [`PerSegmentReaderView`] (which delegates to the
+/// cross-segment cache). Doc ids are global in both, so the same cached set is
+/// valid in either context. Returns `None` when no cache is reachable, so the
+/// caller falls back to the query's normal matcher.
+fn cached_filter_doc_ids(
+    query: &dyn Query,
+    reader: &dyn LexicalIndexReader,
+) -> Result<Option<Arc<RoaringTreemap>>> {
+    if let Some(inverted) = reader.as_any().downcast_ref::<InvertedIndexReader>() {
+        return Ok(Some(inverted.matching_doc_ids(query)?));
+    }
+    if let Some(view) = reader.as_any().downcast_ref::<PerSegmentReaderView>() {
+        return Ok(Some(view.matching_doc_ids(query)?));
+    }
+    Ok(None)
+}
+
+/// Build the matcher for a single boolean clause, reusing the snapshot-scoped
+/// filter cache for cacheable `Occur::Filter` clauses (#764).
+///
+/// A Filter clause selects documents without contributing to scoring, so its
+/// matched set can be served from the cache as a `RoaringTreemap` and iterated
+/// via a membership-only [`PreComputedMatcher`] instead of re-walking posting
+/// lists. Any non-Filter clause, an uncacheable query
+/// ([`Query::cache_key`] is `None`), or a reader without a reachable cache
+/// falls back to the query's normal matcher — so behaviour is unchanged there.
+fn clause_matcher(
+    clause: &BooleanClause,
+    reader: &dyn LexicalIndexReader,
+) -> Result<Box<dyn Matcher>> {
+    if clause.occur == Occur::Filter
+        && clause.query.cache_key().is_some()
+        && let Some(bitmap) = cached_filter_doc_ids(clause.query.as_ref(), reader)?
+    {
+        let doc_ids: Vec<u64> = bitmap.iter().collect();
+        return Ok(Box::new(PreComputedMatcher::new(doc_ids)));
+    }
+    clause.query.matcher(reader)
+}
+
 impl Query for BooleanQuery {
     fn matcher(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Matcher>> {
         if self.clauses.is_empty() {
@@ -194,12 +242,12 @@ impl Query for BooleanQuery {
             let mut positive_matcher = if !required_clauses.is_empty() {
                 if required_clauses.len() == 1 {
                     // Single required clause
-                    required_clauses[0].query.matcher(reader)?
+                    clause_matcher(required_clauses[0], reader)?
                 } else {
                     // Multiple required clauses - use ConjunctionMatcher
                     let mut matchers = Vec::new();
                     for clause in &required_clauses {
-                        let matcher = clause.query.matcher(reader)?;
+                        let matcher = clause_matcher(clause, reader)?;
                         if matcher.is_exhausted() {
                             return Ok(Box::new(EmptyMatcher::new()));
                         }


### PR DESCRIPTION
Closes #764. Follow-up of #578.

## Problem

#578 cached only the engine's **top-level** `filter_query`. When a filter is expressed as an `Occur::Filter` clause **inside** a `BooleanQuery` — which the engine itself builds as `must(user_query).filter(filter_query)` (`engine.rs:1261-1272`) — `BooleanQuery::matcher` re-walked the filter's posting list on every search. So a filtered lexical/hybrid query evaluated the same filter **twice**: once cached (for the vector side's `allowed_ids`), once uncached (inside the boolean for the lexical side).

## Change

- **`BooleanQuery::matcher`** now serves cacheable `Occur::Filter` clauses from `QueryFilterCache`. A new `clause_matcher` helper resolves the clause's doc-id set via `matching_doc_ids()` and iterates it with a membership-only **`PreComputedMatcher`** (reused — no new matcher type) instead of building the clause's full matcher. Non-Filter clauses, uncacheable queries (`cache_key() == None`), and readers without a reachable cache fall back to the existing matcher unchanged. Only `Occur::Filter` is affected (it does not contribute to scoring), so the scorer path is untouched.
- **Fan-out support.** `PerSegmentReaderView` gains a `global_matching_doc_ids` closure (mirroring its existing `global_term_info` closure) that resolves a filter clause against the **cross-segment** cache. Doc ids are global across segments, so the global set intersects correctly with each segment's local user-query matcher — the per-segment fan-out path on multi-segment indexes now reuses the cache too.

## Correctness

- Global filter set ∩ segment-local user-query matcher == the per-segment result of the uncached path (proven by the equivalence test below).
- Deletions are excluded on both sides (cached set and posting matcher).
- Re-entrancy safe: `matching_doc_ids` acquires the cache lock only for get/put; the matcher drain runs outside the lock.

## Verification

- `cargo build` (full workspace + bindings) ✅
- `cargo clippy --all-targets -- -D warnings` — zero warnings ✅
- `cargo fmt --check` — clean ✅
- `cargo test -p laurus --lib` — 1076 passed / 0 failed (+2 new) ✅
- Integration: `unified_filter` / `hybrid_unification` / `unified_search` / `unified_engine` ✅
- `markdownlint-cli2` — 0 errors; docs (en + ja) updated ✅

New tests:
- `filter_clause_reuses_cache_single_segment` — a repeated filtered boolean registers a cache hit on the `Occur::Filter` clause.
- `filter_clause_cache_matches_uncached_multi_segment` — **cache-on == cache-off** for a filtered boolean across a 4-segment index (exercises the fan-out path through `PerSegmentReaderView::matching_doc_ids`); sanity: `must(alpha=even) ∩ filter(beta=%3) == ids divisible by 6`.

## Follow-up (out of scope)

On a cold cache, a multi-segment fan-out can have all N segments miss simultaneously and each drain the filter globally. The engine path is unaffected (the cache is already warm from `allowed_ids`); a future single-flight guard could dedupe the cold-start case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)