### PR TITLE
feat(bindings): expose HNSW quantizer and rerank_storage on all language bindings

### DIFF
--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -73,7 +73,7 @@ class Schema {
 | `addGeoField(name, stored?, indexed?)` | 地理座標フィールド。 |
 | `addGeo3dField(name, stored?, indexed?)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `addDatetimeField(name, stored?, indexed?)` | UTC 日時フィールド。 |
-| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?)` | HNSW ベクトルフィールド。 |
+| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?)` | HNSW ベクトルフィールド。 |
 | `addFlatField(name, dimension, distance?, embedder?)` | Flat（全探索）ベクトルフィールド。 |
 | `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)` | IVF ベクトルフィールド。 |
 | `addEmbedder(name, config)` | 名前付き Embedder を登録。 |
@@ -82,6 +82,11 @@ class Schema {
 | `dynamicFieldPolicy()` | 現在のポリシーを小文字の文字列で返す。 |
 | `fieldNames()` | 全フィールド名を返す。 |
 | `toString()` | スキーマの文字列表現（`"Schema(fields=[...])"` 形式）を返す。 |
+
+**ベクトル量子化とリランクストレージ**（HNSW フィールド）:
+
+- `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvectorCount`（`dimension` を割り切れる値）が必須です。
+- `rerankStorage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
 
 #### Dynamic field policy（動的フィールドポリシー）
 

--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -61,9 +61,14 @@ new \Laurus\Schema()
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | 地理座標フィールド（緯度/経度）。 |
 | `addGeo3dField(string $name, bool $stored = true, bool $indexed = true): void` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `addDatetimeField(string $name, bool $stored = true, bool $indexed = true): void` | UTC 日時フィールド。 |
-| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null): void` | HNSW 近似最近傍ベクトルフィールド。 |
+| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null): void` | HNSW 近似最近傍ベクトルフィールド。 |
 | `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null): void` | Flat（総当たり）ベクトルフィールド。 |
 | `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null): void` | IVF 近似最近傍ベクトルフィールド。 |
+
+**ベクトル量子化とリランクストレージ**（HNSW フィールド）:
+
+- `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvectorCount`（`dimension` を割り切れる値）が必須です。
+- `rerankStorage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
 
 ### その他のメソッド
 

--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -63,9 +63,14 @@ class Schema:
 | `add_geo_field(name, *, stored=True, indexed=True)` | 地理座標フィールド（緯度/経度）。 |
 | `add_geo3d_field(name, *, stored=True, indexed=True)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `add_datetime_field(name, *, stored=True, indexed=True)` | UTC 日時フィールド。 |
-| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, embedder=None)` | HNSW 近似最近傍ベクトルフィールド。 |
+| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None)` | HNSW 近似最近傍ベクトルフィールド。 |
 | `add_flat_field(name, dimension, *, distance="cosine", embedder=None)` | Flat（総当たり）ベクトルフィールド。 |
 | `add_ivf_field(name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None)` | IVF 近似最近傍ベクトルフィールド。 |
+
+**ベクトル量子化とリランクストレージ**（HNSW フィールド）:
+
+- `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvector_count`（`dimension` を割り切れる値）が必須です。
+- `rerank_storage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
 
 ### その他のメソッド
 

--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -61,9 +61,14 @@ Laurus::Schema.new
 | `add_geo_field(name, stored: true, indexed: true)` | 地理座標フィールド（緯度/経度）。 |
 | `add_geo3d_field(name, stored: true, indexed: true)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `add_datetime_field(name, stored: true, indexed: true)` | UTC 日時フィールド。 |
-| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, embedder: nil)` | HNSW 近似最近傍ベクトルフィールド。 |
+| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil)` | HNSW 近似最近傍ベクトルフィールド。 |
 | `add_flat_field(name, dimension, distance: "cosine", embedder: nil)` | Flat（総当たり）ベクトルフィールド。 |
 | `add_ivf_field(name, dimension, distance: "cosine", n_clusters: 100, n_probe: 1, embedder: nil)` | IVF 近似最近傍ベクトルフィールド。 |
+
+**ベクトル量子化とリランクストレージ**（HNSW フィールド）:
+
+- `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvector_count`（`dimension` を割り切れる値）が必須です。
+- `rerank_storage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
 
 ### その他のメソッド
 

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -206,13 +206,16 @@ WASM バインディングは `Geo3dDistanceQuery` / `Geo3dBoundingBoxQuery` /
 
 バイナリデータフィールドを追加します。
 
-#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?)`
+#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?)`
 
 HNSW ベクトルインデックスフィールドを追加します。
 
 - `distance`: `"cosine"`（デフォルト）、`"euclidean"`、`"dot_product"`、`"manhattan"`、`"angular"`
 - `m`: 分岐係数（デフォルト 16）
 - `efConstruction`: 構築時の探索幅（デフォルト 200）
+- `quantizer`: `"scalar_8bit"`（デフォルト）または `"product_quantization"`（`subvectorCount` が必須）
+- `subvectorCount`: PQ サブベクトル数。`dimension` を割り切れる値を指定します
+- `rerankStorage`: 省略（デフォルト）するか、`"f32"` を指定して完全精度のリランクサイドカーを保存します
 
 #### `addFlatField(name, dimension, distance?, embedder?)`
 
@@ -224,6 +227,11 @@ IVF ベクトルインデックスフィールドを追加します。
 
 - `nClusters`: パーティショニングクラスタ数（デフォルト 100）
 - `nProbe`: 検索時にプローブするクラスタ数（デフォルト 1）
+
+**ベクトル量子化とリランクストレージ**（HNSW フィールド）:
+
+- `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvectorCount`（`dimension` を割り切れる値）が必須です。
+- `rerankStorage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
 
 #### `addAnalyzer(name, analyzer)`
 

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -73,7 +73,7 @@ class Schema {
 | `addGeoField(name, stored?, indexed?)` | Geographic coordinate field. |
 | `addGeo3dField(name, stored?, indexed?)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `addDatetimeField(name, stored?, indexed?)` | UTC datetime field. |
-| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?)` | HNSW vector field. |
+| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?)` | HNSW vector field. |
 | `addFlatField(name, dimension, distance?, embedder?)` | Flat (brute-force) vector field. |
 | `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)` | IVF vector field. |
 | `addEmbedder(name, config)` | Register a named embedder. |
