### PR TITLE
feat(server,bindings): expose WAL group commit through proto, server, and bindings (#820)

### DIFF
--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -9,6 +9,7 @@ class Index {
   static create(
     path?: string | null,
     schema?: Schema,
+    walSyncPolicy?: WalSyncPolicy,
   ): Promise<Index>;
 }
 ```
@@ -19,6 +20,7 @@ class Index {
 | :--- | :--- | :--- | :--- |
 | `path` | `string \| null` | `null` | 永続化ストレージのディレクトリ。`null` でインメモリ。 |
 | `schema` | `Schema` | 空 | スキーマ定義。 |
+| `walSyncPolicy` | `WalSyncPolicy` | レコードごと | WAL の永続性ポリシー。省略するとデフォルトのレコードごとの `fsync` を使用します。[WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照。 |
 
 ### メソッド
 
@@ -29,6 +31,7 @@ class Index {
 | `getDocuments(id)` | 指定 ID の全バージョンを取得。 |
 | `deleteDocuments(id)` | 指定 ID の全バージョンを削除。 |
 | `commit()` | 書き込みをフラッシュし変更を検索可能にする。 |
+| `flushWal()` | WAL の永続性バリアを強制する。[WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照。 |
 | `search(query, limit?, offset?)` | DSL 文字列で検索。 |
 | `searchTerm(field, term, limit?, offset?)` | 完全一致 Term 検索。 |
 | `searchVector(field, vector, limit?, offset?)` | 事前計算ベクトルで検索。 |
@@ -48,6 +51,70 @@ interface IndexStats {
   vectorFields: Record<string, { count: number; dimension: number }>;
 }
 ```
+
+### WAL 同期ポリシー / 永続性
+
+永続インデックスでは、すべての書き込みが先行書き込みログ（WAL）に追記されます。
+デフォルトでは WAL は**すべての**レコードごとに `fsync` されるため、Promise が
+解決した時点で各書き込みは完全に永続化されます。`Index.create` はオプションの
+`walSyncPolicy` を受け付け、永続性を一部犠牲にして書き込みスループットを
+向上させることができます。また `flushWal()` で必要なときに永続性バリアを
+強制できます。
+
+```typescript
+class WalSyncPolicy {
+  static perRecord(): WalSyncPolicy;
+  static group(
+    maxRecords?: number,
+    maxBytes?: number,
+    maxIntervalMs?: number,
+  ): WalSyncPolicy;
+}
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `WalSyncPolicy.perRecord()` | デフォルト。WAL レコードごとに `fsync` し、書き込みごとに完全に永続化します。 |
+| `WalSyncPolicy.group(...)` | グループコミット。複数の書き込みにまたがって `fsync` をまとめます。 |
+
+`group(...)` のパラメータ（引数を省略するとそのデフォルトを維持）:
+
+| パラメータ | デフォルト | 説明 |
+| :--- | :--- | :--- |
+| `maxRecords` | `1024` | この件数のレコードが蓄積されたらフラッシュします。 |
+| `maxBytes` | `1048576`（1 MiB） | この量の未同期バイトが蓄積されたらフラッシュします。 |
+| `maxIntervalMs` | なし | 任意の定期フラッシュタイマー（ミリ秒）。省略するとタイマー無効。 |
+
+グループコミットでは、`maxRecords` または `maxBytes` の**いずれか**に達した
+時点で WAL がフラッシュされ、`commit()` 時にも必ずフラッシュされます。
+クラッシュ時には最後の未同期バッチまでを失う可能性があります — これは
+SQLite の `synchronous = NORMAL` と同じトレードオフです。完全な `commit()` を
+行わずにこれまで書き込んだ内容をディスクへ強制するには `flushWal()` を
+呼び出します。
+
+| メソッド | 説明 |
+| :--- | :--- |
+| `flushWal()` | 今すぐ WAL の永続性バリアを強制します。`Promise<void>` を返します。 |
+
+```javascript
+import { Index, WalSyncPolicy } from "laurus-nodejs";
+
+// 1 秒の定期フラッシュタイマー付きでグループコミットを有効化します。
+const policy = WalSyncPolicy.group(4096, undefined, 1000);
+const index = await Index.create("./myindex", schema, policy);
+
+for (let i = 0; i < 10000; i++) {
+  await index.putDocument(`doc${i}`, { title: `Document ${i}` });
+}
+
+// まだコミットせずに永続性バリアを強制します。
+await index.flushWal();
+
+await index.commit(); // WAL もフラッシュされます
+```
+
+`walSyncPolicy` を省略する（または `WalSyncPolicy.perRecord()` を渡す）と、
+デフォルトの完全に永続的な動作が維持されます。
 
 ---
 

--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -5,7 +5,7 @@
 Laurus 検索エンジンをラップするメインクラスです。
 
 ```php
-new \Laurus\Index(?string $path = null, ?Schema $schema = null)
+new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $wal_sync_policy = null)
 ```
 
 ### コンストラクタ
@@ -14,6 +14,7 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null)
 | :--- | :--- | :--- | :--- |
 | `$path` | `string\|null` | `null` | 永続ストレージのディレクトリパス。`null` の場合はインメモリインデックスを作成します。 |
 | `$schema` | `Schema\|null` | `null` | スキーマ定義。省略時は空のスキーマが使用されます。 |
+| `$wal_sync_policy` | `WalSyncPolicy\|null` | `null` | 先行書き込みログ（WAL）の耐久性ポリシー。`null` の場合はデフォルトのレコードごと fsync を維持します。[WAL 同期ポリシーと耐久性](#wal-同期ポリシーと耐久性) を参照。 |
 
 ### メソッド
 
@@ -24,6 +25,7 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null)
 | `getDocuments(string $id): array` | 指定 ID の全保存バージョンを返します。 |
 | `deleteDocuments(string $id): void` | 指定 ID の全バージョンを削除します。 |
 | `commit(): void` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |
+| `flushWal(): void` | WAL の耐久バリアをオンデマンドで強制します。未同期の WAL レコードを同期的に fsync します。group-commit ポリシー下で実行する場合に有用です（下記参照）。 |
 | `search(mixed $query, int $limit = 10, int $offset = 0): array` | 検索クエリを実行します。`SearchResult` の配列を返します。 |
 | `searchBatch(array $queries, int $limit = 10, int $offset = 0): array` | 独立した複数の検索を 1 回の呼び出しで実行します。各クエリは内部の tokio ランタイム上で並列に dispatch されます。`results[i]` は `queries[i]` に対応し、`SearchResult` の配列の配列を返します。入力が空の配列の場合は `[]` を返します。 |
 | `stats(): array` | インデックス統計（`"documentCount"`、`"vectorFields"`）を返します。 |
@@ -38,6 +40,57 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null)
 - **`SearchRequest`**（完全な制御が必要な場合）
 
 `searchBatch` の `$queries` 配列の各要素も同じ種類の値を受け付けます。DSL 文字列・クエリオブジェクト・`SearchRequest` を 1 つのバッチ内で混在させることもできます。
+
+### WAL 同期ポリシーと耐久性
+
+先行書き込みログ（WAL: Write-Ahead Log）は、コミット済みデータをクラッシュ
+から保護します。デフォルトでは WAL は完全に耐久的で、すべてのレコードは
+書き込みが返る前に `fsync` されます。**group commit（グループコミット）**
+を有効にすると、`fsync` 呼び出しをまとめることで、耐久性をいくらか引き換えに
+書き込みスループットを向上させられます。
+
+#### WalSyncPolicy
+
+`Laurus\WalSyncPolicy` は WAL のフラッシュ方法を記述するイミュータブルな
+値オブジェクトです。`Index` コンストラクタの `$wal_sync_policy` 引数に渡します。
+
+```php
+// デフォルト: 書き込みごとに耐久（各レコードを個別に fsync）。
+\Laurus\WalSyncPolicy::perRecord(): WalSyncPolicy
+
+// Group commit: fsync をまとめてコストを償却。
+\Laurus\WalSyncPolicy::group(
+    ?int $max_records = null,      // このレコード数でフラッシュ（デフォルト 1024）
+    ?int $max_bytes = null,        // このバイト数でフラッシュ（デフォルト 1 MiB）
+    ?int $max_interval_ms = null,  // このミリ秒ごとに定期的にもフラッシュ
+): WalSyncPolicy
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `WalSyncPolicy::perRecord()` | デフォルト。すべてのレコードは書き込みが返る前に `fsync` されます。書き込みごとに完全に耐久的です。 |
+| `WalSyncPolicy::group($max_records, $max_bytes, $max_interval_ms)` | `fsync` をまとめます。すべての引数が `null` の場合はデフォルト（`max_records = 1024`、`max_bytes = 1 MiB`、タイマーなし）を使用します。WAL は `$max_records` **または** `$max_bytes` のいずれかが蓄積したとき、および毎回の `commit()` 時にフラッシュされます。`$max_interval_ms` を指定すると、定期タイマーでもフラッシュします。 |
+
+Group commit は SQLite の `synchronous = NORMAL` に相当します。クラッシュ時に
+失われるのは最後の未同期バッチのレコードまでで、インデックスが破損する
+ことはありません。レコードは常に `commit()` 時に耐久化されるため、成功した
+`commit()` はポリシーに関わらず耐久バリアとなります。
+
+#### フラッシュの強制
+
+コミットの合間に耐久バリアを強制するには `flushWal()` を呼び出します。
+例えば、バッチが安全に永続化されたことを通知する前などです。未同期の
+レコードを同期的に `fsync` します。デフォルトのレコードごとポリシーでは
+実質的に no-op です。
+
+```php
+// group commit を有効にし、必要に応じて耐久性を強制する。
+$policy = \Laurus\WalSyncPolicy::group(4096, 4 * 1024 * 1024);
+$index = new \Laurus\Index("./myindex", null, $policy);
+
+$index->putDocument("doc1", ["title" => "Hello"]);
+$index->flushWal(); // group バッチが満杯でなくてもレコードが永続化される
+```
 
 ---
 

--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -6,7 +6,12 @@ Laurus 検索エンジンをラップするメインクラスです。
 
 ```python
 class Index:
-    def __init__(self, path: str | None = None, schema: Schema | None = None) -> None: ...
+    def __init__(
+        self,
+        path: str | None = None,
+        schema: Schema | None = None,
+        wal_sync_policy: WalSyncPolicy | None = None,
+    ) -> None: ...
 ```
 
 ### コンストラクタ
@@ -15,6 +20,7 @@ class Index:
 | :--- | :--- | :--- | :--- |
 | `path` | `str \| None` | `None` | 永続ストレージのディレクトリパス。`None` の場合はインメモリインデックスを作成します。 |
 | `schema` | `Schema \| None` | `None` | スキーマ定義。省略時は空のスキーマが使用されます。 |
