### PR TITLE
feat(store/wal): opt-in group-commit durability policy (#542 Phase 4a)

### DIFF
--- a/docs/ja/src/laurus/api_reference.md
+++ b/docs/ja/src/laurus/api_reference.md
@@ -19,6 +19,7 @@ cargo doc --open
 | `engine.get_documents(id).await?` | 外部IDによるすべてのドキュメント/チャンクの取得 |
 | `engine.search(request).await?` | 検索リクエストの実行 |
 | `engine.commit().await?` | 保留中のすべての変更をストレージにフラッシュ |
+| `engine.flush_wal()?` | full commit なしで WAL を durable 化（[WAL 耐久性ポリシー](persistence.md#wal-耐久性ポリシー)参照） |
 | `engine.add_field(name, field_option).await?` | 稼働中のエンジンにフィールドを動的に追加 |
 | `engine.delete_field(name).await?` | 稼働中のエンジンからフィールドを動的に削除 |
 | `engine.schema()` | 現在のスキーマへの参照を取得 |
@@ -33,6 +34,7 @@ cargo doc --open
 | `EngineBuilder::new(storage, schema)` | StorageとSchemaでBuilderを作成 |
 | `.analyzer(Arc<dyn Analyzer>)` | テキストAnalyzerを設定（デフォルト: `StandardAnalyzer`） |
 | `.embedder(Arc<dyn Embedder>)` | ベクトルEmbedderを設定（オプション） |
+| `.wal_sync_policy(policy)` | WAL 耐久性ポリシーを設定（デフォルト: `WalSyncPolicy::PerRecord`。[WAL 耐久性ポリシー](persistence.md#wal-耐久性ポリシー)参照） |
 | `.build().await?` | `Engine` を構築 |
 
 ## Schema

--- a/docs/ja/src/laurus/persistence.md
+++ b/docs/ja/src/laurus/persistence.md
@@ -94,6 +94,43 @@ engine.add_document("doc-3", doc3).await?;
 
 > **ヒント:** コミットはセグメントをストレージにフラッシュするため比較的コストが高い操作です。バルクインデキシングでは、`commit()` を呼び出す前に多数のドキュメントをバッチ処理してください。
 
+## WAL 耐久性ポリシー
+
+既定では、各 `add`/`delete` は返る前に WAL を fsync するため、成功した書き込みがクラッシュで失われることはありません。大量に取り込む場合、この書き込みごとの fsync がスループットのボトルネックになります。`WalSyncPolicy` により、書き込みごとの耐久性とスループットをトレードオフできます。
+
+| ポリシー | 耐久性 | スループット | 相当 |
+| :--- | :--- | :--- | :--- |
+| `PerRecord`（既定） | 成功した書き込みは必ず durable | 書き込みごとに 1 回 fsync で律速 | SQLite `synchronous = FULL` |
+| `Group { max_records, max_bytes }` | クラッシュ時に未 sync の最終バッチまで失う可能性 | fsync をバッチで償却 | SQLite `synchronous = NORMAL` |
+
+`Group` では fsync が遅延され、前回の sync 以降に **`max_records` 件**または **`max_bytes` バイト**のいずれか（先に到達した方）が蓄積した時点で 1 回発行されます。ビルダーで設定します。
+
+```rust
+use laurus::WalSyncPolicy;
+
+let engine = Engine::builder(storage, schema)
+    // 既定閾値（1024 件 / 1 MiB）でのグループコミット。
+    .wal_sync_policy(WalSyncPolicy::group_with_defaults())
+    // ...または任意のバッチサイズを指定:
+    // .wal_sync_policy(WalSyncPolicy::Group { max_records: 4096, max_bytes: 4 * 1024 * 1024 })
+    .build()
+    .await?;
+```
+
+### 耐久性の保証
+
+- **`commit()` は両ポリシーで hard barrier です。** いずれのストアを materialize する前に WAL を強制的に durable 化するため、WAL がコミット済みインデックスより durability で劣ることはありません。`commit()` 成功後は、ポリシーに関わらず全データが durable です。
+- **`flush_wal()` は full commit なしでオンデマンドに flush します。** `Group` におけるクラッシュ時の損失窓を、アプリ任意の地点で抑えるための手段で、SQLite の WAL チェックポイントに相当します。
+
+  ```rust
+  engine.add_document("doc-1", doc1).await?;
+  engine.flush_wal()?; // セグメントをコミットせずに WAL を durable 化
+  ```
+
+- **途中で切れた末尾レコードは決して復活しません。** 各レコードは CRC-32 でフレーミングされ、リカバリ時にチェックサムに失敗した（または切り詰められた）レコードはそれ以降もろとも破棄されます。よって復旧後のログは常にギャップのない有効な接頭辞であり、グループコミットが失うのは直近書き込みの **末尾（suffix）** のみで、それ以前を破損させることはありません。
+
+> **注意:** `Group` はオプトインです。既定の `PerRecord` ポリシーは変更されないため、既存コードは何も変えずに書き込みごとの耐久性を維持します。
+
 ## ストレージレイアウト
 
 エンジンは `PrefixedStorage` を使用してデータを整理します。

--- a/docs/src/laurus/api_reference.md
+++ b/docs/src/laurus/api_reference.md
@@ -19,6 +19,7 @@ The central coordinator for all indexing and search operations.
 | `engine.get_documents(id).await?` | Get all documents/chunks by external ID |
 | `engine.search(request).await?` | Execute a search request |
 | `engine.commit().await?` | Flush all pending changes to storage |
+| `engine.flush_wal()?` | Force the WAL durable without a full commit (see [WAL Durability Policy](persistence.md#wal-durability-policy)) |
 | `engine.add_field(name, field_option).await?` | Dynamically add a new field to the schema at runtime |
 | `engine.delete_field(name).await?` | Remove a field from the schema at runtime |
 | `engine.schema()` | Return the current `Schema` |
@@ -33,6 +34,7 @@ The central coordinator for all indexing and search operations.
 | `EngineBuilder::new(storage, schema)` | Create a builder with storage and schema |
 | `.analyzer(Arc<dyn Analyzer>)` | Set the text analyzer (default: `StandardAnalyzer`) |
 | `.embedder(Arc<dyn Embedder>)` | Set the vector embedder (optional) |
+| `.wal_sync_policy(policy)` | Set the WAL durability policy (default: `WalSyncPolicy::PerRecord`; see [WAL Durability Policy](persistence.md#wal-durability-policy)) |
 | `.build().await?` | Build the `Engine` |
 
 ## Schema

--- a/docs/src/laurus/persistence.md
+++ b/docs/src/laurus/persistence.md
@@ -94,6 +94,43 @@ engine.add_document("doc-3", doc3).await?;
 
 > **Tip:** Commits are relatively expensive because they flush segments to storage. For bulk indexing, batch many documents before calling `commit()`.
 
+## WAL Durability Policy
+
+By default, each `add`/`delete` fsyncs the WAL before returning, so a successful write can never be lost to a crash. When ingesting at high volume, that per-write fsync becomes the throughput bottleneck. The `WalSyncPolicy` lets you trade per-write durability for throughput:
+
+| Policy | Durability | Throughput | Analogue |
+| :--- | :--- | :--- | :--- |
+| `PerRecord` (default) | Every successful write is durable | Bounded by one fsync per write | SQLite `synchronous = FULL` |
+| `Group { max_records, max_bytes }` | A crash may lose up to the last unsynced batch | fsync amortized over a batch | SQLite `synchronous = NORMAL` |
+
+Under `Group`, the fsync is deferred and issued once **either** `max_records` records **or** `max_bytes` bytes have accumulated since the last sync (whichever comes first). Configure it on the builder:
+
+```rust
+use laurus::WalSyncPolicy;
+
+let engine = Engine::builder(storage, schema)
+    // Group commit with the default thresholds (1024 records / 1 MiB).
+    .wal_sync_policy(WalSyncPolicy::group_with_defaults())
+    // ...or choose your own batch size:
+    // .wal_sync_policy(WalSyncPolicy::Group { max_records: 4096, max_bytes: 4 * 1024 * 1024 })
+    .build()
+    .await?;
+```
+
+### Durability Guarantees
+
+- **`commit()` is a hard barrier under both policies.** It forces the WAL durable before materializing any store, so the WAL is never less durable than the committed indexes. After a successful `commit()`, all data is durable regardless of policy.
+- **`flush_wal()` forces a flush on demand** without a full commit — the way to bound the crash-loss window under `Group` at an application-chosen point, analogous to a SQLite WAL checkpoint:
+
+  ```rust
+  engine.add_document("doc-1", doc1).await?;
+  engine.flush_wal()?; // the WAL is now durable, without committing segments
+  ```
+
+- **A torn trailing record is never resurrected.** Each record is CRC-32 framed; on recovery a record that fails its checksum (or is truncated) is dropped along with everything after it, so the recovered log is always a gap-free valid prefix — group commit only ever risks losing a *suffix* of recent writes, never corrupting earlier ones.
+
+> **Note:** `Group` is opt-in; the default `PerRecord` policy is unchanged, so existing code keeps its per-write durability with no changes.
+
 ## Storage Layout
 
 The engine uses `PrefixedStorage` to organize data:

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -22,7 +22,7 @@ use crate::lexical::store::LexicalStore;
 use crate::lexical::store::config::LexicalIndexConfig;
 use crate::storage::Storage;
 use crate::storage::prefixed::PrefixedStorage;
-use crate::store::log::{DocumentLog, LogEntry};
+use crate::store::log::{DocumentLog, LogEntry, WalSyncPolicy};
 use crate::vector::store::VectorStore;
 use crate::vector::store::config::VectorIndexConfig;
 
@@ -502,6 +502,23 @@ impl Engine {
         // After successful commit to all stores, truncate the log
         self.log.truncate()?;
         Ok(())
+    }
+
+    /// Force every appended-but-unsynced WAL record durable, without a full
+    /// [`commit`](Self::commit) (Issue #542).
+    ///
+    /// Under the default [`WalSyncPolicy::PerRecord`] this is a near-no-op: each
+    /// `add`/`delete` already fsyncs, so there is nothing pending. Under
+    /// [`WalSyncPolicy::Group`] appends defer their fsync, so this is the way to
+    /// bound the crash-loss window at an application-chosen point — analogous to
+    /// SQLite's manual WAL checkpoint — without paying the cost of materializing
+    /// the lexical/vector indexes that [`commit`](Self::commit) entails.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing or fsyncing the open WAL writer fails.
+    pub fn flush_wal(&self) -> Result<()> {
+        self.log.flush_wal()
     }
 
     /// Get combined index statistics from both the lexical and vector stores.
@@ -1670,6 +1687,7 @@ pub struct EngineBuilder {
     embedder: Option<Arc<dyn Embedder>>,
     runtime_analyzers: HashMap<String, Arc<dyn Analyzer>>,
     embedding_cache_capacity: Option<usize>,
+    wal_sync_policy: WalSyncPolicy,
 }
 
 impl EngineBuilder {
@@ -1682,6 +1700,7 @@ impl EngineBuilder {
             embedder: None,
             runtime_analyzers: HashMap::new(),
             embedding_cache_capacity: None,
+            wal_sync_policy: WalSyncPolicy::default(),
         }
     }
 
@@ -1748,6 +1767,26 @@ impl EngineBuilder {
         self
     }
 
+    /// Set the WAL durability policy (Issue #542).
+    ///
+    /// Defaults to [`WalSyncPolicy::PerRecord`], where every `add`/`delete`
+    /// fsyncs the WAL before returning, so a successful write can never be lost
+    /// to a crash. Switch to [`WalSyncPolicy::Group`] to defer and batch the
+    /// fsync — much higher ingest throughput at the cost of losing up to the
+    /// last unsynced batch on a crash. [`Engine::commit`] is a hard durability
+    /// barrier under both policies, and [`Engine::flush_wal`] forces a flush on
+    /// demand.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy` - The durability policy. Use
+    ///   [`WalSyncPolicy::group_with_defaults`] for group commit with the
+    ///   default batch thresholds.
+    pub fn wal_sync_policy(mut self, policy: WalSyncPolicy) -> Self {
+        self.wal_sync_policy = policy;
+        self
+    }
+
     /// Build the [`Engine`].
     ///
     /// Creates the lexical store, vector store, and document log (WAL),
@@ -1775,10 +1814,11 @@ impl EngineBuilder {
         let lexical = LexicalStore::new(lexical_storage, lexical_config)?;
         let vector = VectorStore::new(vector_storage, vector_config)?;
 
-        let log = Arc::new(DocumentLog::new(
+        let log = Arc::new(DocumentLog::with_sync_policy(
             self.storage,
             "engine.wal",
             document_storage,
+            self.wal_sync_policy,
         )?);
 
         let embedding_cache = self
@@ -2039,6 +2079,50 @@ mod tests {
             1,
             "Should find doc via dynamically added field"
         );
+    }
+
+    /// An engine built with [`WalSyncPolicy::Group`] plumbs the policy through to
+    /// the WAL, accepts [`Engine::flush_wal`] as an on-demand durability barrier,
+    /// and commits searchable results (Issue #542, Phase 4).
+    #[tokio::test]
+    async fn test_group_commit_policy_is_wired_and_searchable() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "title",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+            )
+            .build();
+
+        let engine = Engine::builder(storage, schema)
+            .wal_sync_policy(WalSyncPolicy::group_with_defaults())
+            .build()
+            .await
+            .unwrap();
+
+        engine
+            .add_document(
+                "doc1",
+                Document::builder()
+                    .add_text("title", "group commit")
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        // Under the group policy the append defers its fsync; an on-demand
+        // flush_wal (no full commit) must succeed as a durability barrier.
+        engine.flush_wal().unwrap();
+
+        engine.commit().await.unwrap();
+
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:group"))
+            .limit(10)
+            .build();
+        let results = engine.search(request).await.unwrap();
+        assert_eq!(results.len(), 1, "group-committed doc must be searchable");
     }
 
     #[tokio::test]

--- a/laurus/src/lib.rs
+++ b/laurus/src/lib.rs
@@ -106,6 +106,7 @@ pub use lexical::search::searcher::{
 };
 pub use maintenance::deletion::DeletionConfig;
 pub use storage::{Storage, StorageConfig, StorageFactory};
+pub use store::log::WalSyncPolicy;
 pub use vector::core::distance::DistanceMetric;
 pub use vector::core::field::{FlatOption, HnswOption, IvfOption};
 pub use vector::core::quantization::QuantizationMethod;

--- a/laurus/src/store/log.rs
+++ b/laurus/src/store/log.rs
@@ -84,6 +84,59 @@ pub struct LogRecord {
     pub entry: LogEntry,
 }
 
+/// Durability policy governing when WAL appends are fsync'd.
+///
+/// This trades the durability of an individual `append` against ingest
+/// throughput; [`commit`](crate::Engine::commit) is a hard barrier under both
+/// policies (it always forces the WAL durable before materializing any store).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum WalSyncPolicy {
+    /// Fsync after every record (the default). An `append` returns only once its
+    /// record is durable, so a successful add/put can never be lost to a crash.
+    PerRecord,
+    /// Defer the fsync and amortize it over a batch: flush when **either**
+    /// `max_records` records **or** `max_bytes` bytes have accumulated since the
+    /// last sync (whichever comes first), and unconditionally at
+    /// [`commit`](crate::Engine::commit). An `append` may return before its
+    /// record is durable, so a crash can lose up to the last unsynced batch —
+    /// comparable to SQLite's `synchronous = NORMAL`. A torn trailing record is
+    /// never resurrected: it is dropped on recovery via the CRC + prefix-stop
+    /// path, keeping the recovered log gap-free.
+    Group {
+        /// Flush once this many records have accumulated since the last sync.
+        max_records: usize,
+        /// Flush once this many appended bytes have accumulated since the last
+        /// sync.
+        max_bytes: usize,
+    },
+}
+
+impl Default for WalSyncPolicy {
+    /// The default is [`WalSyncPolicy::PerRecord`], preserving per-record
+    /// durability for callers that do not opt into group commit.
+    fn default() -> Self {
+        Self::PerRecord
+    }
+}
+
+/// Default batch size (record count) for [`WalSyncPolicy::Group`].
+pub const DEFAULT_GROUP_MAX_RECORDS: usize = 1024;
+
+/// Default batch size (bytes) for [`WalSyncPolicy::Group`]: 1 MiB.
+pub const DEFAULT_GROUP_MAX_BYTES: usize = 1024 * 1024;
+
+impl WalSyncPolicy {
+    /// A [`WalSyncPolicy::Group`] policy using the default batch thresholds
+    /// ([`DEFAULT_GROUP_MAX_RECORDS`] records / [`DEFAULT_GROUP_MAX_BYTES`]
+    /// bytes, whichever is reached first).
+    pub fn group_with_defaults() -> Self {
+        Self::Group {
+            max_records: DEFAULT_GROUP_MAX_RECORDS,
+            max_bytes: DEFAULT_GROUP_MAX_BYTES,
+        }
+    }
+}
+
 /// Magic bytes at the start of a v2 (CRC-framed) WAL file.
 const WAL_MAGIC: &[u8; 4] = b"LWAL";
 
@@ -120,6 +173,14 @@ struct WalWriterState {
     /// skip a redundant fsync at commit time when nothing is pending (true under
     /// the default per-record contract, where every append already synced).
     dirty: bool,
+    /// Number of records appended since the last successful `flush_and_sync()`.
+    /// Drives the [`WalSyncPolicy::Group`] record-count threshold; reset to 0
+    /// on flush.
+    unsynced_records: usize,
+    /// Number of bytes appended since the last successful `flush_and_sync()`
+    /// (framed length, including the CRC for v2). Drives the
+    /// [`WalSyncPolicy::Group`] byte threshold; reset to 0 on flush.
+    unsynced_bytes: usize,
 }
 
 /// Unified document log providing WAL, doc_id generation, and document storage.
@@ -143,6 +204,10 @@ pub struct DocumentLog {
     wal_writer: Mutex<Option<WalWriterState>>,
     next_seq: AtomicU64,
     doc_store: RwLock<UnifiedDocumentStore>,
+    /// Durability policy controlling when appends are fsync'd. Defaults to
+    /// [`WalSyncPolicy::PerRecord`]; [`WalSyncPolicy::Group`] defers the fsync to
+    /// amortize it over a batch.
+    sync_policy: WalSyncPolicy,
 }
 
 impl DocumentLog {
@@ -154,6 +219,10 @@ impl DocumentLog {
     /// replay the WAL and synchronize both the `next_doc_id` and `next_seq`
     /// counters with the persisted state. Failing to do so may cause
     /// duplicate document IDs.
+    ///
+    /// Equivalent to [`with_sync_policy`](Self::with_sync_policy) with the
+    /// default [`WalSyncPolicy::PerRecord`], where every append is fsync'd before
+    /// returning.
     ///
     /// # Arguments
     ///
@@ -169,6 +238,42 @@ impl DocumentLog {
         wal_path: &str,
         doc_store_storage: Arc<dyn Storage>,
     ) -> Result<Self> {
+        Self::with_sync_policy(
+            wal_storage,
+            wal_path,
+            doc_store_storage,
+            WalSyncPolicy::PerRecord,
+        )
+    }
+
+    /// Create a new document log with WAL and document storage under an explicit
+    /// [`WalSyncPolicy`].
+    ///
+    /// The internal `next_doc_id` counter starts at **1** and is **not**
+    /// automatically recovered from any existing WAL file or document store.
+    /// Callers must invoke [`read_all`](Self::read_all) after construction to
+    /// replay the WAL and synchronize both the `next_doc_id` and `next_seq`
+    /// counters with the persisted state. Failing to do so may cause
+    /// duplicate document IDs.
+    ///
+    /// # Arguments
+    ///
+    /// * `wal_storage` - Storage backend for the WAL file.
+    /// * `wal_path` - Path (relative to the storage root) of the WAL file.
+    /// * `doc_store_storage` - Storage backend for the document store.
+    /// * `sync_policy` - When to fsync WAL appends. [`WalSyncPolicy::PerRecord`]
+    ///   syncs each append; [`WalSyncPolicy::Group`] defers and batches the
+    ///   fsync.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the document store cannot be opened.
+    pub fn with_sync_policy(
+        wal_storage: Arc<dyn Storage>,
+        wal_path: &str,
+        doc_store_storage: Arc<dyn Storage>,
+        sync_policy: WalSyncPolicy,
+    ) -> Result<Self> {
         let doc_store = UnifiedDocumentStore::open(doc_store_storage)?;
         Ok(Self {
             wal_storage,
@@ -177,6 +282,7 @@ impl DocumentLog {
             wal_writer: Mutex::new(None),
             next_seq: AtomicU64::new(1),
             doc_store: RwLock::new(doc_store),
+            sync_policy,
         })
     }
 
@@ -225,6 +331,8 @@ impl DocumentLog {
             out,
             format,
             dirty: false,
+            unsynced_records: 0,
+            unsynced_bytes: 0,
         });
         Ok(())
     }
@@ -233,8 +341,11 @@ impl DocumentLog {
 
     /// Append an upsert entry to the log.
     ///
-    /// Atomically assigns a new doc_id and sequence number, then writes
-    /// the entry to the log file with fsync.
+    /// Atomically assigns a new doc_id and sequence number, then writes the
+    /// entry to the log file. Whether the write is fsync'd before returning
+    /// depends on the configured [`WalSyncPolicy`]: always under
+    /// [`WalSyncPolicy::PerRecord`], or only when the batch threshold is reached
+    /// under [`WalSyncPolicy::Group`].
     ///
     /// Returns `(doc_id, seq_number)`.
     pub fn append(&self, external_id: &str, doc: Document) -> Result<(u64, SeqNumber)> {
@@ -255,12 +366,15 @@ impl DocumentLog {
             },
         };
 
-        Self::write_record(&mut writer_guard, &record)?;
+        Self::write_record(&mut writer_guard, &record, self.sync_policy)?;
 
         Ok((doc_id, seq))
     }
 
     /// Append a delete entry to the log.
+    ///
+    /// As with [`append`](Self::append), the fsync timing follows the configured
+    /// [`WalSyncPolicy`].
     ///
     /// Returns the assigned sequence number.
     pub fn append_delete(&self, doc_id: u64, external_id: &str) -> Result<SeqNumber> {
@@ -277,7 +391,7 @@ impl DocumentLog {
             },
         };
 
-        Self::write_record(&mut writer_guard, &record)?;
+        Self::write_record(&mut writer_guard, &record, self.sync_policy)?;
 
         Ok(seq)
     }
@@ -301,16 +415,24 @@ impl DocumentLog {
         let len_bytes = len.to_le_bytes();
 
         if let Some(state) = state.as_mut() {
+            // Frame size: length prefix (+ CRC for v2) + payload.
+            let mut frame_len = len_bytes.len() + bytes.len();
             state.out.write_all(&len_bytes)?;
             if state.format == WalFormat::V2 {
                 let mut hasher = crc32fast::Hasher::new();
                 hasher.update(&len_bytes);
                 hasher.update(&bytes);
-                state.out.write_all(&hasher.finalize().to_le_bytes())?;
+                let crc = hasher.finalize().to_le_bytes();
+                state.out.write_all(&crc)?;
+                frame_len += crc.len();
             }
             state.out.write_all(&bytes)?;
-            // Bytes are now buffered/written but not yet fsynced.
+            // Bytes are now buffered/written but not yet fsynced. Track how much
+            // is pending so a Group policy can flush once its batch threshold is
+            // reached.
             state.dirty = true;
+            state.unsynced_records += 1;
+            state.unsynced_bytes = state.unsynced_bytes.saturating_add(frame_len);
         }
 
         Ok(())
@@ -329,16 +451,47 @@ impl DocumentLog {
         {
             state.out.flush_and_sync()?;
             state.dirty = false;
+            state.unsynced_records = 0;
+            state.unsynced_bytes = 0;
         }
         Ok(())
     }
 
-    /// Write a single record to the WAL file and fsync it before returning
-    /// (per-record durability — the default contract).
-    fn write_record(state: &mut Option<WalWriterState>, record: &LogRecord) -> Result<()> {
+    /// Append a record and fsync according to `policy`.
+    ///
+    /// Under [`WalSyncPolicy::PerRecord`] the record is always fsync'd before
+    /// returning (per-record durability — the default contract). Under
+    /// [`WalSyncPolicy::Group`] the fsync is deferred and only happens once the
+    /// batch reaches `max_records` records or `max_bytes` bytes since the last
+    /// sync, amortizing one fsync over the batch; [`Self::flush_wal`] (called at
+    /// commit) forces any trailing partial batch durable.
+    fn write_record(
+        state: &mut Option<WalWriterState>,
+        record: &LogRecord,
+        policy: WalSyncPolicy,
+    ) -> Result<()> {
         Self::append_record_bytes(state, record)?;
-        Self::flush_writer(state)?;
+        if Self::batch_ready(state, policy) {
+            Self::flush_writer(state)?;
+        }
         Ok(())
+    }
+
+    /// Whether the pending (unsynced) batch should be flushed now under `policy`.
+    ///
+    /// Always `true` for [`WalSyncPolicy::PerRecord`]; for
+    /// [`WalSyncPolicy::Group`] it is `true` once either batch threshold is met.
+    /// `false` when no writer is open.
+    fn batch_ready(state: &Option<WalWriterState>, policy: WalSyncPolicy) -> bool {
+        match policy {
+            WalSyncPolicy::PerRecord => true,
+            WalSyncPolicy::Group {
+                max_records,
+                max_bytes,
+            } => state.as_ref().is_some_and(|s| {
+                s.unsynced_records >= max_records.max(1) || s.unsynced_bytes >= max_bytes.max(1)
+            }),
+        }
     }
 
     /// Force every appended-but-unsynced WAL record durable.
@@ -614,6 +767,27 @@ mod tests {
         DocumentLog::new(wal_storage, "test.log", doc_storage).unwrap()
     }
 
+    /// A log under [`WalSyncPolicy::Group`] with the given batch thresholds.
+    fn make_group_log(max_records: usize, max_bytes: usize) -> DocumentLog {
+        DocumentLog::with_sync_policy(
+            make_storage(),
+            "test.log",
+            make_storage(),
+            WalSyncPolicy::Group {
+                max_records,
+                max_bytes,
+            },
+        )
+        .unwrap()
+    }
+
+    /// A small upsert document for tests that only care about append counting.
+    fn small_doc() -> Document {
+        Document::builder()
+            .add_field("body", DataValue::Text("x".to_string()))
+            .build()
+    }
+
     #[test]
     fn test_append_and_read() {
         let log = make_log();
@@ -809,6 +983,98 @@ mod tests {
         let records = log.read_all().unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].seq, 1);
+    }
+
+    /// The default policy is per-record, and `group_with_defaults` uses the
+    /// documented batch thresholds (Issue #542, Phase 4).
+    #[test]
+    fn sync_policy_defaults() {
+        assert_eq!(WalSyncPolicy::default(), WalSyncPolicy::PerRecord);
+        assert_eq!(
+            WalSyncPolicy::group_with_defaults(),
+            WalSyncPolicy::Group {
+                max_records: DEFAULT_GROUP_MAX_RECORDS,
+                max_bytes: DEFAULT_GROUP_MAX_BYTES,
+            }
+        );
+    }
+
+    /// Under `Group`, appends below the record threshold buffer their bytes
+    /// without fsyncing; the append that reaches the threshold flushes the whole
+    /// batch and resets the counters, and every record round-trips (Issue #542,
+    /// Phase 4).
+    #[test]
+    fn group_policy_defers_then_flushes_at_record_threshold() {
+        // Flush every 3 records; effectively no byte limit.
+        let log = make_group_log(3, usize::MAX);
+
+        log.append("e1", small_doc()).unwrap();
+        log.append("e2", small_doc()).unwrap();
+        {
+            let guard = log.wal_writer.lock();
+            let state = guard.as_ref().unwrap();
+            assert!(state.dirty, "appends under the threshold stay unsynced");
+            assert_eq!(state.unsynced_records, 2);
+            assert!(state.unsynced_bytes > 0);
+        }
+
+        log.append("e3", small_doc()).unwrap();
+        {
+            let guard = log.wal_writer.lock();
+            let state = guard.as_ref().unwrap();
+            assert!(
+                !state.dirty,
+                "reaching the record threshold flushes the batch"
+            );
+            assert_eq!(state.unsynced_records, 0);
+            assert_eq!(state.unsynced_bytes, 0);
+        }
+
+        assert_eq!(log.read_all().unwrap().len(), 3);
+    }
+
+    /// Under `Group`, a single record that exceeds the byte threshold flushes
+    /// immediately even when the record-count limit is far from reached (Issue
+    /// #542, Phase 4).
+    #[test]
+    fn group_policy_flushes_at_byte_threshold() {
+        // 1-byte budget so any record trips the byte threshold; no count limit.
+        let log = make_group_log(usize::MAX, 1);
+
+        log.append("e1", small_doc()).unwrap();
+        let guard = log.wal_writer.lock();
+        let state = guard.as_ref().unwrap();
+        assert!(
+            !state.dirty,
+            "a record past the byte threshold flushes immediately"
+        );
+        assert_eq!(state.unsynced_bytes, 0);
+    }
+
+    /// Under `Group`, a trailing partial batch (below both thresholds) is left
+    /// unsynced until `flush_wal` — the commit-time barrier — makes it durable
+    /// and round-trips it (Issue #542, Phase 4).
+    #[test]
+    fn group_partial_batch_is_made_durable_by_flush_wal() {
+        let log = make_group_log(1000, usize::MAX);
+
+        log.append("e1", small_doc()).unwrap();
+        log.append("e2", small_doc()).unwrap();
+        assert!(
+            log.wal_writer.lock().as_ref().unwrap().dirty,
+            "a partial batch stays unsynced"
+        );
+
+        log.flush_wal().unwrap();
+        {
+            let guard = log.wal_writer.lock();
+            let state = guard.as_ref().unwrap();
+            assert!(!state.dirty, "flush_wal forces the partial batch durable");
+            assert_eq!(state.unsynced_records, 0);
+            assert_eq!(state.unsynced_bytes, 0);
+        }
+
+        assert_eq!(log.read_all().unwrap().len(), 2);
     }
 
     #[test]

--- a/laurus/tests/wal_recovery_test.rs
+++ b/laurus/tests/wal_recovery_test.rs
@@ -7,7 +7,7 @@ use laurus::storage::file::FileStorageConfig;
 use laurus::storage::{StorageConfig, StorageFactory};
 use laurus::vector::FlatOption;
 use laurus::{DataValue, Document};
-use laurus::{FieldOption, LexicalSearchQuery, Schema};
+use laurus::{FieldOption, LexicalSearchQuery, Schema, WalSyncPolicy};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wal_recovery_uncommitted() -> laurus::Result<()> {
@@ -65,6 +65,60 @@ async fn test_wal_recovery_uncommitted() -> laurus::Result<()> {
             search_results.len(),
             1,
             "Document should be recovered from WAL"
+        );
+    }
+
+    Ok(())
+}
+
+/// Under the group-commit policy (Issue #542, Phase 4) appends defer their
+/// fsync, so durability is reached via [`laurus::Engine::flush_wal`] rather than
+/// per-record. A record made durable by `flush_wal` (without a full commit) must
+/// still recover after an uncommitted reopen, just like the per-record case.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wal_recovery_group_commit_flush_wal() -> laurus::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_config = StorageConfig::File(FileStorageConfig::new(temp_dir.path()));
+    let storage = StorageFactory::create(storage_config)?;
+
+    let config = Schema::builder()
+        .add_field("title", FieldOption::Text(TextOption::default()))
+        .add_field("embedding", FieldOption::Flat(FlatOption::default()))
+        .build();
+
+    // Round 1: index under the group-commit policy and force the WAL durable
+    // with flush_wal(), but DO NOT commit.
+    {
+        let engine = Engine::builder(storage.clone(), config.clone())
+            .wal_sync_policy(WalSyncPolicy::group_with_defaults())
+            .build()
+            .await?;
+
+        let doc1 = Document::builder()
+            .add_field("title", DataValue::Text("Rust Programming".into()))
+            .add_field("embedding", DataValue::Vector(vec![0.1; 128]))
+            .build();
+        engine.put_document("doc1", doc1).await?;
+
+        // The group policy defers the fsync; flush_wal makes the partial batch
+        // durable. Drop the engine WITHOUT commit.
+        engine.flush_wal()?;
+    }
+
+    // Round 2: recover from the WAL.
+    {
+        let engine = Engine::new(storage.clone(), config.clone()).await?;
+        engine.commit().await?;
+
+        let query = Box::new(TermQuery::new("title", "rust"));
+        let search_request = laurus::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::Obj(query))
+            .build();
+        let search_results = engine.search(search_request).await?;
+        assert_eq!(
+            search_results.len(),
+            1,
+            "flush_wal'd group-commit record should recover from WAL"
         );
     }
 


### PR DESCRIPTION
## Summary

Phase 4a of #542 (WAL group commit) — the one contract change in this campaign, gated behind an opt-in flag (**default-off**). Adds a `WalSyncPolicy` that defers and batches the per-append fsync, trading per-write durability for ingest throughput. The default (`PerRecord`) is unchanged, so existing code keeps its per-write durability with no behavior change. Phases 0–3 (#814, #815, #816, #817) already landed.

This is the **core mechanism, without the timer**; the background-timer trigger ships as Phase 4b (see follow-ups) to isolate its WASM/lifecycle complexity.

## What's new

- **`WalSyncPolicy::{PerRecord (default), Group { max_records, max_bytes }}`** with `DEFAULT_GROUP_MAX_RECORDS` (1024) / `DEFAULT_GROUP_MAX_BYTES` (1 MiB) and a `group_with_defaults()` helper. Re-exported at the crate root.
- **`DocumentLog::with_sync_policy()`**; `new()` stays a `PerRecord` wrapper. The writer tracks unsynced record/byte counts; under `Group`, an append flushes once **either** threshold is reached (`batch_ready`), otherwise defers. `commit()`'s `flush_wal` barrier (Phase 3) forces any trailing partial batch durable.
- **`EngineBuilder::wal_sync_policy()`** (additive, default `PerRecord`) and a public **`Engine::flush_wal()`** to force the WAL durable on demand without a full commit (SQLite-checkpoint style).

## Durability semantics

| Policy | Durability | Throughput | Analogue |
| :--- | :--- | :--- | :--- |
| `PerRecord` (default) | Every successful write is durable | one fsync per write | SQLite `synchronous = FULL` |
| `Group { max_records, max_bytes }` | A crash may lose up to the last unsynced batch | fsync amortized over a batch | SQLite `synchronous = NORMAL` |

`commit()` is a hard barrier under both policies. A torn trailing record is never resurrected: CRC framing + prefix-stop on recovery means group commit only ever risks losing a *suffix* of recent writes, never corrupting earlier ones.

## Scope / binding impact

Default-off and purely additive. All **nine** workspace members — including every language binding (python, nodejs, wasm, ruby, php) — compile unchanged. Exposing group commit through proto/bindings is intentionally out of scope (separate issue).

## Verification

- `store::log` unit tests: **18** (5 new): `sync_policy_defaults`, `group_policy_defers_then_flushes_at_record_threshold`, `group_policy_flushes_at_byte_threshold`, `group_partial_batch_is_made_durable_by_flush_wal`.
- Engine: `test_group_commit_policy_is_wired_and_searchable` (builder wiring + `flush_wal` + searchable commit).
- Integration: `wal_recovery_test` **2 pass** (new `test_wal_recovery_group_commit_flush_wal` — a `flush_wal`'d group-mode record recovers after an uncommitted reopen on FileStorage).
- Full `laurus` lib: **1163 pass**.
- `cargo fmt --check` / `cargo clippy --tests -- -D warnings` / `markdownlint-cli2`: clean.

## Docs

EN/JA "WAL Durability Policy" section in `persistence.md` + API reference entries for `wal_sync_policy` / `flush_wal`.

## Follow-ups (to be filed and linked)

- Phase 4b: background-timer flush trigger (with WASM cfg separation).
- proto/binding exposure of group commit.
- `last_wal_seq` co-durability hardening.
- binary WAL payload re-encoding.

Refs #542