### PR TITLE
test(store/wal): prove last_wal_seq co-durability with crash-injection tests (#821)

### DIFF
--- a/docs/ja/src/laurus/persistence.md
+++ b/docs/ja/src/laurus/persistence.md
@@ -144,6 +144,56 @@ let engine = Engine::builder(storage, schema)
 
 > **注意:** `Group` はオプトインです。既定の `PerRecord` ポリシーは変更されないため、既存コードは何も変えずに書き込みごとの耐久性を維持します。
 
+## コミット耐久性ラダーとクラッシュ安全性
+
+`commit()` は固定された順序で状態を永続化します。この順序こそが、どの時点でクラッシュ
+しても復旧可能であることを保証します。lexical/vector の各ストアはそれぞれ独自の
+`last_wal_seq` チェックポイント（materialize 済みの最後の WAL レコードのシーケンス番号）
+を持ち、リカバリで適用済みレコードをスキップできます。永続化される `last_wal_seq` は
+そのストアのオンディスク metadata に保存され、**ストアの commit 時にのみ**書かれます。
+
+コミットラダーは次のとおりです。
+
+1. **`flush_wal()`** — WAL を強制 durable 化（ハードバリア）。`Group` では遅延バッチを
+   fsync し、`PerRecord` では no-op。
+2. **`lexical.commit()`** — lexical セグメントと metadata（`last_wal_seq` を含む）を書き、
+   `sync()`。
+3. **`vector.commit()`** — vector セグメントを書き、`sync()`。
+4. **`commit_documents()`** — document store セグメントを書き、`sync()`。
+5. **`truncate()`** — WAL を空の fsync 済みファイルで置き換える。
+
+この順序は次の 2 つの不変条件を保証します。
+
+- **WAL は永続化された index より durable でないことはない。** `last_wal_seq` はステップ 2
+  以降でのみ永続化され、必ずステップ 1 のバリアの後に実行されるため、コミット済み index が
+  まだ durable でない WAL レコードを参照することはありません。
+- **すべてのストアは WAL が truncate される前に完全に durable 化される。** ステップ 2〜4 は
+  ステップ 5 が WAL を空にする前にそれぞれ `sync()` するため、WAL はそれが記述したデータが
+  安全に materialize された後にのみ破棄されます。
+
+リカバリは次回の `build()` で WAL を replay し、各ストアの `last_wal_seq` 以下のレコードを
+スキップします。replay は**冪等（idempotent）**です。各レコードを元々記録された `doc_id`
+の下で再適用するため、再実行は重複ではなく上書きになります。各ストアが独自のチェックポイント
+を持つため、途中で失敗した commit は各ストアを異なる `last_wal_seq` のまま残し、リカバリは
+各ストアに不足している分だけを再適用します。（vector store は現状チェックポイントを `0` の
+まま保持するため、毎回のリカバリで保持中の WAL を全件 replay します。正しく冪等ですが、
+最適化はまだです。）
+
+次の表は各ステップでクラッシュした場合の結果を示します（ステップ 1 のバリアが既に走っている
+ため、`PerRecord` と `Group` で同一です）。
+
+| クラッシュ地点 | ディスク上で durable | リカバリの結果 |
+| --- | --- | --- |
+| ステップ 1 の後、2 の前 | WAL のみ | 保留中の全レコードを両ストアへ replay |
+| ステップ 2 の後、3 の前 | WAL + lexical（`last_wal_seq = N`） | lexical は ≤ N をスキップ、vector は WAL から replay |
+| ステップ 3 の後、4 の前 | WAL + lexical + vector | 両ストアがスキップ、documents は WAL から復元 |
+| ステップ 4 の後、5 の前 | WAL + 全ストア | WAL は残存、両ストアがスキップ、重複なし |
+| ステップ 5 の後 | 全ストア、WAL は空 | replay 対象なし |
+
+コミット済み index が失われた WAL レコードを参照する interleaving は存在しないため、group
+commit は文書化された契約（`flush_wal()` や `commit()` でまだ durable 化されていない書き込みの
+*末尾* をクラッシュで失い得る）を超える新たな耐久性ギャップを生みません。
+
 ## ストレージレイアウト
 
 エンジンは `PrefixedStorage` を使用してデータを整理します。

--- a/docs/src/laurus/persistence.md
+++ b/docs/src/laurus/persistence.md
@@ -144,6 +144,57 @@ let engine = Engine::builder(storage, schema)
 
 > **Note:** `Group` is opt-in; the default `PerRecord` policy is unchanged, so existing code keeps its per-write durability with no changes.
 
+## Commit Durability Ladder & Crash Safety
+
+`commit()` persists state in a fixed order, and the order is what makes a crash
+at any point recoverable. Each lexical/vector store tracks its own `last_wal_seq`
+checkpoint — the sequence number of the last WAL record it has materialized — so
+recovery can skip already-applied records. The persisted `last_wal_seq` lives in
+the store's on-disk metadata and is written **only** during the store's commit.
+
+The commit ladder is:
+
+1. **`flush_wal()`** — force the WAL durable (the hard barrier). Under `Group`
+   this fsyncs any deferred batch; under `PerRecord` it is a no-op.
+2. **`lexical.commit()`** — write the lexical segment and metadata (including
+   `last_wal_seq`), then `sync()`.
+3. **`vector.commit()`** — write the vector segment, then `sync()`.
+4. **`commit_documents()`** — write the document store segment, then `sync()`.
+5. **`truncate()`** — replace the WAL with a fresh, empty, fsync'd file.
+
+This order guarantees two invariants:
+
+- **The WAL is never less durable than any persisted index.** `last_wal_seq` is
+  only persisted in step 2+, which always runs *after* the step-1 barrier, so a
+  committed index can never reference a WAL record that is not yet durable.
+- **Every store is fully durable before the WAL is truncated.** Steps 2–4 each
+  `sync()` before step 5 empties the WAL, so the WAL is only discarded once the
+  data it described is safely materialized.
+
+Recovery replays the WAL on the next `build()`, skipping records at or below each
+store's `last_wal_seq`. Replay is **idempotent** — it re-applies each record
+under its originally recorded `doc_id`, so re-running it overwrites rather than
+duplicates. Because each store keeps its own checkpoint, a commit that fails
+partway leaves the stores at different `last_wal_seq` values and recovery simply
+re-applies what each store is missing. (The vector store currently keeps its
+checkpoint at `0`, so it replays the full retained WAL on every recovery —
+correct and idempotent, just not yet optimized.)
+
+The table below shows the outcome of a crash at each step (identical for
+`PerRecord` and `Group`, because the step-1 barrier has already run):
+
+| Crash point | Durable on disk | Recovery outcome |
+| --- | --- | --- |
+| After step 1, before step 2 | WAL only | Replay all pending records into both stores |
+| After step 2, before step 3 | WAL + lexical (`last_wal_seq = N`) | Lexical skips ≤ N; vector replays from WAL |
+| After step 3, before step 4 | WAL + lexical + vector | Both stores skip; documents restored from WAL |
+| After step 4, before step 5 | WAL + all stores | WAL still present; both stores skip, no duplicates |
+| After step 5 | All stores, WAL empty | Nothing to replay |
+
+No interleaving lets a committed index reference a lost WAL record, so group
+commit introduces no new durability gap beyond its documented contract (a crash
+can lose a *suffix* of writes not yet made durable by `flush_wal()` or `commit()`).
+
 ## Storage Layout
 
 The engine uses `PrefixedStorage` to organize data:

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -171,6 +171,15 @@ impl Engine {
     }
 
     /// Recover index state from the document log.
+    ///
+    /// Replays every WAL record that is newer than each store's persisted
+    /// `last_wal_seq` checkpoint. Recovery is **idempotent**: each record is
+    /// re-applied under its originally recorded `doc_id`, so re-running it
+    /// overwrites rather than duplicates. The lexical and vector stores track
+    /// their checkpoints independently, so a commit that failed partway (leaving
+    /// the stores at different `last_wal_seq` values) is reconciled here — each
+    /// store re-applies only what it is missing. See [`Self::commit`] for the
+    /// ordering guarantees that make this safe (Issue #821).
     async fn recover(&self) -> Result<()> {
         // read_all() internally syncs next_doc_id with doc_store segments.
         let records = self.log.read_all()?;
@@ -551,12 +560,24 @@ impl Engine {
 
     /// Commit changes to both stores and truncate the WAL.
     ///
-    /// First forces the WAL durable (a hard barrier, so the WAL is never less
-    /// durable than the indexes about to be committed), then persists all
-    /// pending changes in the lexical store, vector store, and document store
-    /// (in that order), and finally truncates the WAL. After a successful
-    /// commit, the WAL is empty and all data is durable in the underlying
-    /// storage.
+    /// Persists state in a fixed order — the **commit durability ladder** — that
+    /// makes a crash at any step recoverable (Issue #821):
+    ///
+    /// 1. `flush_wal()` — force the WAL durable (the hard barrier).
+    /// 2. `lexical.commit()` — materialize + fsync the lexical store. This is
+    ///    where the lexical `last_wal_seq` checkpoint is persisted.
+    /// 3. `vector.commit()` — materialize + fsync the vector store.
+    /// 4. `commit_documents()` — materialize + fsync the document store.
+    /// 5. `truncate()` — replace the WAL with an empty, fsync'd file.
+    ///
+    /// This order upholds two invariants. First, `last_wal_seq` is persisted
+    /// only in step 2+, always *after* the step-1 barrier, so a committed index
+    /// can never reference a WAL record that is not yet durable. Second, every
+    /// store is fully fsync'd (steps 2–4) before the WAL is truncated (step 5),
+    /// so the WAL is discarded only once the data it described is durable. A
+    /// crash between any two steps therefore leaves enough in the WAL for the
+    /// idempotent replay in [`Self::recover`] to reconstruct a consistent state.
+    /// After a successful commit, the WAL is empty and all data is durable.
     ///
     /// # Errors
     ///

--- a/laurus/tests/wal_crash_injection_test.rs
+++ b/laurus/tests/wal_crash_injection_test.rs
@@ -1,0 +1,347 @@
+//! Crash-injection tests for the WAL / `last_wal_seq` co-durability ladder
+//! (Issue #821, follow-up to #542 group commit).
+//!
+//! [`Engine::commit`] persists state in a fixed order:
+//!
+//! 1. `flush_wal()` — force the WAL durable (the #817 barrier).
+//! 2. `lexical.commit()` — materialize + fsync the lexical store (this is where
+//!    `last_wal_seq` is persisted).
+//! 3. `vector.commit()` — materialize + fsync the vector store.
+//! 4. `commit_documents()` — materialize + fsync the document store.
+//! 5. `truncate()` — replace the WAL with an empty, fsync'd file.
+//!
+//! The invariant under test: a crash at *any* step never loses an acknowledged
+//! record. Because the WAL is forced durable (step 1) before any store persists
+//! its `last_wal_seq` (step 2+), and every store is fully fsync'd before the WAL
+//! is truncated (step 5), recovery can always replay whatever a partial commit
+//! left behind. Replay is idempotent (keyed by the recorded `doc_id`) and each
+//! store tracks its own `last_wal_seq`, so a commit that fails midway recovers
+//! cleanly with no lost or duplicated documents — under both the per-record and
+//! the group-commit sync policies.
+//!
+//! These tests simulate a crash with [`FaultyStorage`], which makes a chosen
+//! storage write fail at a precise point in the ladder. The engine is then
+//! dropped (the crash) and re-opened on the same underlying data to drive WAL
+//! recovery, mirroring the "drop without commit, then re-open" pattern in
+//! `wal_recovery_test.rs`.
+
+use std::sync::{Arc, Mutex};
+
+use tempfile::TempDir;
+
+use laurus::lexical::{TermQuery, TextOption};
+use laurus::storage::file::FileStorageConfig;
+use laurus::storage::{
+    FileMetadata, LoadingMode, Storage, StorageConfig, StorageFactory, StorageInput, StorageOutput,
+};
+use laurus::vector::FlatOption;
+use laurus::{
+    DataValue, Document, Engine, FieldOption, LaurusError, LexicalSearchQuery, Schema,
+    SearchRequestBuilder, WalSyncPolicy,
+};
+
+/// Number of documents indexed per scenario.
+const DOC_COUNT: usize = 5;
+
+/// A shared term present in every document's `title`, used to count recovered
+/// documents via a lexical search.
+const SHARED_TERM: &str = "rust";
+
+/// One-shot fault plan shared between the test body and the [`FaultyStorage`]
+/// wrapper. While `armed`, the first file-creating operation whose (mapped) name
+/// contains `target` fails once and records that it fired in `triggered`.
+#[derive(Debug)]
+struct FaultPlan {
+    /// Whether the fault is active. The test arms it only right before the
+    /// `commit()` under test, so engine setup and document indexing run cleanly.
+    armed: bool,
+    /// Substring matched against the underlying (prefixed) file name, e.g.
+    /// `"lexical/"`, `"vector/"`, `"documents/"`, or `"engine.wal"`.
+    target: String,
+    /// Set to `true` once the fault has fired, so it injects exactly one failure.
+    triggered: bool,
+}
+
+/// A [`Storage`] decorator that injects a single write failure at a chosen
+/// point in the commit ladder, then delegates everything else to `inner`.
+///
+/// Only the file-*creating* operations (`create_output` / `create_temp_output`)
+/// are intercepted; reads, syncs, renames, and the WAL append path pass through
+/// untouched. Failing on the first creation whose name matches `target` models
+/// a crash at the very start of a commit step, before that step has persisted
+/// anything — the cleanest interleaving to reason about.
+#[derive(Debug)]
+struct FaultyStorage {
+    /// The real storage backend that survives the simulated crash.
+    inner: Arc<dyn Storage>,
+    /// The shared, test-controlled fault plan.
+    plan: Arc<Mutex<FaultPlan>>,
+}
+
+impl FaultyStorage {
+    /// Returns `Err` if the fault is armed, untriggered, and `name` matches the
+    /// configured target; otherwise `Ok(())`. Marks the fault as fired so it
+    /// injects exactly one failure.
+    fn maybe_fail(&self, name: &str) -> laurus::Result<()> {
+        let mut plan = self
+            .plan
+            .lock()
+            .map_err(|e| LaurusError::Storage(format!("fault plan lock poisoned: {e}")))?;
+        if plan.armed && !plan.triggered && name.contains(&plan.target) {
+            plan.triggered = true;
+            return Err(LaurusError::Storage(format!(
+                "injected crash before writing '{name}'"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl Storage for FaultyStorage {
+    fn loading_mode(&self) -> LoadingMode {
+        self.inner.loading_mode()
+    }
+
+    fn open_input(&self, name: &str) -> laurus::Result<Box<dyn StorageInput>> {
+        self.inner.open_input(name)
+    }
+
+    fn create_output(&self, name: &str) -> laurus::Result<Box<dyn StorageOutput>> {
+        self.maybe_fail(name)?;
+        self.inner.create_output(name)
+    }
+
+    fn create_output_append(&self, name: &str) -> laurus::Result<Box<dyn StorageOutput>> {
+        self.maybe_fail(name)?;
+        self.inner.create_output_append(name)
+    }
+
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+
+    fn delete_file(&self, name: &str) -> laurus::Result<()> {
+        self.inner.delete_file(name)
+    }
+
+    fn list_files(&self) -> laurus::Result<Vec<String>> {
+        self.inner.list_files()
+    }
+
+    fn file_size(&self, name: &str) -> laurus::Result<u64> {
+        self.inner.file_size(name)
+    }
+
+    fn metadata(&self, name: &str) -> laurus::Result<FileMetadata> {
+        self.inner.metadata(name)
+    }
+
+    fn rename_file(&self, old_name: &str, new_name: &str) -> laurus::Result<()> {
+        self.inner.rename_file(old_name, new_name)
+    }
+
+    fn create_temp_output(&self, prefix: &str) -> laurus::Result<(String, Box<dyn StorageOutput>)> {
+        self.maybe_fail(prefix)?;
+        self.inner.create_temp_output(prefix)
+    }
+
+    fn sync(&self) -> laurus::Result<()> {
+        self.inner.sync()
+    }
+
+    fn close(&mut self) -> laurus::Result<()> {
+        // The wrapper does not own the underlying storage (the test keeps an
+        // `Arc` to it for the recovery round), so closing is a no-op.
+        Ok(())
+    }
+}
+
+/// Build the test schema: one lexical text field and one flat vector field, so
+/// every commit touches both the `lexical/` and `vector/` namespaces.
+fn build_schema() -> Schema {
+    Schema::builder()
+        .add_field("title", FieldOption::Text(TextOption::default()))
+        .add_field("embedding", FieldOption::Flat(FlatOption::default()))
+        .build()
+}
+
+/// Build document `i` with the shared lexical term and a vector payload.
+fn make_doc(i: usize) -> Document {
+    Document::builder()
+        .add_field(
+            "title",
+            DataValue::Text(format!("{SHARED_TERM} programming entry {i}")),
+        )
+        .add_field("embedding", DataValue::Vector(vec![0.1 + i as f32; 128]))
+        .build()
+}
+
+/// Assert that all `DOC_COUNT` documents are present exactly once after recovery.
+async fn assert_all_recovered(engine: &Engine) -> laurus::Result<()> {
+    // Every external id resolves to exactly one document (upsert, no chunks).
+    for i in 0..DOC_COUNT {
+        let docs = engine.get_documents(&format!("doc{i}")).await?;
+        assert_eq!(
+            docs.len(),
+            1,
+            "doc{i} must be recovered exactly once, got {}",
+            docs.len()
+        );
+    }
+
+    // A lexical search on the shared term must return every document and no
+    // duplicates.
+    let query = Box::new(TermQuery::new("title", SHARED_TERM));
+    let request = SearchRequestBuilder::new()
+        .lexical_query(LexicalSearchQuery::Obj(query))
+        .limit(DOC_COUNT * 4)
+        .build();
+    let results = engine.search(request).await?;
+    assert_eq!(
+        results.len(),
+        DOC_COUNT,
+        "lexical search must return all {DOC_COUNT} documents with no duplicates"
+    );
+    Ok(())
+}
+
+/// Drive one crash scenario: index `DOC_COUNT` docs under `policy`, arm a fault
+/// targeting `target`, fail the `commit()` there (the simulated crash), then
+/// re-open on the same data and verify every document recovers.
+async fn run_crash_scenario(policy: WalSyncPolicy, target: &str) -> laurus::Result<()> {
+    let temp = TempDir::new().expect("temp dir");
+    let inner: Arc<dyn Storage> =
+        StorageFactory::create(StorageConfig::File(FileStorageConfig::new(temp.path())))?;
+
+    let plan = Arc::new(Mutex::new(FaultPlan {
+        armed: false,
+        target: target.to_string(),
+        triggered: false,
+    }));
+    let faulty: Arc<dyn Storage> = Arc::new(FaultyStorage {
+        inner: inner.clone(),
+        plan: plan.clone(),
+    });
+
+    let schema = build_schema();
+
+    // Round 1: index, then crash at the chosen commit step.
+    {
+        let engine = Engine::builder(faulty.clone(), schema.clone())
+            .wal_sync_policy(policy)
+            .build()
+            .await?;
+
+        for i in 0..DOC_COUNT {
+            engine.put_document(&format!("doc{i}"), make_doc(i)).await?;
+        }
+
+        // Arm the fault for the commit under test (indexing above ran cleanly).
+        plan.lock().expect("plan lock").armed = true;
+
+        let result = engine.commit().await;
+        assert!(
+            result.is_err(),
+            "commit must fail at the injected crash point '{target}' (policy {policy:?})"
+        );
+        assert!(
+            plan.lock().expect("plan lock").triggered,
+            "the fault targeting '{target}' must have fired (policy {policy:?})"
+        );
+        // Dropping the engine here simulates the crash.
+    }
+
+    // Round 2: re-open on the same underlying storage (no fault) and recover.
+    {
+        let engine = Engine::new(inner.clone(), schema.clone()).await?;
+        // A clean commit after recovery must succeed and truncate the WAL.
+        engine.commit().await?;
+        assert_all_recovered(&engine).await?;
+    }
+
+    // Round 3: re-open once more to prove the post-recovery commit is itself
+    // durable and the WAL is in a clean, replayable state.
+    {
+        let engine = Engine::new(inner.clone(), schema.clone()).await?;
+        assert_all_recovered(&engine).await?;
+    }
+
+    Ok(())
+}
+
+// ── Crash after flush_wal, before lexical.commit (target "lexical/") ──────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_before_lexical_commit_per_record() -> laurus::Result<()> {
+    run_crash_scenario(WalSyncPolicy::PerRecord, "lexical/").await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_before_lexical_commit_group() -> laurus::Result<()> {
+    run_crash_scenario(WalSyncPolicy::group_with_defaults(), "lexical/").await
+}
+
+// ── Crash after lexical.commit, before vector.commit (target "vector/") ───────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_before_vector_commit_per_record() -> laurus::Result<()> {
+    run_crash_scenario(WalSyncPolicy::PerRecord, "vector/").await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_before_vector_commit_group() -> laurus::Result<()> {
+    run_crash_scenario(WalSyncPolicy::group_with_defaults(), "vector/").await
+}
+
+// ── Crash after vector.commit, before commit_documents (target "documents/") ──
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_before_document_commit_per_record() -> laurus::Result<()> {
+    run_crash_scenario(WalSyncPolicy::PerRecord, "documents/").await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_before_document_commit_group() -> laurus::Result<()> {
+    run_crash_scenario(WalSyncPolicy::group_with_defaults(), "documents/").await
+}
+
+// ── Crash after commit_documents, before/at WAL truncate (target "engine.wal") ─
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_before_wal_truncate_per_record() -> laurus::Result<()> {
+    run_crash_scenario(WalSyncPolicy::PerRecord, "engine.wal").await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crash_before_wal_truncate_group() -> laurus::Result<()> {
+    run_crash_scenario(WalSyncPolicy::group_with_defaults(), "engine.wal").await
+}
+
+// ── Harness sanity: an unarmed FaultyStorage commits cleanly ─────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unarmed_faulty_storage_commits_cleanly() -> laurus::Result<()> {
+    let temp = TempDir::new().expect("temp dir");
+    let inner: Arc<dyn Storage> =
+        StorageFactory::create(StorageConfig::File(FileStorageConfig::new(temp.path())))?;
+    let plan = Arc::new(Mutex::new(FaultPlan {
+        armed: false,
+        target: "lexical/".to_string(),
+        triggered: false,
+    }));
+    let faulty: Arc<dyn Storage> = Arc::new(FaultyStorage {
+        inner: inner.clone(),
+        plan,
+    });
+
+    let engine = Engine::builder(faulty, build_schema())
+        .wal_sync_policy(WalSyncPolicy::group_with_defaults())
+        .build()
+        .await?;
+    for i in 0..DOC_COUNT {
+        engine.put_document(&format!("doc{i}"), make_doc(i)).await?;
+    }
+    engine.commit().await?;
+    assert_all_recovered(&engine).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Audits the `last_wal_seq` / WAL commit-ladder co-durability (the latent risk #4 from #542) and proves it with crash-injection tests.

**Audit conclusion: the ladder is already correct — no code fix to the ladder.** `Engine::commit()` persists in a fixed order, each step fully fsync'd before the next:

1. `flush_wal()` — WAL fsync barrier (#817)
2. `lexical.commit()` — write + `storage.sync()` (persists `last_wal_seq`)
3. `vector.commit()` — write + `storage.sync()`
4. `commit_documents()` — write + `storage.sync()`
5. `truncate()` — recreate empty WAL + `flush_and_sync` + `storage.sync()`

Invariants: (a) `last_wal_seq` is persisted only in step 2+, always after the step-1 barrier → a committed index can never reference a not-yet-durable WAL record; (b) every store is fsync'd before the WAL is truncated. Replay is idempotent (keyed by the recorded `doc_id`) and per-store `last_wal_seq` reconciles partial commits.

## Changes

- **tests** (`laurus/tests/wal_crash_injection_test.rs`, new): a `FaultyStorage` wrapper fails a chosen `create_output` at a precise commit step. Scenarios — crash before `lexical.commit` / `vector.commit` / `commit_documents` / WAL `truncate`, under **both `PerRecord` and `Group`**, each asserting all documents recover exactly once with no duplicates after reopen; plus a harness sanity test. 9 tests.
- **docs** (`persistence.md` EN/JA): new "Commit Durability Ladder & Crash Safety" section — the 5-step order, the two invariants, per-store `last_wal_seq` + idempotent replay, and a crash-point → recovery-outcome table.
- **engine**: `Engine::commit()` / `recover()` doc-comments strengthened.

## Note on test scope

The in-process crash model (drop engine → reopen) verifies the **logical** ladder (step ordering, idempotent replay, per-store `last_wal_seq`). It does not verify **physical** fsync durability (a clean process exit keeps the OS page cache); that is verified by code inspection and documented. The vector store keeps its checkpoint at `0` (replays the retained WAL each recovery — correct/idempotent, unoptimized); noted in the docs, out of scope here.

## Testing

- `cargo test -p laurus --test wal_crash_injection_test`: 9 passed; `--test wal_recovery_test`: 2 passed (no regression).
- `cargo clippy --all-targets --features embeddings-all -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- markdownlint (`docs/src/**`, `docs/ja/src/**`): 0 errors.

Closes #821
Refs #542
