### PR TITLE
perf(vector/search): SIMD int8 SQ distance kernels (AVX2/NEON) (#652)

### DIFF
--- a/laurus/benches/vector_search_bench.rs
+++ b/laurus/benches/vector_search_bench.rs
@@ -126,6 +126,10 @@ use laurus::storage::file::FileStorageConfig;
 use laurus::storage::{StorageConfig, StorageFactory};
 use laurus::vector::HnswIndexReader;
 use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::distance_quantized::{
+    abs_diff_u8_to_i32, abs_diff_u8_to_i32_scalar, dot_u8_to_i32, dot_u8_to_i32_scalar,
+    sq_diff_u8_to_i32, sq_diff_u8_to_i32_scalar,
+};
 use laurus::vector::core::rerank::RerankStorageKind;
 use laurus::vector::core::vector::Vector;
 use laurus::vector::index::ManagedVectorIndex;
@@ -306,8 +310,14 @@ fn cache_is_valid(dir: &Path) -> bool {
 fn open_cached_reader(
     dir: &Path,
     config: &VectorIndexTypeConfig,
+    use_mmap: bool,
 ) -> laurus::Result<Arc<dyn VectorIndexReader>> {
-    let file_config = FileStorageConfig::new(dir);
+    let mut file_config = FileStorageConfig::new(dir);
+    // `use_mmap = false` forces `LoadingMode::Eager`, so scalar-quantized
+    // segments load as `VectorStorage::OwnedQuantized` and the search hot loop
+    // dispatches to the int8 `distance_quantized` kernel; mmap (the default)
+    // yields `LoadingMode::Lazy` -> `OnDemand` dequantize-on-get (f32 path).
+    file_config.use_mmap = use_mmap;
     let storage = StorageFactory::create(StorageConfig::File(file_config))?;
     let distance = config.distance_metric();
     let reader: Arc<dyn VectorIndexReader> = match config {
@@ -334,9 +344,14 @@ fn open_cached_reader(
 fn build_cached_reader(
     dir: &Path,
     config: VectorIndexTypeConfig,
+    use_mmap: bool,
     vectors: Vec<(u64, String, Vector)>,
 ) -> laurus::Result<Arc<dyn VectorIndexReader>> {
-    let file_config = FileStorageConfig::new(dir);
+    let mut file_config = FileStorageConfig::new(dir);
+    // Match the read mode the searcher will use so a fresh build returns a
+    // reader in the same loading mode as a cache-hit reopen (see
+    // `open_cached_reader`).
+    file_config.use_mmap = use_mmap;
     let storage = StorageFactory::create(StorageConfig::File(file_config))?;
     let mut index = ManagedVectorIndex::new(config, storage, CACHE_INDEX_NAME)?;
     index.add_vectors(vectors)?;
@@ -379,11 +394,32 @@ fn cached_vector_reader(
     config: VectorIndexTypeConfig,
     build_vectors: impl FnOnce() -> Vec<(u64, String, Vector)>,
 ) -> Arc<dyn VectorIndexReader> {
+    // Default to mmap (`LoadingMode::Lazy`) to preserve the historical
+    // behaviour of every existing bench. Use
+    // [`cached_vector_reader_with_loading`] with `use_mmap = false` to
+    // force eager loading and exercise the int8 `distance_quantized`
+    // kernel (Issue #652).
+    cached_vector_reader_with_loading(slot, config, true, build_vectors)
+}
+
+/// Like [`cached_vector_reader`] but explicitly selects the storage
+/// loading mode.
+///
+/// `use_mmap = false` forces `LoadingMode::Eager`, so scalar-quantized
+/// segments load as `VectorStorage::OwnedQuantized` and the search hot
+/// loop dispatches to the int8 `distance_quantized` kernel. `use_mmap =
+/// true` yields the mmap `Lazy` / `OnDemand` dequantize-on-get f32 path.
+fn cached_vector_reader_with_loading(
+    slot: &str,
+    config: VectorIndexTypeConfig,
+    use_mmap: bool,
+    build_vectors: impl FnOnce() -> Vec<(u64, String, Vector)>,
+) -> Arc<dyn VectorIndexReader> {
     let dir = cache_dir_for(slot);
     let force_rebuild = std::env::var("LAURUS_BENCH_REBUILD").is_ok();
 
     if !force_rebuild && cache_is_valid(&dir) {
-        match open_cached_reader(&dir, &config) {
+        match open_cached_reader(&dir, &config, use_mmap) {
             Ok(reader) => return reader,
             Err(err) => {
                 eprintln!(
@@ -397,7 +433,8 @@ fn cached_vector_reader(
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).expect("create vector bench cache dir");
 
-    build_cached_reader(&dir, config, build_vectors()).expect("vector bench cache build failed")
+    build_cached_reader(&dir, config, use_mmap, build_vectors())
+        .expect("vector bench cache build failed")
 }
 
 // ---------------------------------------------------------------------------
@@ -525,6 +562,111 @@ fn bench_flat_search(c: &mut Criterion) {
                 searcher.search(&request).unwrap()
             });
         });
+    }
+    group.finish();
+}
+
+/// Isolates the int8 `distance_quantized` kernel (Issue #652).
+///
+/// Forces eager loading (`use_mmap = false`) so scalar-quantized
+/// segments load as `VectorStorage::OwnedQuantized`; a field-filtered
+/// Flat search then runs a full linear scan through `distance_quantized`
+/// for every candidate — the purest end-to-end measurement of the int8
+/// kernel with negligible graph-traversal overhead. Sweeps the three
+/// metrics that map to the three kernel shapes:
+/// - `Cosine` → `dot_u8_to_i32`
+/// - `Euclidean` → `sq_diff_u8_to_i32`
+/// - `Manhattan` → `abs_diff_u8_to_i32`
+fn bench_flat_search_int8_kernel(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Flat Search int8 kernel");
+    let dim = 128;
+    // Large corpus so the per-candidate int8 kernel dominates timing.
+    let count = 20_000;
+
+    for &(label, metric) in &[
+        ("cosine_dot", DistanceMetric::Cosine),
+        ("euclidean_sqdiff", DistanceMetric::Euclidean),
+        ("manhattan_absdiff", DistanceMetric::Manhattan),
+    ] {
+        let config = FlatIndexConfig {
+            dimension: dim,
+            distance_metric: metric,
+            ..Default::default()
+        };
+        let slot = format!("flat_int8_eager_n{count}_dim{dim}_{label}");
+        let reader = cached_vector_reader_with_loading(
+            &slot,
+            VectorIndexTypeConfig::Flat(config),
+            false, // eager load -> int8 distance_quantized hot path
+            || generate_vectors(count, dim),
+        );
+        let searcher = FlatVectorSearcher::new(reader).unwrap();
+        let query = generate_query(dim);
+
+        // Sanity check: the field-filtered probe must return top-10 hits
+        // (and therefore engage the quantized scan) before timing.
+        let probe = searcher
+            .search(
+                &VectorIndexQuery::new(query.clone())
+                    .top_k(10)
+                    .field_name("field".to_string()),
+            )
+            .unwrap();
+        assert!(
+            !probe.results.is_empty(),
+            "int8 flat probe must return at least one hit ({label})"
+        );
+
+        group.bench_with_input(BenchmarkId::new("top10", label), &count, |b, _| {
+            b.iter(|| {
+                let request = VectorIndexQuery::new(query.clone())
+                    .top_k(10)
+                    .field_name("field".to_string());
+                searcher.search(&request).unwrap()
+            });
+        });
+    }
+    group.finish();
+}
+
+/// A/B micro-benchmark for the three int8 SQ kernels (Issue #652):
+/// the runtime-dispatched kernel (AVX2 on x86_64, NEON on aarch64) vs
+/// the portable `wide` scalar reference, at representative dimensions.
+/// Isolates the raw kernel speedup with zero search-path overhead —
+/// compare the `dispatch` and `scalar` timings within each
+/// `(kernel, dim)` pair.
+fn bench_int8_kernel_micro(c: &mut Criterion) {
+    use std::hint::black_box;
+
+    type Kernel = fn(&[u8], &[u8]) -> i32;
+    let mut group = c.benchmark_group("int8 kernel micro");
+
+    for &dim in &[128usize, 768] {
+        // Deterministic full-range u8 operands (0..=255).
+        let a: Vec<u8> = (0..dim)
+            .map(|i| (i.wrapping_mul(97).wrapping_add(13) & 0xFF) as u8)
+            .collect();
+        let b: Vec<u8> = (0..dim)
+            .map(|i| (i.wrapping_mul(131).wrapping_add(7) & 0xFF) as u8)
+            .collect();
+
+        let cases: [(&str, Kernel, Kernel); 3] = [
+            ("dot", dot_u8_to_i32, dot_u8_to_i32_scalar),
+            ("sq_diff", sq_diff_u8_to_i32, sq_diff_u8_to_i32_scalar),
+            ("abs_diff", abs_diff_u8_to_i32, abs_diff_u8_to_i32_scalar),
+        ];
+        for (name, dispatch, scalar) in cases {
+            group.bench_with_input(
+                BenchmarkId::new(format!("{name}/dispatch"), dim),
+                &dim,
+                |bch, _| bch.iter(|| dispatch(black_box(&a), black_box(&b))),
+            );
+            group.bench_with_input(
+                BenchmarkId::new(format!("{name}/scalar"), dim),
+                &dim,
+                |bch, _| bch.iter(|| scalar(black_box(&a), black_box(&b))),
+            );
+        }
     }
     group.finish();
 }
@@ -1670,6 +1812,8 @@ criterion_group!(
     bench_ivf_construction,
     bench_hnsw_construction,
     bench_flat_search,
+    bench_flat_search_int8_kernel,
+    bench_int8_kernel_micro,
     bench_ivf_search,
     bench_ivf_search_large_k,
     bench_hnsw_fallback_search,

--- a/laurus/src/vector/core.rs
+++ b/laurus/src/vector/core.rs
@@ -10,4 +10,6 @@ pub mod distance_quantized;
 pub mod field;
 pub mod quantization;
 pub mod rerank;
+pub mod sq_int8_avx2;
+pub mod sq_int8_neon;
 pub mod vector;

--- a/laurus/src/vector/core/distance_quantized.rs
+++ b/laurus/src/vector/core/distance_quantized.rs
@@ -182,11 +182,12 @@ fn approx_dot_product(query: &QuantizedQuery, cand: &[u8], cand_sum_q: u32) -> f
         + scale * scale * dot_q as f32
 }
 
-/// SIMD `Σ a[i] * b[i]` over u8 inputs, accumulating in i32.
+/// `Σ a[i] * b[i]` over u8 inputs, accumulating in i32.
 ///
-/// Uses [`wide::i32x8`] for an 8-wide accumulator. Per-element
-/// `u8 → i32` zero-extension is folded into the SIMD load. The tail
-/// (≤ 7 elements) falls back to scalar.
+/// Dispatches at runtime to an AVX2 kernel on x86_64 (when the CPU
+/// reports AVX2 support), a NEON kernel on aarch64, and the portable
+/// [`dot_u8_to_i32_scalar`] fallback otherwise. All three produce
+/// bit-identical results because the arithmetic is integer.
 ///
 /// # Overflow
 ///
@@ -195,6 +196,34 @@ fn approx_dot_product(query: &QuantizedQuery, cand: &[u8], cand_sum_q: u32) -> f
 /// covering all realistic vector dimensions.
 #[inline]
 pub fn dot_u8_to_i32(a: &[u8], b: &[u8]) -> i32 {
+    debug_assert_eq!(a.len(), b.len());
+    #[cfg(target_arch = "x86_64")]
+    if crate::vector::core::sq_int8_avx2::is_avx2_supported() {
+        // SAFETY: AVX2 is detected at runtime and `a.len() == b.len()`.
+        return unsafe { crate::vector::core::sq_int8_avx2::dot_u8_to_i32_avx2(a, b) };
+    }
+    #[cfg(target_arch = "aarch64")]
+    if crate::vector::core::sq_int8_neon::is_neon_supported() {
+        // SAFETY: NEON is part of the ARMv8 baseline and `a.len() == b.len()`.
+        return unsafe { crate::vector::core::sq_int8_neon::dot_u8_to_i32_neon(a, b) };
+    }
+    dot_u8_to_i32_scalar(a, b)
+}
+
+/// Portable `wide`-based reference for [`dot_u8_to_i32`].
+///
+/// Uses [`wide::i32x8`] for an 8-wide accumulator. Per-element
+/// `u8 → i32` zero-extension is folded into the SIMD load. The tail
+/// (≤ 7 elements) falls back to scalar. Retained as the fallback for
+/// non-AVX2 / non-NEON targets, as the correctness anchor the SIMD
+/// kernels are asserted against, and as the shared `len % 32` /
+/// `len % 16` tail handler for those kernels.
+///
+/// Exposed (hidden from docs) so the `vector_search_bench` A/B
+/// micro-benchmark can time it against the runtime-dispatched
+/// [`dot_u8_to_i32`]; not part of the stable public API.
+#[doc(hidden)]
+pub fn dot_u8_to_i32_scalar(a: &[u8], b: &[u8]) -> i32 {
     debug_assert_eq!(a.len(), b.len());
     let mut acc = i32x8::ZERO;
     let chunks_a = a.chunks_exact(8);
@@ -231,14 +260,35 @@ pub fn dot_u8_to_i32(a: &[u8], b: &[u8]) -> i32 {
     total
 }
 
-/// SIMD `Σ (a[i] - b[i])²` over u8 inputs, accumulating in i32.
+/// `Σ (a[i] - b[i])²` over u8 inputs, accumulating in i32.
 ///
-/// The subtraction widens to i32 first so the result remains correct
-/// even when `a[i] < b[i]` (would underflow in u8). Per-pair
-/// squared diff is at most `255² = 65025`, identical to the dot-product
-/// kernel's per-pair bound, so the same overflow analysis applies.
+/// Dispatches at runtime to AVX2 / NEON / [`sq_diff_u8_to_i32_scalar`]
+/// exactly like [`dot_u8_to_i32`]. Per-pair squared diff is at most
+/// `255² = 65025`, identical to the dot-product kernel's per-pair
+/// bound, so the same overflow analysis applies.
 #[inline]
 pub fn sq_diff_u8_to_i32(a: &[u8], b: &[u8]) -> i32 {
+    debug_assert_eq!(a.len(), b.len());
+    #[cfg(target_arch = "x86_64")]
+    if crate::vector::core::sq_int8_avx2::is_avx2_supported() {
+        // SAFETY: AVX2 is detected at runtime and `a.len() == b.len()`.
+        return unsafe { crate::vector::core::sq_int8_avx2::sq_diff_u8_to_i32_avx2(a, b) };
+    }
+    #[cfg(target_arch = "aarch64")]
+    if crate::vector::core::sq_int8_neon::is_neon_supported() {
+        // SAFETY: NEON is part of the ARMv8 baseline and `a.len() == b.len()`.
+        return unsafe { crate::vector::core::sq_int8_neon::sq_diff_u8_to_i32_neon(a, b) };
+    }
+    sq_diff_u8_to_i32_scalar(a, b)
+}
+
+/// Portable `wide`-based reference for [`sq_diff_u8_to_i32`].
+///
+/// The subtraction widens to i32 first so the result remains correct
+/// even when `a[i] < b[i]` (would underflow in u8). See
+/// [`dot_u8_to_i32_scalar`] for the fallback / tail-handler role.
+#[doc(hidden)]
+pub fn sq_diff_u8_to_i32_scalar(a: &[u8], b: &[u8]) -> i32 {
     debug_assert_eq!(a.len(), b.len());
     let mut acc = i32x8::ZERO;
     let chunks_a = a.chunks_exact(8);
@@ -277,13 +327,34 @@ pub fn sq_diff_u8_to_i32(a: &[u8], b: &[u8]) -> i32 {
     total
 }
 
-/// SIMD `Σ |a[i] - b[i]|` over u8 inputs, accumulating in i32.
+/// `Σ |a[i] - b[i]|` over u8 inputs, accumulating in i32.
 ///
-/// Uses widened `i32` subtraction + [`i32x8::abs`] for the absolute
-/// value. Per-pair magnitude is at most `255`, so accumulation
-/// safety is the same as the other kernels.
+/// Dispatches at runtime to AVX2 / NEON / [`abs_diff_u8_to_i32_scalar`]
+/// exactly like [`dot_u8_to_i32`]. Per-pair magnitude is at most
+/// `255`, so accumulation safety is the same as the other kernels.
 #[inline]
 pub fn abs_diff_u8_to_i32(a: &[u8], b: &[u8]) -> i32 {
+    debug_assert_eq!(a.len(), b.len());
+    #[cfg(target_arch = "x86_64")]
+    if crate::vector::core::sq_int8_avx2::is_avx2_supported() {
+        // SAFETY: AVX2 is detected at runtime and `a.len() == b.len()`.
+        return unsafe { crate::vector::core::sq_int8_avx2::abs_diff_u8_to_i32_avx2(a, b) };
+    }
+    #[cfg(target_arch = "aarch64")]
+    if crate::vector::core::sq_int8_neon::is_neon_supported() {
+        // SAFETY: NEON is part of the ARMv8 baseline and `a.len() == b.len()`.
+        return unsafe { crate::vector::core::sq_int8_neon::abs_diff_u8_to_i32_neon(a, b) };
+    }
+    abs_diff_u8_to_i32_scalar(a, b)
+}
+
+/// Portable `wide`-based reference for [`abs_diff_u8_to_i32`].
+///
+/// Uses widened `i32` subtraction + [`i32x8::abs`] for the absolute
+/// value. See [`dot_u8_to_i32_scalar`] for the fallback / tail-handler
+/// role.
+#[doc(hidden)]
+pub fn abs_diff_u8_to_i32_scalar(a: &[u8], b: &[u8]) -> i32 {
     debug_assert_eq!(a.len(), b.len());
     let mut acc = i32x8::ZERO;
     let chunks_a = a.chunks_exact(8);
@@ -481,7 +552,9 @@ mod tests {
 
     #[test]
     fn dot_simd_matches_scalar_for_various_lengths() {
-        for &dim in &[1, 7, 8, 9, 16, 17, 64, 65, 128, 384, 768] {
+        for &dim in &[
+            1, 7, 8, 9, 16, 17, 31, 32, 33, 64, 65, 96, 100, 128, 384, 768,
+        ] {
             let a = pseudo_random_u8(1, dim);
             let b = pseudo_random_u8(2, dim);
             assert_eq!(
@@ -494,7 +567,9 @@ mod tests {
 
     #[test]
     fn sq_diff_simd_matches_scalar_for_various_lengths() {
-        for &dim in &[1, 7, 8, 9, 16, 17, 64, 65, 128, 384, 768] {
+        for &dim in &[
+            1, 7, 8, 9, 16, 17, 31, 32, 33, 64, 65, 96, 100, 128, 384, 768,
+        ] {
             let a = pseudo_random_u8(3, dim);
             let b = pseudo_random_u8(4, dim);
             assert_eq!(
@@ -507,7 +582,9 @@ mod tests {
 
     #[test]
     fn abs_diff_simd_matches_scalar_for_various_lengths() {
-        for &dim in &[1, 7, 8, 9, 16, 17, 64, 65, 128, 384, 768] {
+        for &dim in &[
+            1, 7, 8, 9, 16, 17, 31, 32, 33, 64, 65, 96, 100, 128, 384, 768,
+        ] {
             let a = pseudo_random_u8(5, dim);
             let b = pseudo_random_u8(6, dim);
             assert_eq!(
@@ -515,6 +592,85 @@ mod tests {
                 scalar_abs_diff(&a, &b),
                 "dim = {dim}: SIMD abs_diff disagrees with scalar"
             );
+        }
+    }
+
+    /// The portable `wide` fallbacks must match the plain scalar
+    /// reference for every length, independent of which kernel the
+    /// dispatcher selects at runtime. This keeps the non-AVX2 / non-NEON
+    /// path covered on an AVX2 host.
+    #[test]
+    fn scalar_fallbacks_match_reference_for_various_lengths() {
+        for &dim in &[
+            1, 7, 8, 9, 16, 17, 31, 32, 33, 64, 65, 96, 100, 128, 384, 768,
+        ] {
+            let a = pseudo_random_u8(7, dim);
+            let b = pseudo_random_u8(8, dim);
+            assert_eq!(
+                dot_u8_to_i32_scalar(&a, &b),
+                scalar_dot(&a, &b),
+                "dot dim={dim}"
+            );
+            assert_eq!(
+                sq_diff_u8_to_i32_scalar(&a, &b),
+                scalar_sq_diff(&a, &b),
+                "sq_diff dim={dim}"
+            );
+            assert_eq!(
+                abs_diff_u8_to_i32_scalar(&a, &b),
+                scalar_abs_diff(&a, &b),
+                "abs_diff dim={dim}"
+            );
+        }
+    }
+
+    /// Directly exercise the AVX2 kernels (not just the dispatcher) so
+    /// the SIMD path is verified even if the dispatcher's runtime probe
+    /// ever changes. Skipped when the host lacks AVX2. Lengths span the
+    /// 32-byte block boundary (`31/32/33/96/100`) to stress the scalar
+    /// tail delegation.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_kernels_match_scalar_when_supported() {
+        use crate::vector::core::sq_int8_avx2::{
+            abs_diff_u8_to_i32_avx2, dot_u8_to_i32_avx2, is_avx2_supported, sq_diff_u8_to_i32_avx2,
+        };
+        if !is_avx2_supported() {
+            return;
+        }
+        for &dim in &[
+            1, 7, 8, 9, 16, 17, 31, 32, 33, 64, 65, 96, 100, 128, 384, 768, 4096,
+        ] {
+            let a = pseudo_random_u8(9, dim);
+            let b = pseudo_random_u8(10, dim);
+            // SAFETY: guarded by `is_avx2_supported()` above.
+            unsafe {
+                assert_eq!(
+                    dot_u8_to_i32_avx2(&a, &b),
+                    scalar_dot(&a, &b),
+                    "dot dim={dim}"
+                );
+                assert_eq!(
+                    sq_diff_u8_to_i32_avx2(&a, &b),
+                    scalar_sq_diff(&a, &b),
+                    "sq_diff dim={dim}"
+                );
+                assert_eq!(
+                    abs_diff_u8_to_i32_avx2(&a, &b),
+                    scalar_abs_diff(&a, &b),
+                    "abs_diff dim={dim}"
+                );
+            }
+        }
+        // All-255 extreme at a realistic dim: exercises the i32 / u64
+        // accumulator bounds documented on the kernels.
+        let a = vec![255u8; 4096];
+        let b = vec![0u8; 4096];
+        // SAFETY: guarded by `is_avx2_supported()` above.
+        unsafe {
+            assert_eq!(dot_u8_to_i32_avx2(&a, &a), 255 * 255 * 4096);
+            assert_eq!(sq_diff_u8_to_i32_avx2(&a, &b), 255 * 255 * 4096);
+            assert_eq!(abs_diff_u8_to_i32_avx2(&a, &b), 255 * 4096);
         }
     }
 

--- a/laurus/src/vector/core/sq_int8_avx2.rs
+++ b/laurus/src/vector/core/sq_int8_avx2.rs
@@ -1,0 +1,227 @@
+//! AVX2 SIMD kernels for the int8 scalar-quantization (SQ) distance
+//! primitives (Issue [#652](https://github.com/mosuka/laurus/issues/652)).
+//!
+//! These modernise the three per-pair integer accumulators used by
+//! [`crate::vector::core::distance_quantized`]:
+//!
+//! - [`dot_u8_to_i32_avx2`] — `Σ a[i] * b[i]`
+//! - [`sq_diff_u8_to_i32_avx2`] — `Σ (a[i] - b[i])²`
+//! - [`abs_diff_u8_to_i32_avx2`] — `Σ |a[i] - b[i]|`
+//!
+//! Each kernel processes **32 bytes per iteration** in a 256-bit
+//! register, versus the portable [`wide::i32x8`] fallback's 8 bytes.
+//!
+//! # Why not `PMADDUBSW`
+//!
+//! `_mm256_maddubs_epi16` computes `u8 × i8`, treating its second
+//! operand as **signed** i8. Scalar quantization produces full-range
+//! `u8` (`0..=255`), so candidate bytes ≥ 128 would be misread as
+//! negative. Instead the dot / sq_diff kernels widen both operands
+//! `u8 → i16` (`_mm256_unpacklo_epi8` / `_mm256_unpackhi_epi8` with a
+//! zero register) and use `_mm256_madd_epi16` (`i16 × i16 → i32`,
+//! adjacent-pair summed). The abs_diff kernel uses `_mm256_sad_epu8`,
+//! which sums `|a - b|` over unsigned bytes directly in one
+//! instruction.
+//!
+//! # Bit-exactness
+//!
+//! All arithmetic is integer, so the SIMD result is bit-identical to
+//! the scalar reference regardless of summation order. The tail
+//! (`len % 32` trailing bytes) is delegated to the scalar kernels in
+//! [`crate::vector::core::distance_quantized`], keeping a single source
+//! of truth for the remainder.
+//!
+//! # Overflow
+//!
+//! The per-pair bounds match the scalar path: `u8 * u8 ≤ 65025`,
+//! `(a - b)² ≤ 65025`, `|a - b| ≤ 255`. For all realistic dimensions
+//! (`dim ≤ 4096`) the i32 / u64 accumulators stay well below their
+//! maxima, exactly as documented on the scalar kernels.
+
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+#[cfg(target_arch = "x86_64")]
+use crate::vector::core::distance_quantized::{
+    abs_diff_u8_to_i32_scalar, dot_u8_to_i32_scalar, sq_diff_u8_to_i32_scalar,
+};
+
+/// Returns `true` when the current x86_64 CPU supports AVX2.
+///
+/// Always returns `false` on non-x86_64 targets. The result of
+/// `is_x86_feature_detected!` is cached after the first call, so
+/// subsequent invocations cost roughly one branch.
+#[inline]
+pub fn is_avx2_supported() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        is_x86_feature_detected!("avx2")
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        false
+    }
+}
+
+/// AVX2 `Σ a[i] * b[i]` over u8 inputs, accumulating in i32.
+///
+/// Widens both operands `u8 → i16` and multiply-accumulates with
+/// `_mm256_madd_epi16`, 32 elements per iteration. The `len % 32` tail
+/// is handled by [`dot_u8_to_i32_scalar`].
+///
+/// # Safety
+///
+/// Caller must guarantee:
+/// - The CPU supports AVX2. Use [`is_avx2_supported`] before calling.
+/// - `a.len() == b.len()` (the callers assert this).
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+pub unsafe fn dot_u8_to_i32_avx2(a: &[u8], b: &[u8]) -> i32 {
+    // SAFETY: caller contract documented above; the intrinsics are
+    // sound when called from a `#[target_feature(enable = "avx2")]`
+    // function on an AVX2-capable CPU, and every load reads exactly
+    // `simd_len <= a.len()` bytes.
+    unsafe {
+        let len = a.len();
+        let simd_len = len & !31; // round down to a multiple of 32
+        let zero = _mm256_setzero_si256();
+        let mut acc = _mm256_setzero_si256();
+        let pa = a.as_ptr();
+        let pb = b.as_ptr();
+
+        let mut i = 0;
+        while i < simd_len {
+            let va = _mm256_loadu_si256(pa.add(i) as *const __m256i);
+            let vb = _mm256_loadu_si256(pb.add(i) as *const __m256i);
+
+            // Widen u8 -> i16 (per 128-bit lane; lane ordering is
+            // irrelevant to the final horizontal sum).
+            let a_lo = _mm256_unpacklo_epi8(va, zero);
+            let a_hi = _mm256_unpackhi_epi8(va, zero);
+            let b_lo = _mm256_unpacklo_epi8(vb, zero);
+            let b_hi = _mm256_unpackhi_epi8(vb, zero);
+
+            // i16 * i16 -> i32, adjacent pairs summed.
+            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(a_lo, b_lo));
+            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(a_hi, b_hi));
+
+            i += 32;
+        }
+
+        let mut total = hsum_epi32(acc);
+        if simd_len < len {
+            total += dot_u8_to_i32_scalar(&a[simd_len..], &b[simd_len..]);
+        }
+        total
+    }
+}
+
+/// AVX2 `Σ (a[i] - b[i])²` over u8 inputs, accumulating in i32.
+///
+/// Widens both operands `u8 → i16`, subtracts in i16 (range
+/// `-255..=255`), then squares and pair-sums with
+/// `_mm256_madd_epi16`. The `len % 32` tail is handled by
+/// [`sq_diff_u8_to_i32_scalar`].
+///
+/// # Safety
+///
+/// Same contract as [`dot_u8_to_i32_avx2`].
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+pub unsafe fn sq_diff_u8_to_i32_avx2(a: &[u8], b: &[u8]) -> i32 {
+    // SAFETY: see the module-level and `dot_u8_to_i32_avx2` contracts;
+    // AVX2 is required and every load stays within `simd_len`.
+    unsafe {
+        let len = a.len();
+        let simd_len = len & !31;
+        let zero = _mm256_setzero_si256();
+        let mut acc = _mm256_setzero_si256();
+        let pa = a.as_ptr();
+        let pb = b.as_ptr();
+
+        let mut i = 0;
+        while i < simd_len {
+            let va = _mm256_loadu_si256(pa.add(i) as *const __m256i);
+            let vb = _mm256_loadu_si256(pb.add(i) as *const __m256i);
+
+            let a_lo = _mm256_unpacklo_epi8(va, zero);
+            let a_hi = _mm256_unpackhi_epi8(va, zero);
+            let b_lo = _mm256_unpacklo_epi8(vb, zero);
+            let b_hi = _mm256_unpackhi_epi8(vb, zero);
+
+            let d_lo = _mm256_sub_epi16(a_lo, b_lo);
+            let d_hi = _mm256_sub_epi16(a_hi, b_hi);
+
+            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(d_lo, d_lo));
+            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(d_hi, d_hi));
+
+            i += 32;
+        }
+
+        let mut total = hsum_epi32(acc);
+        if simd_len < len {
+            total += sq_diff_u8_to_i32_scalar(&a[simd_len..], &b[simd_len..]);
+        }
+        total
+    }
+}
+
+/// AVX2 `Σ |a[i] - b[i]|` over u8 inputs, accumulating in i32.
+///
+/// Uses `_mm256_sad_epu8`, which computes the sum of absolute
+/// differences of unsigned bytes over each 8-byte group in one
+/// instruction, accumulated in four u64 lanes. The `len % 32` tail is
+/// handled by [`abs_diff_u8_to_i32_scalar`].
+///
+/// # Safety
+///
+/// Same contract as [`dot_u8_to_i32_avx2`].
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+pub unsafe fn abs_diff_u8_to_i32_avx2(a: &[u8], b: &[u8]) -> i32 {
+    // SAFETY: see the module-level and `dot_u8_to_i32_avx2` contracts;
+    // AVX2 is required and every load stays within `simd_len`.
+    unsafe {
+        let len = a.len();
+        let simd_len = len & !31;
+        let mut acc = _mm256_setzero_si256();
+        let pa = a.as_ptr();
+        let pb = b.as_ptr();
+
+        let mut i = 0;
+        while i < simd_len {
+            let va = _mm256_loadu_si256(pa.add(i) as *const __m256i);
+            let vb = _mm256_loadu_si256(pb.add(i) as *const __m256i);
+            acc = _mm256_add_epi64(acc, _mm256_sad_epu8(va, vb));
+            i += 32;
+        }
+
+        // Horizontal sum of the four u64 lanes. The total for realistic
+        // dims (`dim * 255`) fits comfortably in i32.
+        let mut lanes = [0i64; 4];
+        _mm256_storeu_si256(lanes.as_mut_ptr() as *mut __m256i, acc);
+        let mut total = (lanes[0] + lanes[1] + lanes[2] + lanes[3]) as i32;
+        if simd_len < len {
+            total += abs_diff_u8_to_i32_scalar(&a[simd_len..], &b[simd_len..]);
+        }
+        total
+    }
+}
+
+/// Horizontal sum of the eight i32 lanes of a 256-bit register.
+///
+/// # Safety
+///
+/// Requires AVX2; only called from `#[target_feature(enable = "avx2")]`
+/// kernels in this module.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn hsum_epi32(v: __m256i) -> i32 {
+    // SAFETY: AVX2 guaranteed by the `#[target_feature]` attribute and
+    // the calling kernels' own contracts.
+    unsafe {
+        let mut lanes = [0i32; 8];
+        _mm256_storeu_si256(lanes.as_mut_ptr() as *mut __m256i, v);
+        lanes.iter().sum()
+    }
+}

--- a/laurus/src/vector/core/sq_int8_neon.rs
+++ b/laurus/src/vector/core/sq_int8_neon.rs
@@ -1,0 +1,180 @@
+//! NEON SIMD kernels for the int8 scalar-quantization (SQ) distance
+//! primitives (Issue [#652](https://github.com/mosuka/laurus/issues/652)).
+//!
+//! Mirrors [`crate::vector::core::sq_int8_avx2`] using aarch64 NEON
+//! intrinsics, processing **16 bytes per iteration** in a 128-bit
+//! register:
+//!
+//! - [`dot_u8_to_i32_neon`] — widen `u8 → u16`, multiply-accumulate
+//!   with `vmlal_u16` into a u32x4 accumulator.
+//! - [`sq_diff_u8_to_i32_neon`] — `vabdq_u8` gives `|a - b|` as u8;
+//!   squaring the absolute difference equals `(a - b)²`, accumulated
+//!   with `vmlal_u16`.
+//! - [`abs_diff_u8_to_i32_neon`] — `vabdq_u8` then `vpadalq_u16`
+//!   pairwise-accumulate into u32x4 (a u16 accumulator would overflow
+//!   for `dim > 257`).
+//!
+//! NEON is mandatory on aarch64 (ARMv8 baseline), so the kernels are
+//! gated solely on `#[cfg(target_arch = "aarch64")]` and need no
+//! runtime feature check the way the AVX2 path does.
+//!
+//! # Bit-exactness / overflow
+//!
+//! As with the AVX2 kernels, the arithmetic is integer and the result
+//! is bit-identical to the scalar reference. The per-pair bounds
+//! (`≤ 65025` for dot / sq_diff, `≤ 255` for abs_diff) keep the u32
+//! accumulator well within range for realistic dimensions, and the
+//! `len % 16` tail is delegated to the scalar kernels in
+//! [`crate::vector::core::distance_quantized`].
+
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::*;
+
+#[cfg(target_arch = "aarch64")]
+use crate::vector::core::distance_quantized::{
+    abs_diff_u8_to_i32_scalar, dot_u8_to_i32_scalar, sq_diff_u8_to_i32_scalar,
+};
+
+/// Returns `true` when the current target supports NEON.
+///
+/// On `aarch64` this is unconditionally `true` because NEON is
+/// mandatory since ARMv8. On any other architecture it returns `false`.
+#[inline]
+pub fn is_neon_supported() -> bool {
+    cfg!(target_arch = "aarch64")
+}
+
+/// NEON `Σ a[i] * b[i]` over u8 inputs, accumulating in i32.
+///
+/// The `len % 16` tail is handled by [`dot_u8_to_i32_scalar`].
+///
+/// # Safety
+///
+/// Caller must guarantee:
+/// - Target architecture is `aarch64` (also enforced by `#[cfg]`).
+/// - `a.len() == b.len()` (the callers assert this).
+#[cfg(target_arch = "aarch64")]
+pub unsafe fn dot_u8_to_i32_neon(a: &[u8], b: &[u8]) -> i32 {
+    // SAFETY: caller contract documented above; NEON intrinsics are
+    // sound on aarch64 (baseline ISA) and every load reads exactly
+    // `simd_len <= a.len()` bytes.
+    unsafe {
+        let len = a.len();
+        let simd_len = len & !15; // round down to a multiple of 16
+        let mut acc = vdupq_n_u32(0);
+        let pa = a.as_ptr();
+        let pb = b.as_ptr();
+
+        let mut i = 0;
+        while i < simd_len {
+            let va = vld1q_u8(pa.add(i));
+            let vb = vld1q_u8(pb.add(i));
+
+            let a_lo = vmovl_u8(vget_low_u8(va)); // u16x8
+            let a_hi = vmovl_u8(vget_high_u8(va));
+            let b_lo = vmovl_u8(vget_low_u8(vb));
+            let b_hi = vmovl_u8(vget_high_u8(vb));
+
+            acc = vmlal_u16(acc, vget_low_u16(a_lo), vget_low_u16(b_lo));
+            acc = vmlal_u16(acc, vget_high_u16(a_lo), vget_high_u16(b_lo));
+            acc = vmlal_u16(acc, vget_low_u16(a_hi), vget_low_u16(b_hi));
+            acc = vmlal_u16(acc, vget_high_u16(a_hi), vget_high_u16(b_hi));
+
+            i += 16;
+        }
+
+        let mut total = vaddvq_u32(acc) as i32;
+        if simd_len < len {
+            total += dot_u8_to_i32_scalar(&a[simd_len..], &b[simd_len..]);
+        }
+        total
+    }
+}
+
+/// NEON `Σ (a[i] - b[i])²` over u8 inputs, accumulating in i32.
+///
+/// `vabdq_u8` yields `|a - b|` as u8; squaring it equals `(a - b)²`.
+/// The `len % 16` tail is handled by [`sq_diff_u8_to_i32_scalar`].
+///
+/// # Safety
+///
+/// Same contract as [`dot_u8_to_i32_neon`].
+#[cfg(target_arch = "aarch64")]
+pub unsafe fn sq_diff_u8_to_i32_neon(a: &[u8], b: &[u8]) -> i32 {
+    // SAFETY: see the module-level and `dot_u8_to_i32_neon` contracts;
+    // NEON is baseline on aarch64 and every load stays within `simd_len`.
+    unsafe {
+        let len = a.len();
+        let simd_len = len & !15;
+        let mut acc = vdupq_n_u32(0);
+        let pa = a.as_ptr();
+        let pb = b.as_ptr();
+
+        let mut i = 0;
+        while i < simd_len {
+            let va = vld1q_u8(pa.add(i));
+            let vb = vld1q_u8(pb.add(i));
+
+            let ad = vabdq_u8(va, vb); // |a - b| as u8
+            let ad_lo = vmovl_u8(vget_low_u8(ad)); // u16x8
+            let ad_hi = vmovl_u8(vget_high_u8(ad));
+
+            acc = vmlal_u16(acc, vget_low_u16(ad_lo), vget_low_u16(ad_lo));
+            acc = vmlal_u16(acc, vget_high_u16(ad_lo), vget_high_u16(ad_lo));
+            acc = vmlal_u16(acc, vget_low_u16(ad_hi), vget_low_u16(ad_hi));
+            acc = vmlal_u16(acc, vget_high_u16(ad_hi), vget_high_u16(ad_hi));
+
+            i += 16;
+        }
+
+        let mut total = vaddvq_u32(acc) as i32;
+        if simd_len < len {
+            total += sq_diff_u8_to_i32_scalar(&a[simd_len..], &b[simd_len..]);
+        }
+        total
+    }
+}
+
+/// NEON `Σ |a[i] - b[i]|` over u8 inputs, accumulating in i32.
+///
+/// `vabdq_u8` yields `|a - b|` as u8; `vpadalq_u16` pairwise-adds the
+/// widened u16 lanes into a u32x4 accumulator (a u16 accumulator would
+/// overflow past `dim = 257`). The `len % 16` tail is handled by
+/// [`abs_diff_u8_to_i32_scalar`].
+///
+/// # Safety
+///
+/// Same contract as [`dot_u8_to_i32_neon`].
+#[cfg(target_arch = "aarch64")]
+pub unsafe fn abs_diff_u8_to_i32_neon(a: &[u8], b: &[u8]) -> i32 {
+    // SAFETY: see the module-level and `dot_u8_to_i32_neon` contracts;
+    // NEON is baseline on aarch64 and every load stays within `simd_len`.
+    unsafe {
+        let len = a.len();
+        let simd_len = len & !15;
+        let mut acc = vdupq_n_u32(0);
+        let pa = a.as_ptr();
+        let pb = b.as_ptr();
+
+        let mut i = 0;
+        while i < simd_len {
+            let va = vld1q_u8(pa.add(i));
+            let vb = vld1q_u8(pb.add(i));
+
+            let ad = vabdq_u8(va, vb); // |a - b| as u8
+            let ad_lo = vmovl_u8(vget_low_u8(ad)); // u16x8
+            let ad_hi = vmovl_u8(vget_high_u8(ad));
+
+            acc = vpadalq_u16(acc, ad_lo);
+            acc = vpadalq_u16(acc, ad_hi);
+
+            i += 16;
+        }
+
+        let mut total = vaddvq_u32(acc) as i32;
+        if simd_len < len {
+            total += abs_diff_u8_to_i32_scalar(&a[simd_len..], &b[simd_len..]);
+        }
+        total
+    }
+}


### PR DESCRIPTION
## Summary

Dispatch the three int8 scalar-quantization (SQ) distance kernels at runtime to **AVX2** (x86_64) / **NEON** (aarch64) / portable `wide::i32x8` **scalar** fallback:

- `dot_u8_to_i32` — `Σ a·b`
- `sq_diff_u8_to_i32` — `Σ (a−b)²`
- `abs_diff_u8_to_i32` — `Σ |a−b|`

These are the hot path for every int8 HNSW / Flat / IVF search. All three code paths are **bit-identical** (integer-only arithmetic); the `len % 32` (AVX2) / `len % 16` (NEON) tail is delegated to the scalar kernels, which are retained as the fallback, the correctness anchor, and the shared tail handler.

## Design notes

- **`PMADDUBSW` is deliberately avoided.** `_mm256_maddubs_epi16` treats its 2nd operand as **signed i8**, which would misread full-range SQ `u8` (bytes ≥ 128) as negative. The dot / sq_diff kernels widen both operands `u8 → i16` and use `_mm256_madd_epi16`; abs_diff uses `_mm256_sad_epu8`. NEON mirrors with `vmlal_u16` / `vabdq_u8` / `vpadalq_u16`.
- **No on-disk format change.** This PR implements only suggestion (2) of #652. The SoA + 32-byte padded layout (suggestions 1 & 3) is a higher-risk format change, split out to #837.
- **Public API unchanged.** The new `*_scalar` reference kernels are `#[doc(hidden)]`.
- **No binding changes needed** — the kernels are internal to `vector::core::distance_quantized`; all bindings (nodejs/php/python/ruby/wasm) get the speedup transparently.

## Benchmark — `bench_int8_kernel_micro`

AVX2 dispatch vs `wide::i32x8` scalar on identical operands (criterion, AVX2 x86_64, median):

| kernel | dim | scalar | AVX2 dispatch | speedup |
| --- | ---: | ---: | ---: | ---: |
| dot | 128 | 15.44 ns | 4.96 ns | 3.11× |
| dot | 768 | 89.48 ns | 23.48 ns | 3.81× |
| sq_diff | 128 | 31.42 ns | 5.34 ns | 5.88× |
| sq_diff | 768 | 165.84 ns | 25.79 ns | 6.43× |
| abs_diff | 128 | 12.30 ns | 3.83 ns | 3.21× |
| abs_diff | 768 | 61.47 ns | 9.33 ns | 6.59× |

**AVX2 is 3.1–6.6× faster than the portable scalar path.**

Also adds `bench_flat_search_int8_kernel` (eager-load `use_mmap=false` forces `OwnedQuantized` to isolate the int8 `distance_quantized` end-to-end path).

## Testing

- `cargo fmt --check`: clean
- `cargo clippy -p laurus --lib --benches -- -D warnings`: no warnings
- `cargo test -p laurus --lib vector::`: 264/264 pass, including:
  - dispatch-vs-scalar equivalence for all three kernels across various lengths
  - scalar-fallback-vs-reference equivalence (covers the non-SIMD path on an AVX2 host)
  - direct AVX2-vs-scalar checks across the 32-byte tail boundary (31/32/33/96/100), the all-255 extreme, and dim=4096 accumulator bounds
  - f32-tolerance checks (cosine / euclidean / manhattan / dot / angular)

## Related

- Refs #652 (kernel part; SoA/padding tracked in #837)
- Follow-up: #837
- Umbrella: #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
