### PR TITLE
perf(lexical/index): O(1) buffered-doc membership probe in remove_pending_document (#570)

### DIFF
--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 
 use crate::analysis::analyzer::analyzer::Analyzer;
 use crate::analysis::analyzer::per_field::PerFieldAnalyzer;
@@ -118,6 +118,16 @@ pub struct InvertedIndexWriter {
     /// Buffered analyzed documents with their assigned doc IDs.
     buffered_docs: Vec<(u64, AnalyzedDocument)>,
 
+    /// Membership index of the doc IDs currently in [`Self::buffered_docs`].
+    ///
+    /// Kept perfectly in sync with `buffered_docs` (every push inserts, every
+    /// clear empties it) so [`Self::remove_pending_document`] can answer
+    /// "is this id buffered?" in O(1). Without it the upsert path scanned the
+    /// whole buffer on every call — `O(N)` per upsert, `O(N²)` over an
+    /// `add × N` ingest, since newly assigned doc IDs are never already
+    /// buffered yet still paid the full scan (Issue #570).
+    buffered_doc_ids: AHashSet<u64>,
+
     /// DocValues writer for the current segment.
     doc_values_writer: DocValuesWriter,
 
@@ -197,6 +207,7 @@ impl InvertedIndexWriter {
             config,
             inverted_index: TermPostingIndex::new(),
             buffered_docs: Vec::new(),
+            buffered_doc_ids: AHashSet::new(),
             doc_values_writer,
             next_doc_id,
             current_segment,
@@ -268,6 +279,7 @@ impl InvertedIndexWriter {
 
         // Buffer the document with its assigned ID
         self.buffered_docs.push((doc_id, analyzed_doc));
+        self.buffered_doc_ids.insert(doc_id);
         self.stats.docs_added += 1;
 
         // Check if we need to flush
@@ -661,6 +673,7 @@ impl InvertedIndexWriter {
 
         // Clear buffers
         self.buffered_docs.clear();
+        self.buffered_doc_ids.clear();
         self.inverted_index = TermPostingIndex::new();
 
         // Reset DocValuesWriter for next segment
@@ -729,6 +742,7 @@ impl InvertedIndexWriter {
         }
         let paths = self.write_segment_files(segment_name)?;
         self.buffered_docs.clear();
+        self.buffered_doc_ids.clear();
         self.inverted_index = TermPostingIndex::new();
         self.stats.segments_created += 1;
         Ok(paths)
@@ -1279,6 +1293,7 @@ impl InvertedIndexWriter {
 
         // Clear all buffers
         self.buffered_docs.clear();
+        self.buffered_doc_ids.clear();
         self.inverted_index = TermPostingIndex::new();
 
         Ok(())
@@ -1319,35 +1334,29 @@ impl InvertedIndexWriter {
 
     /// Remove a pending document with the given ID from in-memory buffers and rebuild indices.
     fn remove_pending_document(&mut self, doc_id: u64) -> Result<()> {
-        // Fast path: nothing buffered
+        // Fast path: nothing buffered.
         if self.buffered_docs.is_empty() {
             return Ok(());
         }
 
-        // Retain only docs with different IDs
-        let mut changed = false;
-        self.buffered_docs.retain(|(id, _)| {
-            let keep = *id != doc_id;
-            if !keep {
-                changed = true;
-            }
-            keep
-        });
-
-        if !changed {
+        // O(1) membership probe. Newly assigned doc IDs (the common `add`
+        // case) are never already buffered, so this returns early and skips
+        // the full-buffer scan + index rebuild below — turning the per-upsert
+        // cost from O(N) into O(1) and the `add × N` ingest from O(N²) into
+        // O(N) (Issue #570). `remove` also drops the id, keeping the set in
+        // sync with the `retain` that follows.
+        if !self.buffered_doc_ids.remove(&doc_id) {
             return Ok(());
         }
 
-        // Rebuild in-memory inverted index and DocValues from the remaining buffered docs
+        // The id was buffered: drop every occurrence from the buffer and
+        // rebuild the in-memory inverted index / DocValues from what remains.
+        self.buffered_docs.retain(|(id, _)| *id != doc_id);
         self.rebuild_in_memory_index()?;
 
-        if changed {
-            // Decrement docs_added for the removed document
-            // Note: remove_pending_document logic in upsert implies removing 1 old version
-            // But if we just removed it from buffer, we un-did the add.
-            if self.stats.docs_added > 0 {
-                self.stats.docs_added -= 1;
-            }
+        // Decrement docs_added for the removed (un-done) document.
+        if self.stats.docs_added > 0 {
+            self.stats.docs_added -= 1;
         }
         Ok(())
     }

--- a/laurus/tests/lexical_upsert_dedup_test.rs
+++ b/laurus/tests/lexical_upsert_dedup_test.rs
@@ -1,0 +1,137 @@
+//! Integration tests for `InvertedIndexWriter::remove_pending_document`
+//! (Issue #570 — replace the per-upsert full-buffer scan with an O(1)
+//! membership probe).
+//!
+//! `Engine::add_document` routes through `upsert_document(doc_id, ..)`, which
+//! calls `remove_pending_document(doc_id)` before indexing. Previously that ran
+//! `buffered_docs.retain(..)` — a full O(N) scan — on every call, even for
+//! freshly assigned doc IDs that can never already be buffered, making an
+//! `add × N` ingest O(N²). The fix keeps a `buffered_doc_ids` set in sync with
+//! `buffered_docs` so the new-id case returns in O(1).
+//!
+//! These tests pin down both branches of the new code path and assert that the
+//! externally observable behaviour is unchanged:
+//! - new, never-seen doc IDs accumulate in the buffer (the O(1) early return);
+//! - re-upserting an already-buffered doc ID still dedups in place and the
+//!   in-memory index reflects only the latest version (the rebuild branch).
+
+use std::sync::Arc;
+
+use laurus::Document;
+use laurus::lexical::{InvertedIndexWriter, InvertedIndexWriterConfig};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+/// Build a writer whose buffer never auto-flushes during a test, so
+/// `buffered_docs` (and the new `buffered_doc_ids` set) stay populated and the
+/// `remove_pending_document` paths are exercised directly.
+fn writer() -> InvertedIndexWriter {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let config = InvertedIndexWriterConfig {
+        // Far above the doc counts used here so no `flush_segment` clears the
+        // buffer mid-test.
+        max_buffered_docs: 1_000_000,
+        ..Default::default()
+    };
+    InvertedIndexWriter::new(storage, config).unwrap()
+}
+
+fn doc(term: &str) -> Document {
+    Document::builder().add_text("title", term).build()
+}
+
+/// New, distinct doc IDs take the O(1) early-return path: every upsert is
+/// buffered, none is dropped, and `docs_added` counts each one exactly once.
+#[test]
+fn distinct_upserts_all_buffered() {
+    let mut w = writer();
+    let n = 500u64;
+
+    for i in 0..n {
+        w.upsert_document(i, doc(&format!("term{i}"))).unwrap();
+    }
+
+    assert_eq!(
+        w.pending_docs(),
+        n as usize,
+        "every distinct upsert must remain buffered"
+    );
+    assert_eq!(
+        w.stats().docs_added,
+        n,
+        "docs_added must equal the number of distinct upserts"
+    );
+
+    // A sampling of the ids is resolvable through the in-memory index.
+    for i in [0u64, 1, 250, n - 1] {
+        assert_eq!(
+            w.find_doc_id_by_term("title", &format!("term{i}")).unwrap(),
+            Some(i),
+            "term{i} must resolve to its buffered doc id"
+        );
+    }
+}
+
+/// Re-upserting an already-buffered doc ID takes the rebuild branch: the buffer
+/// does not grow, `docs_added` stays at one, and the in-memory index reflects
+/// only the latest version (the old term is gone, the new term resolves).
+#[test]
+fn reupsert_same_id_dedups_and_reflects_latest() {
+    let mut w = writer();
+
+    w.upsert_document(7, doc("alpha")).unwrap();
+    assert_eq!(w.pending_docs(), 1);
+    assert_eq!(w.find_doc_id_by_term("title", "alpha").unwrap(), Some(7));
+
+    // Re-upsert the SAME internal id with different content.
+    w.upsert_document(7, doc("beta")).unwrap();
+
+    assert_eq!(
+        w.pending_docs(),
+        1,
+        "re-upserting the same id must not grow the buffer"
+    );
+    assert_eq!(
+        w.stats().docs_added,
+        1,
+        "docs_added must net to one after an add + re-upsert of the same id"
+    );
+    assert_eq!(
+        w.find_doc_id_by_term("title", "beta").unwrap(),
+        Some(7),
+        "the latest version's term must resolve"
+    );
+    assert_eq!(
+        w.find_doc_id_by_term("title", "alpha").unwrap(),
+        None,
+        "the replaced version's term must be gone from the in-memory index"
+    );
+}
+
+/// Interleaving fresh ids with a re-upsert keeps the buffer count and the
+/// membership set consistent: the rebuild branch must not disturb the other
+/// buffered docs, and a later fresh id still appends.
+#[test]
+fn interleaved_new_and_reupsert_stay_consistent() {
+    let mut w = writer();
+
+    w.upsert_document(1, doc("one")).unwrap();
+    w.upsert_document(2, doc("two")).unwrap();
+    w.upsert_document(3, doc("three")).unwrap();
+    assert_eq!(w.pending_docs(), 3);
+
+    // Re-upsert an existing id (rebuild branch) — count stays 3.
+    w.upsert_document(2, doc("twotwo")).unwrap();
+    assert_eq!(w.pending_docs(), 3);
+
+    // The untouched neighbours survive the rebuild.
+    assert_eq!(w.find_doc_id_by_term("title", "one").unwrap(), Some(1));
+    assert_eq!(w.find_doc_id_by_term("title", "three").unwrap(), Some(3));
+    // The re-upserted doc reflects its new term, not the old one.
+    assert_eq!(w.find_doc_id_by_term("title", "twotwo").unwrap(), Some(2));
+    assert_eq!(w.find_doc_id_by_term("title", "two").unwrap(), None);
+
+    // A subsequent fresh id still appends via the O(1) path.
+    w.upsert_document(4, doc("four")).unwrap();
+    assert_eq!(w.pending_docs(), 4);
+    assert_eq!(w.find_doc_id_by_term("title", "four").unwrap(), Some(4));
+}


### PR DESCRIPTION
## Summary

`Engine::add_document` routes through `upsert_document(doc_id, ..)` →
`remove_pending_document(doc_id)`, which ran `buffered_docs.retain(..)` — a full
**O(N)** scan — on *every* call, even for freshly assigned doc IDs that can never
already be buffered. Over an `add × N` ingest that is **O(N²)**.

This adds a `buffered_doc_ids: AHashSet<u64>` kept in sync with `buffered_docs`
(insert on push; clear on every buffer clear — `flush_segment` /
`flush_buffered_to_segment` / `rollback`). `remove_pending_document` now probes
the set in **O(1)** and returns early for non-buffered ids, skipping the scan and
the in-memory index rebuild.

Behaviour is unchanged: the `retain` + index rebuild still runs when the id *is*
buffered (re-upsert dedup), and `docs_added` nets identically. Invariant
`buffered_doc_ids ⊇ {ids in buffered_docs}` holds via a single push site and
clearing both structures together.

## Why

Surfaced by a Phase-0 profile for #542. On `lexical_indexing_bench` DISK
(ext4 NVMe) `ingest/add_documents/10000`, `remove_pending_document` was the **#1
CPU symbol at 12.19%** self-time.

## Verification

- **perf, DISK `add_documents/10000`: `remove_pending_document` 12.19% → 0.17%**
  (gone from the hot path; the top symbol is now the real indexing work
  `add_analyzed_document_to_index` at 11.15%).
- New tests `laurus/tests/lexical_upsert_dedup_test.rs` (3) cover both branches:
  distinct-id O(1) early return, same-id re-upsert dedup, interleaved consistency.
- Regression: `deletion_logic_test`, `lexical_optimize_test`,
  `lexical_auto_merge_test`, `lexical_merge_bkd_test`, `lexical_json_mirror_test`,
  `cargo test -p laurus --lib inverted` (133) — all green.
- `cargo fmt --check` + `cargo clippy -p laurus --all-targets` clean.

## Scope / follow-ups

No on-disk format, public API, or binding change. Related findings filed
separately:
- #812 — `MemoryOutput::flush_and_sync` whole-buffer clone (in-memory WAL-clone
  O(N²) bench artifact).
- #542 — per-doc fsync ≈ 99% of durable ingest; refocused on group commit.

Refs #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)