@@ -82,6 +82,11 @@ class Schema {
 | `dynamicFieldPolicy()` | Return the current policy as a lowercase string. |
 | `fieldNames()` | Return all field names. |
 | `toString()` | Return a string representation of the schema (`"Schema(fields=[...])"`). |
+
+**Vector quantization & rerank storage** (HNSW fields):
+
+- `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvectorCount` (must divide `dimension`).
+- `rerankStorage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
 
 #### Dynamic field policy
 

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -61,9 +61,14 @@ new \Laurus\Schema()
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | Geographic coordinate field (lat/lon). |
 | `addGeo3dField(string $name, bool $stored = true, bool $indexed = true): void` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `addDatetimeField(string $name, bool $stored = true, bool $indexed = true): void` | UTC datetime field. |
-| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null): void` | HNSW approximate nearest-neighbor vector field. |
+| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null): void` | HNSW approximate nearest-neighbor vector field. |
 | `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null): void` | Flat (brute-force) vector field. |
 | `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null): void` | IVF approximate nearest-neighbor vector field. |
+
+**Vector quantization & rerank storage** (HNSW fields):
+
+- `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvectorCount` (must divide `dimension`).
+- `rerankStorage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
 
 ### Other methods
 

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -63,9 +63,14 @@ class Schema:
 | `add_geo_field(name, *, stored=True, indexed=True)` | Geographic coordinate field (lat/lon). |
 | `add_geo3d_field(name, *, stored=True, indexed=True)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `add_datetime_field(name, *, stored=True, indexed=True)` | UTC datetime field. |
-| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, embedder=None)` | HNSW approximate nearest-neighbor vector field. |
+| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None)` | HNSW approximate nearest-neighbor vector field. |
 | `add_flat_field(name, dimension, *, distance="cosine", embedder=None)` | Flat (brute-force) vector field. |
 | `add_ivf_field(name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None)` | IVF approximate nearest-neighbor vector field. |
+
+**Vector quantization & rerank storage** (HNSW fields):
+
+- `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvector_count` (must divide `dimension`).
+- `rerank_storage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
 
 ### Other methods
 

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -61,9 +61,14 @@ Laurus::Schema.new
 | `add_geo_field(name, stored: true, indexed: true)` | Geographic coordinate field (lat/lon). |
 | `add_geo3d_field(name, stored: true, indexed: true)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `add_datetime_field(name, stored: true, indexed: true)` | UTC datetime field. |
-| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, embedder: nil)` | HNSW approximate nearest-neighbor vector field. |
+| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil)` | HNSW approximate nearest-neighbor vector field. |
 | `add_flat_field(name, dimension, distance: "cosine", embedder: nil)` | Flat (brute-force) vector field. |
 | `add_ivf_field(name, dimension, distance: "cosine", n_clusters: 100, n_probe: 1, embedder: nil)` | IVF approximate nearest-neighbor vector field. |
+
+**Vector quantization & rerank storage** (HNSW fields):
+
+- `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvector_count` (must divide `dimension`).
+- `rerank_storage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
 
 ### Other methods
 

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -209,7 +209,7 @@ above.
 
 Add a binary data field.
 
-#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?)`
+#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?)`
 
 Add an HNSW vector index field.
 
@@ -217,6 +217,11 @@ Add an HNSW vector index field.
   `"manhattan"`, `"angular"`
 - `m`: Branching factor (default 16)
 - `efConstruction`: Build-time expansion (default 200)
+- `quantizer`: `"scalar_8bit"` (default) or `"product_quantization"`
+  (requires `subvectorCount`)
+- `subvectorCount`: number of PQ sub-vectors; must divide `dimension`
+- `rerankStorage`: omit (default) or `"f32"` to store a full-precision
+  rerank sidecar
 
 #### `addFlatField(name, dimension, distance?, embedder?)`
 
@@ -228,6 +233,11 @@ Add an IVF vector index field.
 
 - `nClusters`: Number of partitioning clusters (default 100)
 - `nProbe`: Number of clusters to probe at query time (default 1)
