### PR TITLE
perf(vector/hnsw): fold the .hnsw checksum into the Eager load pass (#789)

### DIFF
--- a/laurus/src/storage/checksum.rs
+++ b/laurus/src/storage/checksum.rs
@@ -11,7 +11,10 @@
 //! the bytes on disk are exactly the bytes written, and the checksum is the
 //! caller's to place (typically as a trailing footer).
 
-use std::io::{Read, Result as IoResult, Write};
+use std::io::{Read, Result as IoResult, Seek, SeekFrom, Write};
+
+use crate::error::Result;
+use crate::storage::StorageInput;
 
 /// A [`Write`] wrapper that accumulates a CRC-32 over everything written.
 ///
@@ -116,6 +119,135 @@ impl<R: Read> Read for CrcReader<R> {
     }
 }
 
+/// A [`StorageInput`] wrapper that accumulates a CRC-32 over bytes read
+/// **sequentially** from offset 0, so a reader that parses its payload in a
+/// single forward pass (e.g. the Eager `.hnsw` structural parse) can verify a
+/// trailing CRC footer during that existing pass instead of a second full read
+/// (Issue #789).
+///
+/// Tracking is only meaningful while reads stay sequential: any real seek
+/// (Lazy / OnDemand parsing) clears [`Self::is_sequential`], after which
+/// [`Self::checksum`] must not be trusted. A no-op `Seek(Current(0))` (used by
+/// [`std::io::Seek::stream_position`]) is served from the byte counter and does
+/// **not** break tracking. Pass `track = false` to skip hashing entirely on
+/// paths that will not use the running CRC, so the wrapper degrades to a thin
+/// position-tracking pass-through.
+pub struct ChecksumTrackingInput {
+    inner: Box<dyn StorageInput>,
+    hasher: crc32fast::Hasher,
+    /// Logical position; equals bytes consumed while reads stay sequential.
+    pos: u64,
+    /// Cleared once a real seek desynchronizes the running CRC.
+    sequential: bool,
+    /// When `false`, reads pass through without updating the hasher.
+    track: bool,
+}
+
+impl ChecksumTrackingInput {
+    /// Wrap `inner`, starting from a zero checksum at offset 0. When `track`
+    /// is `false` the running CRC is not maintained (use for paths that will
+    /// not call [`Self::checksum`]).
+    pub fn new(inner: Box<dyn StorageInput>, track: bool) -> Self {
+        Self {
+            inner,
+            hasher: crc32fast::Hasher::new(),
+            pos: 0,
+            sequential: true,
+            track,
+        }
+    }
+
+    /// The CRC-32 of all bytes read so far.
+    pub fn checksum(&self) -> u32 {
+        self.hasher.clone().finalize()
+    }
+
+    /// The number of bytes consumed so far.
+    pub fn bytes_read(&self) -> u64 {
+        self.pos
+    }
+
+    /// Whether every read so far has been sequential (no real seek), i.e.
+    /// whether [`Self::checksum`] reflects a contiguous prefix from offset 0.
+    pub fn is_sequential(&self) -> bool {
+        self.sequential
+    }
+
+    /// Read and hash any remaining bytes up to `len` (a no-op once `pos >=
+    /// len`), so the running CRC covers exactly `len` content bytes after a
+    /// structural parse that may have stopped a few bytes short of the footer.
+    pub fn absorb_to(&mut self, len: u64) -> IoResult<()> {
+        let mut remaining = len.saturating_sub(self.pos);
+        let mut buf = [0u8; 64 * 1024];
+        while remaining > 0 {
+            let want = remaining.min(buf.len() as u64) as usize;
+            self.read_exact(&mut buf[..want])?;
+            remaining -= want as u64;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for ChecksumTrackingInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChecksumTrackingInput")
+            .field("inner", &self.inner)
+            .field("pos", &self.pos)
+            .field("sequential", &self.sequential)
+            .field("track", &self.track)
+            .finish()
+    }
+}
+
+impl Read for ChecksumTrackingInput {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        let n = self.inner.read(buf)?;
+        if self.track {
+            self.hasher.update(&buf[..n]);
+        }
+        self.pos += n as u64;
+        Ok(n)
+    }
+}
+
+impl Seek for ChecksumTrackingInput {
+    fn seek(&mut self, pos: SeekFrom) -> IoResult<u64> {
+        // Serve `stream_position()` (a no-op `Current(0)` seek) from the byte
+        // counter without touching the inner stream, so it does not count as a
+        // real seek that would break sequential CRC tracking.
+        if let SeekFrom::Current(0) = pos {
+            return Ok(self.pos);
+        }
+        // Any real seek desynchronizes the running CRC; mark it untrustworthy
+        // and resync the position from the inner stream.
+        self.sequential = false;
+        let new_pos = self.inner.seek(pos)?;
+        self.pos = new_pos;
+        Ok(new_pos)
+    }
+}
+
+impl StorageInput for ChecksumTrackingInput {
+    fn size(&self) -> Result<u64> {
+        self.inner.size()
+    }
+
+    fn clone_input(&self) -> Result<Box<dyn StorageInput>> {
+        // Return an unwrapped clone of the inner input: clones are used by the
+        // OnDemand (Lazy) read path, which does not participate in the folded
+        // CRC and must not inherit this wrapper's running-checksum state.
+        self.inner.clone_input()
+    }
+
+    fn close(&mut self) -> Result<()> {
+        self.inner.close()
+    }
+
+    // `as_slice` deliberately keeps the default `None`: forcing reads through
+    // `read` guarantees the CRC sees every content byte. The HNSW reader never
+    // uses the zero-copy slice path, so this costs nothing there.
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -162,5 +294,179 @@ mod tests {
         let mut out = Vec::new();
         r.read_to_end(&mut out).unwrap();
         assert_ne!(r.checksum(), good, "a corrupted byte must change the CRC");
+    }
+
+    /// Minimal in-memory [`StorageInput`] over a byte buffer, used to exercise
+    /// [`ChecksumTrackingInput`] without pulling in a full storage backend.
+    #[derive(Debug, Clone)]
+    struct TestInput {
+        cursor: Cursor<Vec<u8>>,
+    }
+
+    impl TestInput {
+        fn new(bytes: Vec<u8>) -> Self {
+            Self {
+                cursor: Cursor::new(bytes),
+            }
+        }
+    }
+
+    impl Read for TestInput {
+        fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+            self.cursor.read(buf)
+        }
+    }
+
+    impl Seek for TestInput {
+        fn seek(&mut self, pos: SeekFrom) -> IoResult<u64> {
+            self.cursor.seek(pos)
+        }
+    }
+
+    impl StorageInput for TestInput {
+        fn size(&self) -> Result<u64> {
+            Ok(self.cursor.get_ref().len() as u64)
+        }
+
+        fn clone_input(&self) -> Result<Box<dyn StorageInput>> {
+            Ok(Box::new(self.clone()))
+        }
+
+        fn close(&mut self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Hash `bytes` with the same CRC-32 used by the footer writer.
+    fn crc32(bytes: &[u8]) -> u32 {
+        let mut h = crc32fast::Hasher::new();
+        h.update(bytes);
+        h.finalize()
+    }
+
+    #[test]
+    fn tracking_input_sequential_checksum_matches_writer() {
+        let data = b"folded crc over a single forward pass".to_vec();
+        let expected = crc32(&data);
+
+        let mut input = ChecksumTrackingInput::new(Box::new(TestInput::new(data.clone())), true);
+        let mut out = Vec::new();
+        input.read_to_end(&mut out).unwrap();
+
+        assert_eq!(out, data);
+        assert!(
+            input.is_sequential(),
+            "a pure forward read stays sequential"
+        );
+        assert_eq!(input.bytes_read(), data.len() as u64);
+        assert_eq!(input.checksum(), expected);
+    }
+
+    #[test]
+    fn tracking_input_stream_position_keeps_sequential() {
+        let data = b"position probe must not break tracking".to_vec();
+        let expected = crc32(&data);
+
+        let mut input = ChecksumTrackingInput::new(Box::new(TestInput::new(data.clone())), true);
+        let mut head = [0u8; 5];
+        input.read_exact(&mut head).unwrap();
+
+        // `stream_position()` issues a no-op `Current(0)` seek; it must be
+        // served from the byte counter without clearing sequential tracking.
+        assert_eq!(input.stream_position().unwrap(), 5);
+        assert!(input.is_sequential());
+
+        let mut rest = Vec::new();
+        input.read_to_end(&mut rest).unwrap();
+        assert!(input.is_sequential());
+        assert_eq!(input.checksum(), expected);
+    }
+
+    #[test]
+    fn tracking_input_real_seek_clears_sequential() {
+        let data = b"a real seek desynchronizes the running crc".to_vec();
+        let mut input = ChecksumTrackingInput::new(Box::new(TestInput::new(data)), true);
+
+        let mut head = [0u8; 4];
+        input.read_exact(&mut head).unwrap();
+        assert!(input.is_sequential());
+
+        input.seek(SeekFrom::Start(10)).unwrap();
+        assert!(
+            !input.is_sequential(),
+            "a real seek must clear sequential tracking"
+        );
+        assert_eq!(input.bytes_read(), 10, "position resyncs from the seek");
+    }
+
+    #[test]
+    fn tracking_input_absorb_to_covers_remainder() {
+        let data = b"structural parse stops a few bytes short of the footer".to_vec();
+        let expected = crc32(&data);
+
+        let mut input = ChecksumTrackingInput::new(Box::new(TestInput::new(data.clone())), true);
+        // Read only a prefix, mimicking a parse that stopped early.
+        let mut prefix = [0u8; 8];
+        input.read_exact(&mut prefix).unwrap();
+
+        input.absorb_to(data.len() as u64).unwrap();
+        assert_eq!(input.bytes_read(), data.len() as u64);
+        assert_eq!(input.checksum(), expected);
+
+        // A second call is a no-op once the position already covers `len`.
+        input.absorb_to(data.len() as u64).unwrap();
+        assert_eq!(input.checksum(), expected);
+    }
+
+    #[test]
+    fn tracking_input_track_false_skips_hashing() {
+        let data = b"pass-through with no running checksum".to_vec();
+
+        let mut input = ChecksumTrackingInput::new(Box::new(TestInput::new(data.clone())), false);
+        let mut out = Vec::new();
+        input.read_to_end(&mut out).unwrap();
+
+        assert_eq!(out, data);
+        assert_eq!(
+            input.bytes_read(),
+            data.len() as u64,
+            "position still tracks"
+        );
+        assert_eq!(
+            input.checksum(),
+            0,
+            "track = false leaves the hasher at the empty-input CRC"
+        );
+    }
+
+    #[test]
+    fn tracking_input_clone_input_unwraps_inner() {
+        // `clone_input` must return a plain inner stream, not another
+        // `ChecksumTrackingInput`: the OnDemand (Lazy) path uses clones and must
+        // not inherit this wrapper's running-checksum state (Issue #789).
+        let data = b"clone returns a plain unwrapped inner stream".to_vec();
+        let mut input = ChecksumTrackingInput::new(Box::new(TestInput::new(data.clone())), true);
+
+        // Advance the wrapper so it carries non-trivial pos + accumulated CRC.
+        let mut head = [0u8; 6];
+        input.read_exact(&mut head).unwrap();
+        let wrapper_crc = input.checksum();
+        assert_ne!(wrapper_crc, 0, "wrapper accumulated a CRC over the prefix");
+
+        // The clone reads the full payload from offset 0 independently, and
+        // touching it does not perturb the wrapper's running CRC.
+        let mut clone = input.clone_input().unwrap();
+        clone.seek(SeekFrom::Start(0)).unwrap();
+        let mut out = Vec::new();
+        clone.read_to_end(&mut out).unwrap();
+        assert_eq!(
+            out, data,
+            "clone reads the full inner payload from the start"
+        );
+        assert_eq!(
+            input.checksum(),
+            wrapper_crc,
+            "operations on the clone must not touch the wrapper's CRC"
+        );
     }
 }

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -90,27 +90,33 @@ impl HnswIndexReader {
         ))
     }
 
