### PR TITLE
fix(vector/store): propagate HnswOption rerank_storage and quantizer into HnswIndexConfig (#790)

### DIFF
--- a/docs/ja/src/concepts/indexing/vector_indexing.md
+++ b/docs/ja/src/concepts/indexing/vector_indexing.md
@@ -306,6 +306,12 @@ memory savings の前提を尊重するため sidecar 読み込みをスキッ�
 （Lazy mode で開いた Stage 2 セグメントは silent に Stage 1 へ
 degrade します）。
 
+sidecar はスキーマの HNSW オプションの `rerank_storage` でフィールド
+ごとに有効化され、その設定はすべての書き込み経路で尊重されます。直接
+の commit、アクティブな書き込みセグメント、セグメントの merge いずれも
+生成したセグメントに対して sidecar を再出力します（マージ後セグメント
+の sidecar はマージ後のベクトルから再構築されます）。
+
 新しい sidecar は末尾に header + payload を対象とする 8 バイトの
 CRC-32 footer を持ち、sidecar を読むすべての経路（searcher のロードと
 writer の再ロード）で検証されます。これにより、ディスク上の静かな破損

--- a/docs/src/concepts/indexing/vector_indexing.md
+++ b/docs/src/concepts/indexing/vector_indexing.md
@@ -303,6 +303,12 @@ Eager; Lazy mode skips the sidecar to honor its memory-savings
 promise (Stage 2 segments opened in Lazy mode silently degrade to
 Stage 1).
 
+The sidecar is enabled per field by `rerank_storage` in the schema's
+HNSW options, and that setting is honored on every write path: direct
+commits, the active write segment, and segment merges all re-emit the
+sidecar for the segment they produce (a merged segment's sidecar is
+rebuilt from the merged vectors).
+
 New sidecars end with an 8-byte CRC-32 footer over the header and
 payload that is verified whenever the sidecar is read (both the
 searcher load and the writer reload), so silent on-disk corruption is

--- a/laurus/src/vector/index/config.rs
+++ b/laurus/src/vector/index/config.rs
@@ -559,6 +559,55 @@ impl std::fmt::Debug for HnswIndexConfig {
     }
 }
 
+impl HnswIndexConfig {
+    /// Build an index config from the schema-level
+    /// [`HnswOption`](crate::vector::core::field::HnswOption)
+    /// (Issue #790).
+    ///
+    /// This is the single place that maps the option-derived fields, so
+    /// a field added to `HnswOption` is propagated (or consciously
+    /// excluded) here instead of being silently dropped at every
+    /// conversion site — the bug class behind Issue #790, where
+    /// `rerank_storage` and `quantizer` never reached the writers.
+    ///
+    /// Mapped fields: `dimension`, `distance` → `distance_metric`, `m`,
+    /// `ef_construction`, `default_ef_search`, `quantizer` →
+    /// `quantization_method`, and `rerank_storage`. All other fields
+    /// keep [`HnswIndexConfig::default`] values; in particular the
+    /// following are *intentionally* not mapped:
+    ///
+    /// * `normalize_vectors` — a per-call-site decision (the segmented
+    ///   path normalizes only for Cosine; the store path keeps its
+    ///   historical default), so callers overlay it explicitly.
+    /// * `embedder` — `HnswOption::embedder` is an embedder *name*
+    ///   (`Option<String>`) while the config holds an
+    ///   `Arc<dyn Embedder>`; resolution happens at the store level.
+    /// * `base_weight` — a scoring-level knob with no config
+    ///   counterpart.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - The schema-level HNSW field option to convert.
+    ///
+    /// # Returns
+    ///
+    /// A config carrying the option-derived fields above and defaults
+    /// for everything else; combine with struct-update syntax to set
+    /// site-specific fields.
+    pub fn from_hnsw_option(opt: &crate::vector::core::field::HnswOption) -> Self {
+        Self {
+            dimension: opt.dimension,
+            distance_metric: opt.distance,
+            m: opt.m,
+            ef_construction: opt.ef_construction,
+            default_ef_search: opt.default_ef_search,
+            quantization_method: opt.quantizer,
+            rerank_storage: opt.rerank_storage,
+            ..Self::default()
+        }
+    }
+}
+
 /// Configuration specific to IVF index.
 ///
 /// These settings control the behavior of the IVF (Inverted File)
