### PR TITLE
feat(store/wal): periodic WAL flush timer for group commit (#542 Phase 4b)

### DIFF
--- a/docs/ja/src/laurus/persistence.md
+++ b/docs/ja/src/laurus/persistence.md
@@ -107,15 +107,28 @@ engine.add_document("doc-3", doc3).await?;
 
 ```rust
 use laurus::WalSyncPolicy;
+use std::time::Duration;
 
 let engine = Engine::builder(storage, schema)
-    // 既定閾値（1024 件 / 1 MiB）でのグループコミット。
+    // 既定閾値（1024 件 / 1 MiB）でのグループコミット（timer なし）。
     .wal_sync_policy(WalSyncPolicy::group_with_defaults())
-    // ...または任意のバッチサイズを指定:
-    // .wal_sync_policy(WalSyncPolicy::Group { max_records: 4096, max_bytes: 4 * 1024 * 1024 })
+    // ...既定閾値 + 500 ms ごとの定期 flush:
+    // .wal_sync_policy(WalSyncPolicy::group_with_interval(Duration::from_millis(500)))
+    // ...または任意のバッチサイズと timer を指定:
+    // .wal_sync_policy(WalSyncPolicy::Group {
+    //     max_records: 4096,
+    //     max_bytes: 4 * 1024 * 1024,
+    //     max_interval: Some(Duration::from_secs(1)),
+    // })
     .build()
     .await?;
 ```
+
+### 定期 flush タイマー
+
+`Group.max_interval` はサイズベースの閾値に時間上限を加えます。設定すると、エンジンは少なくともその間隔ごとに WAL を強制 durable 化する background timer を起動します。これにより、**低い取り込みレート**（record/byte 閾値に到達しない場合）でも末尾の partial batch が無期限に未 sync のまま残ることを防ぎます。保留中のものが無ければ flush は no-op なので、アイドルな timer のコストはゼロです。`None` で timer を無効化します。
+
+> **WASM 注意:** timer は native ターゲットのみで有効です。`wasm32` には background thread が無いため `max_interval` は無視され、耐久性は record/byte 閾値・`commit()`・`flush_wal()` に依存します。
 
 ### 耐久性の保証
 

--- a/docs/src/laurus/persistence.md
+++ b/docs/src/laurus/persistence.md
@@ -107,15 +107,28 @@ Under `Group`, the fsync is deferred and issued once **either** `max_records` re
 
 ```rust
 use laurus::WalSyncPolicy;
+use std::time::Duration;
 
 let engine = Engine::builder(storage, schema)
-    // Group commit with the default thresholds (1024 records / 1 MiB).
+    // Group commit with the default thresholds (1024 records / 1 MiB), no timer.
     .wal_sync_policy(WalSyncPolicy::group_with_defaults())
-    // ...or choose your own batch size:
-    // .wal_sync_policy(WalSyncPolicy::Group { max_records: 4096, max_bytes: 4 * 1024 * 1024 })
+    // ...the default thresholds plus a periodic flush every 500 ms:
+    // .wal_sync_policy(WalSyncPolicy::group_with_interval(Duration::from_millis(500)))
+    // ...or choose your own batch size and timer:
+    // .wal_sync_policy(WalSyncPolicy::Group {
+    //     max_records: 4096,
+    //     max_bytes: 4 * 1024 * 1024,
+    //     max_interval: Some(Duration::from_secs(1)),
+    // })
     .build()
     .await?;
 ```
+
+### Periodic Flush Timer
+
+`Group.max_interval` adds a time bound to the size-based thresholds. When set, the engine runs a background timer that forces the WAL durable at least that often, so a trailing partial batch under a **low ingest rate** — where the record/byte thresholds may never be reached — is not left unsynced indefinitely. The flush is a no-op when nothing is pending, so an idle timer costs nothing. `None` disables the timer.
+
+> **WASM note:** the timer is honored on native targets only. On `wasm32` there are no background threads, so `max_interval` is ignored; durability there relies on the record/byte thresholds, `commit()`, and `flush_wal()`.
 
 ### Durability Guarantees
 

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -38,6 +38,74 @@ pub struct EngineStats {
     pub vector_fields: HashMap<String, crate::vector::index::field::VectorFieldStats>,
 }
 
+/// Background timer that periodically forces the WAL durable under a
+/// [`WalSyncPolicy::Group`] configured with a `max_interval` (Issue #542, Phase
+/// 4b).
+///
+/// Runs a dedicated thread that calls [`DocumentLog::flush_wal`] every interval
+/// — a no-op when nothing is pending, thanks to the dirty guard — so a trailing
+/// partial batch under a low ingest rate is not left unsynced indefinitely (the
+/// record/byte thresholds may never be reached). Dropping the timer wakes the
+/// thread immediately and joins it. Native targets only; on `wasm32` (no
+/// background threads) the timer is never constructed and the interval is
+/// ignored.
+#[cfg(not(target_arch = "wasm32"))]
+struct WalFlushTimer {
+    /// Sending on (or dropping) this channel signals the thread to stop.
+    stop: std::sync::mpsc::Sender<()>,
+    /// Join handle for the flush thread, taken and joined on drop.
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl WalFlushTimer {
+    /// Spawn the flush thread for `doc_log`, forcing the WAL durable every
+    /// `interval`.
+    ///
+    /// # Arguments
+    ///
+    /// * `doc_log` - The document log whose WAL is flushed on each tick.
+    /// * `interval` - How often to flush the WAL.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the OS thread cannot be spawned.
+    fn spawn(doc_log: Arc<DocumentLog>, interval: std::time::Duration) -> Result<Self> {
+        use std::sync::mpsc::RecvTimeoutError;
+
+        let (stop, rx) = std::sync::mpsc::channel::<()>();
+        let handle = std::thread::Builder::new()
+            .name("laurus-wal-flush".to_string())
+            .spawn(move || {
+                // Keep ticking while each wait ends in a timeout: flush the WAL
+                // (a no-op when there is nothing pending). Any other outcome — a
+                // stop signal (`Ok`) or the sender being dropped (`Disconnected`)
+                // — ends the loop and the thread.
+                while let Err(RecvTimeoutError::Timeout) = rx.recv_timeout(interval) {
+                    if let Err(e) = doc_log.flush_wal() {
+                        log::warn!("WAL flush timer: failed to flush WAL: {e}");
+                    }
+                }
+            })?;
+        Ok(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for WalFlushTimer {
+    fn drop(&mut self) {
+        // Wake the thread immediately so it exits without waiting out the
+        // current interval, then join it.
+        let _ = self.stop.send(());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 /// Unified Engine that manages both Lexical and Vector indices.
 ///
 /// This engine acts as a facade, coordinating document ingestion and search
@@ -64,6 +132,12 @@ pub struct Engine {
     /// built in [`Self::unified_query_parser`], so both the direct
     /// `Payloads` path and the DSL path hit the same cache.
     embedding_cache: Option<Arc<EmbeddingCache>>,
+    /// Background WAL flush timer for a [`WalSyncPolicy::Group`] configured with
+    /// a `max_interval`. `None` when no interval is set. Held only to keep the
+    /// timer thread alive for the engine's lifetime; dropping the engine stops
+    /// it. Absent on `wasm32` (no background threads — the interval is ignored).
+    #[cfg(not(target_arch = "wasm32"))]
+    _wal_flush_timer: Option<WalFlushTimer>,
 }
 
 use crate::engine::search::{FusionAlgorithm, SearchResult};
@@ -1826,6 +1900,14 @@ impl EngineBuilder {
             .and_then(NonZeroUsize::new)
             .map(|cap| Arc::new(EmbeddingCache::new(cap)));
 
+        // Start the periodic WAL flush timer when the policy is a group commit
+        // with an interval. Native only; on wasm32 the interval is ignored.
+        #[cfg(not(target_arch = "wasm32"))]
+        let wal_flush_timer = match self.wal_sync_policy.flush_interval() {
+            Some(interval) => Some(WalFlushTimer::spawn(Arc::clone(&log), interval)?),
+            None => None,
+        };
+
         let engine = Engine {
             schema: RwLock::new(self.schema),
             lexical,
@@ -1833,6 +1915,8 @@ impl EngineBuilder {
             log,
             runtime_analyzers: self.runtime_analyzers,
             embedding_cache,
+            #[cfg(not(target_arch = "wasm32"))]
+            _wal_flush_timer: wal_flush_timer,
         };
 
         engine.recover().await?;
@@ -2123,6 +2207,94 @@ mod tests {
             .build();
         let results = engine.search(request).await.unwrap();
         assert_eq!(results.len(), 1, "group-committed doc must be searchable");
+    }
+
+    /// The background flush timer forces a dirty (deferred) WAL writer durable
+    /// within its interval, then stops cleanly on drop (Issue #542, Phase 4b).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn wal_flush_timer_flushes_dirty_writer_and_stops_on_drop() {
+        use std::time::Duration;
+
+        let wal_storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let doc_storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        // Thresholds high enough that a single append never trips them, so only
+        // the timer can flush the writer.
+        let log = Arc::new(
+            DocumentLog::with_sync_policy(
+                wal_storage,
+                "engine.wal",
+                doc_storage,
+                WalSyncPolicy::Group {
+                    max_records: usize::MAX,
+                    max_bytes: usize::MAX,
+                    max_interval: Some(Duration::from_millis(20)),
+                },
+            )
+            .unwrap(),
+        );
+
+        log.append("doc1", Document::builder().add_text("title", "x").build())
+            .unwrap();
+        assert!(
+            log.wal_is_dirty(),
+            "the deferred append leaves the writer dirty"
+        );
+
+        let timer = WalFlushTimer::spawn(Arc::clone(&log), Duration::from_millis(20)).unwrap();
+
+        // Poll up to ~2s for the timer to flush the writer.
+        let mut flushed = false;
+        for _ in 0..200 {
+            if !log.wal_is_dirty() {
+                flushed = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            flushed,
+            "the timer should flush the dirty writer within its interval"
+        );
+
+        // Dropping the timer must return promptly (clean shutdown / thread join).
+        drop(timer);
+    }
+
+    /// An engine built with a group-commit policy that includes a flush interval
+    /// starts and stops its background timer without hanging on drop (Issue
+    /// #542, Phase 4b).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn test_group_commit_with_interval_builds_and_drops_cleanly() {
+        use std::time::Duration;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "title",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+            )
+            .build();
+
+        let engine = Engine::builder(storage, schema)
+            .wal_sync_policy(WalSyncPolicy::group_with_interval(Duration::from_millis(
+                20,
+            )))
+            .build()
+            .await
+            .unwrap();
+
+        engine
+            .add_document(
+                "doc1",
+                Document::builder().add_text("title", "timer").build(),
+            )
+            .await
+            .unwrap();
+
+        // Dropping the engine must stop the background timer without hanging.
+        drop(engine);
     }
 
     #[tokio::test]

--- a/laurus/src/store/log.rs
+++ b/laurus/src/store/log.rs
@@ -45,6 +45,7 @@
 use std::io::{Read, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
@@ -108,6 +109,17 @@ pub enum WalSyncPolicy {
         /// Flush once this many appended bytes have accumulated since the last
         /// sync.
         max_bytes: usize,
+        /// Optional periodic flush interval. When `Some`, the engine runs a
+        /// background timer that forces the WAL durable at least this often, so
+        /// a trailing partial batch under a low ingest rate is not left unsynced
+        /// indefinitely (the record/byte thresholds may never be reached).
+        /// `None` disables the timer, leaving durability to the thresholds,
+        /// [`commit`](crate::Engine::commit), and
+        /// [`flush_wal`](crate::Engine::flush_wal).
+        ///
+        /// Honored on native targets only; on `wasm32` (no background threads)
+        /// the interval is ignored.
+        max_interval: Option<Duration>,
     },
 }
 
@@ -128,11 +140,41 @@ pub const DEFAULT_GROUP_MAX_BYTES: usize = 1024 * 1024;
 impl WalSyncPolicy {
     /// A [`WalSyncPolicy::Group`] policy using the default batch thresholds
     /// ([`DEFAULT_GROUP_MAX_RECORDS`] records / [`DEFAULT_GROUP_MAX_BYTES`]
-    /// bytes, whichever is reached first).
+    /// bytes, whichever is reached first) and **no** periodic flush timer.
     pub fn group_with_defaults() -> Self {
         Self::Group {
             max_records: DEFAULT_GROUP_MAX_RECORDS,
             max_bytes: DEFAULT_GROUP_MAX_BYTES,
+            max_interval: None,
+        }
+    }
+
+    /// A [`WalSyncPolicy::Group`] policy using the default batch thresholds plus
+    /// a periodic flush `interval`, so a trailing partial batch is forced
+    /// durable at least every `interval` even under a low ingest rate.
+    ///
+    /// The timer is honored on native targets only; on `wasm32` the interval is
+    /// ignored (see [`WalSyncPolicy::Group::max_interval`]).
+    ///
+    /// # Arguments
+    ///
+    /// * `interval` - Maximum time a partial batch may remain unsynced.
+    pub fn group_with_interval(interval: Duration) -> Self {
+        Self::Group {
+            max_records: DEFAULT_GROUP_MAX_RECORDS,
+            max_bytes: DEFAULT_GROUP_MAX_BYTES,
+            max_interval: Some(interval),
+        }
+    }
+
+    /// The periodic flush interval for this policy, if any.
+    ///
+    /// Returns the `max_interval` of a [`WalSyncPolicy::Group`], or `None` for
+    /// [`WalSyncPolicy::PerRecord`] or a `Group` without a timer.
+    pub fn flush_interval(&self) -> Option<Duration> {
+        match self {
+            Self::Group { max_interval, .. } => *max_interval,
+            Self::PerRecord => None,
         }
     }
 }
@@ -488,6 +530,8 @@ impl DocumentLog {
             WalSyncPolicy::Group {
                 max_records,
                 max_bytes,
+                // The timer is driven by the engine, not the per-append path.
+                max_interval: _,
             } => state.as_ref().is_some_and(|s| {
                 s.unsynced_records >= max_records.max(1) || s.unsynced_bytes >= max_bytes.max(1)
             }),
@@ -510,6 +554,19 @@ impl DocumentLog {
     pub fn flush_wal(&self) -> Result<()> {
         let mut writer_guard = self.wal_writer.lock();
         Self::flush_writer(&mut writer_guard)
+    }
+
+    /// Test-only: whether the open writer has appended-but-unsynced bytes.
+    ///
+    /// Lets tests observe that a deferred (group-commit) batch has been flushed
+    /// — e.g. by the background flush timer — without exposing the writer
+    /// internals outside the crate.
+    #[cfg(test)]
+    pub(crate) fn wal_is_dirty(&self) -> bool {
+        self.wal_writer
+            .lock()
+            .as_ref()
+            .is_some_and(|state| state.dirty)
     }
 
     /// Read all records from the WAL.
@@ -767,7 +824,8 @@ mod tests {
         DocumentLog::new(wal_storage, "test.log", doc_storage).unwrap()
     }
 
-    /// A log under [`WalSyncPolicy::Group`] with the given batch thresholds.
+    /// A log under [`WalSyncPolicy::Group`] with the given batch thresholds and
+    /// no flush timer.
     fn make_group_log(max_records: usize, max_bytes: usize) -> DocumentLog {
         DocumentLog::with_sync_policy(
             make_storage(),
@@ -776,6 +834,7 @@ mod tests {
             WalSyncPolicy::Group {
                 max_records,
                 max_bytes,
+                max_interval: None,
             },
         )
         .unwrap()
@@ -986,7 +1045,7 @@ mod tests {
     }
 
     /// The default policy is per-record, and `group_with_defaults` uses the
-    /// documented batch thresholds (Issue #542, Phase 4).
+    /// documented batch thresholds with no flush timer (Issue #542, Phase 4).
     #[test]
     fn sync_policy_defaults() {
         assert_eq!(WalSyncPolicy::default(), WalSyncPolicy::PerRecord);
@@ -995,7 +1054,13 @@ mod tests {
             WalSyncPolicy::Group {
                 max_records: DEFAULT_GROUP_MAX_RECORDS,
                 max_bytes: DEFAULT_GROUP_MAX_BYTES,
+                max_interval: None,
             }
+        );
+        assert_eq!(WalSyncPolicy::group_with_defaults().flush_interval(), None);
+        assert_eq!(
+            WalSyncPolicy::group_with_interval(Duration::from_millis(50)).flush_interval(),
+            Some(Duration::from_millis(50))
         );
     }
 


### PR DESCRIPTION
## Summary

Phase 4b of #542 (WAL group commit) — closes #819. Adds an optional **time-based** flush trigger to `WalSyncPolicy::Group` so a trailing partial batch under a **low ingest rate** is not left unsynced indefinitely (the record/byte thresholds may never be reached). Default-off; Phase 4a (#818) shipped the count/byte thresholds.

## What's new

- **`WalSyncPolicy::Group` gains `max_interval: Option<Duration>`**, with `group_with_interval(interval)` and `flush_interval()` helpers. `group_with_defaults()` keeps `max_interval = None` (no timer), preserving Phase 4a behavior.
- **`WalFlushTimer`** runs a dedicated `std::thread` that calls `DocumentLog::flush_wal` every interval — a no-op when nothing is pending, thanks to the dirty guard, so an idle timer costs nothing. Dropping the timer wakes the thread (an `mpsc` stop signal) and joins it for prompt, clean shutdown.
- **`EngineBuilder::build()`** spawns the timer when the policy carries an interval; the `Engine` holds it, so dropping the engine stops it.

## WASM

The timer is gated behind `cfg(not(target_arch = "wasm32"))`, matching the existing `util/time.rs` pattern. On `wasm32` there are no background threads, so `max_interval` is ignored and durability relies on the record/byte thresholds, `commit()`, and `flush_wal()`. `laurus-wasm` compiles for `wasm32-unknown-unknown`.

## Why std::thread (not tokio)

The core crate depends on `tokio` with only `["sync", "macros"]` (no `rt`/`time`). A dedicated `std::thread` + `mpsc::recv_timeout` is runtime-agnostic and keeps the flush off the async runtime; `flush_wal` is synchronous.

## Scope / binding impact

Default-off and additive (the `Group` enum gains one field; no binding constructs it). All **nine** workspace members build, and `laurus-wasm` builds for `wasm32`, so there is **no language-binding impact**.

## Verification

- `store::log`: `sync_policy_defaults` extended with `flush_interval()` assertions; new `cfg(test)` `wal_is_dirty` accessor.
- Engine (native): `wal_flush_timer_flushes_dirty_writer_and_stops_on_drop` (timer flushes a deferred dirty writer within its interval, then drops cleanly) and `test_group_commit_with_interval_builds_and_drops_cleanly` (build + drop lifecycle, no hang).
- Full `laurus` lib: **1165 pass**; `wal_recovery` integration: **2 pass**.
- `cargo fmt --check` / `cargo clippy --tests -- -D warnings` / `markdownlint-cli2`: clean.
- `cargo build -p laurus-wasm --target wasm32-unknown-unknown`: clean.

## Docs

EN/JA "Periodic Flush Timer" subsection + WASM caveat in `persistence.md`, and the builder example updated for `max_interval`.

Refs #542
Closes #819