### PR TITLE
fix(server): wire HnswOption rerank_storage through the proto schema (#793)

### DIFF
--- a/docs/ja/src/laurus-server/grpc_api.md
+++ b/docs/ja/src/laurus-server/grpc_api.md
@@ -100,9 +100,9 @@ message AnalyzerDefinition {
 
 | Lexical フィールド | Vector フィールド |
 | :--- | :--- |
-| `TextOption` (`indexed`, `stored`, `term_vectors`, `analyzer`) | `HnswOption` (`dimension`, `distance`, `m`, `ef_construction`, `base_weight`, `quantizer`, `embedder`) |
-| `IntegerOption` (`indexed`, `stored`, `multi_valued`) | `FlatOption` (`dimension`, `distance`, `base_weight`, `quantizer`, `embedder`) |
-| `FloatOption` (`indexed`, `stored`, `multi_valued`) | `IvfOption` (`dimension`, `distance`, `n_clusters`, `n_probe`, `base_weight`, `quantizer`, `embedder`) |
+| `TextOption` (`indexed`, `stored`, `term_vectors`, `analyzer`) | `HnswOption` (`dimension`, `distance`, `m`, `ef_construction`, `base_weight`, `quantizer`, `embedder`, `rerank_storage`) |
+| `IntegerOption` (`indexed`, `stored`, `multi_valued`) | `FlatOption` (`dimension`, `distance`, `base_weight`, `quantizer`, `embedder`, `rerank_storage`) |
+| `FloatOption` (`indexed`, `stored`, `multi_valued`) | `IvfOption` (`dimension`, `distance`, `n_clusters`, `n_probe`, `base_weight`, `quantizer`, `embedder`, `rerank_storage`) |
 | `BooleanOption` (`indexed`, `stored`) | |
 | `DateTimeOption` (`indexed`, `stored`) | |
 | `GeoOption` (`indexed`, `stored`) | |
@@ -116,6 +116,8 @@ message AnalyzerDefinition {
 **量子化手法:** `SCALAR_8BIT`（デフォルト）, `PRODUCT_QUANTIZATION`（Issue #481 Stage 3 で予約、現状 `Unimplemented`）
 
 `NONE`（量子化なし）は Issue #481 Stage 1 で廃止されました。proto enum 値 0（`QUANTIZATION_METHOD_NONE`）は wire 互換のため予約されていますが、サーバ側で受信すると `Default::default()`（`SCALAR_8BIT`）にフォールバックします。
+
+**Rerank storage:** オプションの `rerank_storage` フィールド（enum `RerankStorageKind`: `UNSPECIFIED` = サイドカーなし、`F32`）は Stage-2 rerank サイドカー（Issue #481 / #793）を有効化します。HNSW フィールドで `F32` を設定すると、commit 時に完全精度の `.hnsw.f32` サイドカーを追加で書き出し、`rerank_factor` を指定した検索が int8 候補を元のベクトルで再スコアします。フィールドを省略（または `UNSPECIFIED`）すると Stage-1 の int8 のみのランキングになります。スキーマの round-trip 整合のため `FlatOption` / `IvfOption` にも保持されますが、これらのインデックスはまだサイドカーを出力しません。
 
 **QuantizationConfig 構造:**
 

--- a/docs/src/laurus-server/grpc_api.md
+++ b/docs/src/laurus-server/grpc_api.md
@@ -100,9 +100,9 @@ Each `FieldOption` is a `oneof` with one of the following field types:
 
 | Lexical Fields | Vector Fields |
 | :--- | :--- |
-| `TextOption` (`indexed`, `stored`, `term_vectors`, `analyzer`) | `HnswOption` (`dimension`, `distance`, `m`, `ef_construction`, `base_weight`, `quantizer`, `embedder`) |
-| `IntegerOption` (`indexed`, `stored`, `multi_valued`) | `FlatOption` (`dimension`, `distance`, `base_weight`, `quantizer`, `embedder`) |
-| `FloatOption` (`indexed`, `stored`, `multi_valued`) | `IvfOption` (`dimension`, `distance`, `n_clusters`, `n_probe`, `base_weight`, `quantizer`, `embedder`) |
+| `TextOption` (`indexed`, `stored`, `term_vectors`, `analyzer`) | `HnswOption` (`dimension`, `distance`, `m`, `ef_construction`, `base_weight`, `quantizer`, `embedder`, `rerank_storage`) |
+| `IntegerOption` (`indexed`, `stored`, `multi_valued`) | `FlatOption` (`dimension`, `distance`, `base_weight`, `quantizer`, `embedder`, `rerank_storage`) |
+| `FloatOption` (`indexed`, `stored`, `multi_valued`) | `IvfOption` (`dimension`, `distance`, `n_clusters`, `n_probe`, `base_weight`, `quantizer`, `embedder`, `rerank_storage`) |
 | `BooleanOption` (`indexed`, `stored`) | |
 | `DateTimeOption` (`indexed`, `stored`) | |
 | `GeoOption` (`indexed`, `stored`) | |
@@ -116,6 +116,8 @@ The `embedder` field in vector options specifies the name of an embedder defined
 **Quantization methods:** `SCALAR_8BIT` (default), `PRODUCT_QUANTIZATION` (reserved for Issue #481 Stage 3, currently `Unimplemented`).
 
 `NONE` (no quantization) was removed in Issue #481 Stage 1. The proto enum value `0` (`QUANTIZATION_METHOD_NONE`) is kept as a wire-compat reservation; if the server receives it, it falls back to `SCALAR_8BIT` via `Default::default()`.
+
+**Rerank storage:** the optional `rerank_storage` field (enum `RerankStorageKind`: `UNSPECIFIED` = no sidecar, `F32`) enables the Stage-2 rerank sidecar (Issue #481 / #793). When set to `F32` on an HNSW field, commit writes an extra full-precision `.hnsw.f32` sidecar so searches that set `rerank_factor` rescore int8 candidates against the original vectors. Omitting the field (or `UNSPECIFIED`) keeps Stage-1 int8-only ranking. The field is also carried on `FlatOption` / `IvfOption` for schema round-tripping, but those indexes do not emit a sidecar yet.
 
 **QuantizationConfig structure:**
 

--- a/laurus-server/proto/laurus/v1/index.proto
+++ b/laurus-server/proto/laurus/v1/index.proto
@@ -193,6 +193,18 @@ message QuantizationConfig {
   uint32 subvector_count = 2;
 }
 
+// Stage-2 rerank sidecar storage kind (Issue #481 / #793). Mirrors
+// laurus::vector::core::rerank::RerankStorageKind. Selecting a kind on
+// an HNSW field makes the writer emit an extra full-precision sidecar
+// (`<segment>.hnsw.f32`) so the searcher can rescore int8 candidates
+// against the original vectors when a query sets `rerank_factor`.
+enum RerankStorageKind {
+  // No rerank sidecar (Stage 1, int8-only). Same as omitting the field.
+  RERANK_STORAGE_KIND_UNSPECIFIED = 0;
+  // Full IEEE-754 single-precision float sidecar (4 bytes per dim).
+  RERANK_STORAGE_KIND_F32 = 1;
+}
+
 message HnswOption {
   uint32 dimension = 1;
   DistanceMetric distance = 2;
@@ -207,6 +219,11 @@ message HnswOption {
   // take precedence. When unset, the searcher uses an internal
   // fallback (`50`). Issue #644.
   optional uint32 default_ef_search = 8;
+  // Stage-2 rerank sidecar storage (Issue #481 / #793). When set to
+  // `F32`, commit emits the `.hnsw.f32` sidecar so searches with
+  // `rerank_factor` rescore against full-precision vectors. Unset (or
+  // `UNSPECIFIED`) keeps Stage-1 int8-only ranking.
+  optional RerankStorageKind rerank_storage = 9;
 }
 
 message FlatOption {
@@ -216,6 +233,10 @@ message FlatOption {
   optional QuantizationConfig quantizer = 4;
   // Embedder name (empty = no auto-embedding).
   string embedder = 5;
+  // Stage-2 rerank sidecar storage (Issue #481 / #793). Carried through
+  // for schema round-tripping; the Flat index does not emit a sidecar
+  // yet, so this is currently inert for Flat fields.
+  optional RerankStorageKind rerank_storage = 6;
 }
 
 message IvfOption {
@@ -227,6 +248,10 @@ message IvfOption {
   optional QuantizationConfig quantizer = 6;
   // Embedder name (empty = no auto-embedding).
   string embedder = 7;
+  // Stage-2 rerank sidecar storage (Issue #481 / #793). Carried through
+  // for schema round-tripping; the IVF index does not emit a sidecar
+  // yet, so this is currently inert for IVF fields.
+  optional RerankStorageKind rerank_storage = 8;
 }
 
 // An embedder configuration.

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use laurus::vector::core::rerank::RerankStorageKind;
 use laurus::{
     AnalyzerDefinition, AnalyzerSpec, BooleanOption, BuiltinAnalyzerSpec, BytesOption,
     CharFilterConfig, DateTimeOption, DistanceMetric, DynamicFieldPolicy, EmbedderDefinition,
@@ -146,6 +147,7 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
             quantizer: Some(quantization_to_proto(&o.quantizer)),
             embedder: o.embedder.clone().unwrap_or_default(),
             default_ef_search: o.default_ef_search.map(|v| v as u32),
+            rerank_storage: o.rerank_storage.map(|k| rerank_storage_to_proto(k) as i32),
         })),
         FieldOption::Flat(o) => Some(Opt::Flat(v1::FlatOption {
             dimension: o.dimension as u32,
@@ -153,6 +155,7 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
             base_weight: o.base_weight,
             quantizer: Some(quantization_to_proto(&o.quantizer)),
             embedder: o.embedder.clone().unwrap_or_default(),
+            rerank_storage: o.rerank_storage.map(|k| rerank_storage_to_proto(k) as i32),
         })),
         FieldOption::Ivf(o) => Some(Opt::Ivf(v1::IvfOption {
             dimension: o.dimension as u32,
@@ -162,6 +165,7 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
             base_weight: o.base_weight,
             quantizer: Some(quantization_to_proto(&o.quantizer)),
             embedder: o.embedder.clone().unwrap_or_default(),
+            rerank_storage: o.rerank_storage.map(|k| rerank_storage_to_proto(k) as i32),
         })),
     };
     v1::FieldOption { option }
@@ -222,7 +226,7 @@ pub fn field_option_from_proto(fo: &v1::FieldOption) -> Option<FieldOption> {
                 .as_ref()
                 .map(quantization_from_proto)
                 .unwrap_or_default(),
-            rerank_storage: None,
+            rerank_storage: o.rerank_storage.and_then(rerank_storage_from_proto),
             embedder: if o.embedder.is_empty() {
                 None
             } else {
@@ -238,7 +242,7 @@ pub fn field_option_from_proto(fo: &v1::FieldOption) -> Option<FieldOption> {
                 .as_ref()
                 .map(quantization_from_proto)
                 .unwrap_or_default(),
-            rerank_storage: None,
+            rerank_storage: o.rerank_storage.and_then(rerank_storage_from_proto),
             embedder: if o.embedder.is_empty() {
                 None
             } else {
@@ -256,7 +260,7 @@ pub fn field_option_from_proto(fo: &v1::FieldOption) -> Option<FieldOption> {
                 .as_ref()
                 .map(quantization_from_proto)
                 .unwrap_or_default(),
-            rerank_storage: None,
+            rerank_storage: o.rerank_storage.and_then(rerank_storage_from_proto),
             embedder: if o.embedder.is_empty() {
                 None
             } else {
@@ -335,6 +339,25 @@ fn quantization_from_proto(q: &v1::QuantizationConfig) -> QuantizationMethod {
         // Phase 1 and revisit when FastScan exits experimental.
         #[cfg(not(feature = "pq-fastscan"))]
         Ok(v1::QuantizationMethod::ProductQuantizationFastscan) => QuantizationMethod::Scalar8Bit,
+    }
+}
+
+/// Convert a laurus [`RerankStorageKind`] into the proto enum (Issue #793).
+fn rerank_storage_to_proto(kind: RerankStorageKind) -> v1::RerankStorageKind {
+    match kind {
+        RerankStorageKind::F32 => v1::RerankStorageKind::F32,
+    }
+}
+
+/// Convert a proto `rerank_storage` enum value into an optional laurus
+/// [`RerankStorageKind`] (Issue #793).
+///
+/// `UNSPECIFIED` and any unknown value map to `None` (Stage-1, no
+/// sidecar), so an absent or zero field keeps the historical behavior.
+fn rerank_storage_from_proto(value: i32) -> Option<RerankStorageKind> {
+    match v1::RerankStorageKind::try_from(value) {
+        Ok(v1::RerankStorageKind::F32) => Some(RerankStorageKind::F32),
+        Ok(v1::RerankStorageKind::Unspecified) | Err(_) => None,
     }
 }
 
@@ -820,6 +843,99 @@ mod tests {
         let proto = to_proto(&schema);
         let back = from_proto(&proto).unwrap();
         assert_eq!(back.dynamic_field_policy, DynamicFieldPolicy::Dynamic);
+    }
+
+    /// Issue #793: an HNSW field's `rerank_storage` and `quantizer`
+    /// survive a proto round-trip. Before #793 the proto `HnswOption`
+    /// had no `rerank_storage` field, so `from_proto` hard-coded `None`
+    /// and the Stage-2 sidecar could never be enabled over gRPC. The
+    /// quantizer assertion is the "audit quantizer" part of the issue —
+    /// it was already wired and must keep round-tripping.
+    #[test]
+    fn hnsw_rerank_storage_and_quantizer_round_trip_through_proto() {
+        let schema = Schema::builder()
+            .add_field(
+                "embedding",
+                FieldOption::Hnsw(HnswOption {
+                    dimension: 8,
+                    rerank_storage: Some(RerankStorageKind::F32),
+                    quantizer: QuantizationMethod::ProductQuantization { subvector_count: 4 },
+                    ..Default::default()
+                }),
+            )
+            .build();
+
+        // Laurus -> proto carries the field (it is absent in the proto
+        // representation before this fix).
+        let proto = to_proto(&schema);
+        let proto_field = proto
+            .fields
+            .get("embedding")
+            .and_then(|f| f.option.as_ref())
+            .expect("embedding field option must be present");
+        match proto_field {
+            v1::field_option::Option::Hnsw(h) => {
+                assert_eq!(
+                    h.rerank_storage,
+                    Some(v1::RerankStorageKind::F32 as i32),
+                    "to_proto must serialize rerank_storage"
+                );
+            }
+            other => panic!("expected proto Hnsw option, got {other:?}"),
+        }
+
+        // proto -> Laurus restores both fields (previously rerank_storage
+        // was hard-coded to None).
+        let back = from_proto(&proto).expect("from_proto must succeed");
+        match back.fields.get("embedding") {
+            Some(FieldOption::Hnsw(h)) => {
+                assert_eq!(h.rerank_storage, Some(RerankStorageKind::F32));
+                assert_eq!(
+                    h.quantizer,
+                    QuantizationMethod::ProductQuantization { subvector_count: 4 }
+                );
+            }
+            other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+        }
+    }
+
+    /// Issue #793: `rerank_storage` round-trips for Flat and IVF fields
+    /// too (carried for schema fidelity even though those indexes do not
+    /// emit a sidecar yet), and an unset value stays `None`.
+    #[test]
+    fn flat_and_ivf_rerank_storage_round_trip_through_proto() {
+        let schema = Schema::builder()
+            .add_field(
+                "flat_vec",
+                FieldOption::Flat(FlatOption {
+                    dimension: 8,
+                    rerank_storage: Some(RerankStorageKind::F32),
+                    ..Default::default()
+                }),
+            )
+            .add_field(
+                "ivf_vec",
+                FieldOption::Ivf(IvfOption {
+                    dimension: 8,
+                    rerank_storage: None,
+                    ..Default::default()
+                }),
+            )
+            .build();
+
+        let back = from_proto(&to_proto(&schema)).expect("from_proto must succeed");
+        match back.fields.get("flat_vec") {
+            Some(FieldOption::Flat(f)) => {
+                assert_eq!(f.rerank_storage, Some(RerankStorageKind::F32));
+            }
+            other => panic!("expected FieldOption::Flat, got {other:?}"),
+        }
+        match back.fields.get("ivf_vec") {
+            Some(FieldOption::Ivf(i)) => {
+                assert_eq!(i.rerank_storage, None);
+            }
+            other => panic!("expected FieldOption::Ivf, got {other:?}"),
+        }
     }
 
     /// `FieldOption::Geo3d` round-trips through the proto `Geo3dOption`

--- a/laurus-server/src/gateway/convert.rs
+++ b/laurus-server/src/gateway/convert.rs
@@ -601,6 +601,26 @@ fn quantizer_to_json(q: &v1::QuantizationConfig) -> Value {
     })
 }
 
+/// Parse the JSON `rerank_storage` field (string, e.g. `"F32"`) into the
+/// proto enum value (Issue #793). Returns `None` (no sidecar) when the
+/// field is absent or unrecognized.
+fn json_to_rerank_storage(json: &Value) -> Option<i32> {
+    match json.get("rerank_storage").and_then(|v| v.as_str()) {
+        Some(s) if s.eq_ignore_ascii_case("f32") => Some(v1::RerankStorageKind::F32 as i32),
+        _ => None,
+    }
+}
+
+/// Render a proto `rerank_storage` enum value as a JSON string (Issue
+/// #793). Returns `None` for `UNSPECIFIED`/unknown so the field is
+/// omitted from the JSON object.
+fn rerank_storage_to_json(value: i32) -> Option<&'static str> {
+    match v1::RerankStorageKind::try_from(value) {
+        Ok(v1::RerankStorageKind::F32) => Some("F32"),
+        _ => None,
+    }
+}
+
 fn json_to_hnsw_option(json: &Value) -> Result<v1::HnswOption, String> {
     Ok(v1::HnswOption {
         dimension: json.get("dimension").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
@@ -629,6 +649,8 @@ fn json_to_hnsw_option(json: &Value) -> Result<v1::HnswOption, String> {
             .get("default_ef_search")
             .and_then(|v| v.as_u64())
             .map(|n| n as u32),
+        // Issue #793: optional Stage-2 rerank sidecar storage.
+        rerank_storage: json_to_rerank_storage(json),
     })
 }
 
@@ -650,6 +672,8 @@ fn json_to_flat_option(json: &Value) -> Result<v1::FlatOption, String> {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string(),
+        // Issue #793: optional Stage-2 rerank sidecar storage.
+        rerank_storage: json_to_rerank_storage(json),
     })
 }
 
@@ -673,6 +697,8 @@ fn json_to_ivf_option(json: &Value) -> Result<v1::IvfOption, String> {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string(),
+        // Issue #793: optional Stage-2 rerank sidecar storage.
+        rerank_storage: json_to_rerank_storage(json),
     })
 }
 
@@ -690,6 +716,9 @@ fn hnsw_option_to_json(opt: &v1::HnswOption) -> Value {
     if !opt.embedder.is_empty() {
         obj["embedder"] = json!(opt.embedder);
     }
+    if let Some(s) = opt.rerank_storage.and_then(rerank_storage_to_json) {
+        obj["rerank_storage"] = json!(s);
+    }
     obj
 }
 
@@ -704,6 +733,9 @@ fn flat_option_to_json(opt: &v1::FlatOption) -> Value {
     }
     if !opt.embedder.is_empty() {
         obj["embedder"] = json!(opt.embedder);
+    }
+    if let Some(s) = opt.rerank_storage.and_then(rerank_storage_to_json) {
+        obj["rerank_storage"] = json!(s);
     }
     obj
 }
@@ -721,6 +753,9 @@ fn ivf_option_to_json(opt: &v1::IvfOption) -> Value {
     }
     if !opt.embedder.is_empty() {
         obj["embedder"] = json!(opt.embedder);
+    }
+    if let Some(s) = opt.rerank_storage.and_then(rerank_storage_to_json) {
+        obj["rerank_storage"] = json!(s);
     }
     obj
 }

--- a/laurus-server/tests/grpc_rerank_sidecar_test.rs
+++ b/laurus-server/tests/grpc_rerank_sidecar_test.rs
@@ -1,0 +1,118 @@
+//! Server-level end-to-end test for Issue #793.
+//!
+//! Before #793 the proto `HnswOption` had no `rerank_storage` field, so
+//! `laurus_server::convert::schema::from_proto` hard-coded
+//! `rerank_storage: None` and a gRPC-created HNSW field could never emit
+//! the Stage-2 rerank sidecar (`.hnsw.f32`).
+//!
+//! This test drives the real server conversion path: a laurus `Schema`
+//! is serialized to the proto representation (`to_proto`) and parsed
+//! back (`from_proto`) — exactly what the `CreateIndex` RPC does with a
+//! client-supplied proto schema — then an `Engine` built from the
+//! round-tripped schema must emit the sidecar on commit.
+
+use std::sync::Arc;
+
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::core::rerank::RerankStorageKind;
+use laurus::{DataValue, DistanceMetric, Document, Engine, FieldOption, HnswOption, Schema};
+
+use laurus_server::convert::schema::{from_proto, to_proto};
+
+/// Sidecar file name as it lands under the engine's vector storage
+/// prefix (`PrefixedStorage("vector", ..)`, index file `vector_index`).
+const SIDECAR_NAME: &str = "vector/vector_index.hnsw.f32";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn grpc_schema_with_rerank_storage_emits_sidecar_on_commit() -> laurus::Result<()> {
+    // A schema as a gRPC client would configure it: HNSW + Stage-2 rerank.
+    let schema = Schema::builder()
+        .add_field(
+            "embedding",
+            FieldOption::Hnsw(HnswOption {
+                dimension: 4,
+                distance: DistanceMetric::Cosine,
+                m: 4,
+                ef_construction: 16,
+                rerank_storage: Some(RerankStorageKind::F32),
+                ..HnswOption::default()
+            }),
+        )
+        .build();
+
+    // Round-trip through the proto representation, the way CreateIndex
+    // does (client sends proto -> server from_proto). This is where
+    // #793's gap lived.
+    let proto = to_proto(&schema);
+    let server_schema = from_proto(&proto).expect("from_proto must succeed");
+
+    // The proto layer must have preserved rerank_storage end to end.
+    match server_schema.fields.get("embedding") {
+        Some(FieldOption::Hnsw(h)) => {
+            assert_eq!(
+                h.rerank_storage,
+                Some(RerankStorageKind::F32),
+                "the proto round-trip must preserve rerank_storage (Issue #793)"
+            );
+        }
+        other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+    }
+
+    // Build an engine from the round-tripped schema and commit a doc.
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let engine = Engine::new(storage.clone(), server_schema).await?;
+    let doc = Document::builder()
+        .add_field("embedding", DataValue::Vector(vec![0.92, 0.31, 0.17, 0.05]))
+        .build();
+    engine.put_document("doc1", doc).await?;
+    engine.commit().await?;
+
+    // The gRPC-configured field must now actually emit the sidecar.
+    assert!(
+        storage.file_exists(SIDECAR_NAME),
+        "a gRPC-created HNSW field with rerank_storage must emit {SIDECAR_NAME} on commit (Issue #793)"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn grpc_schema_without_rerank_storage_emits_no_sidecar() -> laurus::Result<()> {
+    // Pins the no-behavior-change guarantee: a Stage-1 HNSW field
+    // (rerank_storage unset) must not emit a sidecar after #793.
+    let schema = Schema::builder()
+        .add_field(
+            "embedding",
+            FieldOption::Hnsw(HnswOption {
+                dimension: 4,
+                distance: DistanceMetric::Cosine,
+                m: 4,
+                ef_construction: 16,
+                rerank_storage: None,
+                ..HnswOption::default()
+            }),
+        )
+        .build();
+
+    let server_schema = from_proto(&to_proto(&schema)).expect("from_proto must succeed");
+    match server_schema.fields.get("embedding") {
+        Some(FieldOption::Hnsw(h)) => assert_eq!(h.rerank_storage, None),
+        other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+    }
+
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let engine = Engine::new(storage.clone(), server_schema).await?;
+    let doc = Document::builder()
+        .add_field("embedding", DataValue::Vector(vec![1.0, 0.0, 0.0, 0.0]))
+        .build();
+    engine.put_document("doc1", doc).await?;
+    engine.commit().await?;
+
+    assert!(
+        !storage.file_exists(SIDECAR_NAME),
+        "a field without rerank_storage must not emit {SIDECAR_NAME}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

#790 fixed the in-library propagation of `HnswOption::rerank_storage`, but the **gRPC/HTTP server path** could not reach it: the proto schema had no `rerank_storage` field, so `convert/schema.rs` hard-coded `rerank_storage: None` and a server-created HNSW field could never emit the Stage-2 rerank sidecar (`.hnsw.f32`).

- **proto** (`index.proto`): add a `RerankStorageKind` enum (`UNSPECIFIED`/`F32`) and an `optional RerankStorageKind rerank_storage` field on `HnswOption` (9), `FlatOption` (6), `IvfOption` (8), mirroring the existing `default_ef_search` optional pattern. prost generates `Option<i32>` + `RerankStorageKind::{Unspecified, F32}`.
- **gRPC conversion** (`convert/schema.rs`): add `rerank_storage_to_proto`/`rerank_storage_from_proto`; wire `to_proto` (3 arms) and replace the hard-coded `None` in `from_proto` (3 arms).
- **HTTP gateway** (`gateway/convert.rs`): found during implementation — the JSON↔proto gateway builds the same proto structs, so it is wired too (JSON string `"F32"`, matching the CLI TOML).

Flat/IVF carry the field for schema round-trip fidelity even though those indexes do not emit a sidecar yet (HNSW only). The Rust core is unchanged — once the proto carries `rerank_storage`, the #790 writer emits the sidecar automatically.

## Note on the issue premise

The quantizer was **already** mapped both ways on the server path (proto `QuantizationMethod` enum + `QuantizationConfig`), so "always uses Scalar8Bit" was not accurate — only `rerank_storage` was missing. The "audit quantizer" criterion is satisfied and pinned by the round-trip test.

## Tests (the integration test was verified to FAIL when `from_proto` is reverted to `None`)

- Unit (`convert/schema.rs`): `hnsw_rerank_storage_and_quantizer_round_trip_through_proto` (to_proto serializes + from_proto restores rerank_storage; quantizer audit), and a Flat/IVF round-trip.
- Server integration (`tests/grpc_rerank_sidecar_test.rs`): Schema → `to_proto` → `from_proto` (the CreateIndex path) → `Engine` → commit → assert `vector/vector_index.hnsw.f32` exists; plus a no-sidecar guard for the unset case.

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings` (workspace + `laurus-server --features pq-fastscan`), `cargo test -p laurus-server` (30 lib + 2 integration), `cargo test --workspace` (58 binaries, 0 failures), `markdownlint-cli2` (EN/JA, 0 errors). Docs updated EN/JA (`grpc_api.md`).

Wire-compatible: new field numbers only; existing clients unaffected; unset → previous Stage-1 behavior.

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)