### PR TITLE
reliability(store/wal): recover the valid prefix when a trailing WAL record is corrupt (#542 Phase 0)

### DIFF
--- a/laurus/src/store/log.rs
+++ b/laurus/src/store/log.rs
@@ -22,6 +22,15 @@
 //! The WAL log file stores records in a simple binary format:
 //! `[u32: length][json: LogRecord]` repeated for each entry.
 //! Each entry is followed by `flush_and_sync()` for durability.
+//!
+//! ## Recovery
+//!
+//! [`DocumentLog::read_all`] replays the file and stops at the first record it
+//! cannot read in full — a short length prefix, a short body, or a body that
+//! fails to deserialize. Such a torn trailing record (e.g. from a crash
+//! mid-append) is dropped along with everything after it, and the valid prefix
+//! is recovered so the engine can still open. Recovery never skips a bad record
+//! to continue, which keeps the recovered sequence gap-free and consistent.
 
 use std::io::{Read, Write};
 use std::sync::Arc;
@@ -245,7 +254,26 @@ impl DocumentLog {
             reader.read_exact(&mut buffer)?;
             position += len;
 
-            let record: LogRecord = serde_json::from_slice(&buffer)?;
+            // A trailing record with an intact length prefix but a corrupt or
+            // partially written body indicates a torn write (e.g. a crash
+            // mid-append). Stop at the last valid record and recover the durable
+            // prefix instead of aborting recovery — this mirrors the short-read
+            // breaks above and lets the engine open. Recovery stops at the FIRST
+            // bad record (never skip-and-continue), so a later intact-looking
+            // record can never resurrect an op whose predecessors were dropped.
+            // (Issue #542, Phase 0.)
+            let record: LogRecord = match serde_json::from_slice(&buffer) {
+                Ok(record) => record,
+                Err(e) => {
+                    ::log::warn!(
+                        "WAL recovery: dropping corrupt trailing record at byte offset {} \
+                         ({len} body bytes): {e}; recovered {} valid record(s) before it",
+                        position - len,
+                        records.len()
+                    );
+                    break;
+                }
+            };
             if record.seq > max_seq {
                 max_seq = record.seq;
             }
@@ -484,6 +512,85 @@ mod tests {
             assert_eq!(doc_id, 3);
             assert_eq!(seq, 3);
         }
+    }
+
+    /// Write one framed record manually, returning its `[u32 len][body]` bytes.
+    fn frame(body: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(4 + body.len());
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.extend_from_slice(body);
+        out
+    }
+
+    /// A trailing record with an intact length prefix but a corrupt body (e.g. a
+    /// crash mid-append) must NOT abort recovery: `read_all` recovers the valid
+    /// prefix, drops the torn record, and resyncs counters from the prefix only
+    /// (Issue #542, Phase 0).
+    #[test]
+    fn read_all_recovers_prefix_when_trailing_record_body_is_corrupt() {
+        use std::io::Write as _;
+
+        let wal_storage = make_storage();
+        let doc_storage = make_storage();
+
+        // One valid record followed by a frame whose length prefix is intact but
+        // whose body is not valid JSON.
+        let valid = LogRecord {
+            seq: 1,
+            entry: LogEntry::Upsert {
+                doc_id: 1,
+                external_id: "ext_1".to_string(),
+                document: Document::builder()
+                    .add_field("body", DataValue::Text("hello".to_string()))
+                    .build(),
+            },
+        };
+        {
+            let mut out = wal_storage.create_output("test.log").unwrap();
+            out.write_all(&frame(&serde_json::to_vec(&valid).unwrap()))
+                .unwrap();
+            out.write_all(&frame(b"this is not valid json")).unwrap();
+            out.flush_and_sync().unwrap();
+            out.close().unwrap();
+        }
+
+        let log = DocumentLog::new(wal_storage, "test.log", doc_storage).unwrap();
+
+        // Recovery must succeed (not error) and yield only the valid prefix.
+        let records = log.read_all().unwrap();
+        assert_eq!(records.len(), 1, "only the valid prefix is recovered");
+        assert_eq!(records[0].seq, 1);
+
+        // Counters are resynced from the recovered prefix only: the next append
+        // continues monotonically without a gap.
+        assert_eq!(log.last_seq(), 1);
+        assert_eq!(log.next_doc_id(), 2);
+        let doc = Document::builder()
+            .add_field("body", DataValue::Text("next".to_string()))
+            .build();
+        let (doc_id, seq) = log.append("ext_2", doc).unwrap();
+        assert_eq!(doc_id, 2);
+        assert_eq!(seq, 2);
+    }
+
+    /// An empty/garbage-only WAL (no valid leading record) recovers nothing
+    /// rather than erroring.
+    #[test]
+    fn read_all_recovers_nothing_when_first_record_is_corrupt() {
+        use std::io::Write as _;
+
+        let wal_storage = make_storage();
+        let doc_storage = make_storage();
+        {
+            let mut out = wal_storage.create_output("test.log").unwrap();
+            out.write_all(&frame(b"garbage")).unwrap();
+            out.flush_and_sync().unwrap();
+            out.close().unwrap();
+        }
+
+        let log = DocumentLog::new(wal_storage, "test.log", doc_storage).unwrap();
+        let records = log.read_all().unwrap();
+        assert!(records.is_empty(), "no valid prefix to recover");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`DocumentLog::read_all` aborted the **entire engine open** if a WAL record's
length prefix was intact but its body failed to deserialize — a torn write from
a crash mid-append — via `serde_json::from_slice(&buffer)?` (`log.rs`). One
corrupt trailing record made the index unopenable.

This treats a body-decode failure like the existing short-read breaks: stop at
the last valid record, drop the torn tail, and recover the durable prefix so the
engine opens. Recovery stops at the **first** bad record (never
skip-and-continue), keeping the recovered sequence gap-free; counters resync
from the prefix only. A `WARN` is logged per dropped record so operators still
learn data was lost.

## Why (Phase 0 of #542)

This is the foundation the rest of #542 builds on. A Phase-0 profile showed
per-doc WAL fsync ≈ 99% of durable ingest wall-time, so #542 introduces opt-in
**group commit** (deferred fsync). Deferring fsync widens the torn-tail window,
so recovery must degrade gracefully rather than abort. Landing this first — with
no on-disk format change, no durability-contract change, and no signature/binding
impact — de-risks the CRC framing (Phase 1) and group commit (Phase 4) that
follow.

Behavior change: a corrupt in-bound record body previously failed engine open
loudly; it now drops the torn tail, logs a WARN, and opens — strictly more
available, and the loud failure was arguably a reliability bug.

## Tests

- `store::log::read_all_recovers_prefix_when_trailing_record_body_is_corrupt`
  — valid record + corrupt-body trailing frame → `read_all` returns only the
  prefix, no error; counters (`last_seq`, `next_doc_id`) resync from the prefix
  and the next append continues gap-free.
- `store::log::read_all_recovers_nothing_when_first_record_is_corrupt`
  — garbage-only WAL recovers nothing rather than erroring.
- Existing `store::log` unit tests (7 total) and `wal_recovery_test` integration
  test green; `cargo fmt --check` + `cargo clippy -p laurus --all-targets` clean.

## Scope

Recovery hardening only — no on-disk format change, no durability-contract
change, no public signature or binding impact. Part of the #542 plan (Phase 0 of
0–4); subsequent phases (CRC framing, group commit behind an opt-in
`EngineBuilder` flag) land separately.

Refs #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)