### PR TITLE
perf(engine/hybrid): run lexical and vector searches in parallel (#659)

### DIFF
--- a/docs/src/concepts/search/hybrid_search.md
+++ b/docs/src/concepts/search/hybrid_search.md
@@ -36,6 +36,14 @@ sequenceDiagram
     Engine-->>User: Vec of SearchResult
 ```
 
+The lexical and vector searches are independent, so the engine runs them
+concurrently rather than one after the other. Any query embedding is computed
+first (the vector search depends on it), then both searches execute in parallel.
+As a result the hybrid latency is bounded by the *slower* of the two searches
+(`max(lexical, vector)`) instead of their sum, which matters most when both
+sides do substantial work. Fusion is order-independent, so concurrent execution
+returns exactly the same ranked list as a sequential run.
+
 ## Basic Usage
 
 ### Builder API

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -1295,24 +1295,27 @@ impl Engine {
 
         let fetch_count = request_offset.saturating_add(request_limit);
 
-        let lexical_hits = if let Some(query) = &lexical_query_to_use {
+        // Build the lexical request; the search itself runs in parallel below.
+        let lex_req = if let Some(query) = &lexical_query_to_use {
             let q = query.clone_box();
             let overfetch_limit = if vector_search_request.is_some() {
                 fetch_count.saturating_mul(2)
             } else {
                 fetch_count
             };
-            let req = crate::lexical::search::searcher::LexicalSearchRequest::new(q)
-                .limit(overfetch_limit)
-                .load_documents(false);
-
-            self.lexical.search(req)?.hits
+            Some(
+                crate::lexical::search::searcher::LexicalSearchRequest::new(q)
+                    .limit(overfetch_limit)
+                    .load_documents(false),
+            )
         } else {
-            Vec::new()
+            None
         };
 
-        // 2. Execute Vector Search
-        let vector_hits = if let Some(vector_req) = &vector_search_request {
+        // 2. Build the vector request — including the async payload embedding,
+        // which must complete before the (synchronous) search runs in parallel
+        // below.
+        let vec_req = if let Some(vector_req) = &vector_search_request {
             let mut vreq = vector_req.clone();
             if lexical_search_request.is_some() && vreq.params.limit < fetch_count.saturating_mul(2)
             {
@@ -1380,10 +1383,26 @@ impl Engine {
                 vreq.query =
                     crate::vector::search::searcher::VectorSearchQuery::Vectors(query_vectors);
             }
-            self.vector.search(vreq)?.hits
+            Some(vreq)
         } else {
-            Vec::new()
+            None
         };
+
+        // Run the independent lexical and vector searches (#659). On native
+        // builds both synchronous searches overlap via `rayon::join`, so the
+        // hybrid latency drops from `lex + vec` toward `max(lex, vec)`. The
+        // closures take disjoint immutable borrows of `self.lexical` /
+        // `self.vector` plus the moved requests, so they are `Send`. On wasm32
+        // (no rayon) they run sequentially. Fusion below is order-independent,
+        // so the result set is identical either way.
+        let run_lexical = || lex_req.map(|r| self.lexical.search(r)).transpose();
+        let run_vector = || vec_req.map(|r| self.vector.search(r)).transpose();
+        #[cfg(feature = "native")]
+        let (lex_res, vec_res) = rayon::join(run_lexical, run_vector);
+        #[cfg(not(feature = "native"))]
+        let (lex_res, vec_res) = (run_lexical(), run_vector());
+        let lexical_hits = lex_res?.map(|r| r.hits).unwrap_or_default();
+        let vector_hits = vec_res?.map(|r| r.hits).unwrap_or_default();
 
         // 3. Fusion
         if lexical_search_request.is_some() && vector_search_request.is_some() {


### PR DESCRIPTION
## Summary

The hybrid search path in `Engine::search` executed the independent **lexical** and **vector** searches sequentially, blocking the executor for `lex + vec`. Both stores' `search` is synchronous, so this overlaps them with `rayon::join` after the filter/embed preprocessing (which the vector search depends on) completes. Hybrid latency now drops from `lex + vec` toward `max(lex, vec)`.

- Filter computation (`matching_doc_ids`) and the async payload embedding stay in the sequential preprocessing stage, since the vector search depends on them. Only the two synchronous searches are parallelized.
- Fusion is order-independent, so the **result set and ordering are unchanged**; the public API is untouched (no binding changes needed).

## Verification

| Check | Result |
| :--- | :--- |
| `cargo test -p laurus --lib` | 1114 passed / 0 failed |
| hybrid integration suites (`hybrid_unification_test`, `advanced_fusion_test`, `unified_search_test`) | 0 failed |
| `cargo fmt --check` | OK |
| `cargo clippy --all-targets -- -D warnings` | clean |
| markdownlint | 0 error |

### Benchmark — `hybrid_search_bench` (median, before → after)

| config | before (sequential) | after (parallel) | Δ |
| :--- | ---: | ---: | ---: |
| rrf/5000 | 305.6 µs | 288.2 µs | **−5.7%** |
| weighted_sum/5000 | 340.6 µs | 279.4 µs | **−18.0%** |
| top_k/k_10 | 369.3 µs | 296.2 µs | **−19.8%** |
| top_k/k_100 | 1.122 ms | 987.1 µs | **−12.0%** |
| top_k/k_500 | 3.527 ms | 3.100 ms | **−12.1%** |

All five configs improve with a consistent downward trend and no regression. The absolute speedup is core-count dependent, so the gate is "hybrid latency drops, no regression" rather than a fixed ratio.

Closes #659