+| `wal_sync_policy` | `WalSyncPolicy \| None` | `None` | WAL の永続性ポリシー。`None` の場合はデフォルトのレコードごとの `fsync` を使用します。[WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照してください。 |
 
 ### メソッド
 
@@ -25,6 +31,7 @@ class Index:
 | `get_documents(id) -> list[dict]` | 指定 ID の全保存バージョンを返します。 |
 | `delete_documents(id)` | 指定 ID の全バージョンを削除します。 |
 | `commit()` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |
+| `flush_wal()` | WAL の永続性バリアを強制します。[WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照してください。 |
 | `search(query, *, limit=10, offset=0) -> list[SearchResult]` | 検索クエリを実行します。 |
 | `search_batch(queries, *, limit=10, offset=0) -> list[list[SearchResult]]` | 独立した複数の検索を 1 回の呼び出しで実行します。各クエリは内部の tokio ランタイム上で並列に dispatch されます。`results[i]` は `queries[i]` に対応し、入力が空のリストの場合は `[]` を返します。 |
 | `stats() -> dict` | インデックス統計（`document_count`、`vector_fields`）を返します。 |
@@ -39,6 +46,70 @@ class Index:
 - **`SearchRequest`**（完全な制御が必要な場合）
 
 `search_batch` の `queries` リストの各要素も同じ種類の値を受け付けます。DSL 文字列・クエリオブジェクト・`SearchRequest` を 1 つのバッチ内で混在させることもできます。
+
+### WAL 同期ポリシー / 永続性
+
+永続インデックスでは、すべての書き込みが先行書き込みログ（WAL）に追記されます。
+デフォルトでは WAL は**すべての**レコードごとに `fsync` されるため、呼び出しが
+返った時点で各書き込みは完全に永続化されます。コンストラクタはオプションの
+`wal_sync_policy` を受け付け、永続性を一部犠牲にして書き込みスループットを
+向上させることができます。また `flush_wal()` で必要なときに永続性バリアを
+強制できます。
+
+```python
+class WalSyncPolicy:
+    @staticmethod
+    def per_record() -> WalSyncPolicy: ...
+    @staticmethod
+    def group(
+        max_records: int | None = None,
+        max_bytes: int | None = None,
+        max_interval_ms: int | None = None,
+    ) -> WalSyncPolicy: ...
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `WalSyncPolicy.per_record()` | デフォルト。WAL レコードごとに `fsync` し、書き込みごとに完全に永続化します。 |
+| `WalSyncPolicy.group(...)` | グループコミット。複数の書き込みにまたがって `fsync` をまとめます。 |
+
+`group()` のパラメータ（いずれもキーワード指定可。`None` はデフォルトを維持）:
+
+| パラメータ | デフォルト | 説明 |
+| :--- | :--- | :--- |
+| `max_records` | `1024` | この件数のレコードが蓄積されたらフラッシュします。 |
+| `max_bytes` | `1048576`（1 MiB） | この量の未同期バイトが蓄積されたらフラッシュします。 |
+| `max_interval_ms` | `None` | 任意の定期フラッシュタイマー（ミリ秒）。`None` でタイマー無効。 |
+
+グループコミットでは、`max_records` または `max_bytes` の**いずれか**に達した
+時点で WAL がフラッシュされ、`commit()` 時にも必ずフラッシュされます。
+クラッシュ時には最後の未同期バッチまでを失う可能性があります — これは
+SQLite の `synchronous = NORMAL` と同じトレードオフです。完全な `commit()` を
+行わずにこれまで書き込んだ内容をディスクへ強制するには `flush_wal()` を
+呼び出します。
+
+| メソッド | 説明 |
+| :--- | :--- |
+| `flush_wal()` | 今すぐ WAL の永続性バリアを強制します。同期メソッドで `None` を返します。 |
+
+```python
+import laurus
+
+# 1 秒の定期フラッシュタイマー付きでグループコミットを有効化します。
+policy = laurus.WalSyncPolicy.group(max_records=4096, max_interval_ms=1000)
+index = laurus.Index(path="./myindex", wal_sync_policy=policy)
+
+for i in range(10_000):
+    index.put_document(f"doc{i}", {"title": f"Document {i}"})
+
+# まだコミットせずに永続性バリアを強制します。
+index.flush_wal()
+
+index.commit()  # WAL もフラッシュされます
+```
+
+`wal_sync_policy` を省略する（または `WalSyncPolicy.per_record()` を渡す）と、
+デフォルトの完全に永続的な動作が維持されます。
 
 ---
 

--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -5,7 +5,7 @@
 Laurus 検索エンジンをラップするメインクラスです。
 
 ```ruby
-Laurus::Index.new(path: nil, schema: nil)
+Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil)
 ```
 
 ### コンストラクタ
@@ -14,6 +14,7 @@ Laurus::Index.new(path: nil, schema: nil)
 | :--- | :--- | :--- | :--- |
 | `path:` | `String \| nil` | `nil` | 永続ストレージのディレクトリパス。`nil` の場合はインメモリインデックスを作成します。 |
 | `schema:` | `Schema \| nil` | `nil` | スキーマ定義。省略時は空のスキーマが使用されます。 |
+| `wal_sync_policy:` | `WalSyncPolicy \| nil` | `nil` | 先行書き込みログ（WAL）の耐久性ポリシー。`nil` の場合はデフォルトのレコードごと fsync を維持します。[WAL 同期ポリシーと耐久性](#wal-同期ポリシーと耐久性) を参照。 |
 
 ### メソッド
 
@@ -24,6 +25,7 @@ Laurus::Index.new(path: nil, schema: nil)
 | `get_documents(id) -> Array<Hash>` | 指定 ID の全保存バージョンを返します。 |
 | `delete_documents(id)` | 指定 ID の全バージョンを削除します。 |
 | `commit` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |
+| `flush_wal` | WAL の耐久バリアをオンデマンドで強制します。未同期の WAL レコードを同期的に fsync し、`nil` を返します。group-commit ポリシー下で実行する場合に有用です（下記参照）。 |
 | `search(query, limit: 10, offset: 0) -> Array<SearchResult>` | 検索クエリを実行します。 |
 | `search_batch(queries, limit: 10, offset: 0) -> Array<Array<SearchResult>>` | 独立した複数の検索を 1 回の呼び出しで実行します。各クエリは内部の tokio ランタイム上で並列に dispatch されます。`results[i]` は `queries[i]` に対応し、入力が空の配列の場合は `[]` を返します。 |
 | `stats -> Hash` | インデックス統計（`"document_count"`、`"vector_fields"`）を返します。 |
@@ -38,6 +40,57 @@ Laurus::Index.new(path: nil, schema: nil)
 - **`SearchRequest`**（完全な制御が必要な場合）
 
 `search_batch` の `queries` 配列の各要素も同じ種類の値を受け付けます。DSL 文字列・クエリオブジェクト・`SearchRequest` を 1 つのバッチ内で混在させることもできます。
+
+### WAL 同期ポリシーと耐久性
+
+先行書き込みログ（WAL: Write-Ahead Log）は、コミット済みデータをクラッシュ
+から保護します。デフォルトでは WAL は完全に耐久的で、すべてのレコードは
+書き込みが返る前に `fsync` されます。**group commit（グループコミット）**
+を有効にすると、`fsync` 呼び出しをまとめることで、耐久性をいくらか引き換えに
+書き込みスループットを向上させられます。
+
+#### WalSyncPolicy
+
+`Laurus::WalSyncPolicy` は WAL のフラッシュ方法を記述するイミュータブルな
+値オブジェクトです。`Index.new(wal_sync_policy:)` に渡します。
+
+```ruby
+# デフォルト: 書き込みごとに耐久（各レコードを個別に fsync）。
+Laurus::WalSyncPolicy.per_record
+
+# Group commit: fsync をまとめてコストを償却。
+Laurus::WalSyncPolicy.group(
+  max_records: nil,      # このレコード数でフラッシュ（デフォルト 1024）
+  max_bytes: nil,        # このバイト数でフラッシュ（デフォルト 1 MiB）
+  max_interval_ms: nil,  # このミリ秒ごとに定期的にもフラッシュ
+)
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `WalSyncPolicy.per_record` | デフォルト。すべてのレコードは書き込みが返る前に `fsync` されます。書き込みごとに完全に耐久的です。 |
+| `WalSyncPolicy.group(max_records:, max_bytes:, max_interval_ms:)` | `fsync` をまとめます。引数なしの場合はデフォルト（`max_records: 1024`、`max_bytes: 1 MiB`、タイマーなし）を使用します。WAL は `max_records` **または** `max_bytes` のいずれかが蓄積したとき、および毎回の `commit` 時にフラッシュされます。`max_interval_ms:` を指定すると、定期タイマーでもフラッシュします。 |
+
+Group commit は SQLite の `synchronous = NORMAL` に相当します。クラッシュ時に
+失われるのは最後の未同期バッチのレコードまでで、インデックスが破損する
+ことはありません。レコードは常に `commit` 時に耐久化されるため、成功した
+`commit` はポリシーに関わらず耐久バリアとなります。
+
+#### フラッシュの強制
+
+コミットの合間に耐久バリアを強制するには `flush_wal` を呼び出します。
+例えば、バッチが安全に永続化されたことを通知する前などです。未同期の
+レコードを同期的に `fsync` し、`nil` を返します。デフォルトのレコードごと
+ポリシーでは実質的に no-op です。
+
+```ruby
+# group commit を有効にし、必要に応じて耐久性を強制する。
+policy = Laurus::WalSyncPolicy.group(max_records: 4096, max_bytes: 4 * 1024 * 1024)
+index = Laurus::Index.new(path: "./myindex", wal_sync_policy: policy)
+
+index.put_document("doc1", { "title" => "Hello" })
+index.flush_wal  # group バッチが満杯でなくてもレコードが永続化される
+```
 
 ---
 

--- a/docs/ja/src/laurus-server/configuration.md
+++ b/docs/ja/src/laurus-server/configuration.md
@@ -40,6 +40,12 @@ http_port = 8080  # オプション: HTTP ゲートウェイを有効化
 
 [index]
 data_dir = "./laurus_data"
+
+[index.wal]
+sync_policy = "group"          # "per_record"（デフォルト） | "group"
+group_max_records = 1024       # オプション; デフォルト 1024
+group_max_bytes = 1048576      # オプション; デフォルト 1 MiB
+group_max_interval_ms = 1000   # オプション; 未設定時は background timer なし（native のみ）
 ```
 
 ログの詳細度は設定ファイルではなく、`RUST_LOG` 環境変数で制御します（デフォルト: `info`）。
@@ -59,6 +65,28 @@ data_dir = "./laurus_data"
 | フィールド | 型 | デフォルト | 説明 |
 | :--- | :--- | :--- | :--- |
 | `data_dir` | String | `"./laurus_data"` | インデックスデータディレクトリのパス |
+
+#### `[index.wal]` セクション
+
+Write-Ahead Log（WAL）の耐久性ポリシーを制御します。セクション全体を省略した場合、
+WAL は **per-record** fsync を使用します（各書き込みは返る前に durable 化されます）。
+このポリシーは、起動時に開かれるインデックスと、後から `CreateIndex` で作成される
+インデックスの両方に適用されます。耐久性のトレードオフについては
+[永続化と WAL → WAL 耐久性ポリシー](../laurus/persistence.md#wal-耐久性ポリシー)
+を参照してください。
+
+| フィールド | 型 | デフォルト | 説明 |
+| :--- | :--- | :--- | :--- |
+| `sync_policy` | String | `"per_record"` | 耐久性ポリシー: `"per_record"`（書き込みごとに fsync）または `"group"`（fsync をバッチ化） |
+| `group_max_records` | Integer | `1024` | グループコミットのみ。前回 sync 以降にこの件数のレコードが蓄積したら flush |
+| `group_max_bytes` | Integer | `1048576` | グループコミットのみ。前回 sync 以降にこのバイト数が蓄積したら flush（デフォルト 1 MiB） |
+| `group_max_interval_ms` | Integer | -- | グループコミットのみ。定期 background flush の間隔（ミリ秒）。未設定時は timer なし。**native ターゲットのみ** — `wasm32` では無視される |
+
+`sync_policy = "group"` の場合、WAL は前回 sync 以降に **`group_max_records` 件**または
+**`group_max_bytes` バイト**のいずれか（先に到達した方）が蓄積した時点、および commit 時に
+無条件で flush します。クラッシュ時には未 sync の最終バッチまで失う可能性があります
+（SQLite `synchronous = NORMAL` に相当）。途中で切れた末尾レコードはリカバリ時に
+破棄されるため、復旧後のログにはギャップが生じません。
 
 ## 環境変数
 

--- a/docs/ja/src/laurus-server/grpc_api.md
+++ b/docs/ja/src/laurus-server/grpc_api.md
@@ -8,7 +8,7 @@
 | :--- | :--- | :--- |
 | `HealthService` | `Check` | ヘルスチェック |
 | `IndexService` | `CreateIndex`, `GetIndex`, `GetSchema`, `AddField`, `DeleteField` | インデックスのライフサイクルとスキーマ |
-| `DocumentService` | `PutDocument`, `AddDocument`, `GetDocuments`, `DeleteDocuments`, `Commit` | ドキュメント CRUD とコミット |
+| `DocumentService` | `PutDocument`, `AddDocument`, `GetDocuments`, `DeleteDocuments`, `Commit`, `FlushWal` | ドキュメント CRUD・コミット・WAL flush |
 | `SearchService` | `Search`, `SearchStream` | 単発検索とストリーミング検索 |
 
 ---
@@ -317,6 +317,22 @@ rpc DeleteDocuments(DeleteDocumentsRequest) returns (DeleteDocumentsResponse);
 ```protobuf
 rpc Commit(CommitRequest) returns (CommitResponse);
 ```
+
+### `FlushWal`
+
+バッファされた WAL レコードを full commit なしで durable 化します。両メッセージとも空です。デフォルトの per-record sync ポリシーでは near no-op です（各書き込みは既に fsync 済み）。グループコミットポリシーでは、現在の partial batch をオンデマンドで flush し、クラッシュ時の損失窓を抑えます。`Commit` と異なりセグメントを materialize しないため、バッファされた変更は後続の `Commit` まで検索に反映されません。
+
+```protobuf
+rpc FlushWal(FlushWalRequest) returns (FlushWalResponse);
+
+message FlushWalRequest {}
+
+message FlushWalResponse {}
+```
+
+WAL の耐久性ポリシーはサーバ側の `[index.wal]` 設定セクションで構成します。[設定 → `[index.wal]` セクション](configuration.md#indexwal-セクション) および [永続化と WAL → WAL 耐久性ポリシー](../laurus/persistence.md#wal-耐久性ポリシー) を参照してください。
+
+**HTTP ゲートウェイ:** `POST /v1/flush_wal`
 
 ---
 

--- a/docs/ja/src/laurus-server/http_gateway.md
+++ b/docs/ja/src/laurus-server/http_gateway.md
@@ -39,6 +39,7 @@ laurus serve --config config.toml
 | GET | `/v1/documents/{id}` | `DocumentService/GetDocuments` | ID でドキュメントを取得 |
 | DELETE | `/v1/documents/{id}` | `DocumentService/DeleteDocuments` | ID でドキュメントを削除 |
 | POST | `/v1/commit` | `DocumentService/Commit` | 保留中の変更をコミット |
+| POST | `/v1/flush_wal` | `DocumentService/FlushWal` | full commit なしでバッファされた WAL レコードを durable 化 |
 | POST | `/v1/search` | `SearchService/Search` | 検索（単発） |
 | POST | `/v1/search/stream` | `SearchService/SearchStream` | 検索（Server-Sent Events） |
 
@@ -156,6 +157,14 @@ curl -X DELETE http://localhost:8080/v1/documents/doc1
 
 ```bash
 curl -X POST http://localhost:8080/v1/commit
+```
+
+### WAL のフラッシュ
+
+バッファされた WAL レコードを full commit なしで durable 化します。成功時は `{}` を返します。デフォルトの per-record sync ポリシーでは near no-op です。グループコミットポリシーでは、現在の partial batch をオンデマンドで flush します。バッファされた変更は後続の `POST /v1/commit` まで検索に反映されません。
+
+```bash
+curl -X POST http://localhost:8080/v1/flush_wal
 ```
 
 ### 検索

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -6,21 +6,27 @@
 
 ### 静的メソッド
 
-#### `Index.create(schema?)`
+#### `Index.create(schema?, walSyncPolicy?)`
 
 新しいインメモリ（一時）インデックスを作成します。
 
 - **引数:**
   - `schema` (Schema, 省略可) -- スキーマ定義
+  - `walSyncPolicy` (WalSyncPolicy, 省略可) -- WAL の永続性ポリシー。省略すると
+    デフォルトのレコードごとの同期を使用します。
+    [WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照してください。
 - **戻り値:** `Promise<Index>`
 
-#### `Index.open(name, schema?)`
+#### `Index.open(name, schema?, walSyncPolicy?)`
 
 OPFS で永続化されたインデックスを開くか、新規作成します。
 
 - **引数:**
   - `name` (string) -- インデックス名（OPFS サブディレクトリ）
   - `schema` (Schema, 省略可) -- スキーマ定義
+  - `walSyncPolicy` (WalSyncPolicy, 省略可) -- WAL の永続性ポリシー。省略すると
+    デフォルトのレコードごとの同期を使用します。
+    [WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照してください。
 - **戻り値:** `Promise<Index>`
 
 ### インスタンスメソッド
@@ -58,6 +64,15 @@ OPFS で永続化されたインデックスを開くか、新規作成します
 
 書き込みをフラッシュし、変更を検索可能にします。
 `Index.open()` で作成したインデックスの場合、OPFS にも自動永続化されます。
+
+- **戻り値:** `Promise<void>`
+
+#### `flushWal()`
+
+インメモリエンジンの WAL に対して永続性バリアを強制します。wasm 固有の
+注意点については [WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性) を
+参照してください — 特にこれは OPFS への永続化を**行いません**。永続的な
+永続化には `commit()` を呼び出してください。
 
 - **戻り値:** `Promise<void>`
 
@@ -143,6 +158,79 @@ DSL 文字列クエリで検索します。
 インデックス統計を返します。
 
 - **戻り値:** `{ documentCount: number, vectorFields: { [name]: { count, dimension } } }`
+
+## WAL 同期ポリシー / 永続性
+
+各書き込みは、エンジンのインメモリ先行書き込みログ（WAL）に追記されます。
+`Index.create` と `Index.open` はオプションの `walSyncPolicy` を受け付け、
+WAL をどの頻度でフラッシュするかを制御します。デフォルト（引数を省略）は
+レコードごとの同期です。
+
+```typescript
+class WalSyncPolicy {
+  static perRecord(): WalSyncPolicy;
+  static group(
+    maxRecords?: number,
+    maxBytes?: number,
+    maxIntervalMs?: number,
+  ): WalSyncPolicy;
+}
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `WalSyncPolicy.perRecord()` | デフォルト。WAL レコードごとにフラッシュします。 |
+| `WalSyncPolicy.group(...)` | グループコミット。複数の書き込みにまたがってフラッシュをまとめます。 |
+
+`group(...)` のパラメータ（引数を省略するとそのデフォルトを維持）:
+
+| パラメータ | デフォルト | 説明 |
+| :--- | :--- | :--- |
+| `maxRecords` | `1024` | この件数のレコードが蓄積されたらフラッシュします。 |
+| `maxBytes` | `1048576`（1 MiB） | この量の未同期バイトが蓄積されたらフラッシュします。 |
+| `maxIntervalMs` | なし | 定期フラッシュタイマー（ミリ秒）。**wasm では no-op**（注意点を参照）。 |
+
+グループコミットでは、`maxRecords` または `maxBytes` の**いずれか**に達した
+時点でエンジン WAL がフラッシュされ、`commit()` 時にも必ずフラッシュされます。
+クラッシュ時には最後の未同期バッチまでを失う可能性があります — これは
+SQLite の `synchronous = NORMAL` と同じトレードオフです。
+
+### `flushWal()`（永続性バリア）
+
+`flushWal()` はインメモリエンジンの WAL を必要なときにフラッシュします。
+
+- **戻り値:** `Promise<void>`
+
+### WASM の注意点
+
+WebAssembly にはバックグラウンドスレッドや直接のファイルシステムがないため、
+ネイティブバインディングとは 2 点で動作が異なります:
+
+- **`maxIntervalMs` は no-op です。** 定期フラッシュタイマーには
+  バックグラウンドスレッドが必要ですが、wasm では利用できません。
+  グループコミットは `maxRecords` / `maxBytes` のしきい値到達時と
+  `commit()` 時にはフラッシュされます。
+- **`flushWal()` はインメモリエンジンの WAL のみをフラッシュします。**
+  OPFS への永続化は引き続き `commit()` で行われます。wasm で永続的に
+  永続化するには `commit()` を呼び出してください。
+
+```javascript
+import { Index, Schema, WalSyncPolicy } from "./pkg/laurus_wasm.js";
+
+const schema = new Schema();
+schema.addTextField("title");
+
+// グループコミットを有効化。maxIntervalMs は受け付けられますが wasm では無視されます。
+const policy = WalSyncPolicy.group(4096, undefined, 1000);
+const index = await Index.open("my-index", schema, policy);
+
+for (let i = 0; i < 10000; i++) {
+  await index.putDocument(`doc${i}`, { title: `Document ${i}` });
+}
+
+await index.flushWal(); // エンジン WAL をフラッシュ（OPFS ではない）
+await index.commit();   // 変更を検索可能にし、かつ OPFS に永続化する
+```
 
 ## Schema
 

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -9,6 +9,7 @@ class Index {
   static create(
     path?: string | null,
     schema?: Schema,
+    walSyncPolicy?: WalSyncPolicy,
   ): Promise<Index>;
 }
 ```
@@ -19,6 +20,7 @@ class Index {
 | :--- | :--- | :--- | :--- |
 | `path` | `string \| null` | `null` | Directory for persistent storage. `null` creates an in-memory index. |
 | `schema` | `Schema` | empty | Schema definition. |
+| `walSyncPolicy` | `WalSyncPolicy` | per-record | WAL durability policy. Omit to keep the default per-record `fsync`. See [WAL sync policy / durability](#wal-sync-policy--durability). |
 
 ### Methods
 
@@ -29,6 +31,7 @@ class Index {
 | `getDocuments(id)` | Return all stored versions for the given ID. |
 | `deleteDocuments(id)` | Delete all versions for the given ID. |
 | `commit()` | Flush writes and make pending changes searchable. |
+| `flushWal()` | Force a durable WAL barrier. See [WAL sync policy / durability](#wal-sync-policy--durability). |
 | `search(query, limit?, offset?)` | Search with a DSL string. |
 | `searchTerm(field, term, limit?, offset?)` | Search with an exact term match. |
 | `searchVector(field, vector, limit?, offset?)` | Search with a pre-computed vector. |
@@ -48,6 +51,68 @@ interface IndexStats {
   vectorFields: Record<string, { count: number; dimension: number }>;
 }
 ```
+
+### WAL sync policy / durability
+
+For a persistent index, every write is appended to a write-ahead log (WAL).
+By default the WAL is `fsync`-ed on **every** record, so each write is fully
+durable as soon as its Promise resolves. `Index.create` accepts an optional
+`walSyncPolicy` to trade some durability for higher write throughput, and
+`flushWal()` forces a durable barrier on demand.
+
+```typescript
+class WalSyncPolicy {
+  static perRecord(): WalSyncPolicy;
+  static group(
+    maxRecords?: number,
+    maxBytes?: number,
+    maxIntervalMs?: number,
+  ): WalSyncPolicy;
+}
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `WalSyncPolicy.perRecord()` | Default. `fsync` after every WAL record; fully durable per write. |
+| `WalSyncPolicy.group(...)` | Group commit. Batches `fsync` across writes. |
+
+`group(...)` parameters (omit any argument to keep its default):
+
+| Parameter | Default | Description |
+| :--- | :--- | :--- |
+| `maxRecords` | `1024` | Flush once this many records have accumulated. |
+| `maxBytes` | `1048576` (1 MiB) | Flush once this many unsynced bytes have accumulated. |
+| `maxIntervalMs` | none | Optional periodic flush timer (milliseconds). Omit to disable the timer. |
+
+With group commit the WAL is flushed when **either** `maxRecords` or
+`maxBytes` is reached, and always at `commit()`. A crash can lose up to the
+last unsynced batch — the same trade-off as SQLite's `synchronous = NORMAL`.
+Call `flushWal()` to force everything written so far to disk without a full
+`commit()`.
+
+| Method | Description |
+| :--- | :--- |
+| `flushWal()` | Force a durable WAL barrier now. Returns `Promise<void>`. |
+
+```javascript
+import { Index, WalSyncPolicy } from "laurus-nodejs";
+
+// Opt into group commit with a 1-second periodic flush timer.
+const policy = WalSyncPolicy.group(4096, undefined, 1000);
+const index = await Index.create("./myindex", schema, policy);
+
+for (let i = 0; i < 10000; i++) {
+  await index.putDocument(`doc${i}`, { title: `Document ${i}` });
+}
+
+// Force a durable barrier without committing yet.
+await index.flushWal();
+
+await index.commit(); // also flushes the WAL
+```
+
+Omit `walSyncPolicy` (or pass `WalSyncPolicy.perRecord()`) to keep the
+default, fully durable behaviour.
 
 ---
 

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -5,7 +5,7 @@
 The primary entry point. Wraps the Laurus search engine.
 
 ```php
-new \Laurus\Index(?string $path = null, ?Schema $schema = null)
+new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $wal_sync_policy = null)
 ```
 
 ### Constructor
@@ -14,6 +14,7 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null)
 | :--- | :--- | :--- | :--- |
 | `$path` | `string\|null` | `null` | Directory path for persistent storage. `null` creates an in-memory index. |
 | `$schema` | `Schema\|null` | `null` | Schema definition. An empty schema is used when omitted. |
+| `$wal_sync_policy` | `WalSyncPolicy\|null` | `null` | Write-ahead log (WAL) durability policy. `null` keeps the default per-record fsync. See [WAL sync policy & durability](#wal-sync-policy--durability). |
 
 ### Methods
 
@@ -24,6 +25,7 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null)
 | `getDocuments(string $id): array` | Return all stored versions for the given ID. |
 | `deleteDocuments(string $id): void` | Delete all versions for the given ID. |
 | `commit(): void` | Flush buffered writes and make all pending changes searchable. |
+| `flushWal(): void` | Force a durable WAL barrier on demand. Synchronously fsyncs any unsynced WAL records. Useful when running under a group-commit policy (see below). |
 | `search(mixed $query, int $limit = 10, int $offset = 0): array` | Execute a search query. Returns an array of `SearchResult`. |
 | `searchBatch(array $queries, int $limit = 10, int $offset = 0): array` | Execute multiple independent searches in one call. Each query is dispatched in parallel on the underlying tokio runtime. `results[i]` corresponds to `queries[i]`. Returns an array of arrays of `SearchResult`. Empty input returns `[]`. |
 | `stats(): array` | Return index statistics (`"documentCount"`, `"vectorFields"`). |
@@ -38,6 +40,56 @@ The `$query` parameter accepts any of the following:
 - A **`SearchRequest`** for full control
 
 The same value kinds are accepted as the elements of `searchBatch`'s `$queries` array — DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch.
+
+### WAL sync policy & durability
+
+The write-ahead log (WAL) protects committed data against crashes. By
+default the WAL is fully durable: every record is `fsync`ed before the write
+returns. You can trade some durability for higher write throughput by opting
+into **group commit**, which batches `fsync` calls.
+
+#### WalSyncPolicy
+
+`Laurus\WalSyncPolicy` is an immutable value object describing how the WAL is
+flushed. Pass it to the `Index` constructor's `$wal_sync_policy` argument.
+
+```php
+// Default: durable per write (each record is fsynced individually).
+\Laurus\WalSyncPolicy::perRecord(): WalSyncPolicy
+
+// Group commit: batch fsyncs to amortise their cost.
+\Laurus\WalSyncPolicy::group(
+    ?int $max_records = null,      // flush after this many records (default 1024)
+    ?int $max_bytes = null,        // flush after this many bytes (default 1 MiB)
+    ?int $max_interval_ms = null,  // also flush periodically after this many ms
+): WalSyncPolicy
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `WalSyncPolicy::perRecord()` | Default. Every record is `fsync`ed before the write returns — fully durable per write. |
+| `WalSyncPolicy::group($max_records, $max_bytes, $max_interval_ms)` | Batch `fsync`s. With all arguments `null` uses the defaults (`max_records = 1024`, `max_bytes = 1 MiB`, no timer). The WAL is flushed when **either** `$max_records` **or** `$max_bytes` accumulate, and on every `commit()`. Pass `$max_interval_ms` to also flush on a periodic timer. |
+
+Group commit is analogous to SQLite's `synchronous = NORMAL`: a crash can lose
+at most the last unsynced batch of records, but the index never corrupts.
+Records are always made durable at `commit()`, so a successful `commit()` is a
+durability barrier regardless of policy.
+
+#### Forcing a flush
+
+Call `flushWal()` to force a durable barrier between commits — for example
+before signalling that a batch has been safely persisted. It synchronously
+`fsync`s any unsynced records. Under the default per-record policy it is
+effectively a no-op.
+
+```php
+// Opt into group commit, then force durability on demand.
+$policy = \Laurus\WalSyncPolicy::group(4096, 4 * 1024 * 1024);
+$index = new \Laurus\Index("./myindex", null, $policy);
+
+$index->putDocument("doc1", ["title" => "Hello"]);
+$index->flushWal(); // records persisted even though the group batch is not full
+```
 
 ---
 

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -6,7 +6,12 @@ The primary entry point. Wraps the Laurus search engine.
 
 ```python
 class Index:
-    def __init__(self, path: str | None = None, schema: Schema | None = None) -> None: ...
+    def __init__(
+        self,
+        path: str | None = None,
+        schema: Schema | None = None,
+        wal_sync_policy: WalSyncPolicy | None = None,
+    ) -> None: ...
 ```
 
 ### Constructor