-    /// Verify the CRC-32 footer of a `.hnsw` segment if present (Issue #786).
+    /// Probe the trailing CRC-32 footer of a `.hnsw` segment (Issue #786) and
+    /// return the stored checksum if a valid footer is present, leaving `input`
+    /// rewound to offset 0.
     ///
-    /// New segments end with `[magic u32][crc-32 u32]` over all preceding
-    /// bytes (written via [`crate::storage::checksum::CrcWriter`]). The footer
-    /// is detected by the magic at `size - 8`; legacy segments without it skip
-    /// verification (back-compat). On a present footer the CRC over the
-    /// content is recomputed and compared. The input is left rewound to the
-    /// start so the caller's structural parse runs unchanged.
+    /// Unlike a full verification this reads **only** the 8-byte footer, not the
+    /// whole file: the Eager load path folds the actual CRC computation into its
+    /// single structural pass (Issue #789), so it just needs the expected value
+    /// up front. New segments end with `[magic u32][crc-32 u32]` over all
+    /// preceding bytes (written via [`crate::storage::checksum::CrcWriter`]); the
+    /// footer is detected by the magic at `size - 8`. Legacy footer-less
+    /// segments return `None` (verification is skipped, back-compat).
     ///
     /// # Arguments
     ///
     /// * `input` - The opened `.hnsw` segment stream.
