### PR TITLE
fix(vector/index): bound reader/writer allocations sized from unverified on-disk header counts

### DIFF
--- a/docs/src/concepts/indexing/vector_indexing.md
+++ b/docs/src/concepts/indexing/vector_indexing.md
@@ -323,6 +323,29 @@ remaining after the payload — sidecars written before the footer was
 introduced have zero trailing bytes and still load, with verification
 skipped.
 
+#### Bounded allocations from on-disk header counts
+
+Every vector segment header carries element counts (`num_vectors`,
+`n_clusters`, the HNSW graph's `node_count` / `layer_count` /
+`neighbor_count`) and per-record byte lengths (`field_name_len`, PQ
+`codes`) that the reader uses to size `Vec` / `HashMap` capacities and
+read buffers. The HNSW CRC footer is verified before the structural
+parse, but legacy footer-less segments — and the writer reload paths,
+which run no footer verification — reach those counts unverified. A
+single flipped byte could otherwise turn a small count into a multi-GiB
+allocation request that aborts the process through `handle_alloc_error`
+(out of memory) before any corruption check runs.
+
+To prevent that, the HNSW, Flat, and IVF loaders bound each such
+allocation against ground truth — the true file length from
+`StorageInput::size()`. Because the bytes a count or buffer describes
+must physically exist in the file, a header that declares more elements
+or bytes than the file can hold is rejected as a corrupted segment
+*before* the allocation. This generalizes the rerank sidecar's
+file-size bound to the main segment readers and covers legacy
+footer-less segments, so a corrupt or hostile header surfaces a clean
+"corrupted segment" error rather than an OOM abort.
+
 #### Recall vs speed trade-off
 
 `rerank_factor` lets you exchange a small per-query rerank cost

