### PR TITLE
perf(lexical/search): skip deletion-bitmap RwLock for no-deletion segments (#831)

### DIFF
--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -761,14 +761,18 @@ impl SegmentReader {
 
     /// Check whether a global doc_id is marked as deleted in this segment.
     pub fn is_deleted(&self, doc_id: u64) -> Result<bool> {
-        // Find deletion bitmap
+        // Lock-free fast path: a segment with no deletions can never mark a doc
+        // deleted, so skip the `deletion_bitmap` RwLock acquire entirely. This
+        // is hot on the scoring path, which probes deletion status per scored
+        // doc (often redundantly, since the posting iterator is already
+        // deletion-filtered at decode time via `filter_deleted_soa`).
+        if !self.info.has_deletions {
+            return Ok(false);
+        }
+
+        // Find deletion bitmap (load on demand the first time).
         if self.deletion_bitmap.read().unwrap().is_none() {
-            // Try to load bitmap if segment has deletions
-            if self.info.has_deletions {
-                self.load_deletion_bitmap()?;
-            } else {
-                return Ok(false);
-            }
+            self.load_deletion_bitmap()?;
         }
 
         let bitmap_lock = self.deletion_bitmap.read().unwrap();


### PR DESCRIPTION
Closes #831

## Problem

`SegmentReader::is_deleted` is probed **per scored doc** on the search hot path (via `field_length`, BMW, and result collection), but it acquired the `deletion_bitmap` `RwLock` *before* checking `self.info.has_deletions`. For a segment with **no deletions** (the common case) that wastes a `RwLock` read acquire on every probe. The check is also redundant for scoring: the posting iterator is already deletion-filtered at decode time (`filter_deleted_soa`), so the doc is known live.

This surfaced after #830 (#576) removed the posting-list deep clone that had masked the cost. Profiling `boolean_query/should_or_high_freq/5000` (frame pointers) attributed **~10.7% of search self-time to `is_deleted`**, dominated by this lock on a deletion-free corpus.

## Change

Check the lock-free `has_deletions` bool first and return `Ok(false)` immediately when the segment has no deletions, skipping the `RwLock` entirely. Semantically identical — a segment with no deletions can never mark a doc deleted. No API / contract / format change.

## Benchmarks (vs `main`, `lexical_search_bench`, no regressions)

| config | change |
|--------|--------|
| boolean_query/should_or/{100,1000,5000} | −23.3% / −21.1% / −15.8% |
| boolean_query/should_or_high_freq/{100,1000,5000} | −12.8% / −7.3% / −9.7% |
| topk_or_multi_segment/n=1000/segments={1,4,8} | −20.3% / −25.5% / −23.3% |
| topk_or_multi_segment/n=10000/segments={1,4,8} | −7.7% / −18.7% / −20.7% |

`topk` (BMW) improved too — `is_deleted` is probed on that path as well, not just via `field_length`.

## Tests

- Deletion-exclusion tests pass and cover both branches: `test_count_term_query_excludes_deleted` (has_deletions) and `test_count_term_query_o1_no_deletions` (fast path).
- `cargo test -p laurus --lib lexical`: 469 passed.
- `cargo clippy --all-targets --features embeddings-all -- -D warnings`, `cargo fmt --check`: clean.

## Out of scope

`field_length`'s own per-doc `RwLock` + nested `BTreeMap` probe (~26% on the same profile) — the columnar-DocValues / segment-local-doc-id direction (#688 / #686 / #586), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)