@@ -665,5 +714,52 @@ impl std::fmt::Debug for IvfIndexConfig {
             .field("max_segments", &self.max_segments)
             .field("embedder", &self.embedder.name())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vector::core::field::HnswOption;
+    use crate::vector::core::rerank::RerankStorageKind;
+
+    /// Issue #790: every option-derived field must be mapped by
+    /// `from_hnsw_option`, and the intentionally unmapped fields must
+    /// keep their `HnswIndexConfig::default()` values.
+    #[test]
+    fn from_hnsw_option_maps_every_option_derived_field() {
+        let opt = HnswOption {
+            dimension: 8,
+            distance: DistanceMetric::Euclidean,
+            m: 5,
+            ef_construction: 33,
+            default_ef_search: Some(77),
+            base_weight: 2.5,
+            quantizer: quantization::QuantizationMethod::ProductQuantization { subvector_count: 4 },
+            rerank_storage: Some(RerankStorageKind::F32),
+            embedder: Some("my-embedder".to_string()),
+        };
+
+        let config = HnswIndexConfig::from_hnsw_option(&opt);
+
+        // Mapped fields (all chosen to differ from the defaults).
+        assert_eq!(config.dimension, 8);
+        assert_eq!(config.distance_metric, DistanceMetric::Euclidean);
+        assert_eq!(config.m, 5);
+        assert_eq!(config.ef_construction, 33);
+        assert_eq!(config.default_ef_search, Some(77));
+        assert_eq!(
+            config.quantization_method,
+            quantization::QuantizationMethod::ProductQuantization { subvector_count: 4 }
+        );
+        assert_eq!(config.rerank_storage, Some(RerankStorageKind::F32));
+
+        // Intentionally unmapped fields stay at their defaults.
+        let defaults = HnswIndexConfig::default();
+        assert_eq!(config.normalize_vectors, defaults.normalize_vectors);
+        assert_eq!(config.use_quantization, defaults.use_quantization);
+        assert_eq!(config.auto_compaction, defaults.auto_compaction);
+        assert_eq!(config.max_segments, defaults.max_segments);
+        assert_eq!(config.embedder.name(), defaults.embedder.name());
     }
 }