@@ -15,6 +20,7 @@ class Index:
 | :--- | :--- | :--- | :--- |
 | `path` | `str \| None` | `None` | Directory path for persistent storage. `None` creates an in-memory index. |
 | `schema` | `Schema \| None` | `None` | Schema definition. An empty schema is used when omitted. |
+| `wal_sync_policy` | `WalSyncPolicy \| None` | `None` | WAL durability policy. `None` keeps the default per-record `fsync`. See [WAL sync policy / durability](#wal-sync-policy--durability). |
 
 ### Methods
 
@@ -25,6 +31,7 @@ class Index:
 | `get_documents(id) -> list[dict]` | Return all stored versions for the given ID. |
 | `delete_documents(id)` | Delete all versions for the given ID. |
 | `commit()` | Flush buffered writes and make all pending changes searchable. |
+| `flush_wal()` | Force a durable WAL barrier. See [WAL sync policy / durability](#wal-sync-policy--durability). |
 | `search(query, *, limit=10, offset=0) -> list[SearchResult]` | Execute a search query. |
 | `search_batch(queries, *, limit=10, offset=0) -> list[list[SearchResult]]` | Execute multiple independent searches in one call. Each query is dispatched in parallel on the underlying tokio runtime. `results[i]` corresponds to `queries[i]`. Empty input returns `[]`. |
 | `stats() -> dict` | Return index statistics (`document_count`, `vector_fields`). |
@@ -39,6 +46,68 @@ The `query` parameter accepts any of the following:
 - A **`SearchRequest`** for full control
 
 The same value kinds are accepted as the elements of `search_batch`'s `queries` list — DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch.
+
+### WAL sync policy / durability
+
+For a persistent index, every write is appended to a write-ahead log (WAL).
+By default the WAL is `fsync`-ed on **every** record, so each write is fully
+durable as soon as the call returns. The constructor accepts an optional
+`wal_sync_policy` to trade some durability for higher write throughput, and
+`flush_wal()` forces a durable barrier on demand.
+
+```python
+class WalSyncPolicy:
+    @staticmethod
+    def per_record() -> WalSyncPolicy: ...
+    @staticmethod
+    def group(
+        max_records: int | None = None,
+        max_bytes: int | None = None,
+        max_interval_ms: int | None = None,
+    ) -> WalSyncPolicy: ...
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `WalSyncPolicy.per_record()` | Default. `fsync` after every WAL record; fully durable per write. |
+| `WalSyncPolicy.group(...)` | Group commit. Batches `fsync` across writes. |
+
+`group()` parameters (all keyword-friendly, `None` keeps the default):
+
+| Parameter | Default | Description |
+| :--- | :--- | :--- |
+| `max_records` | `1024` | Flush once this many records have accumulated. |
+| `max_bytes` | `1048576` (1 MiB) | Flush once this many unsynced bytes have accumulated. |
+| `max_interval_ms` | `None` | Optional periodic flush timer (milliseconds). `None` disables the timer. |
+
+With group commit the WAL is flushed when **either** `max_records` or
+`max_bytes` is reached, and always at `commit()`. A crash can lose up to the
+last unsynced batch — the same trade-off as SQLite's `synchronous = NORMAL`.
+Call `flush_wal()` to force everything written so far to disk without a full
+`commit()`.
+
+| Method | Description |
+| :--- | :--- |
+| `flush_wal()` | Force a durable WAL barrier now. Synchronous; returns `None`. |
+
+```python
+import laurus
+
+# Opt into group commit with a 1-second periodic flush timer.
+policy = laurus.WalSyncPolicy.group(max_records=4096, max_interval_ms=1000)
+index = laurus.Index(path="./myindex", wal_sync_policy=policy)
+
+for i in range(10_000):
+    index.put_document(f"doc{i}", {"title": f"Document {i}"})
+
+# Force a durable barrier without committing yet.
+index.flush_wal()
+
+index.commit()  # also flushes the WAL
+```
+
+Omit `wal_sync_policy` (or pass `WalSyncPolicy.per_record()`) to keep the
+default, fully durable behaviour.
 
 ---
 

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -5,7 +5,7 @@
 The primary entry point. Wraps the Laurus search engine.
 
 ```ruby
-Laurus::Index.new(path: nil, schema: nil)
+Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil)
 ```
 
 ### Constructor
@@ -14,6 +14,7 @@ Laurus::Index.new(path: nil, schema: nil)
 | :--- | :--- | :--- | :--- |
 | `path:` | `String \| nil` | `nil` | Directory path for persistent storage. `nil` creates an in-memory index. |
 | `schema:` | `Schema \| nil` | `nil` | Schema definition. An empty schema is used when omitted. |
+| `wal_sync_policy:` | `WalSyncPolicy \| nil` | `nil` | Write-ahead log (WAL) durability policy. `nil` keeps the default per-record fsync. See [WAL sync policy & durability](#wal-sync-policy--durability). |
 
 ### Methods
 
@@ -24,6 +25,7 @@ Laurus::Index.new(path: nil, schema: nil)
 | `get_documents(id) -> Array<Hash>` | Return all stored versions for the given ID. |
 | `delete_documents(id)` | Delete all versions for the given ID. |
 | `commit` | Flush buffered writes and make all pending changes searchable. |
+| `flush_wal` | Force a durable WAL barrier on demand. Synchronously fsyncs any unsynced WAL records and returns `nil`. Useful when running under a group-commit policy (see below). |
 | `search(query, limit: 10, offset: 0) -> Array<SearchResult>` | Execute a search query. |
 | `search_batch(queries, limit: 10, offset: 0) -> Array<Array<SearchResult>>` | Execute multiple independent searches in one call. Each query is dispatched in parallel on the underlying tokio runtime. `results[i]` corresponds to `queries[i]`. Empty input returns `[]`. |
 | `stats -> Hash` | Return index statistics (`"document_count"`, `"vector_fields"`). |
@@ -38,6 +40,56 @@ The `query` parameter accepts any of the following:
 - A **`SearchRequest`** for full control
 
 The same value kinds are accepted as the elements of `search_batch`'s `queries` Array — DSL strings, query objects, and `SearchRequest` instances may be mixed within a single batch.
+
+### WAL sync policy & durability
+
+The write-ahead log (WAL) protects committed data against crashes. By
+default the WAL is fully durable: every record is `fsync`ed before the write
+returns. You can trade some durability for higher write throughput by opting
+into **group commit**, which batches `fsync` calls.
+
+#### WalSyncPolicy
+
+`Laurus::WalSyncPolicy` is an immutable value object describing how the WAL
+is flushed. Pass it to `Index.new(wal_sync_policy:)`.
+
+```ruby
+# Default: durable per write (each record is fsynced individually).
+Laurus::WalSyncPolicy.per_record
+
+# Group commit: batch fsyncs to amortise their cost.
+Laurus::WalSyncPolicy.group(
+  max_records: nil,      # flush after this many records (default 1024)
+  max_bytes: nil,        # flush after this many bytes (default 1 MiB)
+  max_interval_ms: nil,  # also flush periodically after this many ms
+)
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `WalSyncPolicy.per_record` | Default. Every record is `fsync`ed before the write returns — fully durable per write. |
+| `WalSyncPolicy.group(max_records:, max_bytes:, max_interval_ms:)` | Batch `fsync`s. With no arguments uses the defaults (`max_records: 1024`, `max_bytes: 1 MiB`, no timer). The WAL is flushed when **either** `max_records` **or** `max_bytes` accumulate, and on every `commit`. Pass `max_interval_ms:` to also flush on a periodic timer. |
+
+Group commit is analogous to SQLite's `synchronous = NORMAL`: a crash can lose
+at most the last unsynced batch of records, but the index never corrupts.
+Records are always made durable at `commit`, so a successful `commit` is a
+durability barrier regardless of policy.
+
+#### Forcing a flush
+
+Call `flush_wal` to force a durable barrier between commits — for example
+before signalling that a batch has been safely persisted. It synchronously
+`fsync`s any unsynced records and returns `nil`. Under the default
+per-record policy it is effectively a no-op.
+
+```ruby
+# Opt into group commit, then force durability on demand.
+policy = Laurus::WalSyncPolicy.group(max_records: 4096, max_bytes: 4 * 1024 * 1024)
+index = Laurus::Index.new(path: "./myindex", wal_sync_policy: policy)
+
+index.put_document("doc1", { "title" => "Hello" })
+index.flush_wal  # records persisted even though the group batch is not full
+```
 
 ---
 

--- a/docs/src/laurus-server/configuration.md
+++ b/docs/src/laurus-server/configuration.md
@@ -40,6 +40,12 @@ http_port = 8080  # Optional: enables HTTP Gateway
 
 [index]
 data_dir = "./laurus_data"
+
+[index.wal]
+sync_policy = "group"          # "per_record" (default) | "group"
+group_max_records = 1024       # optional; default 1024
+group_max_bytes = 1048576      # optional; default 1 MiB
+group_max_interval_ms = 1000   # optional; no background timer when unset (native only)
 ```
 
 Log verbosity is controlled by the `RUST_LOG` environment variable (default: `info`), not through the config file.
@@ -59,6 +65,28 @@ Log verbosity is controlled by the `RUST_LOG` environment variable (default: `in
 | Field | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `data_dir` | String | `"./laurus_data"` | Path to the index data directory |
+
+#### `[index.wal]` Section
+
+Controls the Write-Ahead Log (WAL) durability policy. When the whole section is
+omitted, the WAL uses **per-record** fsync (every write is durable before it
+returns). The policy applies to both an index opened at boot and any index
+created later through `CreateIndex`. See
+[Persistence & WAL → WAL Durability Policy](../laurus/persistence.md#wal-durability-policy)
+for the durability trade-off.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `sync_policy` | String | `"per_record"` | Durability policy: `"per_record"` (fsync every write) or `"group"` (batch fsyncs) |
+| `group_max_records` | Integer | `1024` | Group commit only. Flush once this many records accumulate since the last sync |
+| `group_max_bytes` | Integer | `1048576` | Group commit only. Flush once this many bytes accumulate since the last sync (default 1 MiB) |
+| `group_max_interval_ms` | Integer | -- | Group commit only. Periodic background flush interval in milliseconds. No timer runs when unset. **Native targets only** — ignored on `wasm32` |
+
+Under `sync_policy = "group"`, the WAL flushes when **either** `group_max_records`
+records **or** `group_max_bytes` bytes have accumulated since the last sync
+(whichever comes first), and unconditionally on commit. A crash can lose up to
+the last unsynced batch (comparable to SQLite `synchronous = NORMAL`); a torn
+trailing record is dropped on recovery, so the recovered log is gap-free.
 
 ## Environment Variables
 

--- a/docs/src/laurus-server/grpc_api.md
+++ b/docs/src/laurus-server/grpc_api.md
@@ -8,7 +8,7 @@ All services are defined under the `laurus.v1` protobuf package.
 | :--- | :--- | :--- |
 | `HealthService` | `Check` | Health checking |
 | `IndexService` | `CreateIndex`, `GetIndex`, `GetSchema`, `AddField`, `DeleteField` | Index lifecycle and schema |
-| `DocumentService` | `PutDocument`, `AddDocument`, `GetDocuments`, `DeleteDocuments`, `Commit` | Document CRUD and commit |
+| `DocumentService` | `PutDocument`, `AddDocument`, `GetDocuments`, `DeleteDocuments`, `Commit`, `FlushWal` | Document CRUD, commit, and WAL flush |
 | `SearchService` | `Search`, `SearchStream` | Unary and streaming search |
 
 ---
@@ -318,6 +318,22 @@ Commit pending changes (additions and deletions) to the index. Changes are not v
 ```protobuf
 rpc Commit(CommitRequest) returns (CommitResponse);
 ```
+
+### `FlushWal`
+
+Force buffered WAL records durable without a full commit. Both messages are empty. This is a near no-op under the default per-record sync policy (every write is already fsync'd); under the group-commit policy it flushes the current partial batch on demand, bounding the crash-loss window. Unlike `Commit`, it does not materialize segments, so buffered changes remain invisible to search until a subsequent `Commit`.
+
+```protobuf
+rpc FlushWal(FlushWalRequest) returns (FlushWalResponse);
+
+message FlushWalRequest {}
+
+message FlushWalResponse {}
+```
+
+The WAL durability policy is configured server-side via the `[index.wal]` config section. See [Configuration → `[index.wal]` Section](configuration.md#indexwal-section) and [Persistence & WAL → WAL Durability Policy](../laurus/persistence.md#wal-durability-policy).
+
+**HTTP gateway:** `POST /v1/flush_wal`
 
 ---
 

--- a/docs/src/laurus-server/http_gateway.md
+++ b/docs/src/laurus-server/http_gateway.md
@@ -39,6 +39,7 @@ If `http_port` is not set, only the gRPC server starts.
 | GET | `/v1/documents/{id}` | `DocumentService/GetDocuments` | Get documents by ID |
 | DELETE | `/v1/documents/{id}` | `DocumentService/DeleteDocuments` | Delete documents by ID |
 | POST | `/v1/commit` | `DocumentService/Commit` | Commit pending changes |
+| POST | `/v1/flush_wal` | `DocumentService/FlushWal` | Force buffered WAL records durable without a full commit |
 | POST | `/v1/search` | `SearchService/Search` | Search (unary) |
 | POST | `/v1/search/stream` | `SearchService/SearchStream` | Search (Server-Sent Events) |
 
@@ -160,6 +161,14 @@ curl -X DELETE http://localhost:8080/v1/documents/doc1
 
 ```bash
 curl -X POST http://localhost:8080/v1/commit
+```
+
+### Flush WAL
+
+Forces buffered WAL records durable without a full commit. Returns `{}` on success. This is a near no-op under the default per-record sync policy; under the group-commit policy it flushes the current partial batch on demand. Buffered changes stay invisible to search until a subsequent `POST /v1/commit`.
+
+```bash
+curl -X POST http://localhost:8080/v1/flush_wal
 ```
 
 ### Search

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -6,21 +6,27 @@ The main entry point for creating and querying search indexes.
 
 ### Static Methods
 
-#### `Index.create(schema?)`
+#### `Index.create(schema?, walSyncPolicy?)`
 
 Create a new in-memory (ephemeral) index.
 
 - **Parameters:**
   - `schema` (Schema, optional) -- Schema definition.
+  - `walSyncPolicy` (WalSyncPolicy, optional) -- WAL durability policy. Omit
+    to keep the default per-record sync. See
+    [WAL sync policy / durability](#wal-sync-policy--durability).
 - **Returns:** `Promise<Index>`
 
-#### `Index.open(name, schema?)`
+#### `Index.open(name, schema?, walSyncPolicy?)`
 
 Open or create a persistent index backed by OPFS.
 
 - **Parameters:**
   - `name` (string) -- Index name (OPFS subdirectory).
   - `schema` (Schema, optional) -- Schema definition.
+  - `walSyncPolicy` (WalSyncPolicy, optional) -- WAL durability policy. Omit
+    to keep the default per-record sync. See
+    [WAL sync policy / durability](#wal-sync-policy--durability).
 - **Returns:** `Promise<Index>`
 
 ### Instance Methods
@@ -60,6 +66,15 @@ Delete all versions of a document.
 
 Flush writes and make changes searchable. If opened with
 `Index.open()`, data is also persisted to OPFS.
+
+- **Returns:** `Promise<void>`
+
+#### `flushWal()`
+
+Force a durable WAL barrier on the in-memory engine WAL. See
+[WAL sync policy / durability](#wal-sync-policy--durability) for the wasm
+caveats — notably, this does **not** persist to OPFS; call `commit()` for
+durable persistence.
 
 - **Returns:** `Promise<void>`
 
@@ -145,6 +160,77 @@ documents closest to `(x, y, z)`. The optional `initialRadiusM` and
 Return index statistics.
 
 - **Returns:** `{ documentCount: number, vectorFields: { [name]: { count, dimension } } }`
+
+## WAL sync policy / durability
+
+Each write is appended to the engine's in-memory write-ahead log (WAL).
+`Index.create` and `Index.open` accept an optional `walSyncPolicy` that
+controls how often that WAL is flushed. The default (omit the argument) is
+per-record sync.
+
+```typescript
+class WalSyncPolicy {
+  static perRecord(): WalSyncPolicy;
+  static group(
+    maxRecords?: number,
+    maxBytes?: number,
+    maxIntervalMs?: number,
+  ): WalSyncPolicy;
+}
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `WalSyncPolicy.perRecord()` | Default. Flush after every WAL record. |
+| `WalSyncPolicy.group(...)` | Group commit. Batch the flush across writes. |
+
+`group(...)` parameters (omit any argument to keep its default):
+
+| Parameter | Default | Description |
+| :--- | :--- | :--- |
+| `maxRecords` | `1024` | Flush once this many records have accumulated. |
+| `maxBytes` | `1048576` (1 MiB) | Flush once this many unsynced bytes have accumulated. |
+| `maxIntervalMs` | none | Periodic flush timer (milliseconds). **No-op on wasm** (see caveats). |
+
+With group commit the engine WAL is flushed when **either** `maxRecords` or
+`maxBytes` is reached, and always at `commit()`. A crash can lose up to the
+last unsynced batch — the same trade-off as SQLite's `synchronous = NORMAL`.
+
+### `flushWal()` (durable barrier)
+
+`flushWal()` forces a flush of the in-memory engine WAL on demand.
+
+- **Returns:** `Promise<void>`
+
+### WASM caveats
+
+WebAssembly has no background threads or direct filesystem, so two behaviours
+differ from the native bindings:
+
+- **`maxIntervalMs` is a no-op.** The periodic flush timer requires a
+  background thread, which is unavailable on wasm. Group commit still flushes
+  on the `maxRecords` / `maxBytes` thresholds and at `commit()`.
+- **`flushWal()` flushes the in-memory engine WAL only.** OPFS persistence
+  still happens at `commit()`. For durable persistence on wasm, call
+  `commit()`.
+
+```javascript
+import { Index, Schema, WalSyncPolicy } from "./pkg/laurus_wasm.js";
+
+const schema = new Schema();
+schema.addTextField("title");
+
+// Opt into group commit. maxIntervalMs is accepted but ignored on wasm.
+const policy = WalSyncPolicy.group(4096, undefined, 1000);
+const index = await Index.open("my-index", schema, policy);
+
+for (let i = 0; i < 10000; i++) {
+  await index.putDocument(`doc${i}`, { title: `Document ${i}` });
+}
+
+await index.flushWal(); // flushes the engine WAL (not OPFS)
+await index.commit();   // makes changes searchable AND persists to OPFS
+```
 
 ## Schema
 

--- a/laurus-nodejs/README.md
+++ b/laurus-nodejs/README.md
@@ -83,6 +83,28 @@ const stats = index.stats();
 // } }
 ```
 
+### Durability / WAL
+
+A persistent index writes every change to a write-ahead log (WAL). By default
+the WAL is `fsync`-ed on every record, so each write is fully durable. Opt into
+group commit to batch `fsync` for higher write throughput (a crash can lose up
+to the last unsynced batch, like SQLite's `synchronous = NORMAL`):
+
+```javascript
+import { Index, WalSyncPolicy } from "laurus-nodejs";
+
+// maxRecords, maxBytes, maxIntervalMs (all optional)
+const policy = WalSyncPolicy.group(4096, undefined, 1000);
+const index = await Index.create("./myindex", schema, policy);
+
+await index.putDocument("doc1", { title: "Hello" });
+await index.flushWal(); // force a durable barrier on demand
+await index.commit();   // also flushes the WAL
+```
+
+Omit `walSyncPolicy` (or pass `WalSyncPolicy.perRecord()`) to keep the default
+per-record durability.
+
 ### Schema
 
 ```javascript

--- a/laurus-nodejs/README_ja.md
+++ b/laurus-nodejs/README_ja.md
@@ -81,6 +81,29 @@ const stats = index.stats();
 // } }
 ```
 
+### 永続性 / WAL
+
+永続インデックスはすべての変更を先行書き込みログ（WAL）に書き込みます。
+デフォルトでは WAL はレコードごとに `fsync` されるため、各書き込みは完全に
+永続化されます。書き込みスループットを高めるためにグループコミットを有効化
+すると `fsync` をまとめられます（クラッシュ時には SQLite の
+`synchronous = NORMAL` と同様に最後の未同期バッチまでを失う可能性があります）:
+
+```javascript
+import { Index, WalSyncPolicy } from "laurus-nodejs";
+
+// maxRecords, maxBytes, maxIntervalMs（いずれも省略可）
+const policy = WalSyncPolicy.group(4096, undefined, 1000);
+const index = await Index.create("./myindex", schema, policy);
+
+await index.putDocument("doc1", { title: "Hello" });
+await index.flushWal(); // 必要なときに永続性バリアを強制
+await index.commit();   // WAL もフラッシュされます
+```
+
+`walSyncPolicy` を省略する（または `WalSyncPolicy.perRecord()` を渡す）と、
+デフォルトのレコードごとの永続性が維持されます。
+
 ### Schema
 
 ```javascript

--- a/laurus-nodejs/__tests__/index.spec.mjs
+++ b/laurus-nodejs/__tests__/index.spec.mjs
@@ -21,6 +21,7 @@ import {
   SynonymDictionary,
   WhitespaceTokenizer,
   SynonymGraphFilter,
+  WalSyncPolicy,
 } from "../index.js";
 
 // ---------------------------------------------------------------------------
@@ -78,6 +79,39 @@ describe("Index creation", () => {
     schema.addTextField("title");
     const index = await Index.create(null, schema);
     expect(index).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WAL sync policy
+// ---------------------------------------------------------------------------
+
+describe("WAL sync policy", () => {
+  it("accepts perRecord() and group(...) factories", () => {
+    expect(WalSyncPolicy.perRecord()).toBeDefined();
+    expect(WalSyncPolicy.group()).toBeDefined();
+    expect(WalSyncPolicy.group(256, 4096, 1000)).toBeDefined();
+  });
+
+  it("creates a group-commit index, flushes the WAL, and retrieves docs", async () => {
+    const schema = new Schema();
+    schema.addTextField("title");
+    const index = await Index.create(null, schema, WalSyncPolicy.group());
+    await index.putDocument("doc1", { title: "Group commit" });
+    await index.flushWal();
+    await index.commit();
+    const docs = await index.getDocuments("doc1");
+    expect(docs).toHaveLength(1);
+    expect(docs[0].title).toBe("Group commit");
+  });
+
+  it("flushWal is a no-op fast path under perRecord", async () => {
+    const index = await Index.create(null, undefined, WalSyncPolicy.perRecord());
+    await index.putDocument("doc1", { title: "Per record" });
+    await index.flushWal();
+    await index.commit();
+    const docs = await index.getDocuments("doc1");
+    expect(docs).toHaveLength(1);
   });
 });
 

--- a/laurus-nodejs/src/index.rs
+++ b/laurus-nodejs/src/index.rs
@@ -11,6 +11,7 @@ use crate::search::{
     JsSearchRequest, JsSearchResult, build_dsl_request, build_lexical_request,
     build_vector_request, to_js_search_result,
 };
+use crate::wal::JsWalSyncPolicy;
 use laurus::{Engine, Storage, StorageConfig, StorageFactory};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -74,16 +75,27 @@ impl JsIndex {
     /// * `path` - Directory path for persistent storage.
     ///     Pass `null` or omit for an ephemeral in-memory index.
     /// * `schema` - Schema definition. If omitted, an empty schema is used.
+    /// * `wal_sync_policy` - Optional WAL durability policy (see
+    ///     `WalSyncPolicy`). When omitted, the default per-record policy is
+    ///     used, where every append is fsync'd before it returns.
     ///
     /// # Returns
     ///
     /// A new `Index` instance.
     #[napi(factory)]
-    pub async fn create(path: Option<String>, schema: Option<&JsSchema>) -> Result<Self> {
+    pub async fn create(
+        path: Option<String>,
+        schema: Option<&JsSchema>,
+        wal_sync_policy: Option<&JsWalSyncPolicy>,
+    ) -> Result<Self> {
         let storage = create_storage(path.as_deref())?;
         let schema = schema.map(|s| s.inner.clone()).unwrap_or_default();
 
-        let engine = Engine::new(storage, schema).await.map_err(laurus_err)?;
+        let mut builder = Engine::builder(storage, schema);
+        if let Some(policy) = wal_sync_policy {
+            builder = builder.wal_sync_policy(policy.inner);
+        }
+        let engine = builder.build().await.map_err(laurus_err)?;
 
         Ok(Self {
             engine: Arc::new(engine),
@@ -167,6 +179,26 @@ impl JsIndex {
     #[napi]
     pub async fn commit(&self) -> Result<()> {
         self.engine.commit().await.map_err(laurus_err)
+    }
+
+    /// Force the write-ahead log durable on demand.
+    ///
+    /// Under the default `WalSyncPolicy.perRecord()` policy every append is
+    /// already fsync'd, so this is a no-op fast path. Under
+    /// `WalSyncPolicy.group(...)` the fsync of each append is deferred and
+    /// batched for throughput, which means a crash can lose the last unsynced
+    /// batch; calling `flushWal()` forces the current batch durable without the
+    /// heavier work of a full `commit()` (which also materializes the index).
+    /// Use it to bound the durability window of a group-commit index — for
+    /// example after a logical unit of ingest — when you do not yet want the
+    /// changes to become searchable.
+    ///
+    /// # Returns
+    ///
+    /// Resolves once the WAL has been fsync'd, or rejects if the flush fails.
+    #[napi]
+    pub async fn flush_wal(&self) -> Result<()> {
+        self.engine.flush_wal().map_err(laurus_err)
     }
 
     // ── Search ────────────────────────────────────────────────────────────

--- a/laurus-nodejs/src/lib.rs
+++ b/laurus-nodejs/src/lib.rs
@@ -20,3 +20,4 @@ mod index;
 mod query;
 mod schema;
 mod search;
+mod wal;

--- a/laurus-nodejs/src/wal.rs
+++ b/laurus-nodejs/src/wal.rs
@@ -1,0 +1,119 @@
+//! Node.js wrapper for the WAL (write-ahead log) durability policy.
+//!
+//! Exposes [`laurus::WalSyncPolicy`] to JavaScript as the `WalSyncPolicy`
+//! value object, mirroring the same factory-method surface used by the other
+//! language bindings.
+
+use std::time::Duration;
+
+use laurus::{DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, WalSyncPolicy};
+use napi_derive::napi;
+
+// ---------------------------------------------------------------------------
+// WalSyncPolicy
+// ---------------------------------------------------------------------------
+
+/// WAL durability policy — controls when write-ahead-log appends are fsync'd.
+///
+/// This trades the durability of an individual write against ingest
+/// throughput. `commit()` is always a hard durability barrier under either
+/// policy (it forces the WAL durable before materializing the index), and
+/// `Index.flushWal()` forces a flush on demand.
+///
+/// Construct one of the two variants with the static factory methods and pass
+/// it to `Index.create(path, schema, policy)`.
+///
+/// ## Example
+///
+/// ```javascript
+/// const { Index, Schema, WalSyncPolicy } = require("laurus-nodejs");
+///
+/// const schema = new Schema();
+/// schema.addTextField("title");
+///
+/// // Group commit with default thresholds (higher ingest throughput, but a
+/// // crash can lose the last unsynced batch — comparable to SQLite's
+/// // synchronous = NORMAL).
+/// const index = await Index.create("./idx", schema, WalSyncPolicy.group());
+///
+/// // Group commit with explicit thresholds and a 1s periodic flush timer.
+/// const policy = WalSyncPolicy.group(256, 4096, 1000);
+///
+/// // Per-record durability (the default if no policy is supplied): every
+/// // append is fsync'd before it returns.
+/// const strict = WalSyncPolicy.perRecord();
+/// ```
+#[napi(js_name = "WalSyncPolicy")]
+#[derive(Clone, Copy)]
+pub struct JsWalSyncPolicy {
+    /// The wrapped Laurus durability policy.
+    pub(crate) inner: WalSyncPolicy,
+}
+
+#[napi]
+impl JsWalSyncPolicy {
+    /// Create a per-record durability policy.
+    ///
+    /// Every WAL append is fsync'd before it returns, so a successful
+    /// `putDocument` / `addDocument` / `deleteDocuments` can never be lost to a
+    /// crash. This is the default policy when no policy is passed to
+    /// `Index.create`.
+    ///
+    /// # Returns
+    ///
+    /// A `WalSyncPolicy` representing `PerRecord`.
+    #[napi(factory)]
+    pub fn per_record() -> Self {
+        Self {
+            inner: WalSyncPolicy::PerRecord,
+        }
+    }
+
+    /// Create a group-commit durability policy.
+    ///
+    /// The fsync is deferred and amortized over a batch: the WAL is flushed
+    /// when **either** `maxRecords` records **or** `maxBytes` bytes have
+    /// accumulated since the last sync (whichever comes first), unconditionally
+    /// at `commit()`, and — when `maxIntervalMs` is supplied — at least once per
+    /// interval via a background timer. An append may return before its record
+    /// is durable, so a crash can lose up to the last unsynced batch.
+    ///
+    /// All arguments are optional; omitted thresholds fall back to the Laurus
+    /// defaults. `WalSyncPolicy.group()` therefore yields group commit with the
+    /// default thresholds and no timer, and passing only `maxIntervalMs` yields
+    /// the defaults plus a periodic flush.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_records` - Flush once this many records have accumulated since the
+    ///   last sync. Defaults to `laurus::DEFAULT_GROUP_MAX_RECORDS` (1024).
+    /// * `max_bytes` - Flush once this many appended bytes have accumulated
+    ///   since the last sync. Defaults to `laurus::DEFAULT_GROUP_MAX_BYTES`
+    ///   (1 MiB).
+    /// * `max_interval_ms` - Optional periodic flush interval in milliseconds.
+    ///   When omitted, no background timer runs and durability is left to the
+    ///   thresholds, `commit()`, and `flushWal()`. Honored on native targets
+    ///   only.
+    ///
+    /// # Returns
+    ///
+    /// A `WalSyncPolicy` representing `Group`.
+    #[napi(factory)]
+    pub fn group(
+        max_records: Option<u32>,
+        max_bytes: Option<u32>,
+        max_interval_ms: Option<f64>,
+    ) -> Self {
+        Self {
+            inner: WalSyncPolicy::Group {
+                max_records: max_records
+                    .map(|v| v as usize)
+                    .unwrap_or(DEFAULT_GROUP_MAX_RECORDS),
+                max_bytes: max_bytes
+                    .map(|v| v as usize)
+                    .unwrap_or(DEFAULT_GROUP_MAX_BYTES),
+                max_interval: max_interval_ms.map(|ms| Duration::from_millis(ms as u64)),
+            },
+        }
+    }
+}

--- a/laurus-php/README.md
+++ b/laurus-php/README.md
@@ -227,6 +227,32 @@ $stats = $index->stats();
 echo "Document count: " . $stats["documentCount"] . "\n";
 ```
 
+## Durability / WAL
+
+The write-ahead log (WAL) is fully durable by default: every record is
+`fsync`ed before the write returns. To trade some durability for higher write
+throughput, opt into **group commit** by passing a `WalSyncPolicy` to the
+`Index` constructor. Group commit batches `fsync` calls, flushing when either
+the record count (default 1024) or byte threshold (default 1 MiB) is reached,
+and on every `commit()`. A crash can lose at most the last unsynced batch
+(like SQLite's `synchronous = NORMAL`); the index never corrupts. Call
+`flushWal()` to force a durable barrier on demand.
+
+```php
+use Laurus\Index;
+use Laurus\WalSyncPolicy;
+
+// Default: per-record fsync (omit the argument entirely).
+$index = new Index();
+
+// Opt into group commit, then force a flush when needed.
+$policy = WalSyncPolicy::group(4096, 4 * 1024 * 1024);
+$index = new Index("./myindex", null, $policy);
+
+$index->putDocument("doc1", ["title" => "Hello"]);
+$index->flushWal(); // persist now, without waiting for the batch to fill
+```
+
 ## Feature Flags
 
 Optional Cargo feature flags enable additional embedding backends:

--- a/laurus-php/README_ja.md
+++ b/laurus-php/README_ja.md
@@ -227,6 +227,33 @@ $stats = $index->stats();
 echo "ドキュメント数: " . $stats["documentCount"] . "\n";
 ```
 
+## 耐久性 / WAL
+
+先行書き込みログ（WAL）はデフォルトで完全に耐久的です。すべてのレコードは
+書き込みが返る前に `fsync` されます。耐久性をいくらか引き換えに書き込み
+スループットを向上させたい場合は、`Index` コンストラクタに `WalSyncPolicy`
+を渡して **group commit（グループコミット）** を有効にします。group commit は
+`fsync` をまとめ、レコード数（デフォルト 1024）またはバイト数（デフォルト
+1 MiB）のいずれかに達したとき、および毎回の `commit()` 時にフラッシュします。
+クラッシュ時に失われるのは最後の未同期バッチまでで（SQLite の
+`synchronous = NORMAL` と同様）、インデックスが破損することはありません。
+オンデマンドで耐久バリアを強制するには `flushWal()` を呼び出します。
+
+```php
+use Laurus\Index;
+use Laurus\WalSyncPolicy;
+
+// デフォルト: レコードごとの fsync（引数を省略する）。
+$index = new Index();
+
+// group commit を有効にし、必要なときにフラッシュを強制する。
+$policy = WalSyncPolicy::group(4096, 4 * 1024 * 1024);
+$index = new Index("./myindex", null, $policy);
+
+$index->putDocument("doc1", ["title" => "Hello"]);
+$index->flushWal(); // バッチが満杯になるのを待たずに今すぐ永続化
+```
+
 ## 機能フラグ
 
 オプションの Cargo 機能フラグで追加のエンベディングバックエンドを有効にできます:

--- a/laurus-php/src/index.rs
+++ b/laurus-php/src/index.rs
@@ -5,12 +5,135 @@ use std::sync::Arc;
 
 use ext_php_rs::prelude::*;
 use ext_php_rs::types::{ZendHashTable, Zval};
-use laurus::{Engine, EngineStats, Storage, StorageConfig, StorageFactory};
+use laurus::{
+    DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, Engine, EngineStats, Storage,
+    StorageConfig, StorageFactory, WalSyncPolicy,
+};
 
 use crate::convert::{document_to_hashtable, hashtable_to_document};
 use crate::errors::laurus_err;
 use crate::schema::PhpSchema;
 use crate::search::{PhpSearchResult, build_request_from_php, to_php_search_result};
+
+// ---------------------------------------------------------------------------
+// WalSyncPolicy
+// ---------------------------------------------------------------------------
+
+/// Write-ahead-log (WAL) durability policy (`Laurus\WalSyncPolicy`).
+///
+/// This is a value object wrapping the Rust [`laurus::WalSyncPolicy`]. It is
+/// passed to [`PhpIndex::__construct`] as the optional third argument and
+/// controls when the engine forces appended records durable (fsync).
+///
+/// Construct one with the static factory methods rather than `new`:
+///
+/// ```php
+/// use Laurus\Index;
+/// use Laurus\WalSyncPolicy;
+///
+/// // Per-record durability (the default): every add/put is fsynced before
+/// // it returns, so a successful write can never be lost to a crash.
+/// $policy = WalSyncPolicy::perRecord();
+///
+/// // Group commit with the built-in default thresholds.
+/// $policy = WalSyncPolicy::group();
+///
+/// // Group commit with custom thresholds and a 1 s periodic flush.
+/// $policy = WalSyncPolicy::group(4096, 4 * 1024 * 1024, 1000);
+///
+/// $index = new Index(null, null, $policy);
+/// ```
+#[php_class]
+#[php(name = "Laurus\\WalSyncPolicy")]
+#[derive(Clone, Copy)]
+pub struct PhpWalSyncPolicy {
+    /// The wrapped Rust durability policy passed to the engine builder.
+    pub inner: WalSyncPolicy,
+}
+
+#[php_impl]
+impl PhpWalSyncPolicy {
+    /// Create a per-record durability policy.
+    ///
+    /// Every `addDocument` / `putDocument` is fsynced before it returns, so a
+    /// successful write can never be lost to a crash. This is the safest policy
+    /// and the engine default when no `wal_sync_policy` is supplied to
+    /// [`PhpIndex::__construct`], at the cost of the lowest ingest throughput.
+    ///
+    /// # Returns
+    ///
+    /// A `WalSyncPolicy` wrapping [`WalSyncPolicy::PerRecord`].
+    pub fn per_record() -> Self {
+        Self {
+            inner: WalSyncPolicy::PerRecord,
+        }
+    }
+
+    /// Create a group-commit durability policy.
+    ///
+    /// The engine defers the fsync and amortizes it over a batch: it flushes
+    /// when **either** `max_records` records **or** `max_bytes` bytes have
+    /// accumulated since the last sync (whichever comes first), and
+    /// unconditionally at `commit()`. This trades per-record durability for
+    /// ingest throughput — a crash can lose the most recent unsynced batch of
+    /// appends. `commit()` is still a hard durability barrier, and `flushWal()`
+    /// forces a flush on demand.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_records` - Flush after this many records accumulate since the
+    ///   last sync. Defaults to laurus' built-in
+    ///   [`DEFAULT_GROUP_MAX_RECORDS`] (1024) when null.
+    /// * `max_bytes` - Flush after this many appended bytes accumulate since
+    ///   the last sync. Defaults to laurus' built-in
+    ///   [`DEFAULT_GROUP_MAX_BYTES`] (1 MiB) when null.
+    /// * `max_interval_ms` - Optional periodic flush interval in milliseconds.
+    ///   When provided, the engine runs a background timer that forces the WAL
+    ///   durable at least this often so a trailing partial batch under a low
+    ///   ingest rate is not left unsynced indefinitely. Null disables the
+    ///   timer.
+    ///
+    /// # Returns
+    ///
+    /// A `WalSyncPolicy` wrapping [`WalSyncPolicy::Group`].
+    pub fn group(
+        max_records: Option<i64>,
+        max_bytes: Option<i64>,
+        max_interval_ms: Option<i64>,
+    ) -> Self {
+        Self {
+            inner: WalSyncPolicy::Group {
+                max_records: max_records
+                    .map(|v| v as usize)
+                    .unwrap_or(DEFAULT_GROUP_MAX_RECORDS),
+                max_bytes: max_bytes
+                    .map(|v| v as usize)
+                    .unwrap_or(DEFAULT_GROUP_MAX_BYTES),
+                max_interval: max_interval_ms.map(|v| std::time::Duration::from_millis(v as u64)),
+            },
+        }
+    }
+
+    /// Return a string representation.
+    pub fn __to_string(&self) -> String {
+        match self.inner {
+            WalSyncPolicy::PerRecord => "WalSyncPolicy.perRecord()".to_string(),
+            WalSyncPolicy::Group {
+                max_records,
+                max_bytes,
+                max_interval,
+            } => format!(
+                "WalSyncPolicy.group(max_records={}, max_bytes={}, max_interval_ms={})",
+                max_records,
+                max_bytes,
+                match max_interval {
+                    Some(d) => d.as_millis().to_string(),
+                    None => "null".to_string(),
+                }
+            ),
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Index
@@ -56,7 +179,15 @@ impl PhpIndex {
     /// * `path` - Directory path for persistent storage. Pass null (default)
     ///   for an ephemeral in-memory index.
     /// * `schema` - Schema definition (optional).
-    pub fn __construct(path: Option<String>, schema: Option<&PhpSchema>) -> PhpResult<Self> {
+    /// * `wal_sync_policy` - Optional [`PhpWalSyncPolicy`] controlling when the
+    ///   write-ahead log is forced durable. Defaults to per-record durability
+    ///   ([`WalSyncPolicy::PerRecord`]) when null. Use
+    ///   [`PhpWalSyncPolicy::group`] for higher-throughput group commit.
+    pub fn __construct(
+        path: Option<String>,
+        schema: Option<&PhpSchema>,
+        wal_sync_policy: Option<&PhpWalSyncPolicy>,
+    ) -> PhpResult<Self> {
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| ext_php_rs::exception::PhpException::default(e.to_string()))?;
 
@@ -67,9 +198,12 @@ impl PhpIndex {
             None => laurus::Schema::default(),
         };
 
-        let engine = rt
-            .block_on(Engine::new(storage, schema_val))
-            .map_err(laurus_err)?;
+        let mut builder = Engine::builder(storage, schema_val);
+        if let Some(policy) = wal_sync_policy {
+            builder = builder.wal_sync_policy(policy.inner);
+        }
+
+        let engine = rt.block_on(builder.build()).map_err(laurus_err)?;
 
         Ok(Self {
             engine: Arc::new(engine),
@@ -158,6 +292,30 @@ impl PhpIndex {
     pub fn commit(&self) -> PhpResult<()> {
         let engine = self.engine.clone();
         self.rt.block_on(engine.commit()).map_err(laurus_err)
+    }
+
+    /// Force the write-ahead log (WAL) durable without materializing the index.
+    ///
+    /// This synchronously fsyncs any appended-but-unsynced records and returns
+    /// once they are on stable storage. It runs directly on the calling thread
+    /// (the underlying `Engine::flush_wal` is synchronous), so unlike
+    /// `commit()` it does not block on the tokio runtime.
+    ///
+    /// # Durability trade-off
+    ///
+    /// This matters only under a group-commit [`PhpWalSyncPolicy`]
+    /// ([`PhpWalSyncPolicy::group`]), where individual appends are batched and
+    /// not yet durable. Under the default per-record policy
+    /// ([`PhpWalSyncPolicy::per_record`]) every append is already durable, so
+    /// this call is a cheap no-op-ish flush.
+    ///
+    /// With group commit a crash can lose the most recent unsynced batch of
+    /// appends. Call `flushWal()` to bound that window on demand without paying
+    /// the cost of a full `commit()` (which also fsyncs the WAL but additionally
+    /// materializes the in-memory index state). Use `flushWal()` when you want
+    /// the WAL durable but do not yet need the new documents to be searchable.
+    pub fn flush_wal(&self) -> PhpResult<()> {
+        self.engine.flush_wal().map_err(laurus_err)
     }
 
     // ── Search ────────────────────────────────────────────────────────────

--- a/laurus-php/src/lib.rs
+++ b/laurus-php/src/lib.rs
@@ -28,6 +28,7 @@ pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
         // Core
         .class::<index::PhpIndex>()
+        .class::<index::PhpWalSyncPolicy>()
         .class::<schema::PhpSchema>()
         // Search result & request, fusion algorithms
         .class::<search::PhpRRF>()

--- a/laurus-php/tests/LaurusTest.php
+++ b/laurus-php/tests/LaurusTest.php
@@ -691,4 +691,74 @@ class LaurusTest extends TestCase
         $this->expectException(\Throwable::class);
         $schema->addHnswField("embedding", 4, null, 16, 200, null, null, null, null, "bogus");
     }
+
+    // ── WAL group-commit / WalSyncPolicy (#820) ───────────────────────────
+
+    public function testIndexWithGroupCommitWalPolicy(): void
+    {
+        // An index built with a group-commit policy must still behave
+        // identically: documents survive flushWal() + commit() and remain
+        // retrievable.
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+        $idx = new Laurus\Index(null, $schema, Laurus\WalSyncPolicy::group());
+
+        $idx->putDocument("doc1", ["title" => "Hello"]);
+        // flushWal() forces the WAL durable without materializing the index.
+        $idx->flushWal();
+        // commit() makes the document searchable / retrievable.
+        $idx->commit();
+
+        $docs = $idx->getDocuments("doc1");
+        $this->assertCount(1, $docs);
+        $this->assertEquals("Hello", $docs[0]["title"]);
+    }
+
+    public function testFlushWalUnderPerRecordPolicy(): void
+    {
+        // flushWal() is also valid under the default per-record policy, where
+        // it is effectively a no-op since every append is already durable.
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+        $idx = new Laurus\Index(null, $schema, Laurus\WalSyncPolicy::perRecord());
+
+        $idx->putDocument("doc1", ["title" => "World"]);
+        $idx->flushWal();
+        $idx->commit();
+
+        $docs = $idx->getDocuments("doc1");
+        $this->assertCount(1, $docs);
+    }
+
+    public function testWalSyncPolicyFactoriesAccepted(): void
+    {
+        // Both factories build a value object that the Index constructor
+        // accepts. group() with explicit thresholds + interval must also work.
+        $perRecord = Laurus\WalSyncPolicy::perRecord();
+        $this->assertNotNull($perRecord);
+
+        $group = Laurus\WalSyncPolicy::group(256, 4096, 1000);
+        $this->assertNotNull($group);
+
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+
+        $idx1 = new Laurus\Index(null, $schema, $perRecord);
+        $this->assertNotNull($idx1);
+
+        $idx2 = new Laurus\Index(null, $schema, $group);
+        $this->assertNotNull($idx2);
+    }
+
+    public function testWalSyncPolicyDefaultsOmittedConstruct(): void
+    {
+        // Omitting wal_sync_policy entirely keeps the existing behavior
+        // (per-record durability), preserving backward compatibility.
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+        $idx = new Laurus\Index(null, $schema);
+        $idx->putDocument("doc1", ["title" => "Backward compatible"]);
+        $idx->commit();
+        $this->assertCount(1, $idx->getDocuments("doc1"));
+    }
 }

--- a/laurus-python/README.md
+++ b/laurus-python/README.md
@@ -69,6 +69,27 @@ schema.add_hnsw_field("embedding", dimension=384)
 index = laurus.Index(path="./myindex", schema=schema)
 ```
 
+## Durability / WAL
+
+A persistent index writes every change to a write-ahead log (WAL). By default
+the WAL is `fsync`-ed on every record, so each write is fully durable. Opt into
+group commit to batch `fsync` for higher write throughput (a crash can lose up
+to the last unsynced batch, like SQLite's `synchronous = NORMAL`):
+
+```python
+import laurus
+
+policy = laurus.WalSyncPolicy.group(max_records=4096, max_interval_ms=1000)
+index = laurus.Index(path="./myindex", schema=schema, wal_sync_policy=policy)
+
+index.put_document("doc1", {"title": "Hello"})
+index.flush_wal()  # force a durable barrier on demand
+index.commit()     # also flushes the WAL
+```
+
+Omit `wal_sync_policy` (or pass `laurus.WalSyncPolicy.per_record()`) to keep
+the default per-record durability.
+
 ## Query Types
 
 | Query class | Description |

--- a/laurus-python/README_ja.md
+++ b/laurus-python/README_ja.md
@@ -69,6 +69,28 @@ schema.add_hnsw_field("embedding", dimension=384)
 index = laurus.Index(path="./myindex", schema=schema)
 ```
 
+## 永続性 / WAL
+
+永続インデックスはすべての変更を先行書き込みログ（WAL）に書き込みます。
+デフォルトでは WAL はレコードごとに `fsync` されるため、各書き込みは完全に
+永続化されます。書き込みスループットを高めるためにグループコミットを有効化
+すると `fsync` をまとめられます（クラッシュ時には SQLite の
+`synchronous = NORMAL` と同様に最後の未同期バッチまでを失う可能性があります）:
+
+```python
+import laurus
+
+policy = laurus.WalSyncPolicy.group(max_records=4096, max_interval_ms=1000)
+index = laurus.Index(path="./myindex", schema=schema, wal_sync_policy=policy)
+
+index.put_document("doc1", {"title": "Hello"})
+index.flush_wal()  # 必要なときに永続性バリアを強制
+index.commit()     # WAL もフラッシュされます
+```
+
+`wal_sync_policy` を省略する（または `laurus.WalSyncPolicy.per_record()` を
+渡す）と、デフォルトのレコードごとの永続性が維持されます。
+
 ## クエリタイプ
 
 | クエリクラス | 説明 |

--- a/laurus-python/src/index.rs
+++ b/laurus-python/src/index.rs
@@ -7,10 +7,130 @@ use crate::convert::{dict_to_document, document_to_dict};
 use crate::errors::laurus_err;
 use crate::schema::PySchema;
 use crate::search::{PySearchResult, build_request_from_py, to_py_search_result};
-use laurus::{Engine, EngineStats, Storage, StorageConfig, StorageFactory};
+use laurus::{
+    DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, Engine, EngineStats, Storage,
+    StorageConfig, StorageFactory, WalSyncPolicy,
+};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+
+// ---------------------------------------------------------------------------
+// WalSyncPolicy
+// ---------------------------------------------------------------------------
+
+/// Durability policy that controls when Write-Ahead Log (WAL) appends are
+/// flushed (`fsync`'d) to durable storage.
+///
+/// This is a value object wrapping the Rust [`laurus::WalSyncPolicy`]. It is
+/// passed to [`Index`] at construction time via the `wal_sync_policy` keyword
+/// argument. It trades the durability of an *individual* write against ingest
+/// throughput; [`Index.commit`] is always a hard durability barrier regardless
+/// of the policy in effect.
+///
+/// ## Constructing a policy
+///
+/// ```python
+/// import laurus
+///
+/// # Per-record durability (the default): every append is fsync'd
+/// # before it returns. Safest, lowest ingest throughput.
+/// policy = laurus.WalSyncPolicy.per_record()
+///
+/// # Group-commit durability with default thresholds (batch fsyncs).
+/// policy = laurus.WalSyncPolicy.group()
+///
+/// # Group-commit with explicit thresholds and a flush interval.
+/// policy = laurus.WalSyncPolicy.group(
+///     max_records=4096,
+///     max_bytes=4 * 1024 * 1024,
+///     max_interval_ms=1000,
+/// )
+///
+/// index = laurus.Index(wal_sync_policy=policy)
+/// ```
+#[pyclass(name = "WalSyncPolicy", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyWalSyncPolicy {
+    /// The wrapped Rust durability policy.
+    pub inner: WalSyncPolicy,
+}
+
+#[pymethods]
+impl PyWalSyncPolicy {
+    /// Create a per-record durability policy.
+    ///
+    /// Every WAL append is fsync'd to durable storage before the write call
+    /// returns. This is the safest policy and the default behaviour when no
+    /// `wal_sync_policy` is supplied to [`Index`], at the cost of the lowest
+    /// ingest throughput.
+    ///
+    /// Returns:
+    ///     A `WalSyncPolicy` wrapping `WalSyncPolicy::PerRecord`.
+    #[staticmethod]
+    pub fn per_record() -> Self {
+        Self {
+            inner: WalSyncPolicy::PerRecord,
+        }
+    }
+
+    /// Create a group-commit durability policy.
+    ///
+    /// WAL appends are batched and fsync'd together once any of the configured
+    /// thresholds is reached, rather than one fsync per record. This increases
+    /// ingest throughput at the cost of potentially losing the last unsynced
+    /// batch on a crash. [`Index.commit`] remains a hard durability barrier,
+    /// and [`Index.flush_wal`] forces a flush on demand.
+    ///
+    /// Args:
+    ///     max_records: Flush after this many records accumulate since the last
+    ///         flush. Defaults to laurus' built-in
+    ///         `DEFAULT_GROUP_MAX_RECORDS` (1024) when `None`.
+    ///     max_bytes: Flush after this many bytes accumulate since the last
+    ///         flush. Defaults to laurus' built-in `DEFAULT_GROUP_MAX_BYTES`
+    ///         (1 MiB) when `None`.
+    ///     max_interval_ms: Optional time-based flush interval in milliseconds.
+    ///         When set, a background timer flushes the WAL at least this often
+    ///         even if the size thresholds have not been reached. When `None`
+    ///         (the default) no time-based flushing occurs.
+    ///
+    /// Returns:
+    ///     A `WalSyncPolicy` wrapping `WalSyncPolicy::Group { .. }`.
+    #[staticmethod]
+    #[pyo3(signature = (max_records=None, max_bytes=None, max_interval_ms=None))]
+    pub fn group(
+        max_records: Option<usize>,
+        max_bytes: Option<usize>,
+        max_interval_ms: Option<u64>,
+    ) -> Self {
+        Self {
+            inner: WalSyncPolicy::Group {
+                max_records: max_records.unwrap_or(DEFAULT_GROUP_MAX_RECORDS),
+                max_bytes: max_bytes.unwrap_or(DEFAULT_GROUP_MAX_BYTES),
+                max_interval: max_interval_ms.map(std::time::Duration::from_millis),
+            },
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        match self.inner {
+            WalSyncPolicy::PerRecord => "WalSyncPolicy.per_record()".to_string(),
+            WalSyncPolicy::Group {
+                max_records,
+                max_bytes,
+                max_interval,
+            } => format!(
+                "WalSyncPolicy.group(max_records={}, max_bytes={}, max_interval_ms={})",
+                max_records,
+                max_bytes,
+                match max_interval {
+                    Some(d) => d.as_millis().to_string(),
+                    None => "None".to_string(),
+                }
+            ),
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Index
@@ -76,18 +196,29 @@ impl PyIndex {
     ///     path: Directory path for persistent storage.
     ///           Pass `None` (default) for an ephemeral in-memory index.
     ///     schema: Schema definition.  If omitted, an empty schema is used.
+    ///     wal_sync_policy: Optional [`WalSyncPolicy`] controlling when WAL
+    ///           appends are fsync'd. When `None` (the default), laurus uses
+    ///           per-record durability (every append is fsync'd before it
+    ///           returns).
     #[new]
-    #[pyo3(signature = (path=None, schema=None))]
-    pub fn new(path: Option<String>, schema: Option<&PySchema>) -> PyResult<Self> {
+    #[pyo3(signature = (path=None, schema=None, wal_sync_policy=None))]
+    pub fn new(
+        path: Option<String>,
+        schema: Option<&PySchema>,
+        wal_sync_policy: Option<&PyWalSyncPolicy>,
+    ) -> PyResult<Self> {
         let rt =
             tokio::runtime::Runtime::new().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
         let storage = create_storage(path.as_deref())?;
         let schema = schema.map(|s| s.inner.clone()).unwrap_or_default();
 
-        let engine = rt
-            .block_on(Engine::new(storage, schema))
-            .map_err(laurus_err)?;
+        let mut builder = Engine::builder(storage, schema);
+        if let Some(p) = wal_sync_policy {
+            builder = builder.wal_sync_policy(p.inner);
+        }
+
+        let engine = rt.block_on(builder.build()).map_err(laurus_err)?;
 
         Ok(Self {
             engine: Arc::new(engine),
@@ -158,6 +289,32 @@ impl PyIndex {
     pub fn commit(&self, _py: Python) -> PyResult<()> {
         let engine = self.engine.clone();
         self.rt.block_on(engine.commit()).map_err(laurus_err)
+    }
+
+    /// Force any buffered Write-Ahead Log (WAL) appends to be flushed
+    /// (`fsync`'d) to durable storage.
+    ///
+    /// This matters only under a group-commit [`WalSyncPolicy`]
+    /// ([`WalSyncPolicy.group`]), where individual appends are batched and not
+    /// fsync'd immediately. Under the default per-record policy
+    /// ([`WalSyncPolicy.per_record`]) every append is already durable, so this
+    /// call is effectively a no-op.
+    ///
+    /// Durability trade-off: with group commit, a crash can lose the most
+    /// recent unsynced batch of appends. Call `flush_wal()` to bound that
+    /// window on demand without paying for a full [`commit`], which would also
+    /// materialize the in-memory index state. Use `flush_wal()` when you want
+    /// the WAL durable but do not yet need the pending changes to be
+    /// searchable; use [`commit`] when you need both.
+    ///
+    /// This call is synchronous and does not make any pending changes
+    /// searchable; use [`commit`] for that.
+    ///
+    /// Raises:
+    ///     An exception if the underlying WAL flush fails (for example, an I/O
+    ///     error while fsync'ing).
+    pub fn flush_wal(&self, _py: Python) -> PyResult<()> {
+        self.engine.flush_wal().map_err(laurus_err)
     }
 
     // ── Search ────────────────────────────────────────────────────────────

--- a/laurus-python/src/lib.rs
+++ b/laurus-python/src/lib.rs
@@ -17,7 +17,7 @@ mod schema;
 mod search;
 
 use analysis::{PySynonymDictionary, PySynonymGraphFilter, PyToken, PyWhitespaceTokenizer};
-use index::PyIndex;
+use index::{PyIndex, PyWalSyncPolicy};
 use pyo3::prelude::*;
 use query::{
     PyBooleanQuery, PyFuzzyQuery, PyGeo3dBoundingBoxQuery, PyGeo3dDistanceQuery,
@@ -53,6 +53,7 @@ fn laurus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // ── Core ─────────────────────────────────────────────────────────────
     m.add_class::<PyIndex>()?;
     m.add_class::<PySchema>()?;
+    m.add_class::<PyWalSyncPolicy>()?;
 
     // ── Search result & request ───────────────────────────────────────────
     m.add_class::<PySearchResult>()?;

--- a/laurus-python/tests/test_index.py
+++ b/laurus-python/tests/test_index.py
@@ -90,6 +90,57 @@ def test_get_documents_unknown_id(index):
 
 
 # ---------------------------------------------------------------------------
+# WAL sync policy
+# ---------------------------------------------------------------------------
+
+
+def test_wal_sync_policy_constructors():
+    """All WalSyncPolicy constructors build without error."""
+    assert laurus.WalSyncPolicy.per_record() is not None
+    assert laurus.WalSyncPolicy.group() is not None
+    assert (
+        laurus.WalSyncPolicy.group(
+            max_records=4096, max_bytes=2 * 1024 * 1024, max_interval_ms=1000
+        )
+        is not None
+    )
+
+
+def test_index_accepts_wal_sync_policies():
+    """Index construction accepts every WalSyncPolicy variant."""
+    assert laurus.Index(wal_sync_policy=laurus.WalSyncPolicy.per_record()) is not None
+    assert laurus.Index(wal_sync_policy=laurus.WalSyncPolicy.group()) is not None
+    assert (
+        laurus.Index(
+            wal_sync_policy=laurus.WalSyncPolicy.group(
+                max_records=8, max_bytes=4096, max_interval_ms=500
+            )
+        )
+        is not None
+    )
+
+
+def test_index_group_commit_flush_wal_then_commit():
+    """A document written under group commit is retrievable after flush+commit."""
+    idx = laurus.Index(wal_sync_policy=laurus.WalSyncPolicy.group())
+    idx.put_document("doc1", {"title": "Group Commit"})
+    idx.flush_wal()
+    idx.commit()
+    docs = idx.get_documents("doc1")
+    assert len(docs) == 1
+
+
+def test_flush_wal_per_record_is_noop():
+    """flush_wal() is a harmless no-op under the default per-record policy."""
+    idx = laurus.Index()
+    idx.put_document("doc1", {"title": "Per Record"})
+    idx.flush_wal()
+    idx.commit()
+    docs = idx.get_documents("doc1")
+    assert len(docs) == 1
+
+
+# ---------------------------------------------------------------------------
 # Stats
 # ---------------------------------------------------------------------------
 

--- a/laurus-ruby/src/index.rs
+++ b/laurus-ruby/src/index.rs
@@ -7,6 +7,7 @@ use crate::convert::{document_to_hash, hash_to_document};
 use crate::errors::laurus_err;
 use crate::schema::RbSchema;
 use crate::search::{build_request_from_rb, to_rb_search_result};
+use crate::wal::RbWalSyncPolicy;
 use laurus::{Engine, EngineStats, Storage, StorageConfig, StorageFactory};
 use magnus::prelude::*;
 use magnus::scan_args::{get_kwargs, scan_args};
@@ -54,17 +55,27 @@ impl RbIndex {
     ///   - `path:` (String, optional): Directory path for persistent storage.
     ///     Pass `nil` (default) for an ephemeral in-memory index.
     ///   - `schema:` (Schema, optional): Schema definition.
+    ///   - `wal_sync_policy:` (WalSyncPolicy, optional): WAL durability policy.
+    ///     Defaults to per-record fsync (highest durability). Pass
+    ///     `Laurus::WalSyncPolicy.group(...)` to enable group commit for higher
+    ///     write throughput; use `flush_wal` to force durability on demand.
     fn new(args: &[Value]) -> Result<Self, Error> {
         let ruby = Ruby::get().expect("called from Ruby thread");
         let args = scan_args::<(), (), (), (), RHash, ()>(args)?;
-        let kwargs = get_kwargs::<_, (), (Option<Option<String>>, Option<Option<&RbSchema>>), ()>(
-            args.keywords,
-            &[],
-            &["path", "schema"],
-        )?;
-        let (path, schema) = kwargs.optional;
+        let kwargs = get_kwargs::<
+            _,
+            (),
+            (
+                Option<Option<String>>,
+                Option<Option<&RbSchema>>,
+                Option<Option<&RbWalSyncPolicy>>,
+            ),
+            (),
+        >(args.keywords, &[], &["path", "schema", "wal_sync_policy"])?;
+        let (path, schema, wal_sync_policy) = kwargs.optional;
         let path = path.flatten();
         let schema_ref = schema.flatten();
+        let wal_sync_policy = wal_sync_policy.flatten();
 
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
@@ -74,9 +85,12 @@ impl RbIndex {
             .map(|s| s.inner.borrow().clone())
             .unwrap_or_default();
 
-        let engine = rt
-            .block_on(Engine::new(storage, schema))
-            .map_err(laurus_err)?;
+        let mut builder = Engine::builder(storage, schema);
+        if let Some(policy) = wal_sync_policy {
+            builder = builder.wal_sync_policy(policy.inner);
+        }
+
+        let engine = rt.block_on(builder.build()).map_err(laurus_err)?;
 
         Ok(Self {
             engine: Arc::new(engine),
@@ -163,6 +177,30 @@ impl RbIndex {
     fn commit(&self) -> Result<(), Error> {
         let engine = self.engine.clone();
         self.rt.block_on(engine.commit()).map_err(laurus_err)
+    }
+
+    /// Force any buffered Write-Ahead Log (WAL) appends to durable storage.
+    ///
+    /// This is an on-demand durability barrier and runs synchronously (no async
+    /// runtime is involved). Its effect depends on the configured
+    /// `wal_sync_policy`:
+    ///
+    /// * Under the default `Laurus::WalSyncPolicy.per_record`, every append is
+    ///   already fsync'd as it happens, so this is effectively a no-op.
+    /// * Under `Laurus::WalSyncPolicy.group(...)`, appends are buffered and
+    ///   their fsync is deferred for throughput; `flush_wal` fsyncs the
+    ///   outstanding batch immediately, guaranteeing those records survive a
+    ///   crash without waiting for a threshold or the next `commit`.
+    ///
+    /// Unlike `commit`, this does **not** make pending documents searchable; it
+    /// only guarantees their durability in the WAL. Call `commit` to publish
+    /// changes to searches.
+    ///
+    /// # Returns
+    ///
+    /// `nil` on success, or raises if the underlying fsync fails.
+    fn flush_wal(&self) -> Result<(), Error> {
+        self.engine.flush_wal().map_err(laurus_err)
     }
 
     // ── Search ────────────────────────────────────────────────────────────
@@ -364,6 +402,7 @@ pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
         magnus::method!(RbIndex::delete_documents, 1),
     )?;
     class.define_method("commit", magnus::method!(RbIndex::commit, 0))?;
+    class.define_method("flush_wal", magnus::method!(RbIndex::flush_wal, 0))?;
     class.define_method("search", magnus::method!(RbIndex::search, -1))?;
     class.define_method("search_batch", magnus::method!(RbIndex::search_batch, -1))?;
     class.define_method("stats", magnus::method!(RbIndex::stats, 0))?;

--- a/laurus-ruby/src/lib.rs
+++ b/laurus-ruby/src/lib.rs
@@ -18,6 +18,7 @@ mod index;
 mod query;
 mod schema;
 mod search;
+mod wal;
 
 use magnus::{Error, Ruby};
 
@@ -29,6 +30,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     // Core
     index::define(ruby, &module)?;
     schema::define(ruby, &module)?;
+    wal::define(ruby, &module)?;
 
     // Search result & request, fusion algorithms
     search::define(ruby, &module)?;

--- a/laurus-ruby/src/wal.rs
+++ b/laurus-ruby/src/wal.rs
@@ -1,0 +1,154 @@
+//! Ruby wrapper for the Laurus [`laurus::WalSyncPolicy`] value object.
+//!
+//! Exposes `Laurus::WalSyncPolicy` with the two construction class methods
+//! `per_record` and `group`, mirroring the durability policy plumbed through
+//! [`laurus::EngineBuilder::wal_sync_policy`]. The resulting value object is
+//! passed to `Laurus::Index.new(wal_sync_policy: ...)`.
+
+use std::time::Duration;
+
+use laurus::{DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, WalSyncPolicy};
+use magnus::prelude::*;
+use magnus::scan_args::{get_kwargs, scan_args};
+use magnus::{Error, RHash, RModule, Ruby, Value};
+
+// ---------------------------------------------------------------------------
+// WalSyncPolicy
+// ---------------------------------------------------------------------------
+
+/// Ruby value object wrapping a [`laurus::WalSyncPolicy`].
+///
+/// A WAL (Write-Ahead Log) sync policy controls when buffered WAL appends are
+/// fsync'd to durable storage:
+///
+/// * `Laurus::WalSyncPolicy.per_record` — the default. Every `put_document` /
+///   `add_document` / `delete_documents` append is fsync'd before the call
+///   returns. Highest durability (no data loss on crash), lowest throughput.
+/// * `Laurus::WalSyncPolicy.group(...)` — group commit. Appends are buffered
+///   and fsync'd once a record-count, byte, or time threshold is reached,
+///   trading a small crash-loss window for much higher write throughput.
+///
+/// # Examples
+///
+/// ```ruby
+/// require "laurus"
+///
+/// # Default per-record durability.
+/// policy = Laurus::WalSyncPolicy.per_record
+///
+/// # Group commit with the built-in defaults (1024 records / 1 MiB).
+/// policy = Laurus::WalSyncPolicy.group
+///
+/// # Group commit with custom thresholds and a 1 s flush timer.
+/// policy = Laurus::WalSyncPolicy.group(
+///   max_records: 256,
+///   max_bytes: 4096,
+///   max_interval_ms: 1000
+/// )
+///
+/// index = Laurus::Index.new(wal_sync_policy: policy)
+/// ```
+#[magnus::wrap(class = "Laurus::WalSyncPolicy")]
+pub struct RbWalSyncPolicy {
+    /// The wrapped core policy, forwarded verbatim to the engine builder.
+    pub inner: WalSyncPolicy,
+}
+
+impl RbWalSyncPolicy {
+    /// Build the per-record durability policy
+    /// ([`laurus::WalSyncPolicy::PerRecord`]).
+    ///
+    /// Every WAL append is fsync'd before the originating write returns, so no
+    /// committed-before-crash data can be lost. This is the engine default and
+    /// matches the behavior when `wal_sync_policy:` is omitted from
+    /// `Laurus::Index.new`.
+    ///
+    /// # Returns
+    ///
+    /// A `Laurus::WalSyncPolicy` wrapping
+    /// [`laurus::WalSyncPolicy::PerRecord`].
+    fn per_record() -> Self {
+        Self {
+            inner: WalSyncPolicy::PerRecord,
+        }
+    }
+
+    /// Build the group-commit durability policy
+    /// ([`laurus::WalSyncPolicy::Group`]).
+    ///
+    /// Group commit buffers WAL appends and defers the fsync until a threshold
+    /// is reached, batching the durability cost across many writes for higher
+    /// throughput at the price of a bounded crash-loss window.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - Keyword arguments (all optional):
+    ///   - `max_records:` (Integer): Flush after this many buffered records.
+    ///     Defaults to [`laurus::DEFAULT_GROUP_MAX_RECORDS`] (1024).
+    ///   - `max_bytes:` (Integer): Flush after this many buffered bytes.
+    ///     Defaults to [`laurus::DEFAULT_GROUP_MAX_BYTES`] (1 MiB).
+    ///   - `max_interval_ms:` (Integer): Maximum time, in milliseconds, that an
+    ///     append may stay un-fsync'd before a background timer flushes it.
+    ///     When omitted, no time-based flush timer is installed and the policy
+    ///     relies solely on the record-count and byte thresholds.
+    ///
+    /// Calling `group` with no arguments yields the default group-commit
+    /// thresholds with no flush timer.
+    ///
+    /// # Returns
+    ///
+    /// A `Laurus::WalSyncPolicy` wrapping [`laurus::WalSyncPolicy::Group`], or
+    /// an `ArgumentError` if an unexpected keyword is supplied.
+    fn group(args: &[Value]) -> Result<Self, Error> {
+        let args = scan_args::<(), (), (), (), RHash, ()>(args)?;
+        let kwargs = get_kwargs::<_, (), (Option<usize>, Option<usize>, Option<u64>), ()>(
+            args.keywords,
+            &[],
+            &["max_records", "max_bytes", "max_interval_ms"],
+        )?;
+        let (max_records, max_bytes, max_interval_ms) = kwargs.optional;
+        Ok(Self {
+            inner: WalSyncPolicy::Group {
+                max_records: max_records.unwrap_or(DEFAULT_GROUP_MAX_RECORDS),
+                max_bytes: max_bytes.unwrap_or(DEFAULT_GROUP_MAX_BYTES),
+                max_interval: max_interval_ms.map(Duration::from_millis),
+            },
+        })
+    }
+
+    /// Human-readable representation for `inspect` / `to_s`.
+    fn inspect(&self) -> String {
+        match self.inner {
+            WalSyncPolicy::PerRecord => "WalSyncPolicy(PerRecord)".to_string(),
+            WalSyncPolicy::Group {
+                max_records,
+                max_bytes,
+                max_interval,
+            } => format!(
+                "WalSyncPolicy(Group max_records={max_records} max_bytes={max_bytes} max_interval={max_interval:?})"
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class registration
+// ---------------------------------------------------------------------------
+
+/// Register the `Laurus::WalSyncPolicy` class and its methods.
+///
+/// # Arguments
+///
+/// * `ruby` - Ruby interpreter handle.
+/// * `module` - The `Laurus` module.
+pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("WalSyncPolicy", ruby.class_object())?;
+    class.define_singleton_method(
+        "per_record",
+        magnus::function!(RbWalSyncPolicy::per_record, 0),
+    )?;
+    class.define_singleton_method("group", magnus::function!(RbWalSyncPolicy::group, -1))?;
+    class.define_method("inspect", magnus::method!(RbWalSyncPolicy::inspect, 0))?;
+    class.define_method("to_s", magnus::method!(RbWalSyncPolicy::inspect, 0))?;
+    Ok(())
+}

--- a/laurus-ruby/test/test_index.rb
+++ b/laurus-ruby/test/test_index.rb
@@ -44,6 +44,34 @@ class TestIndex < Minitest::Test
   end
 
   # ---------------------------------------------------------------------------
+  # WAL sync policy / group commit
+  # ---------------------------------------------------------------------------
+
+  def test_wal_sync_policy_constructors
+    # Both constructors build accepted value objects.
+    per_record = Laurus::WalSyncPolicy.per_record
+    refute_nil per_record
+
+    group = Laurus::WalSyncPolicy.group(max_records: 256, max_bytes: 4096, max_interval_ms: 1000)
+    refute_nil group
+
+    # group with no args == defaults; both are accepted by Index.new.
+    refute_nil Laurus::Index.new(wal_sync_policy: Laurus::WalSyncPolicy.per_record)
+    refute_nil Laurus::Index.new(wal_sync_policy: Laurus::WalSyncPolicy.group)
+    refute_nil Laurus::Index.new(wal_sync_policy: group)
+  end
+
+  def test_index_with_group_commit_flush_and_commit
+    idx = Laurus::Index.new(wal_sync_policy: Laurus::WalSyncPolicy.group)
+    idx.put_document("doc1", { "title" => "Group commit" })
+    # flush_wal forces WAL durability without publishing to searches.
+    idx.flush_wal
+    idx.commit
+    docs = idx.get_documents("doc1")
+    assert_equal 1, docs.length
+  end
+
+  # ---------------------------------------------------------------------------
   # Document CRUD
   # ---------------------------------------------------------------------------
 

--- a/laurus-server/proto/laurus/v1/document.proto
+++ b/laurus-server/proto/laurus/v1/document.proto
@@ -19,6 +19,11 @@ service DocumentService {
 
   // Commit pending changes to persistent storage.
   rpc Commit(CommitRequest) returns (CommitResponse);
+
+  // Force any buffered WAL records durable without a full commit. Useful under
+  // the group-commit sync policy to flush a partial batch on demand; a near
+  // no-op under the default per-record policy.
+  rpc FlushWal(FlushWalRequest) returns (FlushWalResponse);
 }
 
 message PutDocumentRequest {
@@ -52,3 +57,7 @@ message DeleteDocumentsResponse {}
 message CommitRequest {}
 
 message CommitResponse {}
+
+message FlushWalRequest {}
+
+message FlushWalResponse {}

--- a/laurus-server/src/config.rs
+++ b/laurus-server/src/config.rs
@@ -4,8 +4,10 @@
 //! index storage, and logging. All sections have sensible defaults so that
 //! a minimal (or even empty) TOML file produces a working configuration.
 
+use laurus::{DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, WalSyncPolicy};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// Top-level configuration loaded from a TOML file.
 #[derive(Debug, Deserialize, Default)]
@@ -49,12 +51,78 @@ pub struct IndexConfig {
     /// Defaults to `"./laurus_data"`.
     #[serde(default = "default_data_dir")]
     pub data_dir: PathBuf,
+    /// Write-ahead log durability settings. Defaults to per-record fsync.
+    #[serde(default)]
+    pub wal: WalConfig,
 }
 
 impl Default for IndexConfig {
     fn default() -> Self {
         Self {
             data_dir: default_data_dir(),
+            wal: WalConfig::default(),
+        }
+    }
+}
+
+/// The WAL sync policy selector deserialized from the config file.
+///
+/// Mirrors the variants of [`laurus::WalSyncPolicy`] without their parameters;
+/// the [`WalConfig`] group thresholds are applied when the policy is
+/// [`SyncPolicyKind::Group`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncPolicyKind {
+    /// Fsync after every record (default); maps to [`WalSyncPolicy::PerRecord`].
+    #[default]
+    PerRecord,
+    /// Batch fsyncs; maps to [`WalSyncPolicy::Group`] with the [`WalConfig`]
+    /// thresholds.
+    Group,
+}
+
+/// Write-ahead log durability configuration.
+///
+/// Selects the [`laurus::WalSyncPolicy`] used for the index. The default is
+/// [`SyncPolicyKind::PerRecord`], preserving per-record durability. When
+/// `sync_policy = "group"`, the optional `group_*` thresholds tune the batch;
+/// unset thresholds fall back to [`laurus::DEFAULT_GROUP_MAX_RECORDS`] /
+/// [`laurus::DEFAULT_GROUP_MAX_BYTES`].
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+pub struct WalConfig {
+    /// Which durability policy to use. Defaults to `per_record`.
+    #[serde(default)]
+    pub sync_policy: SyncPolicyKind,
+    /// Flush once this many records accumulate (group policy only). Falls back
+    /// to [`laurus::DEFAULT_GROUP_MAX_RECORDS`] when unset.
+    #[serde(default)]
+    pub group_max_records: Option<usize>,
+    /// Flush once this many bytes accumulate (group policy only). Falls back to
+    /// [`laurus::DEFAULT_GROUP_MAX_BYTES`] when unset.
+    #[serde(default)]
+    pub group_max_bytes: Option<usize>,
+    /// Periodic flush interval in milliseconds (group policy only). When unset
+    /// no background timer runs. Honored on native targets only.
+    #[serde(default)]
+    pub group_max_interval_ms: Option<u64>,
+}
+
+impl WalConfig {
+    /// Convert this configuration into a [`laurus::WalSyncPolicy`].
+    ///
+    /// # Returns
+    ///
+    /// [`WalSyncPolicy::PerRecord`] when `sync_policy` is `per_record`, or
+    /// [`WalSyncPolicy::Group`] with the configured thresholds (defaults applied
+    /// for unset values) when `sync_policy` is `group`.
+    pub fn to_policy(&self) -> WalSyncPolicy {
+        match self.sync_policy {
+            SyncPolicyKind::PerRecord => WalSyncPolicy::PerRecord,
+            SyncPolicyKind::Group => WalSyncPolicy::Group {
+                max_records: self.group_max_records.unwrap_or(DEFAULT_GROUP_MAX_RECORDS),
+                max_bytes: self.group_max_bytes.unwrap_or(DEFAULT_GROUP_MAX_BYTES),
+                max_interval: self.group_max_interval_ms.map(Duration::from_millis),
+            },
         }
     }
 }
@@ -91,5 +159,56 @@ impl Config {
         let content = std::fs::read_to_string(path)?;
         let config: Config = toml::from_str(&content)?;
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_wal_policy_is_per_record() {
+        // An empty config (no [index.wal] section) must keep per-record fsync.
+        let config: Config = toml::from_str("").unwrap();
+        assert_eq!(config.index.wal.sync_policy, SyncPolicyKind::PerRecord);
+        assert_eq!(config.index.wal.to_policy(), WalSyncPolicy::PerRecord);
+    }
+
+    #[test]
+    fn group_policy_uses_defaults_when_thresholds_omitted() {
+        let toml = r#"
+            [index.wal]
+            sync_policy = "group"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.index.wal.sync_policy, SyncPolicyKind::Group);
+        assert_eq!(
+            config.index.wal.to_policy(),
+            WalSyncPolicy::Group {
+                max_records: DEFAULT_GROUP_MAX_RECORDS,
+                max_bytes: DEFAULT_GROUP_MAX_BYTES,
+                max_interval: None,
+            }
+        );
+    }
+
+    #[test]
+    fn group_policy_honors_explicit_thresholds_and_interval() {
+        let toml = r#"
+            [index.wal]
+            sync_policy = "group"
+            group_max_records = 256
+            group_max_bytes = 4096
+            group_max_interval_ms = 500
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.index.wal.to_policy(),
+            WalSyncPolicy::Group {
+                max_records: 256,
+                max_bytes: 4096,
+                max_interval: Some(Duration::from_millis(500)),
+            }
+        );
     }
 }

--- a/laurus-server/src/context.rs
+++ b/laurus-server/src/context.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use anyhow::{Context, bail};
 use laurus::storage::file::FileStorageConfig;
-use laurus::{Engine, Schema, StorageConfig, StorageFactory};
+use laurus::{Engine, Schema, StorageConfig, StorageFactory, WalSyncPolicy};
 
 /// Filename used to persist the index schema inside the data directory.
 const SCHEMA_FILE: &str = "schema.toml";
@@ -24,8 +24,9 @@ const STORE_DIR: &str = "store";
 ///
 /// # Arguments
 ///
-/// * `data_dir` - Root directory where the index files will be stored.
-/// * `schema`   - The schema definition describing the index fields.
+/// * `data_dir`  - Root directory where the index files will be stored.
+/// * `schema`    - The schema definition describing the index fields.
+/// * `wal_policy` - WAL durability policy threaded into the engine builder.
 ///
 /// # Returns
 ///
@@ -35,7 +36,11 @@ const STORE_DIR: &str = "store";
 ///
 /// Returns an error if an index already exists at `data_dir`, if directory
 /// creation fails, or if the engine cannot be initialised.
-pub async fn create_index(data_dir: &Path, schema: &Schema) -> anyhow::Result<Engine> {
+pub async fn create_index(
+    data_dir: &Path,
+    schema: &Schema,
+    wal_policy: WalSyncPolicy,
+) -> anyhow::Result<Engine> {
     let schema_path = data_dir.join(SCHEMA_FILE);
     if schema_path.exists() {
         bail!(
@@ -57,7 +62,10 @@ pub async fn create_index(data_dir: &Path, schema: &Schema) -> anyhow::Result<En
     let store_path = data_dir.join(STORE_DIR);
     let storage_config = StorageConfig::File(FileStorageConfig::new(&store_path));
     let storage = StorageFactory::create(storage_config)?;
-    let engine = Engine::new(storage, schema.clone()).await?;
+    let engine = Engine::builder(storage, schema.clone())
+        .wal_sync_policy(wal_policy)
+        .build()
+        .await?;
 
     Ok(engine)
 }
@@ -69,7 +77,8 @@ pub async fn create_index(data_dir: &Path, schema: &Schema) -> anyhow::Result<En
 ///
 /// # Arguments
 ///
-/// * `data_dir` - Root directory of an existing index.
+/// * `data_dir`  - Root directory of an existing index.
+/// * `wal_policy` - WAL durability policy threaded into the engine builder.
 ///
 /// # Returns
 ///
@@ -80,7 +89,7 @@ pub async fn create_index(data_dir: &Path, schema: &Schema) -> anyhow::Result<En
 /// Returns an error if no index exists at `data_dir` (i.e. `schema.toml` is
 /// missing), if the schema file cannot be read or parsed, or if the engine
 /// fails to initialise.
-pub async fn open_index(data_dir: &Path) -> anyhow::Result<Engine> {
+pub async fn open_index(data_dir: &Path, wal_policy: WalSyncPolicy) -> anyhow::Result<Engine> {
     let schema_path = data_dir.join(SCHEMA_FILE);
     if !schema_path.exists() {
         bail!(
@@ -96,7 +105,10 @@ pub async fn open_index(data_dir: &Path) -> anyhow::Result<Engine> {
     let store_path = data_dir.join(STORE_DIR);
     let storage_config = StorageConfig::File(FileStorageConfig::new(&store_path));
     let storage = StorageFactory::open(storage_config)?;
-    let engine = Engine::new(storage, schema).await?;
+    let engine = Engine::builder(storage, schema)
+        .wal_sync_policy(wal_policy)
+        .build()
+        .await?;
 
     Ok(engine)
 }

--- a/laurus-server/src/gateway.rs
+++ b/laurus-server/src/gateway.rs
@@ -56,6 +56,7 @@ pub fn create_router(state: GatewayState) -> Router {
                 .delete(document::delete_documents),
         )
         .route("/v1/commit", post(document::commit))
+        .route("/v1/flush_wal", post(document::flush_wal))
         .route("/v1/search", post(search::search))
         .route("/v1/search/stream", post(search::search_stream))
         .route("/v1/search/batch", post(search::search_batch))

--- a/laurus-server/src/gateway/document.rs
+++ b/laurus-server/src/gateway/document.rs
@@ -103,3 +103,15 @@ pub async fn commit(State(mut state): State<GatewayState>) -> Result<Json<Value>
 
     Ok(Json(json!({})))
 }
+
+/// `POST /v1/flush_wal` — Forces buffered WAL records durable without a full
+/// commit (group-commit on-demand barrier; near no-op under per-record sync).
+pub async fn flush_wal(State(mut state): State<GatewayState>) -> Result<Json<Value>, Response> {
+    state
+        .document_client
+        .flush_wal(v1::FlushWalRequest {})
+        .await
+        .map_err(|s| GatewayError(s).into_response())?;
+
+    Ok(Json(json!({})))
+}

--- a/laurus-server/src/server.rs
+++ b/laurus-server/src/server.rs
@@ -55,8 +55,12 @@ pub async fn run(config: &Config) -> anyhow::Result<()> {
     tracing::info!("Laurus server starting");
     tracing::info!("Data directory: {}", config.index.data_dir.display());
 
+    // Resolve the WAL durability policy once; it applies to both the boot-time
+    // open below and any index created later via the CreateIndex RPC.
+    let wal_policy = config.index.wal.to_policy();
+
     // Open an existing index. If none exists, start without an index.
-    let engine = match context::open_index(&config.index.data_dir).await {
+    let engine = match context::open_index(&config.index.data_dir, wal_policy).await {
         Ok(engine) => {
             tracing::info!("Opened existing index");
             Some(engine)
@@ -77,6 +81,7 @@ pub async fn run(config: &Config) -> anyhow::Result<()> {
     let index_service = IndexService {
         engine: engine.clone(),
         data_dir,
+        wal_policy,
     };
     let search_service = SearchService {
         engine: engine.clone(),

--- a/laurus-server/src/service/document.rs
+++ b/laurus-server/src/service/document.rs
@@ -13,8 +13,9 @@ use laurus::Engine;
 use crate::convert::{document as doc_convert, error};
 use crate::proto::laurus::v1::{
     AddDocumentRequest, AddDocumentResponse, CommitRequest, CommitResponse, DeleteDocumentsRequest,
-    DeleteDocumentsResponse, GetDocumentsRequest, GetDocumentsResponse, PutDocumentRequest,
-    PutDocumentResponse, document_service_server::DocumentService as DocumentServiceTrait,
+    DeleteDocumentsResponse, FlushWalRequest, FlushWalResponse, GetDocumentsRequest,
+    GetDocumentsResponse, PutDocumentRequest, PutDocumentResponse,
+    document_service_server::DocumentService as DocumentServiceTrait,
 };
 
 /// gRPC DocumentService implementation.
@@ -125,5 +126,69 @@ impl DocumentServiceTrait for DocumentService {
         engine.commit().await.map_err(error::to_status)?;
 
         Ok(Response::new(CommitResponse {}))
+    }
+
+    /// Forces any buffered WAL records durable without a full commit.
+    ///
+    /// A near no-op under the default per-record sync policy; under the
+    /// group-commit policy it flushes a partial batch on demand.
+    async fn flush_wal(
+        &self,
+        _request: Request<FlushWalRequest>,
+    ) -> Result<Response<FlushWalResponse>, Status> {
+        let guard = self.engine.read().await;
+        let engine = Self::get_engine_ref(&guard)?;
+        engine.flush_wal().map_err(error::to_status)?;
+
+        Ok(Response::new(FlushWalResponse {}))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use laurus::storage::memory::MemoryStorage;
+    use laurus::{Schema, Storage, WalSyncPolicy};
+
+    async fn service_with_engine(policy: WalSyncPolicy) -> DocumentService {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let engine = Engine::builder(storage, Schema::default())
+            .wal_sync_policy(policy)
+            .build()
+            .await
+            .unwrap();
+        DocumentService {
+            engine: Arc::new(RwLock::new(Some(engine))),
+        }
+    }
+
+    #[tokio::test]
+    async fn flush_wal_fails_without_an_index() {
+        let service = DocumentService {
+            engine: Arc::new(RwLock::new(None)),
+        };
+        let status = service
+            .flush_wal(Request::new(FlushWalRequest {}))
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn flush_wal_succeeds_under_per_record_policy() {
+        let service = service_with_engine(WalSyncPolicy::PerRecord).await;
+        service
+            .flush_wal(Request::new(FlushWalRequest {}))
+            .await
+            .expect("flush_wal must succeed (near no-op) under per-record policy");
+    }
+
+    #[tokio::test]
+    async fn flush_wal_succeeds_under_group_policy() {
+        let service = service_with_engine(WalSyncPolicy::group_with_defaults()).await;
+        service
+            .flush_wal(Request::new(FlushWalRequest {}))
+            .await
+            .expect("flush_wal must act as a durability barrier under group policy");
     }
 }

--- a/laurus-server/src/service/index.rs
+++ b/laurus-server/src/service/index.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
-use laurus::Engine;
+use laurus::{Engine, WalSyncPolicy};
 
 use crate::context;
 use crate::convert::{error, schema as schema_convert};
@@ -27,6 +27,8 @@ pub struct IndexService {
     pub engine: Arc<RwLock<Option<Engine>>>,
     /// Filesystem path where the index data is persisted.
     pub data_dir: PathBuf,
+    /// WAL durability policy applied to indices created via this service.
+    pub wal_policy: WalSyncPolicy,
 }
 
 #[tonic::async_trait]
@@ -48,7 +50,7 @@ impl IndexServiceTrait for IndexService {
             return Err(Status::already_exists("Index already exists"));
         }
 
-        let engine = context::create_index(&self.data_dir, &schema)
+        let engine = context::create_index(&self.data_dir, &schema, self.wal_policy)
             .await
             .map_err(error::anyhow_to_status)?;
         *guard = Some(engine);

--- a/laurus-wasm/README.md
+++ b/laurus-wasm/README.md
@@ -80,6 +80,31 @@ const stats = index.stats();
 // } }
 ```
 
+### Durability / WAL
+
+Each change is appended to the engine's in-memory write-ahead log (WAL). By
+default the WAL is flushed on every record. Opt into group commit to batch the
+flush for higher write throughput (a crash can lose up to the last unsynced
+batch, like SQLite's `synchronous = NORMAL`):
+
+```javascript
+import { Index, Schema, WalSyncPolicy } from "./pkg/laurus_wasm.js";
+
+// maxRecords, maxBytes, maxIntervalMs (all optional)
+const policy = WalSyncPolicy.group(4096, undefined, 1000);
+const index = await Index.open("my-index", schema, policy);
+
+await index.putDocument("doc1", { title: "Hello" });
+await index.flushWal(); // flushes the engine WAL only
+await index.commit();   // makes changes searchable AND persists to OPFS
+```
+
+WASM caveats: the `maxIntervalMs` background timer is a **no-op** on wasm (no
+background threads), and `flushWal()` flushes the in-memory engine WAL only —
+OPFS persistence still happens at `commit()`. Call `commit()` for durable
+persistence. Omit `walSyncPolicy` (or pass `WalSyncPolicy.perRecord()`) to keep
+the default per-record behaviour.
+
 ### Schema
 
 ```javascript

--- a/laurus-wasm/README_ja.md
+++ b/laurus-wasm/README_ja.md
@@ -80,6 +80,33 @@ const stats = index.stats();
 // } }
 ```
 
+### 永続性 / WAL
+
+各変更は、エンジンのインメモリ先行書き込みログ（WAL）に追記されます。
+デフォルトでは WAL はレコードごとにフラッシュされます。書き込みスループットを
+高めるためにグループコミットを有効化するとフラッシュをまとめられます
+（クラッシュ時には SQLite の `synchronous = NORMAL` と同様に最後の未同期
+バッチまでを失う可能性があります）:
+
+```javascript
+import { Index, Schema, WalSyncPolicy } from "./pkg/laurus_wasm.js";
+
+// maxRecords, maxBytes, maxIntervalMs（いずれも省略可）
+const policy = WalSyncPolicy.group(4096, undefined, 1000);
+const index = await Index.open("my-index", schema, policy);
+
+await index.putDocument("doc1", { title: "Hello" });
+await index.flushWal(); // エンジン WAL のみをフラッシュ
+await index.commit();   // 変更を検索可能にし、かつ OPFS に永続化する
+```
+
+WASM の注意点: `maxIntervalMs` のバックグラウンドタイマーは wasm では
+**no-op** です（バックグラウンドスレッドがないため）。また `flushWal()` は
+インメモリエンジンの WAL のみをフラッシュし、OPFS への永続化は引き続き
+`commit()` で行われます。永続的な永続化には `commit()` を呼び出してください。
+`walSyncPolicy` を省略する（または `WalSyncPolicy.perRecord()` を渡す）と、
+デフォルトのレコードごとの動作が維持されます。
+
 ### Schema
 
 ```javascript

--- a/laurus-wasm/src/index.rs
+++ b/laurus-wasm/src/index.rs
@@ -11,6 +11,7 @@ use crate::query::{
 use crate::schema::WasmSchema;
 use crate::search::{build_dsl_request, build_lexical_request, build_vector_request};
 use crate::storage::OpfsPersistence;
+use crate::wal::WasmWalSyncPolicy;
 use laurus::embedding::embedder::Embedder;
 use laurus::embedding::per_field::PerFieldEmbedder;
 use laurus::embedding::precomputed::PrecomputedEmbedder;
@@ -142,12 +143,18 @@ impl WasmIndex {
     /// # Arguments
     ///
     /// * `schema` - Schema definition.
+    /// * `wal_sync_policy` - Optional WAL durability policy. Defaults to
+    ///   per-record fsync when omitted. Pass `WalSyncPolicy.group()` to opt into
+    ///   group-commit batching.
     ///
     /// # Returns
     ///
     /// A new `Index` instance backed by in-memory storage.
     #[wasm_bindgen]
-    pub async fn create(schema: WasmSchema) -> Result<WasmIndex, JsValue> {
+    pub async fn create(
+        schema: WasmSchema,
+        wal_sync_policy: Option<WasmWalSyncPolicy>,
+    ) -> Result<WasmIndex, JsValue> {
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
         let js_embedders = schema.js_embedders;
         let runtime_analyzers = schema.runtime_analyzers;
@@ -166,6 +173,9 @@ impl WasmIndex {
         }
         for (name, analyzer) in runtime_analyzers {
             builder = builder.register_runtime_analyzer(name, analyzer);
+        }
+        if let Some(policy) = wal_sync_policy {
+            builder = builder.wal_sync_policy(policy.inner);
         }
 
         let engine = builder.build().await.map_err(laurus_err)?;
@@ -188,12 +198,19 @@ impl WasmIndex {
     ///
     /// * `name` - Index name (used as the OPFS subdirectory name).
     /// * `schema` - Schema definition.
+    /// * `wal_sync_policy` - Optional WAL durability policy. Defaults to
+    ///   per-record fsync when omitted. Pass `WalSyncPolicy.group()` to opt into
+    ///   group-commit batching.
     ///
     /// # Returns
     ///
     /// A new `Index` instance backed by OPFS-persistent storage.
     #[wasm_bindgen]
-    pub async fn open(name: String, schema: WasmSchema) -> Result<WasmIndex, JsValue> {
+    pub async fn open(
+        name: String,
+        schema: WasmSchema,
+        wal_sync_policy: Option<WasmWalSyncPolicy>,
+    ) -> Result<WasmIndex, JsValue> {
         let opfs = OpfsPersistence::open(&name).await?;
         let storage = opfs.load().await?;
         let js_embedders = schema.js_embedders;
@@ -212,6 +229,9 @@ impl WasmIndex {
         }
         for (name, analyzer) in runtime_analyzers {
             builder = builder.register_runtime_analyzer(name, analyzer);
+        }
+        if let Some(policy) = wal_sync_policy {
+            builder = builder.wal_sync_policy(policy.inner);
         }
 
         let engine = builder.build().await.map_err(laurus_err)?;
@@ -302,6 +322,28 @@ impl WasmIndex {
         }
 
         Ok(())
+    }
+
+    /// Force every appended-but-unsynced WAL record durable, without a full
+    /// `commit()` (Issue #542 / #820).
+    ///
+    /// Under the default per-record policy this is a near-no-op: each
+    /// `putDocument` / `addDocument` / `deleteDocuments` already fsyncs, so there
+    /// is nothing pending. Under `WalSyncPolicy.group()` appends defer their
+    /// fsync, so this is the way to bound the crash-loss window at an
+    /// application-chosen point without paying the cost of materializing the
+    /// lexical/vector indexes that `commit()` entails.
+    ///
+    /// Unlike `commit()`, this does **not** rebuild the searchable indexes and
+    /// does **not** persist to OPFS — OPFS durability still requires `commit()`.
+    ///
+    /// **wasm note:** the `maxIntervalMs` background flush timer configured via
+    /// `WalSyncPolicy.group()` is a no-op under WebAssembly (it is native-only in
+    /// the core), so `flushWal()` and `commit()` are the only ways to flush a
+    /// deferred group-commit batch on this target.
+    #[wasm_bindgen(js_name = "flushWal")]
+    pub async fn flush_wal(&self) -> Result<(), JsValue> {
+        self.engine.flush_wal().map_err(laurus_err)
     }
 
     // ── Search ────────────────────────────────────────────────────────────

--- a/laurus-wasm/src/lib.rs
+++ b/laurus-wasm/src/lib.rs
@@ -22,3 +22,4 @@ mod query;
 mod schema;
 mod search;
 mod storage;
+mod wal;

--- a/laurus-wasm/src/wal.rs
+++ b/laurus-wasm/src/wal.rs
@@ -1,0 +1,181 @@
+//! WASM wrapper for the Laurus [`WalSyncPolicy`] value object (Issue #820).
+//!
+//! Exposes the write-ahead-log durability policy to JavaScript so that callers
+//! can opt into group-commit batching when constructing an [`crate::index::WasmIndex`].
+
+use std::time::Duration;
+
+use laurus::{DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, WalSyncPolicy};
+use wasm_bindgen::prelude::*;
+
+/// Write-ahead-log (WAL) durability policy for an [`crate::index::WasmIndex`].
+///
+/// Controls when WAL appends are made durable (fsync'd):
+///
+/// - **Per-record** (the default) — every `putDocument` / `addDocument` /
+///   `deleteDocuments` fsyncs the WAL before returning, so a successful write
+///   can never be lost to a crash.
+/// - **Group commit** — fsyncs are deferred and batched until a record-count or
+///   byte threshold is reached, yielding much higher ingest throughput at the
+///   cost of losing up to the last unsynced batch on a crash. Use
+///   `commit()` (a hard durability barrier) or `flushWal()` to bound the
+///   crash-loss window on demand.
+///
+/// ```javascript
+/// import { Index, Schema, WalSyncPolicy } from "laurus-wasm";
+///
+/// const schema = new Schema();
+/// schema.addTextField("title");
+///
+/// // Group commit with default thresholds (1024 records / 1 MiB).
+/// const policy = WalSyncPolicy.group();
+///
+/// // Or customize the thresholds.
+/// const tuned = WalSyncPolicy.group(2048, 2 * 1024 * 1024, 50);
+///
+/// const index = await Index.create(schema, policy);
+/// ```
+///
+/// **wasm note:** the `maxIntervalMs` background flush timer is a no-op under
+/// WebAssembly (the core gates it on native targets only). The record-count and
+/// byte thresholds still apply; call `commit()` or `flushWal()` to flush
+/// explicitly.
+#[wasm_bindgen(js_name = "WalSyncPolicy")]
+#[derive(Clone, Copy)]
+pub struct WasmWalSyncPolicy {
+    /// The wrapped core durability policy passed to `EngineBuilder`.
+    pub(crate) inner: WalSyncPolicy,
+}
+
+#[wasm_bindgen(js_class = "WalSyncPolicy")]
+impl WasmWalSyncPolicy {
+    /// The per-record durability policy: every WAL append is fsync'd before the
+    /// write returns. This is the default and the safest policy.
+    ///
+    /// # Returns
+    ///
+    /// A `WalSyncPolicy` wrapping [`WalSyncPolicy::PerRecord`].
+    #[wasm_bindgen(js_name = "perRecord")]
+    pub fn per_record() -> WasmWalSyncPolicy {
+        WasmWalSyncPolicy {
+            inner: WalSyncPolicy::PerRecord,
+        }
+    }
+
+    /// The group-commit durability policy: WAL fsyncs are deferred and batched
+    /// until a threshold is reached.
+    ///
+    /// Each threshold falls back to the core default when omitted, so
+    /// `WalSyncPolicy.group()` is equivalent to the documented defaults
+    /// (1024 records / 1 MiB / no timer).
+    ///
+    /// # Arguments
+    ///
+    /// * `max_records` - Flush after this many buffered records. Defaults to
+    ///   [`DEFAULT_GROUP_MAX_RECORDS`] (1024) when omitted.
+    /// * `max_bytes` - Flush after this many buffered bytes. Defaults to
+    ///   [`DEFAULT_GROUP_MAX_BYTES`] (1 MiB) when omitted.
+    /// * `max_interval_ms` - Optional time-based flush interval in
+    ///   milliseconds. **No-op under WebAssembly** (the background timer is
+    ///   native-only in the core); the thresholds above still apply.
+    ///
+    /// # Returns
+    ///
+    /// A `WalSyncPolicy` wrapping [`WalSyncPolicy::Group`].
+    #[wasm_bindgen(js_name = "group")]
+    pub fn group(
+        max_records: Option<u32>,
+        max_bytes: Option<u32>,
+        max_interval_ms: Option<f64>,
+    ) -> WasmWalSyncPolicy {
+        WasmWalSyncPolicy {
+            inner: WalSyncPolicy::Group {
+                max_records: max_records
+                    .map(|v| v as usize)
+                    .unwrap_or(DEFAULT_GROUP_MAX_RECORDS),
+                max_bytes: max_bytes
+                    .map(|v| v as usize)
+                    .unwrap_or(DEFAULT_GROUP_MAX_BYTES),
+                max_interval: max_interval_ms.map(|ms| Duration::from_millis(ms as u64)),
+            },
+        }
+    }
+}
+
+// The laurus core crate only compiles when its default `native` feature is on,
+// which laurus-wasm disables (`default-features = false`). As a result the
+// dependency cannot be built for the native host target, so these tests — like
+// the rest of the crate — are exercised on `wasm32` via `wasm_bindgen_test`
+// (run with `wasm-pack test --node`). The assertions are pure value-object
+// checks with no JS or browser interaction.
+#[cfg(test)]
+#[cfg(target_arch = "wasm32")]
+mod tests {
+    use super::WasmWalSyncPolicy;
+    use laurus::{DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, WalSyncPolicy};
+    use std::time::Duration;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    /// `perRecord()` must wrap [`WalSyncPolicy::PerRecord`].
+    #[wasm_bindgen_test]
+    fn per_record_wraps_per_record() {
+        let policy = WasmWalSyncPolicy::per_record();
+        assert!(matches!(policy.inner, WalSyncPolicy::PerRecord));
+    }
+
+    /// `group()` with no arguments must equal the core defaults.
+    #[wasm_bindgen_test]
+    fn group_no_args_uses_defaults() {
+        let policy = WasmWalSyncPolicy::group(None, None, None);
+        match policy.inner {
+            WalSyncPolicy::Group {
+                max_records,
+                max_bytes,
+                max_interval,
+            } => {
+                assert_eq!(max_records, DEFAULT_GROUP_MAX_RECORDS);
+                assert_eq!(max_bytes, DEFAULT_GROUP_MAX_BYTES);
+                assert_eq!(max_interval, None);
+            }
+            WalSyncPolicy::PerRecord => panic!("expected Group, got PerRecord"),
+        }
+    }
+
+    /// Explicit arguments must be threaded through, including the interval as a
+    /// [`Duration`] in milliseconds.
+    #[wasm_bindgen_test]
+    fn group_explicit_args_are_honored() {
+        let policy = WasmWalSyncPolicy::group(Some(2048), Some(2 * 1024 * 1024), Some(50.0));
+        match policy.inner {
+            WalSyncPolicy::Group {
+                max_records,
+                max_bytes,
+                max_interval,
+            } => {
+                assert_eq!(max_records, 2048);
+                assert_eq!(max_bytes, 2 * 1024 * 1024);
+                assert_eq!(max_interval, Some(Duration::from_millis(50)));
+            }
+            WalSyncPolicy::PerRecord => panic!("expected Group, got PerRecord"),
+        }
+    }
+
+    /// A partially specified `group()` call must mix explicit values with
+    /// defaults for the omitted thresholds.
+    #[wasm_bindgen_test]
+    fn group_partial_args_mix_with_defaults() {
+        let policy = WasmWalSyncPolicy::group(Some(64), None, None);
+        match policy.inner {
+            WalSyncPolicy::Group {
+                max_records,
+                max_bytes,
+                max_interval,
+            } => {
+                assert_eq!(max_records, 64);
+                assert_eq!(max_bytes, DEFAULT_GROUP_MAX_BYTES);
+                assert_eq!(max_interval, None);
+            }
+            WalSyncPolicy::PerRecord => panic!("expected Group, got PerRecord"),
+        }
+    }
+}

--- a/laurus/src/lib.rs
+++ b/laurus/src/lib.rs
@@ -106,7 +106,7 @@ pub use lexical::search::searcher::{
 };
 pub use maintenance::deletion::DeletionConfig;
 pub use storage::{Storage, StorageConfig, StorageFactory};
-pub use store::log::WalSyncPolicy;
+pub use store::log::{DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, WalSyncPolicy};
 pub use vector::core::distance::DistanceMetric;
 pub use vector::core::field::{FlatOption, HnswOption, IvfOption};
 pub use vector::core::quantization::QuantizationMethod;


### PR DESCRIPTION
## Summary

Exposes the opt-in WAL group-commit API (added in #542 / #818) through the gRPC proto, the `laurus-server` config, and all five language bindings (python, nodejs, wasm, ruby, php). **The default stays `PerRecord` on every surface**, so existing users are unaffected.

## Design

- **Server: config file** — a `[index.wal]` section selects the policy. The server is single-index and config-driven, so the policy must stay consistent across restart/reopen; a config knob is the natural home, and it is applied to both the boot-time open and `CreateIndex`.

  ```toml
  [index.wal]
  sync_policy = "group"          # "per_record" (default) | "group"
  group_max_records = 1024       # optional; default 1024
  group_max_bytes = 1048576      # optional; default 1 MiB
  group_max_interval_ms = 1000   # optional; native-only timer
  ```

- **proto** — new `DocumentService.FlushWal` RPC (empty messages) + HTTP gateway `POST /v1/flush_wal`, exposing the on-demand durability barrier next to `Commit` / `POST /v1/commit`.
- **Bindings: a `WalSyncPolicy` value object** mirroring the Rust enum — `per_record()` and `group(max_records?, max_bytes?, max_interval_ms?)` (omitted thresholds fall back to the core defaults). Each index constructor gains an optional `wal_sync_policy`, and each index gains `flush_wal`.

## Changes

- **core**: re-export `DEFAULT_GROUP_MAX_RECORDS` / `DEFAULT_GROUP_MAX_BYTES` (additive).
- **proto + server**: `FlushWal` RPC; `[index.wal]` config (`WalConfig::to_policy()`); threading through `context.rs` / `server.rs` / `service/index.rs`; `flush_wal` handler; `POST /v1/flush_wal` gateway route.
- **bindings**: `WalSyncPolicy` value object + constructor option + `flush_wal`/`flushWal` for python / nodejs / wasm / ruby / php.
- **docs (EN/JA)**: server `configuration` / `grpc_api` / `http_gateway`; each binding `api_reference` + README durability section.

## Binding API

| binding | API |
|---|---|
| python | `laurus.WalSyncPolicy.{per_record,group}`, `Index(..., wal_sync_policy=)`, `idx.flush_wal()` |
| nodejs | `WalSyncPolicy.{perRecord,group}`, `Index.create(..., walSyncPolicy?)`, `index.flushWal()` |
| wasm | same; `max_interval` is a no-op and `flushWal` does not persist to OPFS (documented) |
| ruby | `Laurus::WalSyncPolicy.{per_record,group}`, `Index.new(wal_sync_policy:)`, `idx.flush_wal` |
| php | `Laurus\WalSyncPolicy::{perRecord,group}`, `new Index(..., $wal_sync_policy)`, `$idx->flushWal()` |

## Testing

- `cargo clippy --all-targets --features embeddings-all -- -D warnings`: clean (whole workspace, all bindings).
- `cargo fmt --all -- --check`: clean.
- `cargo test -p laurus-server --lib`: 36 passed (3 config + 3 `flush_wal`-handler tests new); core WAL regression green.
- Bindings: pytest 34, vitest 55, wasm_bindgen_test 6, minitest 106 assertions, PHPUnit 54 — all green.
- `cargo build -p laurus-wasm --target wasm32-unknown-unknown`: success.
- markdownlint (`docs/src/**`, `docs/ja/src/**`, `laurus-*/README*.md`): 0 errors.

## Notes

- `laurus/persistence.md` already documented `WalSyncPolicy` / `flush_wal` from #542, so it is unchanged.
- Ruby has no root README (only example READMEs), so its WAL docs live in the mdBook api_reference.

Closes #820
Refs #542
