### PR TITLE
refactor(vector/hnsw): make from_sidecar_payload return Result instead of panicking

### DIFF
--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -553,7 +553,7 @@ impl HnswIndexReader {
                         header.vector_count as usize,
                         payload,
                         &vector_ids,
-                    );
+                    )?;
                     Some(Arc::new(pool))
                 } else {
                     None

--- a/laurus/src/vector/index/rerank_storage.rs
+++ b/laurus/src/vector/index/rerank_storage.rs
@@ -33,6 +33,7 @@ compile_error!(
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::error::{LaurusError, Result};
 use crate::vector::core::rerank::RerankStorageKind;
 
 /// In-memory rerank storage for one segment's full-precision vectors.
@@ -133,29 +134,52 @@ impl RerankStoragePool {
     /// `field_index` without re-encoding the bytes. The assignment
     /// must be `vector_count` long and ordered by position.
     ///
-    /// # Panics
+    /// # Arguments
     ///
-    /// Panics if `payload.len()` does not equal `vector_count * dim *
-    /// bytes_per_element` or if `field_assignment.len()` does not
-    /// equal `vector_count`.
+    /// * `kind` - On-disk encoding of each stored element.
+    /// * `dim` - Vector dimension.
+    /// * `vector_count` - Number of vectors the payload is expected to hold.
+    /// * `payload` - Raw LRS1 payload bytes (becomes [`Self::data`]).
+    /// * `field_assignment` - Per-position `(doc_id, field_name)` pairs,
+    ///   ordered by position.
+    ///
+    /// # Returns
+    ///
+    /// The constructed [`RerankStoragePool`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LaurusError::Index`] if `payload.len()` does not equal
+    /// `vector_count * dim * bytes_per_element`, or if
+    /// `field_assignment.len()` does not equal `vector_count` — both
+    /// indicate the sidecar payload and its declared shape are
+    /// inconsistent (corruption). Validating here instead of panicking
+    /// keeps a corrupt or hostile sidecar from aborting the process
+    /// (Issue #805).
     pub fn from_sidecar_payload(
         kind: RerankStorageKind,
         dim: usize,
         vector_count: usize,
         payload: Vec<u8>,
         field_assignment: &[(u64, String)],
-    ) -> Self {
+    ) -> Result<Self> {
         let record_size = Self::record_size(dim, kind);
-        assert_eq!(
-            payload.len(),
-            vector_count * record_size,
-            "sidecar payload length mismatch"
-        );
-        assert_eq!(
-            field_assignment.len(),
-            vector_count,
-            "field assignment length mismatch"
-        );
+        let expected_len = vector_count * record_size;
+        if payload.len() != expected_len {
+            return Err(LaurusError::index(format!(
+                "rerank sidecar payload length mismatch: expected {expected_len} bytes \
+                 (vector_count={vector_count} * dim={dim} * \
+                 bytes_per_element={}), got {}",
+                kind.bytes_per_element(),
+                payload.len()
+            )));
+        }
+        if field_assignment.len() != vector_count {
+            return Err(LaurusError::index(format!(
+                "rerank sidecar field assignment length mismatch: expected {vector_count}, got {}",
+                field_assignment.len()
+            )));
+        }
 
         let mut by_field: HashMap<String, HashMap<u64, u32>> = HashMap::new();
         for (pos, (doc_id, field)) in field_assignment.iter().enumerate() {
@@ -170,13 +194,13 @@ impl RerankStoragePool {
             .map(|(field, map)| (field, Arc::new(map)))
             .collect();
 
-        Self {
+        Ok(Self {
             kind,
             dim,
             data: payload,
             field_index,
             vector_count,
-        }
+        })
     }
 
     /// Borrow the f32 slice for `(doc_id, field)`.
@@ -386,34 +410,49 @@ mod tests {
             2,
             payload,
             &assignment,
-        );
+        )
+        .unwrap();
         assert_eq!(pool.vector_count, 2);
         assert_eq!(pool.get_f32_slice(7, "f").unwrap(), &vectors[0..4]);
         assert_eq!(pool.get_f32_slice(9, "f").unwrap(), &vectors[4..8]);
     }
 
+    /// Assert `err` is a [`LaurusError::Index`] whose message contains
+    /// `fragment`.
+    fn assert_index_error(err: LaurusError, fragment: &str) {
+        match err {
+            LaurusError::Index(msg) => assert!(
+                msg.contains(fragment),
+                "message {msg:?} should contain {fragment:?}"
+            ),
+            other => panic!("expected Index error, got {other:?}"),
+        }
+    }
+
     #[test]
-    #[should_panic(expected = "payload length mismatch")]
-    fn from_sidecar_payload_panics_on_wrong_payload_size() {
-        RerankStoragePool::from_sidecar_payload(
+    fn from_sidecar_payload_rejects_wrong_payload_size() {
+        let err = RerankStoragePool::from_sidecar_payload(
             RerankStorageKind::F32,
             4,
             2,
             vec![0u8; 10], // expects 32 bytes
             &[(1u64, "f".to_string()), (2u64, "f".to_string())],
-        );
+        )
+        .unwrap_err();
+        assert_index_error(err, "payload length mismatch");
     }
 
     #[test]
-    #[should_panic(expected = "field assignment length mismatch")]
-    fn from_sidecar_payload_panics_on_wrong_assignment_size() {
-        RerankStoragePool::from_sidecar_payload(
+    fn from_sidecar_payload_rejects_wrong_assignment_size() {
+        let err = RerankStoragePool::from_sidecar_payload(
             RerankStorageKind::F32,
             4,
             2,
             vec![0u8; 32],
             &[(1u64, "f".to_string())], // wrong length
-        );
+        )
+        .unwrap_err();
+        assert_index_error(err, "field assignment length mismatch");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`RerankStoragePool::from_sidecar_payload` (`laurus/src/vector/index/rerank_storage.rs`) validated its inputs with `assert_eq!`, i.e. it **panicked** on a payload-length or field-assignment-length mismatch:

```rust
assert_eq!(payload.len(), vector_count * record_size, "sidecar payload length mismatch");
assert_eq!(field_assignment.len(), vector_count, "field assignment length mismatch");
```

It is a `pub` constructor fed by on-disk sidecar data, and the project convention (CLAUDE.md) is to surface such errors via `Result` (`thiserror`) rather than panic. This makes the constructor defensively safe so a corrupt/hostile sidecar cannot abort the process.

## Changes

- `from_sidecar_payload` now returns `Result<Self>` and returns `LaurusError::Index` (with a descriptive message) on a length mismatch instead of panicking. The `# Panics` doc section is replaced with `# Arguments` / `# Returns` / `# Errors`.
- The single production call site in `hnsw/reader.rs` propagates the error with `?` (the enclosing reader load already returns `Result`).
- The two `#[should_panic]` unit tests are rewritten to assert the clean `LaurusError::Index` error path; the round-trip test now `.unwrap()`s.
- `build()` is left unchanged — it is an internal, writer-fed path (records produced in-process), out of scope for this issue.

## Notes

In the current production path the error is **defensive only**: `read_sidecar` (#791) guarantees `payload.len() == vector_count * dim * bytes_per_element`, and the reader already validates `header.dim == dimension` and `header.vector_count == vector_ids.len()` before calling this constructor. The conversion removes the panic for any future/alternative caller and aligns with the no-panic convention.

## Verification

- `cargo test -p laurus --lib` → 1132 passed (incl. 18 rerank_storage / hnsw)
- `cargo fmt --check` clean
- `cargo clippy --all-targets --features embeddings-all -- -D warnings` clean
- `cargo build -p laurus-wasm --target wasm32-unknown-unknown` OK

An adversarial review confirmed the happy path is byte-for-byte unchanged, the only production caller is updated, and `?` type-checks; no defects found.

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)