--- a/laurus/src/storage.rs
+++ b/laurus/src/storage.rs
@@ -559,6 +559,24 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
 /// A trait for reading data from storage.
 pub trait StorageInput: Read + Seek + Send + Sync + std::fmt::Debug {
     /// Get the size of the input stream.
+    ///
+    /// # Contract
+    ///
+    /// Implementations **must** return the true total byte length of the
+    /// backing file, independent of the current `Seek` position. Both
+    /// [`FileStorage`](crate::storage::file::FileStorage) (mmap and buffered
+    /// inputs) and [`MemoryStorage`](crate::storage::memory::MemoryStorage)
+    /// honor this today.
+    ///
+    /// Segment loaders rely on this as ground truth to bound allocations
+    /// sized from not-yet-verified on-disk header counts: a header that
+    /// declares more elements or bytes than the file can physically hold is
+    /// rejected as corruption *before* the allocation, so a flipped byte
+    /// cannot drive a multi-GiB `with_capacity` that aborts the process via
+    /// `handle_alloc_error` (Issues #791 and #806; see
+    /// [`crate::vector::index::alloc_bounds`]). A backend that returns a
+    /// truncated or inflated size would weaken that guard, so new backends
+    /// must preserve the invariant.
     fn size(&self) -> Result<u64>;
 
     /// Clone this input stream.

--- a/laurus/src/vector/index.rs
+++ b/laurus/src/vector/index.rs
@@ -6,6 +6,7 @@
 //! - Vector quantization and compression
 //! - Index optimization and maintenance
 
+pub(crate) mod alloc_bounds;
 pub mod config;
 pub mod factory;
 pub mod field;

--- a/laurus/src/vector/index/alloc_bounds.rs
+++ b/laurus/src/vector/index/alloc_bounds.rs
@@ -1,0 +1,159 @@
+//! Allocation bounds for on-disk vector segment parsing (Issue #806).
+//!
+//! Generalizes the Issue #791 technique. A vector segment reader/loader
+//! takes element counts and byte lengths straight from an on-disk header
+//! that has **not** yet been integrity-checked. The `.hnsw` CRC footer
+//! (Issue #786) is verified before the reader's structural parse, but
+//! *legacy footer-less segments* — and every writer load path, which does
+//! not run the footer verification at all — reach these counts unverified.
+//! A single flipped byte can turn a small `num_vectors` / `node_count` /
+//! `field_name_len` into a multi-GiB allocation request that aborts the
+//! process through `handle_alloc_error` (OOM) instead of surfacing a clean
+//! "corrupted segment" error.
+//!
+//! These helpers reject impossible sizes up front by comparing the
+//! header-declared size against ground truth: the true byte length of the
+//! file, obtained from [`crate::storage::StorageInput::size`]. Because the
+//! bytes a count or buffer describes must physically exist in the file, any
+//! size larger than the bytes left in the relevant section is provably
+//! corruption and is rejected before a single byte is allocated.
+//!
+//! Loaders capture `file_size = input.size()?` once and pass the bytes
+//! still available (`file_size - stream_position`) as `available`; per-record
+//! checks reuse the section's starting `available` so no extra `seek` /
+//! `stream_position` syscall is added inside the hot per-record loops.
+
+use crate::error::{LaurusError, Result};
+
+/// Bound a header-declared element `count` against the bytes available in
+/// the file before it is used to reserve a `Vec` / `HashMap` capacity.
+///
+/// Each element occupies at least `min_stride` bytes on disk, so a region of
+/// `available` bytes can hold at most `available / min_stride` of them. A
+/// `count` larger than that cannot be backed by real data and is treated as
+/// corruption — preventing a `with_capacity(count)` that would request
+/// gigabytes from a flipped byte and abort via `handle_alloc_error`.
+///
+/// # Arguments
+///
+/// * `count` - The element count parsed from the (unverified) header.
+/// * `min_stride` - A lower bound on the on-disk byte size of one element.
+///   Pass the smallest number of bytes every element is guaranteed to
+///   occupy; `0` is treated as `1` so the division never traps.
+/// * `available` - The number of bytes the file can still supply for these
+///   elements (typically `file_size - current_position`).
+/// * `what` - A short label naming the count, used in the error message.
+///
+/// # Returns
+///
+/// `count` unchanged when it fits.
+///
+/// # Errors
+///
+/// [`LaurusError::Index`] when `count` exceeds what `available` bytes can
+/// hold (the segment is corrupted).
+pub(crate) fn checked_capacity(
+    count: usize,
+    min_stride: u64,
+    available: u64,
+    what: &str,
+) -> Result<usize> {
+    let stride = min_stride.max(1);
+    let max_elements = available / stride;
+    if count as u64 > max_elements {
+        return Err(LaurusError::index(format!(
+            "{what}: header declares {count} elements but at most {max_elements} can fit in the \
+             {available} bytes left in the file — vector segment is corrupted"
+        )));
+    }
+    Ok(count)
+}
+
+/// Bound a header-declared byte `len` against the bytes available in the
+/// file before it is used to size a `vec![0u8; len]` (or equivalent) read
+/// buffer.
+///
+/// A single record's buffer can never be larger than the bytes remaining in
+/// the file, so a `len` that exceeds `available` is corruption and is
+/// rejected before the buffer is allocated.
+///
+/// # Arguments
+///
+/// * `len` - The byte length parsed from the (unverified) header.
+/// * `available` - The number of bytes the file can still supply (typically
+///   `file_size - current_position`).
+/// * `what` - A short label naming the length, used in the error message.
+///
+/// # Returns
+///
+/// `len` unchanged when it fits.
+///
+/// # Errors
+///
+/// [`LaurusError::Index`] when `len` exceeds `available` (the segment is
+/// corrupted).
+pub(crate) fn checked_len(len: usize, available: u64, what: &str) -> Result<usize> {
+    if len as u64 > available {
+        return Err(LaurusError::index(format!(
+            "{what}: header declares {len} bytes but only {available} bytes are left in the file \
+             — vector segment is corrupted"
+        )));
+    }
+    Ok(len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_capacity_accepts_a_count_that_fits() {
+        // 10 elements * 4 bytes = 40 <= 40 available.
+        assert_eq!(checked_capacity(10, 4, 40, "n").unwrap(), 10);
+    }
+
+    #[test]
+    fn checked_capacity_accepts_exact_fit() {
+        assert_eq!(checked_capacity(5, 8, 40, "n").unwrap(), 5);
+    }
+
+    #[test]
+    fn checked_capacity_rejects_a_count_that_overflows_the_file() {
+        // A flipped byte turning the count huge while the file holds only
+        // a handful of bytes must be rejected, not allocated.
+        let err = checked_capacity(1usize << 40, 8, 64, "num_vectors").unwrap_err();
+        match err {
+            LaurusError::Index(msg) => {
+                assert!(msg.contains("num_vectors"), "message should name the count");
+                assert!(msg.contains("corrupted"), "message should flag corruption");
+            }
+            other => panic!("expected Index error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn checked_capacity_treats_zero_stride_as_one() {
+        // A zero stride must not divide-by-zero; it degrades to a 1-byte
+        // lower bound so the count is bounded by `available`.
+        assert!(checked_capacity(64, 0, 64, "n").is_ok());
+        assert!(checked_capacity(65, 0, 64, "n").is_err());
+    }
+
+    #[test]
+    fn checked_len_accepts_a_length_that_fits() {
+        assert_eq!(checked_len(16, 16, "field_name_len").unwrap(), 16);
+        assert_eq!(checked_len(0, 16, "field_name_len").unwrap(), 0);
+    }
+
+    #[test]
+    fn checked_len_rejects_a_length_beyond_the_file() {
+        let err = checked_len(1usize << 31, 16, "field_name_len").unwrap_err();
+        match err {
+            LaurusError::Index(msg) => {
+                assert!(msg.contains("field_name_len"));
+                assert!(msg.contains("corrupted"));
+            }
+            other => panic!("expected Index error, got {other:?}"),
+        }
+    }
+}

--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -78,11 +78,18 @@ impl FlatVectorIndexReader {
         path: &str,
         distance_metric: DistanceMetric,
     ) -> Result<Self> {
-        use std::io::Read;
+        use crate::vector::index::alloc_bounds::{checked_capacity, checked_len};
+        use std::io::{Read, Seek};
 
         // Open the index file
         let file_name = format!("{}.flat", path);
         let mut input = storage.open_input(&file_name)?;
+
+        // Ground truth for bounding allocations sized from the unverified
+        // header counts below (Issue #806). The `.flat` reader has no
+        // pre-parse checksum, so every header count reaches its allocation
+        // unverified.
+        let file_size = input.size()?;
 
         // Read metadata
         let mut num_vectors_buf = [0u8; 4];
@@ -115,10 +122,24 @@ impl FlatVectorIndexReader {
             }
         };
 
+        // Bytes left for the per-vector records section, captured once at its
+        // start (Issue #806). Each record is at least doc_id (8) +
+        // field_name_len (4) + the fixed quantized payload (dim int8 + 8 meta),
+        // so this stride also bounds the per-record `dimension`-sized int8 read.
+        let records_remaining =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let record_stride = 12 + quantized_record_payload_size(dimension) as u64;
+
         let (vectors, vector_ids) = match storage.loading_mode() {
             crate::storage::LoadingMode::Eager => {
                 // Step 7 of #481 Stage 1: load vectors as int8 + meta
                 // directly into a QuantizedVectorPool.
+                checked_capacity(
+                    num_vectors,
+                    record_stride,
+                    records_remaining,
+                    "flat num_vectors",
+                )?;
                 let mut vector_ids = Vec::with_capacity(num_vectors);
                 let mut records: Vec<(u64, String, Vec<u8>, QuantizedVectorMeta)> =
                     Vec::with_capacity(num_vectors);
@@ -132,6 +153,7 @@ impl FlatVectorIndexReader {
                     let mut field_name_len_buf = [0u8; 4];
                     input.read_exact(&mut field_name_len_buf)?;
                     let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                    checked_len(field_name_len, records_remaining, "flat field_name_len")?;
 
                     let mut field_name_buf = vec![0u8; field_name_len];
                     input.read_exact(&mut field_name_buf)?;
@@ -158,6 +180,12 @@ impl FlatVectorIndexReader {
                 (VectorStorage::OwnedQuantized(Arc::new(pool)), vector_ids)
             }
             crate::storage::LoadingMode::Lazy => {
+                checked_capacity(
+                    num_vectors,
+                    record_stride,
+                    records_remaining,
+                    "flat num_vectors",
+                )?;
                 let mut offsets = HashMap::with_capacity(num_vectors);
                 let mut vector_ids = Vec::with_capacity(num_vectors);
 
@@ -182,6 +210,7 @@ impl FlatVectorIndexReader {
                     let mut field_name_len_buf = [0u8; 4];
                     input.read_exact(&mut field_name_len_buf)?;
                     let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                    checked_len(field_name_len, records_remaining, "flat field_name_len")?;
 
                     let mut field_name_buf = vec![0u8; field_name_len];
                     input.read_exact(&mut field_name_buf)?;
@@ -561,5 +590,57 @@ impl VectorIterator for FlatVectorIterator {
     fn reset(&mut self) -> Result<()> {
         self.current = 0;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod alloc_bound_tests {
+    use super::*;
+    use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
+    use crate::vector::core::quantization::ScalarQuantParams;
+    use std::io::Write;
+
+    /// Build an in-memory storage holding `bytes` under `name`.
+    fn storage_with(name: &str, bytes: Vec<u8>) -> Arc<dyn Storage> {
+        let storage = MemoryStorage::new(MemoryStorageConfig::default());
+        let mut out = storage.create_output(name).unwrap();
+        out.write_all(&bytes).unwrap();
+        out.flush_and_sync().unwrap();
+        Arc::new(storage)
+    }
+
+    /// Serialized neutral LVS1 (Scalar8Bit) header bytes.
+    fn neutral_header_bytes() -> Vec<u8> {
+        let mut buf = Vec::new();
+        VectorSegmentHeader::scalar_8bit(ScalarQuantParams {
+            offset: 0.0,
+            scale: 1.0,
+        })
+        .write_to(&mut buf)
+        .unwrap();
+        buf
+    }
+
+    #[test]
+    fn load_rejects_oversized_num_vectors_without_aborting() {
+        // A `.flat` segment whose `num_vectors` field is corrupted to a huge
+        // value while the file holds no records must be rejected cleanly,
+        // never drive a multi-GiB `Vec::with_capacity` that aborts the
+        // process via `handle_alloc_error` (Issue #806).
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // num_vectors (corrupt)
+        bytes.extend_from_slice(&4u32.to_le_bytes()); // dimension
+        bytes.extend_from_slice(&neutral_header_bytes()); // LVS1 header, no records
+
+        let storage = storage_with("corrupt.flat", bytes);
+        let err = FlatVectorIndexReader::load(storage, "corrupt", DistanceMetric::Cosine)
+            .expect_err("oversized num_vectors must be rejected as corruption");
+        match err {
+            LaurusError::Index(msg) => {
+                assert!(msg.contains("num_vectors"), "got: {msg}");
+                assert!(msg.contains("corrupted"), "got: {msg}");
+            }
+            other => panic!("expected Index error, got {other:?}"),
+        }
     }
 }

--- a/laurus/src/vector/index/flat/writer.rs
+++ b/laurus/src/vector/index/flat/writer.rs
@@ -10,10 +10,12 @@ use crate::storage::Storage;
 use crate::vector::core::quantization::ScalarQuantParams;
 use crate::vector::core::vector::Vector;
 use crate::vector::index::FlatIndexConfig;
+use crate::vector::index::alloc_bounds::{checked_capacity, checked_len};
 use crate::vector::index::field::LegacyVectorFieldWriter;
 use crate::vector::index::format::{QuantHeader, VectorSegmentHeader};
 use crate::vector::index::quantized_io::{
-    quantize_segment, read_dequantized_vector, write_quantized_record,
+    quantize_segment, quantized_record_payload_size, read_dequantized_vector,
+    write_quantized_record,
 };
 use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
 
@@ -91,11 +93,16 @@ impl FlatIndexWriter {
         storage: Arc<dyn Storage>,
         path: &str,
     ) -> Result<Self> {
-        use std::io::Read;
+        use std::io::{Read, Seek};
 
         // Open the index file
         let file_name = format!("{}.flat", path);
         let mut input = storage.open_input(&file_name)?;
+
+        // Ground truth for bounding allocations sized from unverified header
+        // counts below (Issue #806). Unlike the reader, this writer load path
+        // runs no checksum verification at all, so every count is unverified.
+        let file_size = input.size()?;
 
         // Read metadata
         let mut num_vectors_buf = [0u8; 4];
@@ -138,6 +145,18 @@ impl FlatIndexWriter {
         // Read quantized vectors, dequantizing back to f32 so the
         // in-memory writer state stays compatible with downstream
         // operations (delete_document, vectors() accessor, etc.).
+        // Bytes left for the per-vector records section (Issue #806). Each
+        // record is at least doc_id (8) + field_name_len (4) + the fixed
+        // quantized payload (dim int8 + 8 meta).
+        let records_remaining =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let record_stride = 12 + quantized_record_payload_size(dimension) as u64;
+        checked_capacity(
+            num_vectors,
+            record_stride,
+            records_remaining,
+            "flat num_vectors",
+        )?;
         let mut vectors = Vec::with_capacity(num_vectors);
         for _ in 0..num_vectors {
             let mut doc_id_buf = [0u8; 8];
@@ -148,6 +167,7 @@ impl FlatIndexWriter {
             let mut field_name_len_buf = [0u8; 4];
             input.read_exact(&mut field_name_len_buf)?;
             let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+            checked_len(field_name_len, records_remaining, "flat field_name_len")?;
 
             let mut field_name_buf = vec![0u8; field_name_len];
             input.read_exact(&mut field_name_buf)?;

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -160,7 +160,8 @@ impl HnswIndexReader {
         path: &str,
         distance_metric: DistanceMetric,
     ) -> Result<Self> {
-        use std::io::Read;
+        use crate::vector::index::alloc_bounds::{checked_capacity, checked_len};
+        use std::io::{Read, Seek};
 
         // Open the index file
         let file_name = format!("{}.hnsw", path);
@@ -172,6 +173,10 @@ impl HnswIndexReader {
         // trailing footer), so it works for every loading mode and leaves
         // legacy footer-less segments untouched.
         Self::verify_checksum_footer(&mut *input)?;
+
+        // Ground truth for bounding allocations sized from the (for legacy
+        // footer-less segments, unverified) header counts below (Issue #806).
+        let file_size = input.size()?;
 
         // Read metadata (vector count stored as u64)
         let mut num_vectors_buf = [0u8; 8];
@@ -216,6 +221,16 @@ impl HnswIndexReader {
                     input.read_exact(&mut node_count_buf)?;
                     let node_count = u64::from_le_bytes(node_count_buf) as usize;
 
+                    // Bound every graph allocation by the bytes left in the
+                    // file (Issue #806). The graph trails the vector payload,
+                    // so this remaining count is tight: a corrupt count on a
+                    // small graph can no longer drive a huge `with_capacity`.
+                    // Reused for the inner layer / neighbor counts so no extra
+                    // syscall is taken inside the per-node / per-layer loops.
+                    let graph_remaining =
+                        file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+                    // Each node serializes at least doc_id (8) + layer_count (4).
+                    checked_capacity(node_count, 12, graph_remaining, "hnsw node_count")?;
                     let mut nodes = HashMap::with_capacity(node_count);
 
                     for _ in 0..node_count {
@@ -227,12 +242,21 @@ impl HnswIndexReader {
                         input.read_exact(&mut layer_count_buf)?;
                         let layer_count = u32::from_le_bytes(layer_count_buf) as usize;
 
+                        // Each layer serializes at least its neighbor_count (4).
+                        checked_capacity(layer_count, 4, graph_remaining, "hnsw layer_count")?;
                         let mut layers = Vec::with_capacity(layer_count);
                         for _ in 0..layer_count {
                             let mut neighbor_count_buf = [0u8; 4];
                             input.read_exact(&mut neighbor_count_buf)?;
                             let neighbor_count = u32::from_le_bytes(neighbor_count_buf) as usize;
 
+                            // Each neighbor serializes as a u64 (8 bytes).
+                            checked_capacity(
+                                neighbor_count,
+                                8,
+                                graph_remaining,
+                                "hnsw neighbor_count",
+                            )?;
                             let mut neighbors = Vec::with_capacity(neighbor_count);
                             for _ in 0..neighbor_count {
                                 let mut neighbor_buf = [0u8; 8];
@@ -267,6 +291,12 @@ impl HnswIndexReader {
         // carries Scalar8Bit params today.
         let header = VectorSegmentHeader::read_from(&mut input)?;
 
+        // Bytes left for the per-vector records section, captured once at its
+        // start (Issue #806). Reused by the per-record `field_name_len` /
+        // payload checks below so the hot loop adds no extra syscall.
+        let records_remaining =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+
         let (vectors, vector_ids, graph) = match (&header.quant, storage.loading_mode()) {
             (QuantHeader::Scalar8Bit(params), crate::storage::LoadingMode::Eager) => {
                 // Step 6 of #481 Stage 1: load vectors as int8 + meta
@@ -275,6 +305,17 @@ impl HnswIndexReader {
                 // dequantization. The legacy
                 // VectorIndexReader::get_vector API still works via
                 // VectorStorage::OwnedQuantized's dequantize-on-get.
+                // Each record is at least doc_id (8) + field_name_len (4) +
+                // the fixed quantized payload (dim int8 + 8 meta). Bounding
+                // `num_vectors` by that stride also bounds the per-record
+                // `dimension`-sized int8 read (Issue #806).
+                let record_stride = 12 + quantized_record_payload_size(dimension) as u64;
+                checked_capacity(
+                    num_vectors,
+                    record_stride,
+                    records_remaining,
+                    "hnsw num_vectors",
+                )?;
                 let mut vector_ids = Vec::with_capacity(num_vectors);
                 let mut records: Vec<(u64, String, Vec<u8>, QuantizedVectorMeta)> =
                     Vec::with_capacity(num_vectors);
@@ -287,6 +328,7 @@ impl HnswIndexReader {
                     let mut field_name_len_buf = [0u8; 4];
                     input.read_exact(&mut field_name_len_buf)?;
                     let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                    checked_len(field_name_len, records_remaining, "hnsw field_name_len")?;
                     let mut field_name_buf = vec![0u8; field_name_len];
                     input.read_exact(&mut field_name_buf)?;
                     let field_name = String::from_utf8(field_name_buf).map_err(|e| {
@@ -316,6 +358,13 @@ impl HnswIndexReader {
                 )
             }
             (QuantHeader::Scalar8Bit(params), crate::storage::LoadingMode::Lazy) => {
+                let record_stride = 12 + quantized_record_payload_size(dimension) as u64;
+                checked_capacity(
+                    num_vectors,
+                    record_stride,
+                    records_remaining,
+                    "hnsw num_vectors",
+                )?;
                 let mut offsets = HashMap::with_capacity(num_vectors);
                 let mut vector_ids = Vec::with_capacity(num_vectors);
 
@@ -341,6 +390,7 @@ impl HnswIndexReader {
                     let mut field_name_len_buf = [0u8; 4];
                     input.read_exact(&mut field_name_len_buf)?;
                     let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                    checked_len(field_name_len, records_remaining, "hnsw field_name_len")?;
 
                     let mut field_name_buf = vec![0u8; field_name_len];
                     input.read_exact(&mut field_name_buf)?;
@@ -381,9 +431,18 @@ impl HnswIndexReader {
                 // segments (the OnDemand path's offsets table only
                 // carries Scalar8Bit params), so we eagerly load the
                 // codes regardless of `loading_mode`.
+                let codes_size = pq_params.m as usize;
+                // Each PQ record is at least doc_id (8) + field_name_len (4) +
+                // `codes_size` bytes of codes (Issue #806).
+                checked_capacity(
+                    num_vectors,
+                    12 + codes_size as u64,
+                    records_remaining,
+                    "hnsw num_vectors",
+                )?;
+                checked_len(codes_size, records_remaining, "hnsw pq codes")?;
                 let mut vector_ids = Vec::with_capacity(num_vectors);
                 let mut records: Vec<(u64, String, Vec<u8>)> = Vec::with_capacity(num_vectors);
-                let codes_size = pq_params.m as usize;
 
                 for _ in 0..num_vectors {
                     let mut doc_id_buf = [0u8; 8];
@@ -393,6 +452,7 @@ impl HnswIndexReader {
                     let mut field_name_len_buf = [0u8; 4];
                     input.read_exact(&mut field_name_len_buf)?;
                     let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                    checked_len(field_name_len, records_remaining, "hnsw field_name_len")?;
                     let mut field_name_buf = vec![0u8; field_name_len];
                     input.read_exact(&mut field_name_buf)?;
                     let field_name = String::from_utf8(field_name_buf).map_err(|e| {
@@ -425,6 +485,9 @@ impl HnswIndexReader {
                 // codes via `pq_fastscan_io::read_pq_fastscan_record`
                 // and build a `PqFastScanPool` for the SIMD-friendly
                 // block-transposed in-memory layout.
+                // Each record is at least doc_id (8) + field_name_len (4) +
+                // one byte of packed codes (Issue #806).
+                checked_capacity(num_vectors, 13, records_remaining, "hnsw num_vectors")?;
                 let mut vector_ids = Vec::with_capacity(num_vectors);
                 let mut records: Vec<(u64, String, Vec<u8>)> = Vec::with_capacity(num_vectors);
 
@@ -436,6 +499,7 @@ impl HnswIndexReader {
                     let mut field_name_len_buf = [0u8; 4];
                     input.read_exact(&mut field_name_len_buf)?;
                     let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                    checked_len(field_name_len, records_remaining, "hnsw field_name_len")?;
                     let mut field_name_buf = vec![0u8; field_name_len];
                     input.read_exact(&mut field_name_buf)?;
                     let field_name = String::from_utf8(field_name_buf).map_err(|e| {
@@ -1006,5 +1070,87 @@ impl VectorIterator for HnswVectorIterator {
     fn reset(&mut self) -> Result<()> {
         self.current = 0;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod alloc_bound_tests {
+    use super::*;
+    use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
+    use crate::vector::core::quantization::ScalarQuantParams;
+    use std::io::Write;
+
+    fn storage_with(name: &str, bytes: Vec<u8>) -> Arc<dyn Storage> {
+        let storage = MemoryStorage::new(MemoryStorageConfig::default());
+        let mut out = storage.create_output(name).unwrap();
+        out.write_all(&bytes).unwrap();
+        out.flush_and_sync().unwrap();
+        Arc::new(storage)
+    }
+
+    fn neutral_header_bytes() -> Vec<u8> {
+        let mut buf = Vec::new();
+        VectorSegmentHeader::scalar_8bit(ScalarQuantParams {
+            offset: 0.0,
+            scale: 1.0,
+        })
+        .write_to(&mut buf)
+        .unwrap();
+        buf
+    }
+
+    /// The HNSW preamble: num_vectors (u64) + dimension/m/ef (u32 each).
+    fn preamble(num_vectors: u64, dimension: u32, m: u32, ef: u32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&num_vectors.to_le_bytes());
+        buf.extend_from_slice(&dimension.to_le_bytes());
+        buf.extend_from_slice(&m.to_le_bytes());
+        buf.extend_from_slice(&ef.to_le_bytes());
+        buf
+    }
+
+    #[test]
+    fn load_rejects_oversized_num_vectors_on_footerless_segment() {
+        // The residual exposure for `.hnsw` is a *legacy footer-less* segment:
+        // it skips the Issue #786 checksum and reaches the per-vector
+        // allocation with an unverified header. A corrupt `num_vectors` over a
+        // record-less file must be rejected, never aborted (Issue #806).
+        let mut bytes = preamble(u64::MAX, 4, 16, 200);
+        bytes.extend_from_slice(&neutral_header_bytes()); // no records, no footer
+
+        let storage = storage_with("corrupt.hnsw", bytes);
+        let err = HnswIndexReader::load(storage, "corrupt", DistanceMetric::Cosine)
+            .expect_err("oversized num_vectors must be rejected as corruption");
+        match err {
+            LaurusError::Index(msg) => {
+                assert!(msg.contains("num_vectors"), "got: {msg}");
+                assert!(msg.contains("corrupted"), "got: {msg}");
+            }
+            other => panic!("expected Index error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_rejects_oversized_graph_node_count_on_footerless_segment() {
+        // The graph trails the (empty) vector payload. A corrupt `node_count`
+        // must be bounded by the bytes left for the graph, not allocated up
+        // front (Issue #806).
+        let mut bytes = preamble(0, 4, 16, 200);
+        bytes.extend_from_slice(&neutral_header_bytes()); // zero vector records
+        bytes.push(1u8); // has_graph = true
+        bytes.extend_from_slice(&u64::MAX.to_le_bytes()); // entry_point (== None)
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // max_level
+        bytes.extend_from_slice(&u64::MAX.to_le_bytes()); // node_count (corrupt)
+
+        let storage = storage_with("corrupt_graph.hnsw", bytes);
+        let err = HnswIndexReader::load(storage, "corrupt_graph", DistanceMetric::Cosine)
+            .expect_err("oversized node_count must be rejected as corruption");
+        match err {
+            LaurusError::Index(msg) => {
+                assert!(msg.contains("node_count"), "got: {msg}");
+                assert!(msg.contains("corrupted"), "got: {msg}");
+            }
+            other => panic!("expected Index error, got {other:?}"),
+        }
     }
 }

--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -7,11 +7,13 @@ use crate::storage::Storage;
 use crate::vector::core::rerank::RerankStorageKind;
 use crate::vector::core::vector::Vector;
 use crate::vector::index::HnswIndexConfig;
+use crate::vector::index::alloc_bounds::{checked_capacity, checked_len};
 use crate::vector::index::field::LegacyVectorFieldWriter;
 use crate::vector::index::format::{QuantHeader, VectorSegmentHeader};
 use crate::vector::index::hnsw::graph::HnswGraph;
 use crate::vector::index::quantized_io::{
-    quantize_segment, read_dequantized_vector, write_quantized_record,
+    quantize_segment, quantized_record_payload_size, read_dequantized_vector,
+    write_quantized_record,
 };
 use crate::vector::index::rerank_sidecar::{read_sidecar, write_sidecar};
 use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
@@ -272,11 +274,17 @@ impl HnswIndexWriter {
         storage: Arc<dyn Storage>,
         path: &str,
     ) -> Result<Self> {
-        use std::io::Read;
+        use std::io::{Read, Seek};
 
         // Open the index file
         let file_name = format!("{}.hnsw", path);
         let mut input = storage.open_input(&file_name)?;
+
+        // Ground truth for bounding allocations sized from unverified header
+        // counts below (Issue #806). Unlike the reader, this writer load path
+        // runs no checksum footer verification, so every count — including
+        // those of footer-carrying segments — reaches its allocation unverified.
+        let file_size = input.size()?;
 
         // Read metadata (vector count stored as u64)
         let mut num_vectors_buf = [0u8; 8];
@@ -316,6 +324,25 @@ impl HnswIndexWriter {
         // approximation of the originals; if a Stage 2 sidecar is
         // present we'll overwrite them below with the lossless f32
         // payload.
+        // Bytes left for the per-vector records section (Issue #806). Each
+        // record is at least doc_id (8) + field_name_len (4) + the per-kind
+        // fixed payload, so `record_stride` also bounds the per-record payload
+        // read decoded below.
+        let records_remaining =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let min_payload = match &header.quant {
+            QuantHeader::Scalar8Bit(_) => quantized_record_payload_size(dimension) as u64,
+            QuantHeader::ProductQuantization { params, .. } => params.m as u64,
+            #[cfg(feature = "pq-fastscan")]
+            QuantHeader::ProductQuantizationFastScan { .. } => 1,
+        };
+        let record_stride = 12 + min_payload;
+        checked_capacity(
+            num_vectors,
+            record_stride,
+            records_remaining,
+            "hnsw num_vectors",
+        )?;
         let mut vectors = Vec::with_capacity(num_vectors);
         for _ in 0..num_vectors {
             let mut doc_id_buf = [0u8; 8];
@@ -326,6 +353,7 @@ impl HnswIndexWriter {
             let mut field_name_len_buf = [0u8; 4];
             input.read_exact(&mut field_name_len_buf)?;
             let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+            checked_len(field_name_len, records_remaining, "hnsw field_name_len")?;
 
             let mut field_name_buf = vec![0u8; field_name_len];
             input.read_exact(&mut field_name_buf)?;
@@ -443,6 +471,14 @@ impl HnswIndexWriter {
                 input.read_exact(&mut node_count_buf)?;
                 let node_count = u64::from_le_bytes(node_count_buf) as usize;
 
+                // Bound every graph allocation by the bytes left in the file
+                // (Issue #806). Reused for the inner layer / neighbor counts so
+                // no extra syscall is taken inside the per-node / per-layer
+                // loops.
+                let graph_remaining =
+                    file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+                // Each node serializes at least doc_id (8) + layer_count (4).
+                checked_capacity(node_count, 12, graph_remaining, "hnsw node_count")?;
                 let mut nodes = HashMap::with_capacity(node_count);
 
                 for _ in 0..node_count {
@@ -454,6 +490,8 @@ impl HnswIndexWriter {
                     input.read_exact(&mut layer_count_buf)?;
                     let layer_count = u32::from_le_bytes(layer_count_buf) as usize;
 
+                    // Each layer serializes at least its neighbor_count (4).
+                    checked_capacity(layer_count, 4, graph_remaining, "hnsw layer_count")?;
                     let mut layers = Vec::with_capacity(layer_count);
 
                     for _ in 0..layer_count {
@@ -461,6 +499,13 @@ impl HnswIndexWriter {
                         input.read_exact(&mut neighbor_count_buf)?;
                         let neighbor_count = u32::from_le_bytes(neighbor_count_buf) as usize;
 
+                        // Each neighbor serializes as a u64 (8 bytes).
+                        checked_capacity(
+                            neighbor_count,
+                            8,
+                            graph_remaining,
+                            "hnsw neighbor_count",
+                        )?;
                         let mut neighbors = Vec::with_capacity(neighbor_count);
                         for _ in 0..neighbor_count {
                             let mut neighbor_buf = [0u8; 8];

--- a/laurus/src/vector/index/ivf/reader.rs
+++ b/laurus/src/vector/index/ivf/reader.rs
@@ -84,11 +84,18 @@ impl IvfIndexReader {
         path: &str,
         distance_metric: DistanceMetric,
     ) -> Result<Self> {
+        use crate::vector::index::alloc_bounds::{checked_capacity, checked_len};
         use std::io::{Read, Seek};
 
         // Open the index file
         let file_name = format!("{}.ivf", path);
         let mut input = storage.open_input(&file_name)?;
+
+        // Ground truth for bounding allocations sized from the unverified
+        // header counts below (Issue #806). The `.ivf` reader has no
+        // pre-parse checksum, so every header count reaches its allocation
+        // unverified.
+        let file_size = input.size()?;
 
         // Read metadata
         let mut num_vectors_buf = [0u8; 4];
@@ -107,7 +114,17 @@ impl IvfIndexReader {
         input.read_exact(&mut n_probe_buf)?;
         let n_probe = u32::from_le_bytes(n_probe_buf) as usize;
 
-        // Read centroids
+        // Read centroids. Each centroid serializes as `dimension` f32 values
+        // (4 bytes each), so bounding `n_clusters` by that stride also bounds
+        // each per-centroid `vec![0.0f32; dimension]` allocation (Issue #806).
+        let centroids_remaining =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        checked_capacity(
+            n_clusters,
+            (dimension as u64).saturating_mul(4),
+            centroids_remaining,
+            "ivf centroids",
+        )?;
         let mut centroids = Vec::with_capacity(n_clusters);
         for _ in 0..n_clusters {
             let mut values = vec![0.0f32; dimension];
@@ -142,11 +159,28 @@ impl IvfIndexReader {
             }
         };
 
-        // Read inverted lists, preserving per-cluster grouping.
+        // Bytes left for the inverted-list section, captured once at its start
+        // (Issue #806). Reused by the per-cluster / per-record checks below so
+        // the hot loops add no extra syscall. Each record is at least doc_id
+        // (8) + field_name_len (4) + the fixed quantized payload (dim int8 + 8
+        // meta), so `record_stride` also bounds the per-record int8 read.
+        let lists_remaining =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let record_stride = 12 + quantized_record_payload_size(dimension) as u64;
+
+        // Read inverted lists, preserving per-cluster grouping. Each cluster
+        // serializes at least its list_size (4 bytes).
+        checked_capacity(n_clusters, 4, lists_remaining, "ivf cluster lists")?;
         let mut cluster_to_vectors: Vec<Vec<(u64, String)>> = Vec::with_capacity(n_clusters);
 
         let (vectors, vector_ids) = match storage.loading_mode() {
             crate::storage::LoadingMode::Eager => {
+                checked_capacity(
+                    num_vectors,
+                    record_stride,
+                    lists_remaining,
+                    "ivf num_vectors",
+                )?;
                 let mut vector_ids = Vec::with_capacity(num_vectors);
                 let mut records: Vec<(u64, String, Vec<u8>, QuantizedVectorMeta)> =
                     Vec::with_capacity(num_vectors);
@@ -155,6 +189,7 @@ impl IvfIndexReader {
                     let mut list_size_buf = [0u8; 4];
                     input.read_exact(&mut list_size_buf)?;
                     let list_size = u32::from_le_bytes(list_size_buf) as usize;
+                    checked_capacity(list_size, record_stride, lists_remaining, "ivf list_size")?;
                     let mut cluster_vecs = Vec::with_capacity(list_size);
 
                     for _ in 0..list_size {
@@ -165,6 +200,7 @@ impl IvfIndexReader {
                         let mut field_name_len_buf = [0u8; 4];
                         input.read_exact(&mut field_name_len_buf)?;
                         let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                        checked_len(field_name_len, lists_remaining, "ivf field_name_len")?;
 
                         let mut field_name_buf = vec![0u8; field_name_len];
                         input.read_exact(&mut field_name_buf)?;
@@ -198,6 +234,12 @@ impl IvfIndexReader {
                 (VectorStorage::OwnedQuantized(Arc::new(pool)), vector_ids)
             }
             crate::storage::LoadingMode::Lazy => {
+                checked_capacity(
+                    num_vectors,
+                    record_stride,
+                    lists_remaining,
+                    "ivf num_vectors",
+                )?;
                 let mut offsets = HashMap::with_capacity(num_vectors);
                 let mut vector_ids = Vec::with_capacity(num_vectors);
                 let quant_payload_size = quantized_record_payload_size(dimension) as i64;
@@ -206,6 +248,7 @@ impl IvfIndexReader {
                     let mut list_size_buf = [0u8; 4];
                     input.read_exact(&mut list_size_buf)?;
                     let list_size = u32::from_le_bytes(list_size_buf) as usize;
+                    checked_capacity(list_size, record_stride, lists_remaining, "ivf list_size")?;
                     let mut cluster_vecs = Vec::with_capacity(list_size);
 
                     for _ in 0..list_size {
@@ -218,6 +261,7 @@ impl IvfIndexReader {
                         let mut field_name_len_buf = [0u8; 4];
                         input.read_exact(&mut field_name_len_buf)?;
                         let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                        checked_len(field_name_len, lists_remaining, "ivf field_name_len")?;
 
                         let mut field_name_buf = vec![0u8; field_name_len];
                         input.read_exact(&mut field_name_buf)?;
@@ -635,5 +679,44 @@ impl VectorIterator for IvfVectorIterator {
     fn reset(&mut self) -> Result<()> {
         self.current = 0;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod alloc_bound_tests {
+    use super::*;
+    use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
+    use std::io::Write;
+
+    fn storage_with(name: &str, bytes: Vec<u8>) -> Arc<dyn Storage> {
+        let storage = MemoryStorage::new(MemoryStorageConfig::default());
+        let mut out = storage.create_output(name).unwrap();
+        out.write_all(&bytes).unwrap();
+        out.flush_and_sync().unwrap();
+        Arc::new(storage)
+    }
+
+    #[test]
+    fn load_rejects_oversized_n_clusters_without_aborting() {
+        // An `.ivf` segment whose `n_clusters` field is corrupted to a huge
+        // value while the file holds no centroids must be rejected cleanly,
+        // never drive a multi-GiB `Vec::with_capacity` that aborts the
+        // process via `handle_alloc_error` (Issue #806).
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // num_vectors
+        bytes.extend_from_slice(&4u32.to_le_bytes()); // dimension
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // n_clusters (corrupt)
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // n_probe — file ends here
+
+        let storage = storage_with("corrupt.ivf", bytes);
+        let err = IvfIndexReader::load(storage, "corrupt", DistanceMetric::Cosine)
+            .expect_err("oversized n_clusters must be rejected as corruption");
+        match err {
+            LaurusError::Index(msg) => {
+                assert!(msg.contains("centroids"), "got: {msg}");
+                assert!(msg.contains("corrupted"), "got: {msg}");
+            }
+            other => panic!("expected Index error, got {other:?}"),
+        }
     }
 }

--- a/laurus/src/vector/index/ivf/writer.rs
+++ b/laurus/src/vector/index/ivf/writer.rs
@@ -10,10 +10,12 @@ use crate::storage::Storage;
 use crate::vector::core::quantization::ScalarQuantParams;
 use crate::vector::core::vector::Vector;
 use crate::vector::index::IvfIndexConfig;
+use crate::vector::index::alloc_bounds::{checked_capacity, checked_len};
 use crate::vector::index::field::LegacyVectorFieldWriter;
 use crate::vector::index::format::{QuantHeader, VectorSegmentHeader};
 use crate::vector::index::quantized_io::{
-    quantize_segment, read_dequantized_vector, write_quantized_record,
+    quantize_segment, quantized_record_payload_size, read_dequantized_vector,
+    write_quantized_record,
 };
 use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
 use serde::{Deserialize, Serialize};
@@ -105,11 +107,16 @@ impl IvfIndexWriter {
         storage: Arc<dyn Storage>,
         path: &str,
     ) -> Result<Self> {
-        use std::io::Read;
+        use std::io::{Read, Seek};
 
         // Open the index file
         let file_name = format!("{}.ivf", path);
         let mut input = storage.open_input(&file_name)?;
+
+        // Ground truth for bounding allocations sized from unverified header
+        // counts below (Issue #806). This writer load path runs no checksum
+        // verification, so every count is unverified.
+        let file_size = input.size()?;
 
         // Read metadata
         let mut num_vectors_buf = [0u8; 4];
@@ -135,7 +142,17 @@ impl IvfIndexWriter {
             )));
         }
 
-        // Read centroids
+        // Read centroids. Each centroid serializes as `dimension` f32 values
+        // (4 bytes each), so bounding `n_clusters` by that stride also bounds
+        // each per-centroid `vec![0.0f32; dimension]` allocation (Issue #806).
+        let centroids_remaining =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        checked_capacity(
+            n_clusters,
+            (dimension as u64).saturating_mul(4),
+            centroids_remaining,
+            "ivf centroids",
+        )?;
         let mut centroids = Vec::with_capacity(n_clusters);
         for _ in 0..n_clusters {
             let mut values = vec![0.0f32; dimension];
@@ -171,11 +188,20 @@ impl IvfIndexWriter {
 
         // Read inverted lists, dequantizing each record back to f32
         // for the in-memory writer state.
+        // Bytes left for the inverted-list section (Issue #806). Each record
+        // is at least doc_id (8) + field_name_len (4) + the fixed quantized
+        // payload (dim int8 + 8 meta); each cluster serializes at least its
+        // list_size (4 bytes).
+        let lists_remaining =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let record_stride = 12 + quantized_record_payload_size(dimension) as u64;
+        checked_capacity(n_clusters, 4, lists_remaining, "ivf cluster lists")?;
         let mut inverted_lists = vec![Vec::new(); n_clusters];
         for list in &mut inverted_lists {
             let mut list_size_buf = [0u8; 4];
             input.read_exact(&mut list_size_buf)?;
             let list_size = u32::from_le_bytes(list_size_buf) as usize;
+            checked_capacity(list_size, record_stride, lists_remaining, "ivf list_size")?;
 
             for _ in 0..list_size {
                 let mut doc_id_buf = [0u8; 8];
@@ -186,6 +212,7 @@ impl IvfIndexWriter {
                 let mut field_name_len_buf = [0u8; 4];
                 input.read_exact(&mut field_name_len_buf)?;
                 let field_name_len = u32::from_le_bytes(field_name_len_buf) as usize;
+                checked_len(field_name_len, lists_remaining, "ivf field_name_len")?;
 
                 let mut field_name_buf = vec![0u8; field_name_len];
                 input.read_exact(&mut field_name_buf)?;
@@ -200,7 +227,15 @@ impl IvfIndexWriter {
             }
         }
 
-        // Reconstruct vectors from inverted lists
+        // Reconstruct vectors from inverted lists. `num_vectors` is a separate
+        // header field and is still unverified, so bound it against the same
+        // record section before reserving (Issue #806).
+        checked_capacity(
+            num_vectors,
+            record_stride,
+            lists_remaining,
+            "ivf num_vectors",
+        )?;
         let mut vectors = Vec::with_capacity(num_vectors);
         for list in &inverted_lists {
             vectors.extend(list.iter().cloned());


### PR DESCRIPTION
## Summary

Generalizes the #791 file-size bound to the HNSW / Flat / IVF vector segment loaders. A corrupt or hostile on-disk header count (`num_vectors`, `n_clusters`, the HNSW graph's `node`/`layer`/`neighbor` counts) or per-record length (`field_name_len`, PQ `codes`) could otherwise drive a multi-GiB `with_capacity` / `vec![0u8; len]` that aborts the process via `handle_alloc_error` (OOM) before any corruption check runs.

A new shared helper `laurus/src/vector/index/alloc_bounds.rs` rejects, **before** allocating, any count or length larger than what `StorageInput::size()` shows the file can hold, so a flipped byte surfaces a clean `LaurusError::Index` ("corrupted segment") instead of an OOM abort.

## Approach

- `checked_capacity(count, min_stride, available, what)` — each element is ≥ `min_stride` bytes on disk, so `available` bytes hold at most `available / min_stride` of them; a larger count is corruption.
- `checked_len(len, available, what)` — a per-record buffer can't exceed the bytes left in the file.
- Each loader captures `file_size = input.size()?` once and the bytes remaining per section once; per-record checks reuse that value, so no extra syscall is added in the hot loops (pure arithmetic on the default mmap backend, and the `FileInput` BufReader is never thrashed).

## Scope

Applied to both the reader load paths and the **writer reload paths** (used on append/merge). The writer paths run no checksum footer verification at all, so they reach counts unverified even for footer-carrying segments — a larger exposure than the readers. This also covers **legacy footer-less `.hnsw` segments**, the residual exposure left by the #786 footer (footer-carrying `.hnsw` is already CRC-verified before the structural parse).

## Changes

- `vector/index/alloc_bounds.rs` (new helper + unit tests), registered in `vector/index.rs`
- `vector/index/hnsw/{reader,writer}.rs`, `flat/{reader,writer}.rs`, `ivf/{reader,writer}.rs` — bounded every header-count `with_capacity` and per-record buffer read
- `storage.rs` — documented the `StorageInput::size()` contract loaders rely on
- `docs/src/concepts/indexing/vector_indexing.md` — user-facing "Bounded allocations from on-disk header counts" section

No on-disk format change and no public API signature change.

## Tests

Per-reader `alloc_bound_tests` build a hand-crafted segment whose count is corrupted to a huge value and assert `load()` returns a clean error rather than aborting:

- Flat: oversized `num_vectors`
- IVF: oversized `n_clusters` (centroids)
- HNSW: oversized `num_vectors` **and** oversized graph `node_count`, both on footer-less segments
- `alloc_bounds` helper unit tests (6)

## Verification

- `cargo clippy -p laurus --all-targets --features embeddings-all -- -D warnings` — 0 warnings
- `cargo clippy -p laurus --all-targets --features pq-fastscan -- -D warnings` — 0 warnings
- `cargo test -p laurus --lib` — 1142 passed / 0 failed (10 new tests)
- Integration: `vector_recall_test` (9), `vector_segment_test` (1)
- `markdownlint-cli2` on the edited doc — 0 errors
- `cargo build -p laurus-wasm --target wasm32-unknown-unknown` — builds

Closes #806
