### PR TITLE
refactor(store/wal): force the WAL durable at the top of commit() (#542)

### DIFF
--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -477,16 +477,25 @@ impl Engine {
 
     /// Commit changes to both stores and truncate the WAL.
     ///
-    /// Persists all pending changes in the lexical store, vector store, and
-    /// document store (in that order), then truncates the WAL. After a
-    /// successful commit, the WAL is empty and all data is durable in the
-    /// underlying storage.
+    /// First forces the WAL durable (a hard barrier, so the WAL is never less
+    /// durable than the indexes about to be committed), then persists all
+    /// pending changes in the lexical store, vector store, and document store
+    /// (in that order), and finally truncates the WAL. After a successful
+    /// commit, the WAL is empty and all data is durable in the underlying
+    /// storage.
     ///
     /// # Errors
     ///
-    /// Returns an error if committing the lexical store, vector store,
-    /// document store, or truncating the WAL fails.
+    /// Returns an error if flushing the WAL, committing the lexical store,
+    /// vector store, document store, or truncating the WAL fails.
     pub async fn commit(&self) -> Result<()> {
+        // Hard durability barrier: force the WAL durable before any store
+        // materializes its state, so the WAL is never less durable than the
+        // committed lexical/vector indexes. A near-no-op under the per-record
+        // default (each append already synced, so the dirty guard skips the
+        // fsync); the load-bearing step once group commit defers per-append
+        // fsync (#542 Phase 3).
+        self.log.flush_wal()?;
         self.lexical.commit()?;
         self.vector.commit().await?;
         self.log.commit_documents()?;

--- a/laurus/src/store/log.rs
+++ b/laurus/src/store/log.rs
@@ -114,6 +114,12 @@ enum WalFormat {
 struct WalWriterState {
     out: Box<dyn crate::storage::StorageOutput>,
     format: WalFormat,
+    /// Whether bytes have been appended since the last successful
+    /// `flush_and_sync()`. Set by [`DocumentLog::append_record_bytes`] and
+    /// cleared by [`DocumentLog::flush_writer`]; it lets [`DocumentLog::flush_wal`]
+    /// skip a redundant fsync at commit time when nothing is pending (true under
+    /// the default per-record contract, where every append already synced).
+    dirty: bool,
 }
 
 /// Unified document log providing WAL, doc_id generation, and document storage.
@@ -215,7 +221,11 @@ impl DocumentLog {
             WalFormat::Legacy
         };
 
-        *writer_guard = Some(WalWriterState { out, format });
+        *writer_guard = Some(WalWriterState {
+            out,
+            format,
+            dirty: false,
+        });
         Ok(())
     }
 
@@ -299,16 +309,26 @@ impl DocumentLog {
                 state.out.write_all(&hasher.finalize().to_le_bytes())?;
             }
             state.out.write_all(&bytes)?;
+            // Bytes are now buffered/written but not yet fsynced.
+            state.dirty = true;
         }
 
         Ok(())
     }
 
     /// Flush and fsync the open WAL writer, making every appended-but-unsynced
-    /// record durable. A no-op if no writer is open.
+    /// record durable, then mark it clean.
+    ///
+    /// Honors the [`WalWriterState::dirty`] guard: if nothing has been appended
+    /// since the last sync (the steady state under the per-record contract,
+    /// where every append already synced), the fsync is skipped so a commit-time
+    /// [`Self::flush_wal`] is a true no-op. A no-op if no writer is open.
     fn flush_writer(state: &mut Option<WalWriterState>) -> Result<()> {
-        if let Some(state) = state.as_mut() {
+        if let Some(state) = state.as_mut()
+            && state.dirty
+        {
             state.out.flush_and_sync()?;
+            state.dirty = false;
         }
         Ok(())
     }
@@ -319,6 +339,24 @@ impl DocumentLog {
         Self::append_record_bytes(state, record)?;
         Self::flush_writer(state)?;
         Ok(())
+    }
+
+    /// Force every appended-but-unsynced WAL record durable.
+    ///
+    /// Under the default per-record contract this is a near-no-op: each append
+    /// already self-syncs, so the [`WalWriterState::dirty`] guard skips the
+    /// fsync. It is the load-bearing commit-time barrier once a future
+    /// group-commit path (#542 Phase 4) defers per-append fsync — [`Engine::commit`]
+    /// calls it before any store materializes its state, so the WAL is never
+    /// less durable than the committed lexical/vector indexes. A no-op if no
+    /// writer is currently open (e.g. right after a [`Self::truncate`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing or fsyncing the open WAL writer fails.
+    pub fn flush_wal(&self) -> Result<()> {
+        let mut writer_guard = self.wal_writer.lock();
+        Self::flush_writer(&mut writer_guard)
     }
 
     /// Read all records from the WAL.
@@ -463,12 +501,15 @@ impl DocumentLog {
     pub fn truncate(&self) -> Result<()> {
         {
             let mut writer_guard = self.wal_writer.lock();
-            // Flush + close the open handle before discarding it. Harmless today
-            // (every record is self-synced in `write_record`), but required once
-            // fsync is deferred: dropping the handle without flushing would lose
-            // any appended-but-unsynced bytes (#542 Phase 2).
+            // Flush + close the open handle before discarding it. The flush is
+            // guarded by `dirty`, so it's skipped when every record is already
+            // self-synced (the per-record default) but still runs once fsync is
+            // deferred — dropping the handle with unsynced bytes would lose them
+            // (#542 Phase 2/3).
             if let Some(mut state) = writer_guard.take() {
-                state.out.flush_and_sync()?;
+                if state.dirty {
+                    state.out.flush_and_sync()?;
+                }
                 state.out.close()?;
             }
         }
@@ -689,6 +730,85 @@ mod tests {
         let records = log.read_all().unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].seq, 3);
+    }
+
+    /// `flush_wal` is a no-op when no writer is open — before the first append
+    /// or right after a truncate — returning Ok without opening anything
+    /// (Issue #542, Phase 3).
+    #[test]
+    fn flush_wal_is_noop_without_writer() {
+        let log = make_log();
+        log.flush_wal().unwrap();
+        assert!(
+            log.wal_writer.lock().is_none(),
+            "flush_wal must not open a writer"
+        );
+    }
+
+    /// Under the per-record default every append self-syncs, leaving the writer
+    /// clean, so a commit-time `flush_wal` skips the fsync (a true no-op) while
+    /// the records stay intact (Issue #542, Phase 3).
+    #[test]
+    fn append_leaves_writer_clean_so_flush_wal_is_noop() {
+        let log = make_log();
+        let doc = Document::builder()
+            .add_field("body", DataValue::Text("hello".to_string()))
+            .build();
+        log.append("ext_1", doc).unwrap();
+
+        assert!(
+            !log.wal_writer.lock().as_ref().unwrap().dirty,
+            "a per-record append leaves the writer synced/clean"
+        );
+        log.flush_wal().unwrap();
+        assert!(
+            !log.wal_writer.lock().as_ref().unwrap().dirty,
+            "flush_wal on a clean writer stays clean"
+        );
+
+        assert_eq!(log.read_all().unwrap().len(), 1);
+    }
+
+    /// When bytes are appended without an immediate sync — the deferred path a
+    /// future group-commit mode uses — the writer is dirty and `flush_wal` makes
+    /// the record durable, clears the flag, and the record round-trips (Issue
+    /// #542, Phase 3).
+    #[test]
+    fn flush_wal_syncs_a_dirty_writer() {
+        let log = make_log();
+        let record = LogRecord {
+            seq: 1,
+            entry: LogEntry::Upsert {
+                doc_id: 1,
+                external_id: "ext_1".to_string(),
+                document: Document::builder()
+                    .add_field("body", DataValue::Text("deferred".to_string()))
+                    .build(),
+            },
+        };
+
+        // Simulate a deferred (group-commit) append: open the writer and write
+        // the framed bytes without syncing.
+        {
+            let mut guard = log.wal_writer.lock();
+            log.ensure_writer(&mut guard).unwrap();
+            DocumentLog::append_record_bytes(&mut guard, &record).unwrap();
+            assert!(
+                guard.as_ref().unwrap().dirty,
+                "appended-but-unsynced bytes mark the writer dirty"
+            );
+        }
+
+        // flush_wal makes the deferred record durable and clears the flag.
+        log.flush_wal().unwrap();
+        assert!(
+            !log.wal_writer.lock().as_ref().unwrap().dirty,
+            "flush_wal clears the dirty flag after syncing"
+        );
+
+        let records = log.read_all().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].seq, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 3 of #542 (WAL group commit). Makes `commit()` a **hard WAL durability barrier** so the WAL is never less durable than the indexes it is about to commit, establishing the durability ladder for group commit. Behavior-preserving and a **true no-op under the per-record default**. Phases 0–2 (#814, #815, #816) already landed.

- **`dirty` guard.** `WalWriterState` gains a `dirty` flag: set when bytes are appended (`append_record_bytes`), cleared after fsync (`flush_writer`). `flush_writer` — and `truncate`'s pre-close flush — now skip the fsync when not dirty, so the new commit-time flush issues no syscall in the steady per-record state where every append already synced.
- **Public `DocumentLog::flush_wal()`**, introduced together with its first caller to avoid `dead_code`.
- **`Engine::commit()`** now calls `log.flush_wal()` before committing the lexical, vector, and document stores and truncating the WAL. A near-no-op today; the load-bearing barrier once group commit (Phase 4) defers per-append fsync.

## Durability ladder

Under the per-record default, every `append()` self-syncs, so at commit time the writer is clean and `flush_wal()` issues no fsync. Under a future group mode (Phase 4) appends defer the fsync, leaving the writer dirty; `flush_wal()` at the top of `commit()` then forces it durable before any store materializes its state — so a crash can never leave a committed index referencing a WAL record that was lost.

## Scope

- No public API change and no on-disk format change.
- `DocumentLog` is crate-internal and `Engine::commit` keeps its signature, so there is **no language-binding impact**.

## Verification

- `store::log` unit tests: **14 pass** (3 new):
  - `flush_wal_is_noop_without_writer` — no writer open → Ok, opens nothing.
  - `append_leaves_writer_clean_so_flush_wal_is_noop` — per-record append leaves the writer clean, so commit-time flush is a true no-op; records intact.
  - `flush_wal_syncs_a_dirty_writer` — deferred (unsynced) append marks the writer dirty; `flush_wal` makes it durable, clears the flag, and the record round-trips.
- `store::` **39**, engine commit tests, full `laurus` lib **1158 pass**.
- `wal_recovery` integration test: **pass**.
- `cargo fmt --check` / `cargo clippy --tests -- -D warnings`: clean.

Refs #542