--- a/laurus/src/vector/index/segmented_field.rs
+++ b/laurus/src/vector/index/segmented_field.rs
@@ -112,15 +112,8 @@ impl SegmentedVectorField {
         let segment_id = self.segment_manager.generate_segment_id();
 
         // Get HNSW parameters from config
-        let (dimension, distance, m, ef_construction, default_ef_search) = match &self.config.vector
-        {
-            Some(FieldOption::Hnsw(opt)) => (
-                opt.dimension,
-                opt.distance,
-                opt.m,
-                opt.ef_construction,
-                opt.default_ef_search,
-            ),
+        let opt = match &self.config.vector {
+            Some(FieldOption::Hnsw(opt)) => opt,
             _ => {
                 return Err(LaurusError::invalid_config(
                     "SegmentedVectorField requires HNSW configuration".to_string(),
@@ -128,14 +121,12 @@ impl SegmentedVectorField {
             }
         };
 
+        // Option-derived fields (incl. rerank_storage and the quantizer,
+        // Issue #790) come from the shared conversion helper.
         let hnsw_config = HnswIndexConfig {
-            dimension,
-            distance_metric: distance,
-            m,
-            ef_construction,
-            default_ef_search,
-            normalize_vectors: distance == crate::vector::core::distance::DistanceMetric::Cosine,
-            ..Default::default()
+            normalize_vectors: opt.distance
+                == crate::vector::core::distance::DistanceMetric::Cosine,
+            ..HnswIndexConfig::from_hnsw_option(opt)
         };
 
         let writer_config = VectorIndexWriterConfig {
@@ -165,13 +156,8 @@ impl SegmentedVectorField {
         policy: &dyn crate::vector::index::hnsw::segment::merge_policy::MergePolicy,
     ) -> Result<()> {
         if let Some(candidate) = self.segment_manager.check_merge(policy) {
-            let (dimension, m, ef_construction, default_ef_search) = match &self.config.vector {
-                Some(FieldOption::Hnsw(opt)) => (
-                    opt.dimension,
-                    opt.m,
-                    opt.ef_construction,
-                    opt.default_ef_search,
-                ),
+            let opt = match &self.config.vector {
+                Some(FieldOption::Hnsw(opt)) => opt,
                 _ => {
                     return Err(LaurusError::invalid_config(
                         "SegmentedVectorField requires HNSW configuration".to_string(),
@@ -179,15 +165,20 @@ impl SegmentedVectorField {
                 }
             };
 
+            // Option-derived fields come from the shared conversion
+            // helper (Issue #790). This also fixes a latent bug: the
+            // merge config previously dropped `distance_metric` (and
+            // left `normalize_vectors` at its always-on default), so a
+            // non-Cosine segmented field was merged with the default
+            // Cosine metric and unconditional normalization. Mirror the
+            // active-segment writer: normalize only for Cosine.
             let mut engine = MergeEngine::new(
                 MergeConfig::default(),
                 self.storage.clone(),
                 HnswIndexConfig {
-                    dimension,
-                    m,
-                    ef_construction,
-                    default_ef_search,
-                    ..Default::default()
+                    normalize_vectors: opt.distance
+                        == crate::vector::core::distance::DistanceMetric::Cosine,
+                    ..HnswIndexConfig::from_hnsw_option(opt)
                 },
                 VectorIndexWriterConfig {
                     ..Default::default()

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -133,18 +133,17 @@ impl VectorStore {
                         embedder: config.embedder.clone(),
                         ..Default::default()
                     }),
+                    // Option-derived fields (incl. rerank_storage and the
+                    // quantizer, Issue #790) come from the shared
+                    // conversion helper; only store-level fields are
+                    // overlaid here.
                     FieldOption::Hnsw(opt) => VectorIndexTypeConfig::HNSW(HnswIndexConfig {
-                        dimension: opt.dimension,
-                        distance_metric: opt.distance,
-                        m: opt.m,
-                        ef_construction: opt.ef_construction,
-                        default_ef_search: opt.default_ef_search,
                         // Wire the deletion config's compaction policy into the
                         // index so commit can auto-compact (Issue #782).
                         auto_compaction: config.deletion_config.auto_compaction,
                         compaction_threshold: config.deletion_config.compaction_threshold,
                         embedder: config.embedder.clone(),
-                        ..Default::default()
+                        ..HnswIndexConfig::from_hnsw_option(opt)
                     }),
                     FieldOption::Ivf(opt) => VectorIndexTypeConfig::IVF(IvfIndexConfig {
                         dimension: opt.dimension,
@@ -949,5 +948,59 @@ mod tests {
         assert!(!store.is_closed());
         store.close().await.unwrap();
         assert!(store.is_closed());
+    }
+
+    /// Issue #790: the store-level config conversion must carry
+    /// `rerank_storage` and the quantizer into `HnswIndexConfig`
+    /// (previously dropped to `..Default::default()`, so the Stage-2
+    /// sidecar was never emitted through `VectorStore`/`Engine`).
+    #[test]
+    fn extract_index_type_config_propagates_rerank_and_quantizer() {
+        use crate::vector::core::distance::DistanceMetric;
+        use crate::vector::core::field::{FieldOption, HnswOption};
+        use crate::vector::core::quantization::QuantizationMethod;
+        use crate::vector::core::rerank::RerankStorageKind;
+        use crate::vector::store::config::{VectorFieldConfig, VectorIndexConfig};
+
+        let config = VectorIndexConfig::builder()
+            .field(
+                "vec",
+                VectorFieldConfig {
+                    vector: Some(FieldOption::Hnsw(HnswOption {
+                        dimension: 8,
+                        distance: DistanceMetric::Euclidean,
+                        m: 5,
+                        ef_construction: 33,
+                        default_ef_search: Some(77),
+                        quantizer: QuantizationMethod::ProductQuantization { subvector_count: 4 },
+                        rerank_storage: Some(RerankStorageKind::F32),
+                        ..Default::default()
+                    })),
+                    lexical: None,
+                },
+            )
+            .build()
+            .unwrap();
+
+        let index_config = VectorStore::extract_index_type_config(&config);
+
+        match index_config {
+            VectorIndexTypeConfig::HNSW(c) => {
+                // Issue #790: the previously dropped fields.
+                assert_eq!(c.rerank_storage, Some(RerankStorageKind::F32));
+                assert_eq!(
+                    c.quantization_method,
+                    QuantizationMethod::ProductQuantization { subvector_count: 4 }
+                );
+                // Pre-existing propagation still flows.
+                assert_eq!(c.dimension, 8);
+                assert_eq!(c.distance_metric, DistanceMetric::Euclidean);
+                assert_eq!(c.m, 5);
+                assert_eq!(c.ef_construction, 33);
+                assert_eq!(c.default_ef_search, Some(77));
+                assert_eq!(c.auto_compaction, config.deletion_config.auto_compaction);
+            }
+            other => panic!("expected HNSW config, got {}", other.index_type_name()),
+        }
     }
 }

--- a/laurus/tests/vector_hnsw_rerank_checksum_test.rs
+++ b/laurus/tests/vector_hnsw_rerank_checksum_test.rs
@@ -7,11 +7,12 @@
 //! loads it, while legacy footer-less sidecars (written before #788)
 //! must still load and serve rerank-augmented searches.
 //!
-//! The tests drive the public `HnswIndex` API directly because that is
-//! where `rerank_storage` takes effect today: the `VectorStore`-level
-//! config conversion does not yet propagate `HnswOption::rerank_storage`
-//! into `HnswIndexConfig` (issue #790), so a store-level commit never
-//! emits a sidecar.
+//! The tests drive the public `HnswIndex` API directly so they target
+//! the sidecar format in isolation. (Store/engine-level sidecar
+//! emission is covered separately by `vector_rerank_engine_test.rs`
+//! and `vector_merge_test.rs` since issue #790 wired
+//! `HnswOption::rerank_storage` through the `VectorStore` config
+//! conversion.)
 
 use std::io::{Read, Write};
 use std::sync::Arc;

--- a/laurus/tests/vector_merge_test.rs
+++ b/laurus/tests/vector_merge_test.rs
@@ -1,9 +1,12 @@
+use laurus::storage::Storage;
 use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
 use laurus::vector::DistanceMetric;
 use laurus::vector::StoredVector;
 use laurus::vector::Vector;
 use laurus::vector::VectorFieldConfig;
+use laurus::vector::core::rerank::RerankStorageKind;
 use laurus::vector::index::field::{FieldSearchInput, VectorFieldReader, VectorFieldWriter};
+use laurus::vector::index::hnsw::reader::HnswIndexReader;
 use laurus::vector::index::hnsw::segment::manager::{SegmentManager, SegmentManagerConfig};
 use laurus::vector::index::segmented_field::SegmentedVectorField;
 use laurus::vector::store::request::QueryVector;
@@ -230,6 +233,214 @@ async fn segmented_field_reader_cache_reuses_and_invalidates()
         "cache should have at most the one survivor pre-search; got {}",
         field.reader_cache.len()
     );
+
+    Ok(())
+}
+
+/// Regression test for Issue [#790]: `SegmentedVectorField` dropped
+/// `rerank_storage` (and the quantizer) when converting `HnswOption`
+/// into `HnswIndexConfig`, so neither flushed segments nor merged
+/// segments ever emitted the Stage-2 LRS1 sidecar (`<segment>.hnsw.f32`).
+///
+/// [#790]: https://github.com/mosuka/laurus/issues/790
+#[tokio::test]
+async fn segmented_flush_and_merge_emit_rerank_sidecar() -> Result<(), Box<dyn std::error::Error>> {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+    let manager_config = SegmentManagerConfig {
+        max_segments: 2,
+        merge_factor: 2,
+        min_vectors_per_segment: 1,
+        ..Default::default()
+    };
+    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+
+    let field_config = VectorFieldConfig {
+        vector: Some(FieldOption::Hnsw(HnswOption {
+            dimension: 4,
+            distance: DistanceMetric::Cosine,
+            m: 16,
+            ef_construction: 200,
+            rerank_storage: Some(RerankStorageKind::F32),
+            ..HnswOption::default()
+        })),
+        lexical: None,
+    };
+
+    let field = SegmentedVectorField::create(
+        "embedding",
+        field_config,
+        manager.clone(),
+        storage.clone(),
+        None,
+    )?;
+
+    field
+        .add_stored_vector(1, &StoredVector::new(vec![1.0, 0.0, 0.0, 0.0]), 0)
+        .await?;
+    field.flush().await?;
+    field
+        .add_stored_vector(2, &StoredVector::new(vec![0.0, 1.0, 0.0, 0.0]), 0)
+        .await?;
+    field.flush().await?;
+    field
+        .add_stored_vector(3, &StoredVector::new(vec![0.0, 0.0, 1.0, 0.0]), 0)
+        .await?;
+    field.flush().await?;
+
+    // Every flushed segment must carry its LRS1 sidecar (Issue #790:
+    // the active-segment config previously dropped rerank_storage).
+    let before_ids: Vec<String> = manager
+        .list_segments()
+        .iter()
+        .map(|s| s.segment_id.clone())
+        .collect();
+    assert_eq!(before_ids.len(), 3);
+    for id in &before_ids {
+        let sidecar = format!("{id}.hnsw.f32");
+        assert!(
+            storage.file_exists(&sidecar),
+            "flushed segment must emit {sidecar}"
+        );
+    }
+
+    field.perform_merge()?;
+
+    // Locate the merged segment (the id that was not present before).
+    let after = manager.list_segments();
+    assert_eq!(after.len(), 2);
+    let merged_id = after
+        .iter()
+        .map(|s| s.segment_id.clone())
+        .find(|id| !before_ids.contains(id))
+        .expect("merge must create a new segment");
+
+    let merged_sidecar = format!("{merged_id}.hnsw.f32");
+    assert!(
+        storage.file_exists(&merged_sidecar),
+        "merged segment must re-emit {merged_sidecar} (Issue #790: the \
+         merge-engine config previously dropped rerank_storage)"
+    );
+
+    // The merged sidecar must load into the rerank pool (Eager mode)
+    // and contain exactly the two merged vectors — the anti-fallback
+    // guard from the #788 test.
+    let reader = HnswIndexReader::load(
+        storage.clone() as Arc<dyn Storage>,
+        &merged_id,
+        DistanceMetric::Cosine,
+    )?;
+    let pool = reader
+        .rerank_storage()
+        .expect("merged sidecar must load into the rerank pool");
+    let merged_doc_count = [1u64, 2, 3]
+        .iter()
+        .filter(|doc_id| pool.contains(**doc_id, "embedding"))
+        .count();
+    assert_eq!(
+        merged_doc_count, 2,
+        "the merged pool must contain exactly the 2 merged vectors"
+    );
+
+    Ok(())
+}
+
+/// Regression test for the latent merge-config bug fixed with Issue
+/// [#790]: `perform_merge_with_policy` built its `HnswIndexConfig`
+/// without `distance_metric` (default Cosine) and without
+/// `normalize_vectors` (default `true`), so merging a **Euclidean**
+/// segmented field silently L2-normalized the merged vectors. The
+/// merged vectors must keep their original (non-unit) norms.
+///
+/// [#790]: https://github.com/mosuka/laurus/issues/790
+#[tokio::test]
+async fn segmented_merge_keeps_vectors_unnormalized_for_euclidean()
+-> Result<(), Box<dyn std::error::Error>> {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+    let manager_config = SegmentManagerConfig {
+        max_segments: 2,
+        merge_factor: 2,
+        min_vectors_per_segment: 1,
+        ..Default::default()
+    };
+    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+
+    let field_config = VectorFieldConfig {
+        vector: Some(FieldOption::Hnsw(HnswOption {
+            dimension: 4,
+            distance: DistanceMetric::Euclidean,
+            m: 16,
+            ef_construction: 200,
+            rerank_storage: Some(RerankStorageKind::F32),
+            ..HnswOption::default()
+        })),
+        lexical: None,
+    };
+
+    let field = SegmentedVectorField::create(
+        "embedding",
+        field_config,
+        manager.clone(),
+        storage.clone(),
+        None,
+    )?;
+
+    // All vectors have norms far from 1 so an accidental L2
+    // normalization during merge is unambiguously detectable.
+    let originals: [(u64, [f32; 4]); 3] = [
+        (1, [2.0, 0.0, 0.0, 0.0]),
+        (2, [0.0, 3.0, 0.0, 0.0]),
+        (3, [0.0, 0.0, 4.0, 0.0]),
+    ];
+    for (doc_id, vec) in &originals {
+        field
+            .add_stored_vector(*doc_id, &StoredVector::new(vec.to_vec()), 0)
+            .await?;
+        field.flush().await?;
+    }
+
+    let before_ids: Vec<String> = manager
+        .list_segments()
+        .iter()
+        .map(|s| s.segment_id.clone())
+        .collect();
+    field.perform_merge()?;
+
+    let merged_id = manager
+        .list_segments()
+        .iter()
+        .map(|s| s.segment_id.clone())
+        .find(|id| !before_ids.contains(id))
+        .expect("merge must create a new segment");
+
+    let reader = HnswIndexReader::load(
+        storage.clone() as Arc<dyn Storage>,
+        &merged_id,
+        DistanceMetric::Euclidean,
+    )?;
+    let pool = reader
+        .rerank_storage()
+        .expect("merged sidecar must load into the rerank pool");
+
+    // Whichever two of the three docs were merged, their vectors must
+    // keep the original norms (2/3/4) within int8 dequantization
+    // tolerance — a normalized vector would have norm 1.0.
+    let mut checked = 0;
+    for (doc_id, original) in &originals {
+        if let Some(slice) = pool.get_f32_slice(*doc_id, "embedding") {
+            let norm: f32 = slice.iter().map(|v| v * v).sum::<f32>().sqrt();
+            let expected: f32 = original.iter().map(|v| v * v).sum::<f32>().sqrt();
+            assert!(
+                (norm - expected).abs() < 0.1,
+                "merged vector for doc {doc_id} must keep its original norm \
+                 {expected} (got {norm}); norm 1.0 means the merge config \
+                 normalized a Euclidean field (Issue #790 latent bug)"
+            );
+            checked += 1;
+        }
+    }
+    assert_eq!(checked, 2, "the merged pool must contain 2 of the 3 docs");
 
     Ok(())
 }

--- a/laurus/tests/vector_rerank_engine_test.rs
+++ b/laurus/tests/vector_rerank_engine_test.rs
@@ -1,10 +1,13 @@
-//! End-to-end engine wiring test for Issue #481 Stage 2.
+//! End-to-end engine wiring tests for Issue #481 Stage 2 / Issue #790.
 //!
-//! Verifies that `SearchRequestBuilder::vector_rerank_factor` flows
-//! through `Engine::search` to the HNSW searcher when the field has
-//! `rerank_storage` enabled, and that the request succeeds (no
-//! NotImplemented) for both Stage 2 (sidecar) and Stage 1 (no
-//! sidecar) configurations.
+//! Verifies that `rerank_storage: Some(_)` on a schema field actually
+//! reaches the HNSW writer through the `Engine` → `VectorStore` config
+//! conversion (Issue #790): the commit must emit the LRS1 sidecar
+//! (`vector_index.hnsw.f32`), and `SearchRequestBuilder::vector_rerank_factor`
+//! must flow to the Stage-2 rerank path — not the silent Stage-1
+//! fallback, which by construction returns bit-identical scores with
+//! and without `rerank_factor`. Stage-1 fields (no `rerank_storage`)
+//! must keep their behavior: no sidecar, silent int8 ranking.
 
 use tempfile::TempDir;
 
@@ -12,12 +15,37 @@ use laurus::DistanceMetric;
 use laurus::Engine;
 use laurus::SearchRequestBuilder;
 use laurus::storage::file::FileStorageConfig;
-use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::storage::prefixed::PrefixedStorage;
+use laurus::storage::{Storage, StorageConfig, StorageFactory};
 use laurus::vector::HnswOption;
 use laurus::vector::Vector;
+use laurus::vector::core::distance::DistanceMetric as VectorDistanceMetric;
 use laurus::vector::core::rerank::RerankStorageKind;
+use laurus::vector::index::hnsw::reader::HnswIndexReader;
 use laurus::{DataValue, Document};
 use laurus::{FieldOption, QueryVector, Schema, VectorSearchQuery};
+use std::sync::Arc;
+
+/// Sidecar name as seen by the engine's outer storage: the vector
+/// store works behind `PrefixedStorage("vector", ..)`, and the HNSW
+/// index file is `vector_index.hnsw`.
+const SIDECAR_NAME: &str = "vector/vector_index.hnsw.f32";
+
+/// Build a search request for `query`, optionally asking for Stage-2
+/// rerank with the given factor.
+fn vector_request(query: &[f32], rerank_factor: Option<usize>) -> laurus::SearchRequest {
+    let mut builder = SearchRequestBuilder::new()
+        .vector_query(VectorSearchQuery::Vectors(vec![QueryVector {
+            vector: Vector::new(query.to_vec()),
+            weight: 1.0,
+            fields: Some(vec!["embedding".to_string()]),
+        }]))
+        .limit(1);
+    if let Some(factor) = rerank_factor {
+        builder = builder.vector_rerank_factor(factor);
+    }
+    builder.build()
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn engine_search_with_rerank_factor_succeeds_on_stage2_field() -> laurus::Result<()> {
@@ -40,39 +68,79 @@ async fn engine_search_with_rerank_factor_succeeds_on_stage2_field() -> laurus::
 
     let engine = Engine::new(storage.clone(), schema).await?;
 
-    let doc1 = Document::builder()
-        .add_field("embedding", DataValue::Vector(vec![1.0, 0.0, 0.0, 0.0]))
-        .build();
-    let doc2 = Document::builder()
-        .add_field("embedding", DataValue::Vector(vec![0.0, 1.0, 0.0, 0.0]))
-        .build();
-    let doc3 = Document::builder()
-        .add_field("embedding", DataValue::Vector(vec![0.0, 0.0, 1.0, 0.0]))
-        .build();
-
-    engine.put_document("doc1", doc1).await?;
-    engine.put_document("doc2", doc2).await?;
-    engine.put_document("doc3", doc3).await?;
+    // Non-grid components (not exactly representable on the segment's
+    // int8 affine grid) so the exact-f32 rerank score measurably
+    // differs from the int8 score, and a query *between* the docs so
+    // similarities stay away from the 1.0 clamp.
+    let vectors: [(&str, [f32; 4]); 4] = [
+        ("doc1", [0.92, 0.31, 0.17, 0.05]),
+        ("doc2", [0.13, 0.83, 0.41, 0.27]),
+        ("doc3", [0.05, 0.19, 0.77, 0.61]),
+        ("doc4", [0.33, 0.47, 0.29, 0.71]),
+    ];
+    for (id, vec) in &vectors {
+        let doc = Document::builder()
+            .add_field("embedding", DataValue::Vector(vec.to_vec()))
+            .build();
+        engine.put_document(id, doc).await?;
+    }
     engine.commit().await?;
 
-    // Query close to doc1, asking for rerank_factor = 3. The wiring
-    // must let the request succeed and return doc1 as the top hit.
-    let query_vec = Vector::new(vec![0.99, 0.01, 0.0, 0.0]);
-    let request = SearchRequestBuilder::new()
-        .vector_query(VectorSearchQuery::Vectors(vec![QueryVector {
-            vector: query_vec,
-            weight: 1.0,
-            fields: Some(vec!["embedding".to_string()]),
-        }]))
-        .vector_rerank_factor(3)
-        .limit(1)
-        .build();
+    // Issue #790 acceptance: the commit must have emitted the LRS1
+    // sidecar through the Engine → VectorStore config conversion.
+    assert!(
+        storage.file_exists(SIDECAR_NAME),
+        "commit with rerank_storage: Some(F32) must emit {SIDECAR_NAME} \
+         (Issue #790: option was dropped in extract_index_type_config)"
+    );
 
-    let results = engine.search(request).await?;
-    assert_eq!(results.len(), 1, "expected exactly 1 hit");
+    // Stronger, deterministic guard: reopen the committed segment the
+    // way the vector store does (behind `PrefixedStorage("vector", ..)`,
+    // index file `vector_index`) and assert the sidecar actually loads
+    // into the rerank pool. A fresh `PrefixedStorage` reports Eager
+    // loading (the trait default), so the pool is populated on load —
+    // this proves "the f32 pool exists and is populated", independent
+    // of the score comparison below.
+    let vector_storage: Arc<dyn Storage> =
+        Arc::new(PrefixedStorage::new("vector", storage.clone()));
+    let reader =
+        HnswIndexReader::load(vector_storage, "vector_index", VectorDistanceMetric::Cosine)?;
+    let pool = reader
+        .rerank_storage()
+        .expect("the committed Stage-2 segment must load its rerank pool");
+    let positions = pool
+        .field_position_index("embedding")
+        .expect("the rerank pool must index the 'embedding' field (Issue #790)");
     assert_eq!(
-        results[0].id, "doc1",
+        positions.len(),
+        vectors.len(),
+        "the rerank pool must hold one f32 vector per committed document"
+    );
+
+    let query = [0.87, 0.36, 0.21, 0.09];
+
+    let with_rerank = engine.search(vector_request(&query, Some(3))).await?;
+    assert_eq!(with_rerank.len(), 1, "expected exactly 1 hit");
+    assert_eq!(
+        with_rerank[0].id, "doc1",
         "doc1 should be the closest match to the rerank-augmented query"
+    );
+
+    let without_rerank = engine.search(vector_request(&query, None)).await?;
+    assert_eq!(without_rerank.len(), 1);
+    assert_eq!(without_rerank[0].id, "doc1");
+
+    // The silent Stage-1 fallback returns bit-identical scores with
+    // and without rerank_factor (the searcher's `_` match arm reuses
+    // the same int8 candidates). A real Stage-2 rerank rescores the
+    // top candidates against the original f32 vectors, whose non-grid
+    // components differ from their int8 dequantization — so a score
+    // difference proves the f32 pool was used.
+    assert_ne!(
+        with_rerank[0].score, without_rerank[0].score,
+        "rerank_factor must change the score via the f32 sidecar pool; \
+         identical scores mean the silent Stage-1 fallback was taken \
+         (Issue #790)"
     );
     Ok(())
 }
@@ -109,19 +177,18 @@ async fn engine_search_with_rerank_factor_silently_falls_back_on_stage1_field() 
     engine.put_document("doc2", doc2).await?;
     engine.commit().await?;
 
+    // Pins the no-behavior-change guarantee of Issue #790: a Stage-1
+    // schema must not start emitting a sidecar.
+    assert!(
+        !storage.file_exists(SIDECAR_NAME),
+        "a field without rerank_storage must not emit {SIDECAR_NAME}"
+    );
+
     // Stage 1 segment + rerank_factor must succeed (no NotImplemented)
     // because the searcher silently degrades to int8 ranking.
-    let request = SearchRequestBuilder::new()
-        .vector_query(VectorSearchQuery::Vectors(vec![QueryVector {
-            vector: Vector::new(vec![0.95, 0.05, 0.0, 0.0]),
-            weight: 1.0,
-            fields: Some(vec!["embedding".to_string()]),
-        }]))
-        .vector_rerank_factor(5)
-        .limit(1)
-        .build();
-
-    let results = engine.search(request).await?;
+    let results = engine
+        .search(vector_request(&[0.95, 0.05, 0.0, 0.0], Some(5)))
+        .await?;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id, "doc1");
     Ok(())


### PR DESCRIPTION
## Summary

The store-level config conversion dropped `HnswOption::rerank_storage` and `quantizer` to `..Default::default()`, so a `VectorStore`/`Engine` commit never emitted the Stage-2 rerank sidecar (`.hnsw.f32`) and search silently degraded to Stage-1 (int8) ranking; a non-default quantizer (e.g. ProductQuantization) was likewise ignored and forced to Scalar8Bit.

This centralizes the `HnswOption` → `HnswIndexConfig` mapping in a new `HnswIndexConfig::from_hnsw_option` helper and routes all three production conversion sites through it:

- `VectorStore::extract_index_type_config` Hnsw arm — overlays `auto_compaction`/`compaction_threshold`/`embedder`.
- `SegmentedVectorField::ensure_active_segment` and `perform_merge_with_policy` — overlay `normalize_vectors = (distance == Cosine)`.

The helper's doc comment enumerates the intentionally-unmapped fields (`normalize_vectors`/`embedder`/`base_weight`), so the "new field forgotten at N conversion sites" bug class behind #790 cannot recur silently. The merge site additionally gains `distance_metric` and Cosine-conditional `normalize_vectors`, fixing a **latent bug** where a Euclidean segmented field was merged with the default Cosine metric and unconditional L2 normalization.

## Behavior changes (intended)

- Store-level schemas with a non-default `quantizer` previously silently wrote Scalar8Bit; they now take effect. An invalid PQ config surfaces a `Result` error at commit (correct) instead of silently degrading.
- An existing engine index whose schema already had `rerank_storage: Some` emits a sidecar on its next commit (rebuilt once from dequantized int8; later commits reuse the sidecar's original f32).

On-disk format and public signatures are otherwise unchanged; for users on `rerank_storage: None` + default quantizer the result is bit-identical (no behavior change).

## Tests (each verified to FAIL without the fix)

- Unit: `from_hnsw_option_maps_every_option_derived_field`, `extract_index_type_config_propagates_rerank_and_quantizer`.
- `vector_rerank_engine_test.rs`: asserts the committed sidecar exists, **deterministically reopens the segment and asserts the rerank pool is populated**, asserts `rerank_factor` changes the score (the silent fallback returns bit-identical scores), and pins that a Stage-1 field emits no sidecar.
- `vector_merge_test.rs`: merged-segment sidecar emission/load + Euclidean no-normalize regression.

`cargo fmt --check`, `cargo clippy -- -D warnings` (workspace + wasm32), `cargo test -p laurus` (lib 1127 + all 46 integration binaries, 0 failures), `cargo build -p laurus-wasm --target wasm32-unknown-unknown`, `markdownlint-cli2` (EN/JA) all clean. Docs updated EN/JA.

## Out of scope (follow-up issues filed)

- #793 — proto `HnswOption` lacks `rerank_storage`, so the gRPC server path still can't emit the sidecar (same bug class, proto layer).
- #794 — store-vs-segmented `normalize_vectors` inconsistency (needs a migration plan).
- #795 — merged sidecar rebuilt from dequantized int8 (precision loss).
- #796 — `use_quantization` dead-config cleanup.
- #797 — expose `rerank_storage`/`quantizer` on the language bindings.
- #798 — end-to-end PQ-through-commit test (deferred to avoid PQ k-means platform flakiness).

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)