+    /// * `size` - The total file size (footer included).
     ///
-    /// # Errors
+    /// # Returns
     ///
-    /// Returns [`LaurusError::index`] if a footer is present but its checksum
-    /// does not match the content (corruption), or on I/O failure.
-    fn verify_checksum_footer(input: &mut dyn crate::storage::StorageInput) -> Result<()> {
-        use std::io::{Read, SeekFrom};
+    /// `Some(stored_crc)` when a footer is present, otherwise `None`.
+    fn read_footer_crc(
+        input: &mut dyn crate::storage::StorageInput,
+        size: u64,
+    ) -> Result<Option<u32>> {
+        use std::io::SeekFrom;
 
-        let size = input.size()?;
+        let mut stored = None;
         if size >= crate::vector::index::hnsw::HNSW_FOOTER_LEN {
             let content_len = size - crate::vector::index::hnsw::HNSW_FOOTER_LEN;
             input.seek(SeekFrom::Start(content_len))?;
@@ -118,25 +124,56 @@ impl HnswIndexReader {
             input.read_exact(&mut footer)?;
             let magic = u32::from_le_bytes([footer[0], footer[1], footer[2], footer[3]]);
             if magic == crate::vector::index::hnsw::HNSW_FOOTER_MAGIC {
-                let stored = u32::from_le_bytes([footer[4], footer[5], footer[6], footer[7]]);
-                input.seek(SeekFrom::Start(0))?;
-                let mut crc_in = crate::storage::checksum::CrcReader::new(&mut *input);
-                let mut remaining = content_len;
-                let mut buf = [0u8; 64 * 1024];
-                while remaining > 0 {
-                    let want = remaining.min(buf.len() as u64) as usize;
-                    crc_in.read_exact(&mut buf[..want])?;
-                    remaining -= want as u64;
-                }
-                let computed = crc_in.checksum();
-                if computed != stored {
-                    return Err(LaurusError::index(
-                        "HNSW segment checksum mismatch: .hnsw file is corrupted",
-                    ));
-                }
+                stored = Some(u32::from_le_bytes([
+                    footer[4], footer[5], footer[6], footer[7],
+                ]));
             }
         }
         input.seek(SeekFrom::Start(0))?;
+        Ok(stored)
+    }
+
+    /// Verify that the `content_len` bytes from offset 0 hash to `expected`, in
+    /// an independent sequential pass, then rewind to 0.
+    ///
+    /// Used on the Lazy / OnDemand load path (Issue #789): that parse seeks over
+    /// the vector payload and so cannot fold the checksum into its structural
+    /// pass the way the Eager path does, so the integrity guarantee from
+    /// Issue #786 is preserved here with a dedicated pass.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The opened `.hnsw` segment stream.
+    /// * `content_len` - Number of payload bytes preceding the footer.
+    /// * `expected` - The footer's stored CRC-32.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LaurusError::index`] if the recomputed CRC does not match
+    /// `expected` (corruption), or on I/O failure.
+    fn verify_footer_content(
+        input: &mut dyn crate::storage::StorageInput,
+        content_len: u64,
+        expected: u32,
+    ) -> Result<()> {
+        use std::io::{Read, SeekFrom};
+
+        input.seek(SeekFrom::Start(0))?;
+        let mut crc_in = crate::storage::checksum::CrcReader::new(&mut *input);
+        let mut remaining = content_len;
+        let mut buf = [0u8; 64 * 1024];
+        while remaining > 0 {
+            let want = remaining.min(buf.len() as u64) as usize;
+            crc_in.read_exact(&mut buf[..want])?;
+            remaining -= want as u64;
+        }
+        let computed = crc_in.checksum();
+        input.seek(SeekFrom::Start(0))?;
+        if computed != expected {
+            return Err(LaurusError::index(
+                "HNSW segment checksum mismatch: .hnsw file is corrupted",
+            ));
+        }
         Ok(())
     }
 
@@ -165,18 +202,37 @@ impl HnswIndexReader {
 
         // Open the index file
         let file_name = format!("{}.hnsw", path);
-        let mut input = storage.open_input(&file_name)?;
-
-        // Verify the CRC-32 footer if present (Issue #786), then rewind. This
-        // is an independent sequential pass that does not touch the structural
-        // parse below (which stops at the end of the graph and never reads the
-        // trailing footer), so it works for every loading mode and leaves
-        // legacy footer-less segments untouched.
-        Self::verify_checksum_footer(&mut *input)?;
+        let mut raw_input = storage.open_input(&file_name)?;
 
         // Ground truth for bounding allocations sized from the (for legacy
         // footer-less segments, unverified) header counts below (Issue #806).
-        let file_size = input.size()?;
+        let file_size = raw_input.size()?;
+
+        // Probe the CRC-32 footer (Issue #786) cheaply: read only the 8-byte
+        // footer to learn the expected checksum, not the whole file.
+        let stored_crc = Self::read_footer_crc(&mut *raw_input, file_size)?;
+        let content_len = match stored_crc {
+            Some(_) => file_size - crate::vector::index::hnsw::HNSW_FOOTER_LEN,
+            None => file_size,
+        };
+
+        // Fold the integrity check into the single Eager structural pass
+        // (Issue #789): that pass reads the whole content sequentially, so a CRC
+        // accumulated *during* it verifies the footer with no extra read. The
+        // Lazy / OnDemand parse seeks over the vector payload and so cannot
+        // fold; verify it up front with a dedicated pass instead (the #786
+        // behavior). Footer-less legacy segments have nothing to verify.
+        let eager = matches!(storage.loading_mode(), crate::storage::LoadingMode::Eager);
+        let fold = eager && stored_crc.is_some();
+        if !fold && let Some(expected) = stored_crc {
+            Self::verify_footer_content(&mut *raw_input, content_len, expected)?;
+        }
+
+        // Wrap the input so the structural parse below accumulates the content
+        // CRC as it reads (only when `fold`; otherwise this is a thin
+        // position-tracking pass-through). The wrapper implements `StorageInput`,
+        // so the parse — including the Lazy seeks — is unchanged.
+        let mut input = crate::storage::checksum::ChecksumTrackingInput::new(raw_input, fold);
 
         // Read metadata (vector count stored as u64)
         let mut num_vectors_buf = [0u8; 8];
@@ -526,6 +582,32 @@ impl HnswIndexReader {
                 )
             }
         };
+
+        // Finalize the folded CRC verification (Issue #789). On the Eager path
+        // the structural parse above read every content byte sequentially
+        // through `input`, accumulating the CRC as it went; `absorb_to` covers
+        // any residual bytes (the parse normally stops exactly at the footer, so
+        // this is a no-op), then the running CRC is compared against the
+        // footer's stored value. This replaces the separate full read that
+        // Issue #786 used, so corruption is still detected with no extra I/O.
+        // `is_sequential()` guards the running CRC: the Eager parse never seeks
+        // backward, but if that ever changes the wrapper degrades gracefully to
+        // a dedicated verification pass so the #786 guarantee can never silently
+        // weaken. `fold` is only set in Eager mode with a footer present, so
+        // Lazy/OnDemand and footer-less legacy segments skip this block (they
+        // were verified up front or have nothing to verify).
+        if fold && let Some(expected) = stored_crc {
+            if input.is_sequential() {
+                input.absorb_to(content_len).map_err(LaurusError::Io)?;
+                if input.checksum() != expected {
+                    return Err(LaurusError::index(
+                        "HNSW segment checksum mismatch: .hnsw file is corrupted",
+                    ));
+                }
+            } else {
+                Self::verify_footer_content(&mut input, content_len, expected)?;
+            }
+        }
 
         // Build zero-allocation prefetch lookup. For OwnedQuantized
         // (Step 6+), the address points to the int8 record start

--- a/laurus/src/vector/index/hnsw/tests.rs
+++ b/laurus/src/vector/index/hnsw/tests.rs
@@ -654,3 +654,268 @@ fn hnsw_searcher_honours_per_query_and_schema_ef_search() -> Result<()> {
 
     Ok(())
 }
+
+/// A [`StorageInput`] that counts every byte read from its inner stream, used to
+/// measure the I/O an Eager `.hnsw` load performs (Issue #789).
+#[derive(Debug)]
+struct CountingInput {
+    inner: Box<dyn crate::storage::StorageInput>,
+    counter: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl std::io::Read for CountingInput {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.counter
+            .fetch_add(n as u64, std::sync::atomic::Ordering::Relaxed);
+        Ok(n)
+    }
+}
+
+impl std::io::Seek for CountingInput {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
+impl crate::storage::StorageInput for CountingInput {
+    fn size(&self) -> Result<u64> {
+        self.inner.size()
+    }
+
+    fn clone_input(&self) -> Result<Box<dyn crate::storage::StorageInput>> {
+        Ok(Box::new(CountingInput {
+            inner: self.inner.clone_input()?,
+            counter: Arc::clone(&self.counter),
+        }))
+    }
+
+    fn close(&mut self) -> Result<()> {
+        self.inner.close()
+    }
+
+    // Force every read through `read` (and thus the counter); the HNSW reader
+    // never takes the zero-copy `as_slice` path, so this matches production.
+    fn as_slice(&self) -> Option<&[u8]> {
+        None
+    }
+}
+
+/// A [`Storage`] that wraps another and counts the bytes read from files whose
+/// name ends in `.hnsw`, so a test can assert how many passes a load makes over
+/// the segment (Issue #789). All other operations delegate unchanged.
+#[derive(Debug)]
+struct CountingStorage {
+    inner: Arc<dyn crate::storage::Storage>,
+    hnsw_bytes_read: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl crate::storage::Storage for CountingStorage {
+    fn open_input(&self, name: &str) -> Result<Box<dyn crate::storage::StorageInput>> {
+        let input = self.inner.open_input(name)?;
+        if name.ends_with(".hnsw") {
+            Ok(Box::new(CountingInput {
+                inner: input,
+                counter: Arc::clone(&self.hnsw_bytes_read),
+            }))
+        } else {
+            Ok(input)
+        }
+    }
+
+    fn create_output(&self, name: &str) -> Result<Box<dyn crate::storage::StorageOutput>> {
+        self.inner.create_output(name)
+    }
+
+    fn create_output_append(&self, name: &str) -> Result<Box<dyn crate::storage::StorageOutput>> {
+        self.inner.create_output_append(name)
+    }
+
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+
+    fn delete_file(&self, name: &str) -> Result<()> {
+        self.inner.delete_file(name)
+    }
+
+    fn list_files(&self) -> Result<Vec<String>> {
+        self.inner.list_files()
+    }
+
+    fn file_size(&self, name: &str) -> Result<u64> {
+        self.inner.file_size(name)
+    }
+
+    fn metadata(&self, name: &str) -> Result<crate::storage::FileMetadata> {
+        self.inner.metadata(name)
+    }
+
+    fn rename_file(&self, old_name: &str, new_name: &str) -> Result<()> {
+        self.inner.rename_file(old_name, new_name)
+    }
+
+    fn create_temp_output(
+        &self,
+        prefix: &str,
+    ) -> Result<(String, Box<dyn crate::storage::StorageOutput>)> {
+        self.inner.create_temp_output(prefix)
+    }
+
+    fn sync(&self) -> Result<()> {
+        self.inner.sync()
+    }
+
+    fn close(&mut self) -> Result<()> {
+        // The inner storage is shared behind an `Arc`; nothing to close here.
+        Ok(())
+    }
+}
+
+/// Eager load must read the `.hnsw` segment exactly once (Issue #789).
+///
+/// The integrity CRC is folded into the single structural pass, so the only
+/// `.hnsw` reads are the 8-byte footer probe plus one sequential pass over the
+/// content — `file_size` bytes total. Before #789, verification ran as a
+/// separate full pass, so a footer-carrying segment was read ~twice
+/// (`2 * content_len + 8`). Asserting the exact single-pass byte count is a
+/// deterministic regression guard against the double-read returning.
+#[test]
+fn eager_load_reads_hnsw_segment_exactly_once() -> Result<()> {
+    let inner = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+    let config = HnswIndexConfig {
+        dimension: 4,
+        m: 8,
+        ef_construction: 32,
+        distance_metric: DistanceMetric::Cosine,
+        normalize_vectors: false,
+        ..Default::default()
+    };
+    // A handful of vectors makes the segment comfortably larger than the
+    // 8-byte footer, so a single pass and a double pass differ unambiguously.
+    let vectors: Vec<(u64, String, Vector)> = (0..32)
+        .map(|i| {
+            let f = i as f32;
+            (
+                i,
+                "f".to_string(),
+                Vector::new(vec![f, f + 1.0, f + 2.0, f + 3.0]),
+            )
+        })
+        .collect();
+    let mut writer = HnswIndexWriter::with_storage(
+        config,
+        VectorIndexWriterConfig::default(),
+        "count_seg",
+        Arc::clone(&inner),
+    )?;
+    writer.add_vectors(vectors)?;
+    writer.finalize()?;
+    writer.write()?;
+
+    let file_size = inner.file_size("count_seg.hnsw")?;
+    assert!(
+        file_size > crate::vector::index::hnsw::HNSW_FOOTER_LEN,
+        "segment must carry a footer for this measurement"
+    );
+
+    let hnsw_bytes_read = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let counting: Arc<dyn crate::storage::Storage> = Arc::new(CountingStorage {
+        inner: Arc::clone(&inner),
+        hnsw_bytes_read: Arc::clone(&hnsw_bytes_read),
+    });
+    // Default loading_mode() is Eager, which is the folded path under test.
+    assert!(matches!(
+        counting.loading_mode(),
+        crate::storage::LoadingMode::Eager
+    ));
+
+    let _reader = HnswIndexReader::load(counting, "count_seg", DistanceMetric::Cosine)?;
+
+    let read = hnsw_bytes_read.load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(
+        read, file_size,
+        "Eager load must read the segment exactly once (footer probe + one \
+         folded pass = file_size); a double-read would be ~2x content_len"
+    );
+    Ok(())
+}
+
+/// A corrupted pq-fastscan Eager segment must be rejected by the folded CRC
+/// (Issue #789).
+///
+/// The default-quantizer corruption tests only cover Scalar8Bit. The
+/// `OwnedPqFastScan` branch of [`HnswIndexReader::load`] also reads purely
+/// sequentially (`read_pq_fastscan_record` is `Read`-bound, never seeks), so
+/// `is_sequential()` stays true and the CRC is folded into the single Eager
+/// pass on this branch too. This test locks in that a byte flip on a
+/// non-Scalar8Bit segment is still detected.
+#[cfg(feature = "pq-fastscan")]
+#[test]
+fn eager_load_rejects_corrupted_pq_fastscan_segment() -> Result<()> {
+    use crate::vector::core::quantization::QuantizationMethod;
+    use std::io::{Read, Write};
+
+    let dim = 8usize;
+    let sub = 4usize;
+    let n = 64u64;
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+    let config = HnswIndexConfig {
+        dimension: dim,
+        m: 16,
+        ef_construction: 100,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantizationFastScan {
+            subvector_count: sub,
+        },
+        ..Default::default()
+    };
+    // Deterministic, broadly-spread vectors so the K=16 codebook trainer
+    // converges to non-degenerate centroids (mirrors pq_fastscan_search_test).
+    let vectors: Vec<(u64, String, Vector)> = (0..n)
+        .map(|i| {
+            let s = i as usize;
+            let v: Vec<f32> = (0..dim)
+                .map(|d| ((s * 31 + d * 17) % 257) as f32 - 128.0)
+                .collect();
+            (i, "f".to_string(), Vector::new(v))
+        })
+        .collect();
+    let mut writer = HnswIndexWriter::with_storage(
+        config,
+        VectorIndexWriterConfig::default(),
+        "pqfs_seg",
+        Arc::clone(&storage),
+    )?;
+    writer.add_vectors(vectors)?;
+    writer.finalize()?;
+    writer.write()?;
+
+    // Sanity: the clean segment loads.
+    HnswIndexReader::load(Arc::clone(&storage), "pqfs_seg", DistanceMetric::Euclidean)?;
+
+    // Flip a byte deep in the content (well before the 8-byte footer); the
+    // folded CRC must reject the segment on the next load.
+    let mut bytes = {
+        let mut input = storage.open_input("pqfs_seg.hnsw")?;
+        let mut buf = Vec::new();
+        input
+            .read_to_end(&mut buf)
+            .expect("read pq-fastscan segment");
+        buf
+    };
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xff;
+    {
+        let mut out = storage.create_output("pqfs_seg.hnsw")?;
+        out.write_all(&bytes).expect("rewrite corrupted segment");
+        out.close()?;
+    }
+
+    let result = HnswIndexReader::load(Arc::clone(&storage), "pqfs_seg", DistanceMetric::Euclidean);
+    assert!(
+        result.is_err(),
+        "a corrupted pq-fastscan .hnsw must be rejected on Eager load, got Ok"
+    );
+    Ok(())
+}

--- a/laurus/tests/vector_hnsw_checksum_test.rs
+++ b/laurus/tests/vector_hnsw_checksum_test.rs
@@ -165,6 +165,41 @@ async fn corrupted_hnsw_segment_is_rejected() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn corrupted_hnsw_segment_is_rejected_lazy_mmap() {
+    use laurus::storage::file::FileStorageConfig;
+    use laurus::storage::{StorageConfig, StorageFactory};
+
+    // FileStorage with mmap selects the Lazy load path, which cannot fold the
+    // CRC into its (seeking) structural parse and so verifies the footer up
+    // front in a dedicated pass (Issue #789). This guards that path the same
+    // way the Eager test guards the folded path.
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = FileStorageConfig::new(dir.path());
+    assert!(
+        cfg.use_mmap,
+        "this test must exercise the Lazy (mmap) load path"
+    );
+    let storage = StorageFactory::create(StorageConfig::File(cfg)).unwrap();
+    build_committed(storage.clone()).await;
+
+    // Flip a byte deep in the segment content (well before the 8-byte footer).
+    let mut bytes = read_all(&storage, HNSW_FILE);
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xff;
+    write_all(&storage, HNSW_FILE, &bytes);
+
+    // Open a fresh storage instance so no cached mmap masks the on-disk change.
+    let storage2 =
+        StorageFactory::create(StorageConfig::File(FileStorageConfig::new(dir.path()))).unwrap();
+    let store = laurus::vector::VectorStore::new(storage2, make_config()).unwrap();
+    let result = store.search(request());
+    assert!(
+        result.is_err(),
+        "a corrupted .hnsw must be rejected on the Lazy load path, got {result:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn corrupted_metadata_is_rejected() {
     let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
     build_committed(storage.clone()).await;
@@ -200,5 +235,39 @@ async fn legacy_hnsw_without_footer_still_loads() {
         results.hits.len(),
         10,
         "a footer-less (legacy) segment must still load and search"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn legacy_hnsw_without_footer_still_loads_lazy_mmap() {
+    use laurus::storage::file::FileStorageConfig;
+    use laurus::storage::{StorageConfig, StorageFactory};
+
+    // Mirror of the Eager legacy test for the Lazy (mmap) / OnDemand path: a
+    // footer-less segment yields stored_crc = None, so verification is skipped
+    // up front and the segment loads unchanged (Issue #789 back-compat).
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = FileStorageConfig::new(dir.path());
+    assert!(
+        cfg.use_mmap,
+        "this test must exercise the Lazy (mmap) load path"
+    );
+    let storage = StorageFactory::create(StorageConfig::File(cfg)).unwrap();
+    build_committed(storage.clone()).await;
+
+    // Drop the 8-byte CRC footer to mimic a pre-#786 segment with no checksum.
+    let bytes = read_all(&storage, HNSW_FILE);
+    let legacy = &bytes[..bytes.len() - 8];
+    write_all(&storage, HNSW_FILE, legacy);
+
+    // Open a fresh storage instance so no cached mmap masks the on-disk change.
+    let storage2 =
+        StorageFactory::create(StorageConfig::File(FileStorageConfig::new(dir.path()))).unwrap();
+    let store = laurus::vector::VectorStore::new(storage2, make_config()).unwrap();
+    let results = store.search(request()).unwrap();
+    assert_eq!(
+        results.hits.len(),
+        10,
+        "a footer-less (legacy) segment must still load and search on the Lazy path"
     );
 }


### PR DESCRIPTION
## Summary

Removes the redundant full read of `.hnsw` segments on the **Eager** load path while keeping the #786 corruption guarantee.

`#786` verified the CRC-32 footer with `verify_checksum_footer` — an independent full pass over the content **before** the structural parse. In Eager mode the parse then reads the same content again, so a footer-carrying segment was read ~twice on every reader creation (every searcher-cache miss, i.e. after each `commit()`).

This PR folds the CRC into the single Eager structural pass and verifies the footer after parse — no extra read. The Lazy/OnDemand path (which seeks over the vector payload) keeps a dedicated up-front verification pass; legacy footer-less segments skip verification.

## Changes

- **`storage/checksum.rs`** — new `ChecksumTrackingInput`, a `StorageInput` wrapper that accumulates a CRC over sequential reads. A real seek clears `is_sequential`; the no-op `Current(0)` seek used by `stream_position()` is served from a byte counter so it does not break tracking; `track=false` degrades it to a thin position-tracking pass-through; `absorb_to(len)` covers residual bytes; `clone_input()` returns the unwrapped inner (OnDemand clones inherit no running-CRC state).
- **`vector/index/hnsw/reader.rs`** — `verify_checksum_footer` split into `read_footer_crc` (8-byte footer probe only) and `verify_footer_content` (Lazy dedicated pass). `load()` sets `fold = Eager && footer_present`, runs the structural parse through `ChecksumTrackingInput`, then `absorb_to(content_len)` + compares against the stored CRC, falling back to `verify_footer_content` if `is_sequential()` is unexpectedly false.

## Tests

- `ChecksumTrackingInput` unit tests (sequential CRC, `stream_position` keeps sequential, real seek clears it, `absorb_to`, `track=false`, `clone_input` unwraps inner).
- Corruption rejection on Eager (Scalar8Bit), **Lazy/mmap**, and **pq-fastscan** (feature-gated) segments.
- Legacy footer-less load on both Eager and Lazy/mmap paths.
- **Read-count measurement** (`eager_load_reads_hnsw_segment_exactly_once`): a `CountingStorage` asserts the Eager load reads the segment exactly `file_size` bytes (footer probe + one folded pass). The pre-#789 double-read was ~`2 * content_len + 8`, so this is a deterministic regression guard for the latency-restored criterion.

## Verification

- `cargo test -p laurus --test vector_hnsw_checksum_test` → 5 passed
- `cargo test -p laurus --lib checksum` → 9 passed
- `cargo test -p laurus --lib vector::index::hnsw` → 37 passed (default) / 38 passed (`--features pq-fastscan`)
- `cargo fmt --check` clean; `cargo clippy -p laurus --all-targets -- -D warnings` clean (default and `--features pq-fastscan`)
- `cargo build -p laurus-wasm --target wasm32-unknown-unknown` → success

## Notes

- `HnswIndexReader::load` signature is unchanged → no language-binding impact.
- An adversarial multi-agent review (fold-correctness, position-tracking, lazy/ondemand, back-compat, test-adequacy) found no correctness defects; the actionable coverage gaps it surfaced are included in the tests above.

Closes #789