+
+**Vector quantization & rerank storage** (HNSW fields):
+
+- `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvectorCount` (must divide `dimension`).
+- `rerankStorage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
 
 #### `addAnalyzer(name, analyzer)`
 

--- a/laurus-nodejs/__tests__/vector_quantizer_rerank.spec.mjs
+++ b/laurus-nodejs/__tests__/vector_quantizer_rerank.spec.mjs
@@ -1,0 +1,139 @@
+// Tests for the HNSW quantizer / rerankStorage schema options (Issue #797).
+//
+// These assert the values configured on `addHnswField` actually reach the
+// Rust core via deterministic observables, not merely that search succeeds:
+//
+// * `rerankStorage: "f32"` makes the core write a `*.hnsw.f32` Stage-2
+//   sidecar on disk (mirrors the server-side guard in #793/#800); the
+//   default writes no sidecar.
+// * `quantizer: "product_quantization"` forwards `subvectorCount` to the
+//   core's PQ training, which rejects a count that does not divide the
+//   field dimension.
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Index, Schema } from "../index.js";
+
+// `addHnswField` is positional:
+//   (name, dimension, distance, m, efConstruction, defaultEfSearch,
+//    embedder, quantizer, subvectorCount, rerankStorage)
+function findSidecars(dir) {
+  let found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) found = found.concat(findSidecars(p));
+    else if (entry.name.endsWith(".hnsw.f32")) found.push(p);
+  }
+  return found;
+}
+
+describe("HNSW quantizer / rerankStorage options (#797)", () => {
+  it("rerankStorage 'f32' writes a .hnsw.f32 sidecar on disk", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "laurus-rerank-"));
+    const schema = new Schema();
+    schema.addHnswField(
+      "embedding", 4, undefined, undefined, undefined, undefined, undefined, undefined, undefined, "f32",
+    );
+    const index = await Index.create(dir, schema);
+    await index.putDocument("doc1", { embedding: [0.1, 0.2, 0.3, 0.4] });
+    await index.putDocument("doc2", { embedding: [0.9, 0.8, 0.7, 0.6] });
+    await index.commit();
+    expect(findSidecars(dir).length).toBeGreaterThan(0);
+  });
+
+  it("no rerankStorage writes no sidecar", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "laurus-norerank-"));
+    const schema = new Schema();
+    schema.addHnswField("embedding", 4);
+    const index = await Index.create(dir, schema);
+    await index.putDocument("doc1", { embedding: [0.1, 0.2, 0.3, 0.4] });
+    await index.putDocument("doc2", { embedding: [0.9, 0.8, 0.7, 0.6] });
+    await index.commit();
+    expect(findSidecars(dir).length).toBe(0);
+  });
+
+  it("product_quantization builds and searches the near cluster", async () => {
+    const schema = new Schema();
+    // PQ is an L2 quantizer, so use Euclidean (matching the core's
+    // `test_hnsw_pq_search_returns_corpus_neighbour`).
+    schema.addHnswField(
+      "embedding", 4, "euclidean", undefined, undefined, undefined, undefined, "product_quantization", 2, undefined,
+    );
+    const index = await Index.create(null, schema);
+    // Stable two-cluster corpus mirroring the core's
+    // `test_hnsw_pq_search_returns_corpus_neighbour` (issue #730).
+    const nearOffsets = [
+      [0.0, 0.0, 0.0, 0.0],
+      [0.1, 0.1, 0.1, 0.1],
+      [-0.1, -0.1, -0.1, -0.1],
+      [0.2, -0.2, 0.2, -0.2],
+      [-0.2, 0.2, -0.2, 0.2],
+      [0.05, 0.05, -0.05, -0.05],
+      [-0.05, -0.05, 0.05, 0.05],
+      [0.15, -0.1, 0.1, -0.15],
+    ];
+    const nearBase = [10.0, 10.0, 20.0, 20.0];
+    const farBase = [-100.0, -100.0, -200.0, -200.0];
+    for (let i = 0; i < nearOffsets.length; i++) {
+      await index.putDocument(`near${i}`, {
+        embedding: nearBase.map((b, j) => b + nearOffsets[i][j]),
+      });
+      await index.putDocument(`far${i}`, {
+        embedding: farBase.map((b, j) => b + nearOffsets[i][j]),
+      });
+    }
+    await index.commit();
+
+    const results = await index.searchVector("embedding", nearBase, 3);
+    expect(results.length).toBe(3);
+    expect(results.every((r) => r.id.startsWith("near"))).toBe(true);
+  });
+
+  it("rejects product_quantization whose subvectorCount does not divide the dimension", async () => {
+    const schema = new Schema();
+    schema.addHnswField(
+      "embedding", 4, undefined, undefined, undefined, undefined, undefined, "product_quantization", 3, undefined,
+    );
+    const index = await Index.create(null, schema);
+    await index.putDocument("doc1", { embedding: [0.1, 0.2, 0.3, 0.4] });
+    await expect(index.commit()).rejects.toThrow();
+  });
+
+  it("rejects an unknown quantizer", () => {
+    const schema = new Schema();
+    expect(() =>
+      schema.addHnswField(
+        "embedding", 4, undefined, undefined, undefined, undefined, undefined, "bogus",
+      ),
+    ).toThrow();
+  });
+
+  it("rejects product_quantization without subvectorCount", () => {
+    const schema = new Schema();
+    expect(() =>
+      schema.addHnswField(
+        "embedding", 4, undefined, undefined, undefined, undefined, undefined, "product_quantization",
+      ),
+    ).toThrow();
+  });
+
+  it("rejects subvectorCount for a scalar quantizer", () => {
+    const schema = new Schema();
+    expect(() =>
+      schema.addHnswField(
+        "embedding", 4, undefined, undefined, undefined, undefined, undefined, undefined, 2,
+      ),
+    ).toThrow();
+  });
+
+  it("rejects an unknown rerankStorage", () => {
+    const schema = new Schema();
+    expect(() =>
+      schema.addHnswField(
+        "embedding", 4, undefined, undefined, undefined, undefined, undefined, undefined, undefined, "bogus",
+      ),
+    ).toThrow();
+  });
+});

--- a/laurus-nodejs/src/schema.rs
+++ b/laurus-nodejs/src/schema.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use laurus::{
     BooleanOption, BytesOption, DateTimeOption, DistanceMetric, DynamicFieldPolicy,
     EmbedderDefinition, FieldOption, FlatOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
-    IntegerOption, IvfOption, Schema, TextOption,
+    IntegerOption, IvfOption, QuantizationMethod, RerankStorageKind, Schema, TextOption,
 };
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -28,6 +28,57 @@ fn parse_distance(s: &str) -> Result<DistanceMetric> {
         "angular" => Ok(DistanceMetric::Angular),
         other => Err(napi::Error::from_reason(format!(
             "Unknown distance metric: '{other}'. Valid: cosine, euclidean, dot_product, manhattan, angular"
+        ))),
+    }
+}
+
+/// Parse a quantizer name plus optional `subvectorCount` into a
+/// [`QuantizationMethod`].
+///
+/// Accepts `"scalar_8bit"` / `"scalar"` (the default when `name` is
+/// `None`) and `"product_quantization"` / `"pq"`. Product quantization
+/// requires a `subvector_count` (which must divide the field dimension —
+/// validated by the core at index-build time); supplying it for any other
+/// quantizer is rejected so an incoherent configuration cannot silently
+/// reach the core.
+fn parse_quantizer(
+    name: Option<&str>,
+    subvector_count: Option<usize>,
+) -> Result<QuantizationMethod> {
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None | Some("scalar_8bit") | Some("scalar") => {
+            if subvector_count.is_some() {
+                return Err(napi::Error::from_reason(
+                    "subvectorCount is only valid with quantizer='product_quantization'",
+                ));
+            }
+            Ok(QuantizationMethod::Scalar8Bit)
+        }
+        Some("product_quantization") | Some("pq") => {
+            let subvector_count = subvector_count.ok_or_else(|| {
+                napi::Error::from_reason(
+                    "quantizer='product_quantization' requires subvectorCount \
+                     (must divide the field dimension)",
+                )
+            })?;
+            Ok(QuantizationMethod::ProductQuantization { subvector_count })
+        }
+        Some(other) => Err(napi::Error::from_reason(format!(
+            "Unknown quantizer: '{other}'. Valid: scalar_8bit, product_quantization"
+        ))),
+    }
+}
+
+/// Parse a rerank-storage name into an optional [`RerankStorageKind`].
+///
+/// `None` (the default) keeps the Stage-1 int8-only segment; `"f32"`
+/// enables the Stage-2 full-precision rerank sidecar (`*.hnsw.f32`).
+fn parse_rerank_storage(name: Option<&str>) -> Result<Option<RerankStorageKind>> {
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None => Ok(None),
+        Some("f32") => Ok(Some(RerankStorageKind::F32)),
+        Some(other) => Err(napi::Error::from_reason(format!(
+            "Unknown rerank_storage: '{other}'. Valid: f32"
         ))),
     }
 }
@@ -262,6 +313,14 @@ impl JsSchema {
     ///   searcher uses an internal fallback of 50. Per-query overrides
     ///   via the search request still take precedence.
     /// * `embedder` - Optional embedder name registered via `addEmbedder`.
+    /// * `quantizer` - Vector quantizer — "scalar_8bit" (default) or
+    ///   "product_quantization" (requires `subvectorCount`).
+    /// * `subvectorCount` - Number of PQ sub-vectors. Required when
+    ///   `quantizer` is "product_quantization" and must divide `dimension`;
+    ///   rejected for other quantizers.
+    /// * `rerankStorage` - Stage-2 rerank sidecar — omitted (default) keeps
+    ///   the int8-only segment, "f32" stores full-precision vectors in a
+    ///   `*.hnsw.f32` sidecar for exact rerank distances.
     #[napi]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
@@ -273,6 +332,9 @@ impl JsSchema {
         ef_construction: Option<u32>,
         default_ef_search: Option<u32>,
         embedder: Option<String>,
+        quantizer: Option<String>,
+        subvector_count: Option<u32>,
+        rerank_storage: Option<String>,
     ) -> Result<()> {
         let opt = HnswOption {
             dimension: dimension as usize,
@@ -280,6 +342,8 @@ impl JsSchema {
             m: m.unwrap_or(16) as usize,
             ef_construction: ef_construction.unwrap_or(200) as usize,
             default_ef_search: default_ef_search.map(|v| v as usize),
+            quantizer: parse_quantizer(quantizer.as_deref(), subvector_count.map(|v| v as usize))?,
+            rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
             ..Default::default()
         };

--- a/laurus-php/src/schema.rs
+++ b/laurus-php/src/schema.rs
@@ -9,7 +9,7 @@ use ext_php_rs::types::ZendHashTable;
 use laurus::{
     BooleanOption, BytesOption, DateTimeOption, DistanceMetric, DynamicFieldPolicy,
     EmbedderDefinition, FieldOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
-    IntegerOption, IvfOption, Schema, TextOption,
+    IntegerOption, IvfOption, QuantizationMethod, RerankStorageKind, Schema, TextOption,
 };
 
 /// Parse a distance metric string into [`DistanceMetric`].
@@ -33,6 +33,55 @@ fn parse_distance(s: &str) -> PhpResult<DistanceMetric> {
             other
         )
         .into()),
+    }
+}
+
+/// Parse a quantizer name plus optional `subvector_count` into a
+/// [`QuantizationMethod`].
+///
+/// Accepts `"scalar_8bit"` / `"scalar"` (the default when `name` is
+/// `None`) and `"product_quantization"` / `"pq"`. Product quantization
+/// requires a `subvector_count` (which must divide the field dimension —
+/// validated by the core at index-build time); supplying it for any other
+/// quantizer is rejected so an incoherent configuration cannot silently
+/// reach the core.
+fn parse_quantizer(
+    name: Option<&str>,
+    subvector_count: Option<usize>,
+) -> PhpResult<QuantizationMethod> {
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None | Some("scalar_8bit") | Some("scalar") => {
+            if subvector_count.is_some() {
+                return Err(
+                    "subvector_count is only valid with quantizer 'product_quantization'".into(),
+                );
+            }
+            Ok(QuantizationMethod::Scalar8Bit)
+        }
+        Some("product_quantization") | Some("pq") => match subvector_count {
+            Some(subvector_count) => {
+                Ok(QuantizationMethod::ProductQuantization { subvector_count })
+            }
+            None => Err("quantizer 'product_quantization' requires subvector_count \
+                         (must divide the field dimension)"
+                .into()),
+        },
+        Some(other) => Err(format!(
+            "Unknown quantizer: '{other}'. Valid: scalar_8bit, product_quantization"
+        )
+        .into()),
+    }
+}
+
+/// Parse a rerank-storage name into an optional [`RerankStorageKind`].
+///
+/// `None` (the default) keeps the Stage-1 int8-only segment; `"f32"`
+/// enables the Stage-2 full-precision rerank sidecar (`*.hnsw.f32`).
+fn parse_rerank_storage(name: Option<&str>) -> PhpResult<Option<RerankStorageKind>> {
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None => Ok(None),
+        Some("f32") => Ok(Some(RerankStorageKind::F32)),
+        Some(other) => Err(format!("Unknown rerank_storage: '{other}'. Valid: f32").into()),
     }
 }
 
@@ -230,6 +279,14 @@ impl PhpSchema {
     ///   searcher uses an internal fallback of 50. Per-query overrides
     ///   via the search request still take precedence.
     /// * `embedder` - Embedder name registered via `addEmbedder` (default: "" for none).
+    /// * `quantizer` - Vector quantizer — "scalar_8bit" (default) or
+    ///   "product_quantization" (requires `subvector_count`).
+    /// * `subvector_count` - Number of PQ sub-vectors. Required when
+    ///   `quantizer` is "product_quantization" and must divide `dimension`;
+    ///   rejected for other quantizers.
+    /// * `rerank_storage` - Stage-2 rerank sidecar — omitted (default) keeps
+    ///   the int8-only segment, "f32" stores full-precision vectors in a
+    ///   `*.hnsw.f32` sidecar for exact rerank distances.
     #[php(defaults(m = 16, ef_construction = 200))]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
@@ -241,6 +298,9 @@ impl PhpSchema {
         ef_construction: i64,
         default_ef_search: Option<i64>,
         embedder: Option<String>,
+        quantizer: Option<String>,
+        subvector_count: Option<i64>,
+        rerank_storage: Option<String>,
     ) -> PhpResult<()> {
         let dist_str = distance.unwrap_or_else(|| "cosine".to_string());
         let opt = HnswOption {
@@ -249,6 +309,8 @@ impl PhpSchema {
             m: m as usize,
             ef_construction: ef_construction as usize,
             default_ef_search: default_ef_search.map(|v| v as usize),
+            quantizer: parse_quantizer(quantizer.as_deref(), subvector_count.map(|v| v as usize))?,
+            rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
             ..Default::default()
         };

--- a/laurus-php/tests/LaurusTest.php
+++ b/laurus-php/tests/LaurusTest.php
@@ -555,4 +555,140 @@ class LaurusTest extends TestCase
             $this->assertLessThanOrEqual(1, count($results));
         }
     }
+
+    // ── HNSW quantizer / rerank_storage options (#797) ────────────────────
+    //
+    // These assert the values configured on addHnswField actually reach the
+    // Rust core via deterministic observables, not merely that search
+    // succeeds. addHnswField is positional:
+    //   (name, dimension, distance, m, efConstruction, defaultEfSearch,
+    //    embedder, quantizer, subvectorCount, rerankStorage)
+
+    /**
+     * Recursively collect files under $dir whose name ends with $suffix.
+     */
+    private function findFilesBySuffix(string $dir, string $suffix): array
+    {
+        $found = [];
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($it as $file) {
+            if (str_ends_with($file->getFilename(), $suffix)) {
+                $found[] = $file->getPathname();
+            }
+        }
+        return $found;
+    }
+
+    public function testRerankStorageF32WritesSidecar(): void
+    {
+        $dir = sys_get_temp_dir() . "/laurus_rerank_" . uniqid();
+        mkdir($dir);
+        $schema = new Laurus\Schema();
+        $schema->addHnswField("embedding", 4, null, 16, 200, null, null, null, null, "f32");
+        $idx = new Laurus\Index($dir, $schema);
+        $idx->putDocument("doc1", ["embedding" => [0.1, 0.2, 0.3, 0.4]]);
+        $idx->putDocument("doc2", ["embedding" => [0.9, 0.8, 0.7, 0.6]]);
+        $idx->commit();
+
+        $this->assertNotEmpty(
+            $this->findFilesBySuffix($dir, ".hnsw.f32"),
+            "rerank_storage 'f32' must write a .hnsw.f32 sidecar"
+        );
+    }
+
+    public function testNoRerankStorageWritesNoSidecar(): void
+    {
+        $dir = sys_get_temp_dir() . "/laurus_norerank_" . uniqid();
+        mkdir($dir);
+        $schema = new Laurus\Schema();
+        $schema->addHnswField("embedding", 4);
+        $idx = new Laurus\Index($dir, $schema);
+        $idx->putDocument("doc1", ["embedding" => [0.1, 0.2, 0.3, 0.4]]);
+        $idx->putDocument("doc2", ["embedding" => [0.9, 0.8, 0.7, 0.6]]);
+        $idx->commit();
+
+        $this->assertEmpty($this->findFilesBySuffix($dir, ".hnsw.f32"));
+    }
+
+    public function testProductQuantizationBuildsAndSearches(): void
+    {
+        $schema = new Laurus\Schema();
+        // PQ is an L2 quantizer, so use Euclidean (matching the core's
+        // test_hnsw_pq_search_returns_corpus_neighbour).
+        $schema->addHnswField("embedding", 4, "euclidean", 16, 200, null, null, "product_quantization", 2, null);
+        $idx = new Laurus\Index(null, $schema);
+        // Stable two-cluster corpus mirroring the core (issue #730).
+        $nearOffsets = [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.1, 0.1, 0.1, 0.1],
+            [-0.1, -0.1, -0.1, -0.1],
+            [0.2, -0.2, 0.2, -0.2],
+            [-0.2, 0.2, -0.2, 0.2],
+            [0.05, 0.05, -0.05, -0.05],
+            [-0.05, -0.05, 0.05, 0.05],
+            [0.15, -0.1, 0.1, -0.15],
+        ];
+        $nearBase = [10.0, 10.0, 20.0, 20.0];
+        $farBase = [-100.0, -100.0, -200.0, -200.0];
+        foreach ($nearOffsets as $i => $off) {
+            $near = [];
+            $far = [];
+            foreach ($nearBase as $j => $b) {
+                $near[] = $b + $off[$j];
+            }
+            foreach ($farBase as $j => $b) {
+                $far[] = $b + $off[$j];
+            }
+            $idx->putDocument("near$i", ["embedding" => $near]);
+            $idx->putDocument("far$i", ["embedding" => $far]);
+        }
+        $idx->commit();
+
+        $q = new Laurus\VectorQuery("embedding", $nearBase);
+        $results = $idx->search($q, 3);
+        $this->assertCount(3, $results);
+        foreach ($results as $r) {
+            $this->assertStringStartsWith("near", $r->getId());
+        }
+    }
+
+    public function testPqSubvectorCountMustDivideDimension(): void
+    {
+        $schema = new Laurus\Schema();
+        $schema->addHnswField("embedding", 4, null, 16, 200, null, null, "product_quantization", 3, null);
+        $idx = new Laurus\Index(null, $schema);
+        $idx->putDocument("doc1", ["embedding" => [0.1, 0.2, 0.3, 0.4]]);
+        $this->expectException(\Throwable::class);
+        $idx->commit();
+    }
+
+    public function testUnknownQuantizerRejected(): void
+    {
+        $schema = new Laurus\Schema();
+        $this->expectException(\Throwable::class);
+        $schema->addHnswField("embedding", 4, null, 16, 200, null, null, "bogus");
+    }
+
+    public function testPqRequiresSubvectorCount(): void
+    {
+        $schema = new Laurus\Schema();
+        $this->expectException(\Throwable::class);
+        $schema->addHnswField("embedding", 4, null, 16, 200, null, null, "product_quantization");
+    }
+
+    public function testSubvectorCountRejectedForScalar(): void
+    {
+        $schema = new Laurus\Schema();
+        $this->expectException(\Throwable::class);
+        $schema->addHnswField("embedding", 4, null, 16, 200, null, null, null, 2);
+    }
+
+    public function testUnknownRerankStorageRejected(): void
+    {
+        $schema = new Laurus\Schema();
+        $this->expectException(\Throwable::class);
+        $schema->addHnswField("embedding", 4, null, 16, 200, null, null, null, null, "bogus");
+    }
 }

--- a/laurus-python/src/schema.rs
+++ b/laurus-python/src/schema.rs
@@ -5,7 +5,8 @@ use std::str::FromStr;
 use laurus::{
     AnalyzerSpec, BooleanOption, BuiltinAnalyzerSpec, BytesOption, DateTimeOption, DistanceMetric,
     DynamicFieldPolicy, EmbedderDefinition, FieldOption, FlatOption, FloatOption, Geo3dOption,
-    GeoOption, HnswOption, IntegerOption, IvfOption, Schema, TextOption,
+    GeoOption, HnswOption, IntegerOption, IvfOption, QuantizationMethod, RerankStorageKind, Schema,
+    TextOption,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -74,6 +75,57 @@ fn parse_distance(s: &str) -> PyResult<DistanceMetric> {
         other => Err(PyValueError::new_err(format!(
             "Unknown distance metric: '{}'. Valid: cosine, euclidean, dot_product, manhattan, angular",
             other
+        ))),
+    }
+}
+
+/// Parse a quantizer name plus optional `subvector_count` into a
+/// [`QuantizationMethod`].
+///
+/// Accepts `"scalar_8bit"` / `"scalar"` (the default when `name` is
+/// `None`) and `"product_quantization"` / `"pq"`. Product quantization
+/// requires a `subvector_count` (which must divide the field dimension —
+/// the divisibility itself is validated by the core at index-build time);
+/// supplying `subvector_count` for any other quantizer is rejected so an
+/// incoherent configuration cannot silently reach the core.
+fn parse_quantizer(
+    name: Option<&str>,
+    subvector_count: Option<usize>,
+) -> PyResult<QuantizationMethod> {
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None | Some("scalar_8bit") | Some("scalar") => {
+            if subvector_count.is_some() {
+                return Err(PyValueError::new_err(
+                    "subvector_count is only valid with quantizer='product_quantization'",
+                ));
+            }
+            Ok(QuantizationMethod::Scalar8Bit)
+        }
+        Some("product_quantization") | Some("pq") => {
+            let subvector_count = subvector_count.ok_or_else(|| {
+                PyValueError::new_err(
+                    "quantizer='product_quantization' requires subvector_count \
+                     (must divide the field dimension)",
+                )
+            })?;
+            Ok(QuantizationMethod::ProductQuantization { subvector_count })
+        }
+        Some(other) => Err(PyValueError::new_err(format!(
+            "Unknown quantizer: '{other}'. Valid: scalar_8bit, product_quantization"
+        ))),
+    }
+}
+
+/// Parse a rerank-storage name into an optional [`RerankStorageKind`].
+///
+/// `None` (the default) keeps the Stage-1 int8-only segment; `"f32"`
+/// enables the Stage-2 full-precision rerank sidecar (`*.hnsw.f32`).
+fn parse_rerank_storage(name: Option<&str>) -> PyResult<Option<RerankStorageKind>> {
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None => Ok(None),
+        Some("f32") => Ok(Some(RerankStorageKind::F32)),
+        Some(other) => Err(PyValueError::new_err(format!(
+            "Unknown rerank_storage: '{other}'. Valid: f32"
         ))),
     }
 }
@@ -253,9 +305,18 @@ impl PySchema {
     ///         `ef_search` candidate-list size (Issue #644). When unset,
     ///         the searcher uses an internal fallback of 50. Per-query
     ///         overrides via the search request still take precedence.
+    ///     quantizer: Vector quantizer — "scalar_8bit" (default) or
+    ///         "product_quantization". Product quantization requires
+    ///         `subvector_count`.
+    ///     subvector_count: Number of PQ sub-vectors. Required when
+    ///         `quantizer="product_quantization"` and must divide
+    ///         `dimension`; rejected for other quantizers.
+    ///     rerank_storage: Stage-2 rerank sidecar — None (default) keeps
+    ///         the int8-only segment, "f32" stores full-precision vectors
+    ///         in a `*.hnsw.f32` sidecar for exact rerank distances.
     ///     embedder: Optional embedder name registered via `add_embedder`.
     ///         When set, text payloads are automatically embedded by the Rust engine.
-    #[pyo3(signature = (name, dimension, *, distance="cosine", m=16, ef_construction=200, default_ef_search=None, embedder=None))]
+    #[pyo3(signature = (name, dimension, *, distance="cosine", m=16, ef_construction=200, default_ef_search=None, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
         &mut self,
@@ -265,6 +326,9 @@ impl PySchema {
         m: usize,
         ef_construction: usize,
         default_ef_search: Option<usize>,
+        quantizer: Option<String>,
+        subvector_count: Option<usize>,
+        rerank_storage: Option<String>,
         embedder: Option<String>,
     ) -> PyResult<()> {
         let opt = HnswOption {
@@ -273,6 +337,8 @@ impl PySchema {
             m,
             ef_construction,
             default_ef_search,
+            quantizer: parse_quantizer(quantizer.as_deref(), subvector_count)?,
+            rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
             ..Default::default()
         };

--- a/laurus-python/tests/test_vector_quantizer_rerank.py
+++ b/laurus-python/tests/test_vector_quantizer_rerank.py
@@ -1,0 +1,132 @@
+"""Tests for the HNSW quantizer / rerank_storage schema options (Issue #797).
+
+These assert that the values configured on ``add_hnsw_field`` actually reach
+the Rust core, using deterministic observables rather than only that search
+succeeds:
+
+* ``rerank_storage="f32"`` makes the core write a ``*.hnsw.f32`` Stage-2
+  sidecar on disk (mirrors the server-side guard in #793/#800); the default
+  writes no sidecar.
+* ``quantizer="product_quantization"`` forwards ``subvector_count`` to the
+  core's PQ training, which rejects a count that does not divide the field
+  dimension.
+"""
+
+import pytest
+import laurus
+
+
+# ---------------------------------------------------------------------------
+# rerank_storage reaches the core (on-disk sidecar)
+# ---------------------------------------------------------------------------
+
+
+def test_rerank_storage_f32_writes_sidecar(tmp_path):
+    schema = laurus.Schema()
+    schema.add_hnsw_field("embedding", dimension=4, rerank_storage="f32")
+    idx = laurus.Index(path=str(tmp_path), schema=schema)
+    idx.put_document("doc1", {"embedding": [0.1, 0.2, 0.3, 0.4]})
+    idx.put_document("doc2", {"embedding": [0.9, 0.8, 0.7, 0.6]})
+    idx.commit()
+
+    sidecars = list(tmp_path.rglob("*.hnsw.f32"))
+    assert sidecars, "rerank_storage='f32' must write a .hnsw.f32 rerank sidecar"
+
+
+def test_no_rerank_storage_writes_no_sidecar(tmp_path):
+    schema = laurus.Schema()
+    schema.add_hnsw_field("embedding", dimension=4)
+    idx = laurus.Index(path=str(tmp_path), schema=schema)
+    idx.put_document("doc1", {"embedding": [0.1, 0.2, 0.3, 0.4]})
+    idx.put_document("doc2", {"embedding": [0.9, 0.8, 0.7, 0.6]})
+    idx.commit()
+
+    sidecars = list(tmp_path.rglob("*.hnsw.f32"))
+    assert not sidecars, "no rerank sidecar should exist without rerank_storage"
+
+
+# ---------------------------------------------------------------------------
+# quantizer reaches the core (PQ training honours subvector_count)
+# ---------------------------------------------------------------------------
+
+
+def test_product_quantization_builds_and_searches():
+    schema = laurus.Schema()
+    # PQ is an L2 quantizer, so use Euclidean (matching the core's
+    # `test_hnsw_pq_search_returns_corpus_neighbour`).
+    schema.add_hnsw_field(
+        "embedding",
+        dimension=4,
+        distance="euclidean",
+        quantizer="product_quantization",
+        subvector_count=2,
+    )
+    idx = laurus.Index(schema=schema)
+    # Mirror the stable two-cluster corpus from the core's
+    # `test_hnsw_pq_search_returns_corpus_neighbour` (issue #730): a dense,
+    # widely-separated pair of clusters keeps the PQ codebook stable across
+    # platforms so the near cluster is never displaced by quantization error.
+    near_offsets = [
+        [0.0, 0.0, 0.0, 0.0],
+        [0.1, 0.1, 0.1, 0.1],
+        [-0.1, -0.1, -0.1, -0.1],
+        [0.2, -0.2, 0.2, -0.2],
+        [-0.2, 0.2, -0.2, 0.2],
+        [0.05, 0.05, -0.05, -0.05],
+        [-0.05, -0.05, 0.05, 0.05],
+        [0.15, -0.1, 0.1, -0.15],
+    ]
+    near_base = [10.0, 10.0, 20.0, 20.0]
+    far_base = [-100.0, -100.0, -200.0, -200.0]
+    for i, off in enumerate(near_offsets):
+        idx.put_document(f"near{i}", {"embedding": [b + o for b, o in zip(near_base, off)]})
+        idx.put_document(f"far{i}", {"embedding": [b + o for b, o in zip(far_base, off)]})
+    idx.commit()
+
+    results = idx.search(laurus.VectorQuery("embedding", near_base), limit=3)
+    assert len(results) == 3
+    assert all(r.id.startswith("near") for r in results)
+
+
+def test_pq_subvector_count_must_divide_dimension():
+    """subvector_count=3 does not divide dimension=4, so the core's PQ
+    training must reject it at commit — proving the value reached the core."""
+    schema = laurus.Schema()
+    schema.add_hnsw_field(
+        "embedding", dimension=4, quantizer="product_quantization", subvector_count=3
+    )
+    idx = laurus.Index(schema=schema)
+    idx.put_document("doc1", {"embedding": [0.1, 0.2, 0.3, 0.4]})
+    with pytest.raises(Exception):
+        idx.commit()
+
+
+# ---------------------------------------------------------------------------
+# Builder-level validation (incoherent configs are rejected up front)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_quantizer_rejected():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError):
+        schema.add_hnsw_field("embedding", dimension=4, quantizer="bogus")
+
+
+def test_pq_requires_subvector_count():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError):
+        schema.add_hnsw_field(
+            "embedding", dimension=4, quantizer="product_quantization"
+        )
+
+
+def test_subvector_count_rejected_for_scalar():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError):
+        schema.add_hnsw_field("embedding", dimension=4, subvector_count=2)
+
+
+def test_unknown_rerank_storage_rejected():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError):
+        schema.add_hnsw_field("embedding", dimension=4, rerank_storage="bogus")

--- a/laurus-ruby/src/schema.rs
+++ b/laurus-ruby/src/schema.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use laurus::{
     BooleanOption, BytesOption, DateTimeOption, DistanceMetric, DynamicFieldPolicy,
     EmbedderDefinition, FieldOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
-    IntegerOption, IvfOption, Schema, TextOption,
+    IntegerOption, IvfOption, QuantizationMethod, RerankStorageKind, Schema, TextOption,
 };
 use magnus::prelude::*;
 use magnus::scan_args::{get_kwargs, scan_args};
@@ -27,6 +27,63 @@ fn parse_distance(s: &str) -> Result<DistanceMetric, Error> {
                 "Unknown distance metric: '{}'. Valid: cosine, euclidean, dot_product, manhattan, angular",
                 other
             ),
+        )),
+    }
+}
+
+/// Parse a quantizer name plus optional `subvector_count` into a
+/// [`QuantizationMethod`].
+///
+/// Accepts `"scalar_8bit"` / `"scalar"` (the default when `name` is
+/// `None`) and `"product_quantization"` / `"pq"`. Product quantization
+/// requires a `subvector_count` (which must divide the field dimension —
+/// validated by the core at index-build time); supplying it for any other
+/// quantizer is rejected so an incoherent configuration cannot silently
+/// reach the core.
+fn parse_quantizer(
+    name: Option<&str>,
+    subvector_count: Option<usize>,
+) -> Result<QuantizationMethod, Error> {
+    let ruby = Ruby::get().expect("called from Ruby thread");
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None | Some("scalar_8bit") | Some("scalar") => {
+            if subvector_count.is_some() {
+                return Err(Error::new(
+                    ruby.exception_arg_error(),
+                    "subvector_count is only valid with quantizer: 'product_quantization'",
+                ));
+            }
+            Ok(QuantizationMethod::Scalar8Bit)
+        }
+        Some("product_quantization") | Some("pq") => {
+            let subvector_count = subvector_count.ok_or_else(|| {
+                Error::new(
+                    ruby.exception_arg_error(),
+                    "quantizer: 'product_quantization' requires subvector_count \
+                     (must divide the field dimension)",
+                )
+            })?;
+            Ok(QuantizationMethod::ProductQuantization { subvector_count })
+        }
+        Some(other) => Err(Error::new(
+            ruby.exception_arg_error(),
+            format!("Unknown quantizer: '{other}'. Valid: scalar_8bit, product_quantization"),
+        )),
+    }
+}
+
+/// Parse a rerank-storage name into an optional [`RerankStorageKind`].
+///
+/// `None` (the default) keeps the Stage-1 int8-only segment; `"f32"`
+/// enables the Stage-2 full-precision rerank sidecar (`*.hnsw.f32`).
+fn parse_rerank_storage(name: Option<&str>) -> Result<Option<RerankStorageKind>, Error> {
+    let ruby = Ruby::get().expect("called from Ruby thread");
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None => Ok(None),
+        Some("f32") => Ok(Some(RerankStorageKind::F32)),
+        Some(other) => Err(Error::new(
+            ruby.exception_arg_error(),
+            format!("Unknown rerank_storage: '{other}'. Valid: f32"),
         )),
     }
 }
@@ -308,6 +365,14 @@ impl RbSchema {
     ///     omitted, the searcher uses an internal fallback of 50. Per-query
     ///     overrides via the search request still take precedence.
     ///   - `embedder:` (String, optional): Embedder name registered via `add_embedder`.
+    ///   - `quantizer:` (String, optional): Vector quantizer — "scalar_8bit"
+    ///     (default) or "product_quantization" (requires `subvector_count`).
+    ///   - `subvector_count:` (usize, optional): Number of PQ sub-vectors.
+    ///     Required when `quantizer:` is "product_quantization" and must
+    ///     divide `dimension`; rejected for other quantizers.
+    ///   - `rerank_storage:` (String, optional): Stage-2 rerank sidecar —
+    ///     omitted (default) keeps the int8-only segment, "f32" stores
+    ///     full-precision vectors in a `*.hnsw.f32` sidecar for exact rerank.
     fn add_hnsw_field(&self, args: &[Value]) -> Result<(), Error> {
         let args = scan_args::<(String, usize), (), (), (), RHash, ()>(args)?;
         let (name, dimension) = args.required;
@@ -320,6 +385,9 @@ impl RbSchema {
                 Option<usize>,
                 Option<usize>,
                 Option<Option<String>>,
+                Option<String>,
+                Option<usize>,
+                Option<String>,
             ),
             (),
         >(
@@ -331,9 +399,21 @@ impl RbSchema {
                 "ef_construction",
                 "default_ef_search",
                 "embedder",
+                "quantizer",
+                "subvector_count",
+                "rerank_storage",
             ],
         )?;
-        let (distance, m, ef_construction, default_ef_search, embedder) = kwargs.optional;
+        let (
+            distance,
+            m,
+            ef_construction,
+            default_ef_search,
+            embedder,
+            quantizer,
+            subvector_count,
+            rerank_storage,
+        ) = kwargs.optional;
         let distance_str = distance.as_deref().unwrap_or("cosine");
         let opt = HnswOption {
             dimension,
@@ -341,6 +421,8 @@ impl RbSchema {
             m: m.unwrap_or(16),
             ef_construction: ef_construction.unwrap_or(200),
             default_ef_search,
+            quantizer: parse_quantizer(quantizer.as_deref(), subvector_count)?,
+            rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder: embedder.flatten(),
             ..Default::default()
         };

--- a/laurus-ruby/test/test_vector_quantizer_rerank.rb
+++ b/laurus-ruby/test/test_vector_quantizer_rerank.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "tmpdir"
+
+# Tests for the HNSW quantizer / rerank_storage schema options (Issue #797).
+#
+# These assert the values configured on +add_hnsw_field+ actually reach the
+# Rust core via deterministic observables, not merely that search succeeds:
+#
+# * +rerank_storage: "f32"+ makes the core write a +*.hnsw.f32+ Stage-2
+#   sidecar on disk (mirrors the server-side guard in #793/#800); the
+#   default writes no sidecar.
+# * +quantizer: "product_quantization"+ forwards +subvector_count+ to the
+#   core's PQ training, which rejects a count that does not divide the
+#   field dimension.
+class TestVectorQuantizerRerank < Minitest::Test
+  # Stable two-cluster corpus mirroring the core's
+  # +test_hnsw_pq_search_returns_corpus_neighbour+ (issue #730).
+  NEAR_OFFSETS = [
+    [0.0, 0.0, 0.0, 0.0],
+    [0.1, 0.1, 0.1, 0.1],
+    [-0.1, -0.1, -0.1, -0.1],
+    [0.2, -0.2, 0.2, -0.2],
+    [-0.2, 0.2, -0.2, 0.2],
+    [0.05, 0.05, -0.05, -0.05],
+    [-0.05, -0.05, 0.05, 0.05],
+    [0.15, -0.1, 0.1, -0.15],
+  ].freeze
+  NEAR_BASE = [10.0, 10.0, 20.0, 20.0].freeze
+  FAR_BASE = [-100.0, -100.0, -200.0, -200.0].freeze
+
+  def test_rerank_storage_f32_writes_sidecar
+    Dir.mktmpdir do |dir|
+      schema = Laurus::Schema.new
+      schema.add_hnsw_field("embedding", 4, rerank_storage: "f32")
+      idx = Laurus::Index.new(path: dir, schema: schema)
+      idx.put_document("doc1", { "embedding" => [0.1, 0.2, 0.3, 0.4] })
+      idx.put_document("doc2", { "embedding" => [0.9, 0.8, 0.7, 0.6] })
+      idx.commit
+      refute_empty Dir.glob(File.join(dir, "**", "*.hnsw.f32")),
+                   "rerank_storage: 'f32' must write a .hnsw.f32 sidecar"
+    end
+  end
+
+  def test_no_rerank_storage_writes_no_sidecar
+    Dir.mktmpdir do |dir|
+      schema = Laurus::Schema.new
+      schema.add_hnsw_field("embedding", 4)
+      idx = Laurus::Index.new(path: dir, schema: schema)
+      idx.put_document("doc1", { "embedding" => [0.1, 0.2, 0.3, 0.4] })
+      idx.put_document("doc2", { "embedding" => [0.9, 0.8, 0.7, 0.6] })
+      idx.commit
+      assert_empty Dir.glob(File.join(dir, "**", "*.hnsw.f32"))
+    end
+  end
+
+  def test_product_quantization_builds_and_searches
+    schema = Laurus::Schema.new
+    # PQ is an L2 quantizer, so use Euclidean (matching the core's
+    # test_hnsw_pq_search_returns_corpus_neighbour).
+    schema.add_hnsw_field(
+      "embedding", 4,
+      distance: "euclidean", quantizer: "product_quantization", subvector_count: 2
+    )
+    idx = Laurus::Index.new(schema: schema)
+    NEAR_OFFSETS.each_with_index do |off, i|
+      idx.put_document("near#{i}", { "embedding" => NEAR_BASE.map.with_index { |b, j| b + off[j] } })
+      idx.put_document("far#{i}", { "embedding" => FAR_BASE.map.with_index { |b, j| b + off[j] } })
+    end
+    idx.commit
+
+    results = idx.search(Laurus::VectorQuery.new("embedding", NEAR_BASE), limit: 3)
+    assert_equal 3, results.length
+    assert(results.all? { |r| r.id.start_with?("near") })
+  end
+
+  def test_pq_subvector_count_must_divide_dimension
+    schema = Laurus::Schema.new
+    schema.add_hnsw_field(
+      "embedding", 4, quantizer: "product_quantization", subvector_count: 3
+    )
+    idx = Laurus::Index.new(schema: schema)
+    idx.put_document("doc1", { "embedding" => [0.1, 0.2, 0.3, 0.4] })
+    assert_raises { idx.commit }
+  end
+
+  def test_unknown_quantizer_rejected
+    schema = Laurus::Schema.new
+    assert_raises(ArgumentError) { schema.add_hnsw_field("embedding", 4, quantizer: "bogus") }
+  end
+
+  def test_pq_requires_subvector_count
+    schema = Laurus::Schema.new
+    assert_raises(ArgumentError) do
+      schema.add_hnsw_field("embedding", 4, quantizer: "product_quantization")
+    end
+  end
+
+  def test_subvector_count_rejected_for_scalar
+    schema = Laurus::Schema.new
+    assert_raises(ArgumentError) { schema.add_hnsw_field("embedding", 4, subvector_count: 2) }
+  end
+
+  def test_unknown_rerank_storage_rejected
+    schema = Laurus::Schema.new
+    assert_raises(ArgumentError) { schema.add_hnsw_field("embedding", 4, rerank_storage: "bogus") }
+  end
+end

--- a/laurus-wasm/src/schema.rs
+++ b/laurus-wasm/src/schema.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use laurus::{
     Analyzer, BooleanOption, BytesOption, DateTimeOption, DistanceMetric, DynamicFieldPolicy,
     EmbedderDefinition, FieldOption, FlatOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
-    IntegerOption, IvfOption, Schema, TextOption,
+    IntegerOption, IvfOption, QuantizationMethod, RerankStorageKind, Schema, TextOption,
 };
 use wasm_bindgen::prelude::*;
 
@@ -32,6 +32,57 @@ fn parse_distance(s: &str) -> Result<DistanceMetric, JsValue> {
         "angular" => Ok(DistanceMetric::Angular),
         other => Err(JsValue::from_str(&format!(
             "Unknown distance metric: '{other}'. Valid: cosine, euclidean, dot_product, manhattan, angular"
+        ))),
+    }
+}
+
+/// Parse a quantizer name plus optional `subvectorCount` into a
+/// [`QuantizationMethod`].
+///
+/// Accepts `"scalar_8bit"` / `"scalar"` (the default when `name` is
+/// `None`) and `"product_quantization"` / `"pq"`. Product quantization
+/// requires a `subvector_count` (which must divide the field dimension —
+/// validated by the core at index-build time); supplying it for any other
+/// quantizer is rejected so an incoherent configuration cannot silently
+/// reach the core.
+fn parse_quantizer(
+    name: Option<&str>,
+    subvector_count: Option<usize>,
+) -> Result<QuantizationMethod, JsValue> {
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None | Some("scalar_8bit") | Some("scalar") => {
+            if subvector_count.is_some() {
+                return Err(JsValue::from_str(
+                    "subvectorCount is only valid with quantizer='product_quantization'",
+                ));
+            }
+            Ok(QuantizationMethod::Scalar8Bit)
+        }
+        Some("product_quantization") | Some("pq") => {
+            let subvector_count = subvector_count.ok_or_else(|| {
+                JsValue::from_str(
+                    "quantizer='product_quantization' requires subvectorCount \
+                     (must divide the field dimension)",
+                )
+            })?;
+            Ok(QuantizationMethod::ProductQuantization { subvector_count })
+        }
+        Some(other) => Err(JsValue::from_str(&format!(
+            "Unknown quantizer: '{other}'. Valid: scalar_8bit, product_quantization"
+        ))),
+    }
+}
+
+/// Parse a rerank-storage name into an optional [`RerankStorageKind`].
+///
+/// `None` (the default) keeps the Stage-1 int8-only segment; `"f32"`
+/// enables the Stage-2 full-precision rerank sidecar (`*.hnsw.f32`).
+fn parse_rerank_storage(name: Option<&str>) -> Result<Option<RerankStorageKind>, JsValue> {
+    match name.map(|s| s.to_lowercase()).as_deref() {
+        None => Ok(None),
+        Some("f32") => Ok(Some(RerankStorageKind::F32)),
+        Some(other) => Err(JsValue::from_str(&format!(
+            "Unknown rerank_storage: '{other}'. Valid: f32"
         ))),
     }
 }
@@ -229,6 +280,14 @@ impl WasmSchema {
     ///   searcher uses an internal fallback of 50. Per-query overrides
     ///   via the search request still take precedence.
     /// * `embedder` - Optional embedder name registered via `addEmbedder`.
+    /// * `quantizer` - Vector quantizer — "scalar_8bit" (default) or
+    ///   "product_quantization" (requires `subvectorCount`).
+    /// * `subvectorCount` - Number of PQ sub-vectors. Required when
+    ///   `quantizer` is "product_quantization" and must divide `dimension`;
+    ///   rejected for other quantizers.
+    /// * `rerankStorage` - Stage-2 rerank sidecar — omitted (default) keeps
+    ///   the int8-only segment, "f32" stores full-precision vectors in a
+    ///   `*.hnsw.f32` sidecar for exact rerank distances.
     #[wasm_bindgen(js_name = "addHnswField")]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
@@ -240,6 +299,9 @@ impl WasmSchema {
         ef_construction: Option<u32>,
         default_ef_search: Option<u32>,
         embedder: Option<String>,
+        quantizer: Option<String>,
+        subvector_count: Option<u32>,
+        rerank_storage: Option<String>,
     ) -> Result<(), JsValue> {
         let opt = HnswOption {
             dimension: dimension as usize,
@@ -247,6 +309,8 @@ impl WasmSchema {
             m: m.unwrap_or(16) as usize,
             ef_construction: ef_construction.unwrap_or(200) as usize,
             default_ef_search: default_ef_search.map(|v| v as usize),
+            quantizer: parse_quantizer(quantizer.as_deref(), subvector_count.map(|v| v as usize))?,
+            rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
             ..Default::default()
         };

--- a/laurus/src/lib.rs
+++ b/laurus/src/lib.rs
@@ -109,6 +109,7 @@ pub use storage::{Storage, StorageConfig, StorageFactory};
 pub use vector::core::distance::DistanceMetric;
 pub use vector::core::field::{FlatOption, HnswOption, IvfOption};
 pub use vector::core::quantization::QuantizationMethod;
+pub use vector::core::rerank::RerankStorageKind;
 pub use vector::store::request::{
     QueryPayload, QueryVector, VectorScoreMode, VectorSearchParams, VectorSearchRequest,
 };


### PR DESCRIPTION
## Summary

Exposes the HNSW `quantizer`, `subvector_count`, and `rerank_storage` options on every language binding's schema-field builder (Python, Node.js, wasm, Ruby, PHP). Until now binding users could not select Product Quantization or enable the Stage-2 full-precision rerank sidecar — only the Rust core and the gRPC/proto surface (#793 / #800) exposed them.

Follow-up of #790. The `#793` proto dependency is already merged (#800).

