### PR TITLE
test(vector): assert routing invariant, not exact HNSW recall (#773)

### DIFF
--- a/laurus/tests/vector_field_routing_test.rs
+++ b/laurus/tests/vector_field_routing_test.rs
@@ -135,13 +135,18 @@ async fn test_query_vector_fields_routes() {
         .search(request(Some(vec!["img_vec".into()]), None))
         .unwrap();
     let ids = doc_ids(&results);
+    // Routing invariant (deterministic): the result contains only img_vec docs
+    // and never leaks txt_vec docs. Whether *every* img_vec doc comes back is
+    // an approximate-recall property of the randomized HNSW graph, so we assert
+    // the routing guarantee (non-empty + subset) rather than exact recall, which
+    // is environment-sensitively flaky (Issue #773).
     assert!(
-        ids.contains(&1) && ids.contains(&2),
-        "img_vec docs present: {ids:?}"
+        !ids.is_empty(),
+        "routing must return at least one hit: {ids:?}"
     );
     assert!(
-        !ids.contains(&3) && !ids.contains(&4),
-        "txt_vec docs absent: {ids:?}"
+        ids.iter().all(|id| *id == 1 || *id == 2),
+        "only img_vec docs (1, 2) may be returned: {ids:?}"
     );
 }
 
@@ -156,13 +161,15 @@ async fn test_params_fields_exact() {
         ))
         .unwrap();
     let ids = doc_ids(&results);
+    // Routing invariant: only txt_vec docs may be returned (see #773 for why we
+    // assert the routing guarantee instead of exact recall).
     assert!(
-        ids.contains(&3) && ids.contains(&4),
-        "txt_vec docs present: {ids:?}"
+        !ids.is_empty(),
+        "routing must return at least one hit: {ids:?}"
     );
     assert!(
-        !ids.contains(&1) && !ids.contains(&2),
-        "img_vec docs absent: {ids:?}"
+        ids.iter().all(|id| *id == 3 || *id == 4),
+        "only txt_vec docs (3, 4) may be returned: {ids:?}"
     );
 }
 
@@ -177,13 +184,14 @@ async fn test_params_fields_prefix() {
         ))
         .unwrap();
     let ids = doc_ids(&results);
+    // Routing invariant: only img_vec docs may be returned (see #773).
     assert!(
-        ids.contains(&1) && ids.contains(&2),
-        "img_vec docs present: {ids:?}"
+        !ids.is_empty(),
+        "routing must return at least one hit: {ids:?}"
     );
     assert!(
-        !ids.contains(&3) && !ids.contains(&4),
-        "txt_vec docs absent: {ids:?}"
+        ids.iter().all(|id| *id == 1 || *id == 2),
+        "only img_vec docs (1, 2) may be returned: {ids:?}"
     );
 }
 
@@ -193,12 +201,18 @@ async fn test_no_fields_searches_all() {
     // No field selector anywhere → all fields searched (regression guard).
     let results = store.search(request(None, None)).unwrap();
     let ids = doc_ids(&results);
-    for id in [1, 2, 3, 4] {
-        assert!(
-            ids.contains(&id),
-            "doc {id} should be present with no field filter: {ids:?}"
-        );
-    }
+    // Both fields must be represented, proving neither was skipped. We anchor on
+    // the docs identical to the query (doc 1 in img_vec, doc 3 in txt_vec), which
+    // are the nearest in their field and reliably returned; requiring all four
+    // docs would assert exact recall on a randomized HNSW graph (Issue #773).
+    assert!(
+        ids.iter().any(|id| *id == 1 || *id == 2),
+        "img_vec field must be represented: {ids:?}"
+    );
+    assert!(
+        ids.iter().any(|id| *id == 3 || *id == 4),
+        "txt_vec field must be represented: {ids:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -212,12 +226,14 @@ async fn test_per_query_overrides_params() {
         ))
         .unwrap();
     let ids = doc_ids(&results);
+    // Per-query img_vec wins → only img_vec docs may be returned, never the
+    // request-level txt_vec docs (see #773 for the routing-vs-recall rationale).
     assert!(
-        ids.contains(&1) && ids.contains(&2),
-        "per-query img_vec wins: {ids:?}"
+        !ids.is_empty(),
+        "routing must return at least one hit: {ids:?}"
     );
     assert!(
-        !ids.contains(&3) && !ids.contains(&4),
-        "txt_vec excluded: {ids:?}"
+        ids.iter().all(|id| *id == 1 || *id == 2),
+        "per-query img_vec wins, only docs (1, 2) may be returned: {ids:?}"
     );
 }


### PR DESCRIPTION
## Summary

`vector_field_routing_test.rs` asserted the **presence** of every expected doc (e.g. `ids.contains(&1) && ids.contains(&2)`) on a randomized HNSW graph. That is an exact-recall assertion, which is environment-sensitively flaky: the `Test laurus (ubuntu-latest, x86_64-unknown-linux-gnu, stable)` CI job intermittently returned only the nearest doc (`{1}`) and failed at `vector_field_routing_test.rs:138`, while the aarch64 and Windows jobs of the same run passed. It is **not reproducible locally** (75/75 passes here), consistent with HNSW build-RNG/connectivity non-determinism — the anti-pattern `lessons.md` (2026-05-29) already documents.

All five tests in the file shared this pattern, so all were latent flakes; only `test_query_vector_fields_routes` happened to fire.

## Change

These are **routing** tests. The deterministic guarantee is that a query routed to a field returns **only** that field's docs (no cross-field leakage) — not that approximate search recalls every one. So:

- Single-field routing tests now assert the result is **non-empty and a subset of the targeted field's docs** (drops the flaky per-doc `contains`, keeps the no-leak guarantee).
- `test_no_fields_searches_all` asserts **both fields are represented**, anchored on the docs identical to the query (`doc 1` in `img_vec`, `doc 3` in `txt_vec`, similarity 1.0, reliably returned) instead of requiring all four docs.

The observed failure case `{1}` now passes deterministically (`{1} ⊆ {1,2}` and non-empty), so this resolves the flake without weakening the routing guarantee.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p laurus --test vector_field_routing_test -- -D warnings` — clean
- Ran the test file **40× in a loop — 40/40 pass** (was intermittently failing on CI).

Closes #773