### PR TITLE
perf(lexical/index): defer in-memory index rebuild on buffered-doc removal (#828)

### DIFF
--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -2637,6 +2637,70 @@ mod tests {
         }
     }
 
+    /// #828: updating many docs that are still in the uncommitted buffer must
+    /// stay correct under the deferred in-memory-index rebuild. Each update goes
+    /// through `delete_documents` → `delete_document(old_buffered_id)` →
+    /// `remove_pending_document`, which now defers the rebuild to flush. After
+    /// commit, every external id must resolve to exactly its latest version and
+    /// the live doc count must equal the number of unique ids (no ghosts from
+    /// the superseded buffered versions).
+    #[tokio::test]
+    async fn test_put_document_update_many_before_commit() {
+        use crate::data::DataValue;
+        use crate::engine::schema::FieldOption;
+        use crate::lexical::core::field::TextOption;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field("title", FieldOption::Text(TextOption::default()))
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        let n = 200usize;
+
+        // Phase 1: add N distinct docs into one uncommitted buffer.
+        for i in 0..n {
+            let mut doc = crate::data::Document::new();
+            doc.fields
+                .insert("title".into(), DataValue::Text(format!("v0-{i}")));
+            engine.put_document(&format!("id{i}"), doc).await.unwrap();
+        }
+
+        // Phase 2: update every one of them BEFORE committing. Each update hits
+        // the deferred-rebuild path (the old version is still buffered).
+        for i in 0..n {
+            let mut doc = crate::data::Document::new();
+            doc.fields
+                .insert("title".into(), DataValue::Text(format!("v1-{i}")));
+            engine.put_document(&format!("id{i}"), doc).await.unwrap();
+        }
+
+        engine.commit().await.unwrap();
+
+        let stats = engine.stats().unwrap();
+        assert_eq!(
+            stats.document_count, n as u64,
+            "every external id must collapse to exactly one live doc after the \
+             pre-commit updates (no ghost versions from the deferred rebuild)"
+        );
+
+        // Each id resolves to exactly one doc carrying the updated content.
+        for i in [0usize, 1, n / 2, n - 1] {
+            let docs = engine.get_documents(&format!("id{i}")).await.unwrap();
+            assert_eq!(docs.len(), 1, "id{i} must resolve to a single doc");
+            let title = docs[0]
+                .fields
+                .get("title")
+                .and_then(|v| v.as_text())
+                .map(String::from);
+            assert_eq!(
+                title.as_deref(),
+                Some(format!("v1-{i}").as_str()),
+                "id{i} must carry the updated (v1) content after commit"
+            );
+        }
+    }
+
     /// Regression test for the geo3d demo's "departure + re-arrival"
     /// pattern: put → commit → delete → commit → put-with-same-id →
     /// commit. The post-commit search must return exactly one doc and

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -118,6 +118,21 @@ pub struct InvertedIndexWriter {
     /// Buffered analyzed documents with their assigned doc IDs.
     buffered_docs: Vec<(u64, AnalyzedDocument)>,
 
+    /// Whether [`Self::inverted_index`] / [`Self::doc_values_writer`] are stale
+    /// relative to [`Self::buffered_docs`] and need a rebuild before flush.
+    ///
+    /// Set by [`Self::remove_pending_document`], which drops the doc from
+    /// `buffered_docs` (cheap, order-preserving `retain`) but **defers** the
+    /// expensive `rebuild_in_memory_index` rather than running it per removal.
+    /// The rebuild runs once at flush time (and eagerly on the same-id re-upsert
+    /// path), turning an `update × M` over an `N`-doc uncommitted buffer from
+    /// `O(M·N)` into `O(M) + O(N)` (Issue #828). While dirty, the in-memory
+    /// index still holds the removed doc's postings, so the NRT lookups
+    /// ([`Self::find_doc_id_by_term`] / [`Self::find_doc_ids_by_term`]) filter
+    /// their results by [`Self::buffered_doc_ids`] (the physically-correct live
+    /// set).
+    index_dirty: bool,
+
     /// Membership index of the doc IDs currently in [`Self::buffered_docs`].
     ///
     /// Kept perfectly in sync with `buffered_docs` (every push inserts, every
@@ -207,6 +222,7 @@ impl InvertedIndexWriter {
             config,
             inverted_index: TermPostingIndex::new(),
             buffered_docs: Vec::new(),
+            index_dirty: false,
             buffered_doc_ids: AHashSet::new(),
             doc_values_writer,
             next_doc_id,
@@ -246,10 +262,26 @@ impl InvertedIndexWriter {
         // Analyze the document
         let analyzed_doc = self.analyze_document(doc)?;
 
+        // Same-id re-upsert detection: if this exact id is already buffered, the
+        // deferred-rebuild scheme cannot distinguish the old version's stale
+        // postings from the new version's (both carry this id), so we must purge
+        // the old version from the in-memory index *before* re-indexing. This
+        // never happens on the production engine path (every add gets a fresh
+        // monotonic doc_id), so the eager rebuild here costs nothing in
+        // production and only restores exact NRT state for direct re-upserts.
+        let was_buffered = self.buffered_doc_ids.contains(&doc_id);
+
         // Upsert: remove any pending document with the same ID before adding
         self.remove_pending_document(doc_id)?;
         // Upsert: mark persisted occurrences as deleted (flushed segments)
         self.mark_persisted_doc_deleted(doc_id)?;
+
+        if was_buffered {
+            // Purge the just-removed old version's postings now (eager), so the
+            // re-added version below is the only one in the in-memory index.
+            self.rebuild_in_memory_index()?;
+            self.index_dirty = false;
+        }
 
         // Add the analyzed document with the specified ID
         self.upsert_analyzed_document(doc_id, analyzed_doc)
@@ -351,15 +383,18 @@ impl InvertedIndexWriter {
     pub fn find_doc_id_by_term(&self, field: &str, term: &str) -> Result<Option<u64>> {
         let full_term = format!("{field}:{term}");
 
-        // 1. Check in-memory inverted index
-        if let Some(posting_list) = self.inverted_index.get_posting_list(&full_term) {
-            // Get the last document ID (most recent version if multiple exist, though upsert usually handles that)
-            // Posting list is sorted by doc_id? Usually yes for inverted index.
-            // But TermPostingIndex might just append.
-            // Let's assume the last one is the latest.
-            if let Some(last_posting) = posting_list.postings.last() {
-                return Ok(Some(last_posting.doc_id));
-            }
+        // 1. Check in-memory inverted index. The index may hold stale postings
+        // for docs removed since the last rebuild (deferred under #828), so keep
+        // only ids still in the live buffer and return the highest (latest).
+        if let Some(posting_list) = self.inverted_index.get_posting_list(&full_term)
+            && let Some(doc_id) = posting_list
+                .postings
+                .iter()
+                .map(|p| p.doc_id)
+                .filter(|id| self.buffered_doc_ids.contains(id))
+                .max()
+        {
+            return Ok(Some(doc_id));
         }
 
         // 2. TODO: Check persisted segments
@@ -378,9 +413,18 @@ impl InvertedIndexWriter {
     fn find_doc_ids_by_term(&self, field: &str, term: &str) -> Result<Option<Vec<u64>>> {
         let full_term = format!("{field}:{term}");
 
-        // 1. Check in-memory inverted index
+        // 1. Check in-memory inverted index. The index may hold stale postings
+        // for docs removed since the last rebuild (deferred under #828), so keep
+        // only ids still in the live buffer; a same-id re-upsert can also leave
+        // two postings for one id, so dedup.
         if let Some(posting_list) = self.inverted_index.get_posting_list(&full_term) {
-            let ids: Vec<u64> = posting_list.postings.iter().map(|p| p.doc_id).collect();
+            let mut seen = AHashSet::new();
+            let ids: Vec<u64> = posting_list
+                .postings
+                .iter()
+                .map(|p| p.doc_id)
+                .filter(|id| self.buffered_doc_ids.contains(id) && seen.insert(*id))
+                .collect();
             if !ids.is_empty() {
                 return Ok(Some(ids));
             }
@@ -667,6 +711,13 @@ impl InvertedIndexWriter {
             return Ok(());
         }
 
+        // Materialize any deferred removals (#828) so the in-memory index +
+        // DocValues match `buffered_docs` before they are written to disk.
+        if self.index_dirty {
+            self.rebuild_in_memory_index()?;
+            self.index_dirty = false;
+        }
+
         let segment_name = format!("{}_{:06}", self.config.segment_prefix, self.current_segment);
 
         self.write_segment_files(&segment_name)?;
@@ -674,6 +725,7 @@ impl InvertedIndexWriter {
         // Clear buffers
         self.buffered_docs.clear();
         self.buffered_doc_ids.clear();
+        self.index_dirty = false;
         self.inverted_index = TermPostingIndex::new();
 
         // Reset DocValuesWriter for next segment
@@ -740,9 +792,17 @@ impl InvertedIndexWriter {
         if self.buffered_docs.is_empty() {
             return Ok(Vec::new());
         }
+        // Materialize any deferred removals (#828) before writing. The merge
+        // path only adds distinct, pre-deduped docs so this is normally a no-op,
+        // but the guard keeps the invariant if that ever changes.
+        if self.index_dirty {
+            self.rebuild_in_memory_index()?;
+            self.index_dirty = false;
+        }
         let paths = self.write_segment_files(segment_name)?;
         self.buffered_docs.clear();
         self.buffered_doc_ids.clear();
+        self.index_dirty = false;
         self.inverted_index = TermPostingIndex::new();
         self.stats.segments_created += 1;
         Ok(paths)
@@ -1294,6 +1354,7 @@ impl InvertedIndexWriter {
         // Clear all buffers
         self.buffered_docs.clear();
         self.buffered_doc_ids.clear();
+        self.index_dirty = false;
         self.inverted_index = TermPostingIndex::new();
 
         Ok(())
@@ -1349,10 +1410,16 @@ impl InvertedIndexWriter {
             return Ok(());
         }
 
-        // The id was buffered: drop every occurrence from the buffer and
-        // rebuild the in-memory inverted index / DocValues from what remains.
+        // The id was buffered: drop it from the buffer (cheap, order-preserving
+        // so postings stay doc-id-ascending for the skip-table encode) and
+        // **defer** the expensive in-memory index / DocValues rebuild. The
+        // rebuild runs once at flush time (and eagerly on the same-id re-upsert
+        // path in `upsert_document`), so updating M docs in an N-doc uncommitted
+        // buffer is O(M)+O(N) instead of O(M·N) (Issue #828). Until the rebuild,
+        // the in-memory index still holds this doc's postings; the NRT lookups
+        // filter them out via `buffered_doc_ids`.
         self.buffered_docs.retain(|(id, _)| *id != doc_id);
-        self.rebuild_in_memory_index()?;
+        self.index_dirty = true;
 
         // Decrement docs_added for the removed (un-done) document.
         if self.stats.docs_added > 0 {

--- a/laurus/tests/lexical_upsert_dedup_test.rs
+++ b/laurus/tests/lexical_upsert_dedup_test.rs
@@ -135,3 +135,55 @@ fn interleaved_new_and_reupsert_stay_consistent() {
     assert_eq!(w.pending_docs(), 4);
     assert_eq!(w.find_doc_id_by_term("title", "four").unwrap(), Some(4));
 }
+
+/// #828: removing a buffered doc defers the in-memory index rebuild, so the
+/// removed doc's postings linger in `inverted_index` until flush. The NRT
+/// lookup must still exclude them (filtered by the live buffer set) while
+/// leaving untouched neighbours resolvable. This is the production
+/// `delete_document(old_id)` path where the new version gets a *different* id.
+#[test]
+fn nrt_find_excludes_deferred_removed_doc() {
+    let mut w = writer();
+
+    w.upsert_document(1, doc("alpha")).unwrap();
+    w.upsert_document(2, doc("beta")).unwrap();
+    assert_eq!(w.pending_docs(), 2);
+
+    // Delete a still-buffered doc by a DIFFERENT id than any survivor — this
+    // takes the deferred path (no eager rebuild).
+    w.delete_document(1).unwrap();
+
+    assert_eq!(w.pending_docs(), 1, "the removed doc must leave the buffer");
+    assert_eq!(
+        w.find_doc_id_by_term("title", "alpha").unwrap(),
+        None,
+        "the deferred-removed doc's term must not resolve via NRT lookup"
+    );
+    assert_eq!(
+        w.find_doc_id_by_term("title", "beta").unwrap(),
+        Some(2),
+        "the surviving doc must still resolve while the index is dirty"
+    );
+}
+
+/// #828: a removal sets the deferred-rebuild dirty flag; `rollback` must clear
+/// the buffer AND that flag so a later batch starts clean and is not corrupted
+/// by leftover deferred state.
+#[test]
+fn rollback_clears_deferred_removed_state() {
+    let mut w = writer();
+
+    w.upsert_document(1, doc("alpha")).unwrap();
+    w.delete_document(1).unwrap(); // sets index_dirty, defers rebuild
+    assert_eq!(w.pending_docs(), 0);
+
+    w.rollback().unwrap();
+    assert_eq!(w.pending_docs(), 0);
+
+    // A fresh batch after rollback resolves normally and is unaffected by the
+    // earlier deferred removal (no stale "alpha", clean new state).
+    w.upsert_document(5, doc("gamma")).unwrap();
+    assert_eq!(w.pending_docs(), 1);
+    assert_eq!(w.find_doc_id_by_term("title", "gamma").unwrap(), Some(5));
+    assert_eq!(w.find_doc_id_by_term("title", "alpha").unwrap(), None);
+}


### PR DESCRIPTION
## Summary

`remove_pending_document` removed a still-buffered doc by `buffered_docs.retain(...)` and then **rebuilding the entire in-memory `inverted_index` + DocValues** from the remaining buffered docs — O(N) per removal. This is reached in **production** via `Engine::put_document` (update) → `delete_documents` → `delete_document(old_id)` → `remove_pending_document` when the old version is still in the uncommitted buffer, so updating M docs in an N-doc buffer was **O(M·N)**.

Profiled (release, direct writer, production shape = delete old buffered id + upsert a fresh id):

| N (uncommitted buffer) | 200 updates BEFORE | AFTER | speedup |
|---:|---:|---:|---:|
| 500 | 0.44 s | 2.85 ms | 154× |
| 1000 | 0.95 s | 3.29 ms | 289× |
| 2000 | 2.28 s | 3.86 ms | 591× |
| 4000 | **6.06 s** | **5.67 ms** | **~1070×** |

`per_update` drops from O(N) (~30 ms @ N=4000) to ~constant (~28 µs). This is a real O(N²) on a normal workload (bulk-load-then-correct / streaming upsert / CDC), and finishes the job started by the #813 membership probe (which made the distinct-`add` path O(1)).

## Approach: defer the rebuild to flush

The expensive part is the **rebuild**, not the order-preserving `retain` (cheap shallow moves). So:

- `remove_pending_document` keeps the `retain` (buffer stays physically correct **and** doc-id-ascending — the posting skip-table encode requires ascending ids) and just sets a new `index_dirty` flag instead of rebuilding.
- The rebuild runs **once** at flush (`flush_segment` / `flush_buffered_to_segment`), over the clean buffer, before `write_segment_files`.
- While dirty, the in-memory index still holds the removed doc's postings, so the **only** readers of uncommitted state — `find_doc_id_by_term` / `find_doc_ids_by_term` — filter results by the live `buffered_doc_ids` set (and dedup). General `search` reads only committed segments, so it is unaffected.
- **Same-id re-upsert** (`upsert_document` with a reused buffered id) cannot be distinguished from its own stale postings by the live-set filter, so that path eagerly rebuilds before re-indexing. This **never occurs on the production engine path** (every add gets a fresh monotonic doc_id), so it costs nothing in production — it only happens via the direct writer API (tests).
- `index_dirty` is cleared at flush/rollback.

### Correctness notes
- `docs_added` stays exact (±1). `unique_terms`/`total_postings` transiently overcount until the flush rebuild recomputes them — no correctness path or test reads them between a remove and flush.
- `flush_buffered_to_segment` (merge path) only adds distinct pre-deduped docs, so `index_dirty` is never true there; the guard is defensive.

## Tests
- New engine test `test_put_document_update_many_before_commit` (update 200 buffered docs before commit, then assert post-commit count + latest content) — exercises the deferred rebuild through the real flush + read-back path.
- New writer tests: `nrt_find_excludes_deferred_removed_doc` (deferred-removed doc is filtered from NRT lookups), `rollback_clears_deferred_removed_state`.
- All existing dedup (3) + engine `put_document` (3) tests pass under the same-id eager guard.

## Verification
- Full suite `cargo test -p laurus`: **1450 passed, 0 failed**.
- `cargo clippy --all-targets --features embeddings-all -- -D warnings` clean; `cargo fmt --check` clean.

No public API signature change; no docs reference this internal path; no language-binding impact.

Closes #828