### PR TITLE
ci: free disk space before embeddings-all builds (#775)

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,32 @@
+name: Free disk space
+description: >
+  Reclaim disk space on GitHub-hosted Ubuntu runners by removing large
+  preinstalled toolchains the build does not use. Needed because the
+  `--features embeddings-all` build (candle / tokenizers / hf-hub / image /
+  reqwest) plus the restored Rust build cache can otherwise exhaust the
+  runner's root disk ("No space left on device"). See issue #775.
+
+  Linux-only: the caller gates this with `if: runner.os == 'Linux'`. The
+  removed paths are unused by the Rust / Python / Node toolchains these jobs
+  rely on, so they are safe to delete.
+
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      shell: bash
+      run: |
+        echo "Disk usage before cleanup:"
+        df -h /
+        # Remove large preinstalled toolchains the build never touches. Each
+        # `|| true` keeps the step succeeding even if a path is already absent
+        # (paths differ slightly between runner images).
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /usr/local/.ghcup || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        # Reclaim space held by cached Docker images (none of these jobs use Docker).
+        sudo docker image prune --all --force || true
+        echo "Disk usage after cleanup:"
+        df -h /

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -83,6 +87,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -125,6 +133,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Install protoc
         uses: ./.github/actions/install-protoc
@@ -174,6 +186,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -222,6 +238,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -269,6 +289,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -323,6 +347,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -365,6 +393,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -410,6 +442,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -176,6 +176,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -224,6 +228,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -267,6 +275,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Install protoc
         uses: ./.github/actions/install-protoc
@@ -317,6 +329,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -366,6 +382,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -414,6 +434,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -468,6 +492,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -542,6 +570,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -588,6 +620,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -84,6 +88,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -126,6 +134,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Install protoc
         uses: ./.github/actions/install-protoc
@@ -175,6 +187,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -223,6 +239,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -270,6 +290,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -324,6 +348,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -366,6 +394,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -412,6 +444,10 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v6
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary

The `ubuntu-latest` x86_64 CI jobs that build `--features embeddings-all` (candle / tokenizers / hf-hub / image / reqwest) intermittently die with `No space left on device`. The restored Rust build cache (~790 MB compressed, much larger expanded) plus the `embeddings-all` build artifacts exceed the runner's root disk by a thin margin, so the failure is intermittent. The `ubuntu-24.04-arm` job is unaffected (`skip_embedding_features: true`) and Windows is unaffected (different disk layout). Observed on PRs #772 and #774; cause is only visible via `gh api repos/.../check-runs/<job_id>/annotations`.

## Change

- Add a reusable composite action **`.github/actions/free-disk-space`** that removes unused preinstalled toolchains (.NET, Android SDK, GHC/Haskell, CodeQL bundle) and dangling Docker images (~25-30 GB reclaimed), printing `df -h /` before and after so future disk regressions are diagnosable from the log. This follows the existing local-composite-action pattern (`./.github/actions/install-protoc`).
- Reference it — gated `if: runner.os == 'Linux'`, right after checkout — in the heavy `embeddings-all` jobs of `regression.yml`, `periodic.yml`, and `release.yml`: `clippy`, `test-laurus`, `test-server`, `test-mcp`, `test-cli`, `test-python`, `test-nodejs`, `test-ruby`, `test-php` (9 jobs × 3 workflows = 27 references).

The removed paths are unused by the Rust / Python / Node toolchains these jobs rely on. Because `pull_request` runs use the PR's own workflow definitions, this change **self-validates** — the `Free disk space` step runs on this PR's CI.

## Verification

- All four YAML files parse cleanly.
- Verified (via job-mapping) that every insertion lands in one of the 9 intended jobs in each workflow — none in the `build-*` / `publish-*` artifact jobs.

## Out of scope (possible follow-up)

- `release.yml` `build-*` / `publish-*` artifact jobs (release-gated, not currently failing).

Closes #775