## API (consistent across bindings)

`add_hnsw_field` / `addHnswField` gains three optional parameters:

| Param | Values |
| :--- | :--- |
| `quantizer` | `"scalar_8bit"` (default) / `"scalar"`, or `"product_quantization"` / `"pq"` |
| `subvector_count` | PQ sub-vector count; **required** for product quantization, must divide `dimension` |
| `rerank_storage` | omitted (default, int8-only) or `"f32"` (writes a `*.hnsw.f32` Stage-2 rerank sidecar) |

Naming mirrors the HTTP/gRPC gateway (`"scalar_8bit"` / `"product_quantization"` / `"f32"`).

### Design — flat strings + boundary validation

The bindings already present a flat, stringly-typed surface parsed once at the boundary (`distance`, `policy`, `embedder`). Quantizer/rerank follow that exact pattern via per-binding `parse_quantizer` / `parse_rerank_storage` helpers next to the existing `parse_distance` — uniform across the layer and friendly to `wasm_bindgen` (no `JsValue` struct parsing). The one downside of flat params — a `subvector_count` that is only meaningful for PQ — is recovered by rejecting incoherent combinations at the builder boundary (PQ without `subvector_count`, `subvector_count` for a scalar quantizer, unknown values).

## Changes

- **core**: re-export `RerankStorageKind` at the `laurus` crate root, mirroring the existing `QuantizationMethod` re-export, so bindings can name the type.
- **bindings** (`laurus-{python,nodejs,wasm,ruby,php}/src/schema.rs`): the three options + the two parse helpers; values forwarded into `HnswOption`.
- **tests**: per-binding tests assert the config reaches the core via deterministic observables — `rerank_storage="f32"` writes a `*.hnsw.f32` sidecar on disk (mirrors the #800 server guard); `product_quantization` forwards `subvector_count` to PQ training, which rejects a count that does not divide the dimension. Plus builder-level rejection tests. PQ retrieval tests use Euclidean (PQ is an L2 quantizer) with the stable two-cluster corpus from the core's `test_hnsw_pq_search_returns_corpus_neighbour` (#730).
- **docs**: EN + JA `api_reference.md` updated for all five bindings.

## Verification (all toolchains, locally)

- Python: `maturin develop` + `pytest` — 52 passed (8 new)
- Node.js: `npm run build:debug` + `vitest` — 8 new pass
- wasm: `cargo build` + `cargo clippy` (`wasm32-unknown-unknown`) — clean (CI runs build + clippy only; no test runner)
- Ruby: `rake compile` + minitest — 53 runs, 0 failures (8 new)
- PHP: `cargo build --release -p laurus-php` + `phpunit` — 50 tests, 0 failures (8 new)
- Core + host bindings: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings` — clean
- Docs: `markdownlint-cli2` — 0 errors (154 files)

No on-disk format change. New binding parameters are optional and trailing/keyword, so existing callers are unaffected.

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)