### PR TITLE
perf(vector/search): use the prepared query in HNSW graph traversal calc_dist (#835)

### DIFF
--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use crate::error::Result;
-use crate::vector::core::distance::DistanceMetric;
+use crate::vector::core::distance::{DistanceMetric, PreparedQuery};
 #[cfg(feature = "pq-fastscan")]
 use crate::vector::core::distance_pq_fastscan::PqFastScanQuery;
 use crate::vector::core::distance_quantized::{
@@ -530,6 +530,14 @@ impl HnswSearcher {
                 }
             };
 
+        // f32 reference path (no quantized context): cache the query norm once
+        // so `calc_dist` uses `distance_with_prepared` (candidate-norm-only
+        // kernel) instead of recomputing `‖query‖²` per candidate (#835). The
+        // quantized contexts already carry their own prepared query.
+        let prepared_query = quant_ctx
+            .is_none()
+            .then(|| metric.prepare_query(&query.data));
+
         // Retrieve the per-field prefetch index once per search call (O(1), no allocation).
         // `None` for on-demand (disk-backed) storage; the prefetch loop is skipped entirely.
         let field_prefetch = reader.field_prefetch_index(field_name);
@@ -570,7 +578,14 @@ impl HnswSearcher {
                 if reader.is_deleted(doc_id) {
                     continue;
                 }
-                let d = self.calc_dist(reader, query, quant_ctx.as_ref(), doc_id, field_name)?;
+                let d = self.calc_dist(
+                    reader,
+                    query,
+                    quant_ctx.as_ref(),
+                    prepared_query.as_ref(),
+                    doc_id,
+                    field_name,
+                )?;
                 // Skip docs with no vector in this field (Issue #676);
                 // `finalize_graph_results` also guards this, but skipping here
                 // keeps the heap small.
@@ -599,7 +614,14 @@ impl HnswSearcher {
         // Since HNSW here is single-graph for mixed IDs (potentially), we must hope entry point is valid for calc_dist with this field?
         // Ref discussion: assuming HnswIndex is single-field.
 
-        let mut dist = self.calc_dist(reader, query, quant_ctx.as_ref(), curr_obj, field_name)?;
+        let mut dist = self.calc_dist(
+            reader,
+            query,
+            quant_ctx.as_ref(),
+            prepared_query.as_ref(),
+            curr_obj,
+            field_name,
+        )?;
 
         // 2. Greedy descent
         for lc in (1..=graph.max_level).rev() {
@@ -621,6 +643,7 @@ impl HnswSearcher {
                             reader,
                             query,
                             quant_ctx.as_ref(),
+                            prepared_query.as_ref(),
                             neighbor_id,
                             field_name,
                         )?;
@@ -741,6 +764,7 @@ impl HnswSearcher {
                             reader,
                             query,
                             quant_ctx.as_ref(),
+                            prepared_query.as_ref(),
                             neighbor_id,
                             field_name,
                         )?;
@@ -809,6 +833,7 @@ impl HnswSearcher {
                             reader,
                             query,
                             quant_ctx.as_ref(),
+                            prepared_query.as_ref(),
                             neighbor_id,
                             field_name,
                         )?;
@@ -957,6 +982,7 @@ impl HnswSearcher {
         reader: &HnswIndexReader,
         query: &Vector,
         quant_ctx: Option<&QuantizedSearchCtx>,
+        prepared: Option<&PreparedQuery<'_>>,
         doc_id: u64,
         field_name: &str,
     ) -> Result<f32> {
@@ -968,7 +994,15 @@ impl HnswSearcher {
             return Ok(ctx.distance(doc_id));
         }
         if let Some(target) = reader.get_vector(doc_id, field_name)? {
-            reader.distance_metric().distance(&query.data, &target.data)
+            // f32 reference path. Prefer the prepared query (#835): it caches
+            // the query norm once per search so Cosine/Angular skip the
+            // per-candidate `‖query‖²` accumulation (`simd_dot_and_norm_b`
+            // instead of `simd_dot_and_norms`).
+            let metric = reader.distance_metric();
+            match prepared {
+                Some(prepared) => metric.distance_with_prepared(prepared, &target.data),
+                None => metric.distance(&query.data, &target.data),
+            }
         } else {
             // Vector not found in this field?
             // Should return max distance or error?


### PR DESCRIPTION
Closes #835

## Problem

HNSW graph traversal computes the query→candidate distance in `HnswSearcher::calc_dist`. Its **f32 path** called the un-prepared `DistanceMetric::distance(&query.data, &target.data)`, which for Cosine/Angular runs `simd_dot_and_norms` — re-accumulating the **query** norm (`‖query‖²`) on every candidate even though the query is constant.

Profiling `HNSW Graph Search/top10` (Cosine, f32, frame pointers): **63.78% of search self-time in `simd_dot_and_norms`**, 25.4% in `distance`, and `simd_dot_and_norm_b` (the prepared, candidate-norm-only kernel) at **0.00%** — i.e. the prepared-query path was not used in the graph walk. The infrastructure already exists (`prepare_query` / `distance_with_prepared`); #414 wired it into the linear-scan fallback, and the IVF/Flat searchers use it, but the HNSW graph traversal was left on the un-prepared path.

## Change

Prepare the query once in `search_graph` (only when there is no quantized context) and thread `Option<&PreparedQuery>` into `calc_dist`; the f32 path uses `distance_with_prepared` (→ `simd_dot_and_norm_b`, dot + candidate norm only) when present. Mathematically identical; the quantized path already precomputes norms and is untouched. No on-disk / public API / binding change.

## Benchmarks (`vector_search_bench`, HNSW Graph Search, idle + CPU-pinned + null-pair)

The null pair (main vs its own baseline, ideally ~0%) is shown to bound the host's drift; the true effect is `real − null`:

| config | null (main vs main) | real (prepared vs main) | true effect |
|--------|--------------------:|------------------------:|------------:|
| top10/50000 | −0.4% (p=0.09, stable) | −5.6% (p=0.00) | **~−5.3%** |
| top10/1000 | +2.7% | −4.8% | ~−7.5% |
| top10/5000 | +11.9% (noisy) | −7.6% | improved |

The largest/most-stable config (top10/50000, null-stable) shows a clean ~5% improvement; all configs move in the improvement direction, no regressions. (Applies to the f32 / OnDemand / legacy path; the quantized path is already optimal.)

## Tests

- `cargo test -p laurus --lib vector` (284) + `hnsw` (41) pass — results unchanged.
- `cargo clippy --all-targets --features embeddings-all -- -D warnings`, `cargo fmt --check`: clean.

## Follow-ups (out of scope)

- Precompute `norm = sqrt(norm_sq)` in `PreparedQuery` to drop the residual per-candidate scalar `sqrt`.
- #653's Euclidean-`sqrt` / Angular-`acos` ranking skip (needs Euclidean/Angular benches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)