### PR TITLE
perf(vector/search): SoA + padded in-memory int8 SQ pool (#837)

### DIFF
--- a/laurus/src/vector/core/distance_quantized.rs
+++ b/laurus/src/vector/core/distance_quantized.rs
@@ -39,6 +39,26 @@ use wide::i32x8;
 use crate::vector::core::distance::DistanceMetric;
 use crate::vector::core::quantization::{PqParams, QuantizedVectorMeta, ScalarQuantParams};
 
+/// SIMD block size (bytes) the int8 kernels consume per iteration.
+///
+/// The AVX2 / NEON kernels process a whole number of these blocks; a
+/// payload padded to a multiple of `SIMD_BLOCK` has no scalar tail.
+pub const SIMD_BLOCK: usize = 32;
+
+/// Round `dim` up to the next multiple of [`SIMD_BLOCK`].
+///
+/// Used to size the zero-padded int8 payloads so the distance kernels
+/// run over whole 32-byte blocks with no scalar remainder. This is the
+/// canonical definition shared by the in-memory
+/// [`crate::vector::index::quantized_storage::QuantizedVectorPool`] and
+/// the per-query [`QuantizedQuery`] padding, so both agree on the stride.
+#[inline]
+pub const fn padded_dim(dim: usize) -> usize {
+    // SIMD_BLOCK is a power of two, so mask off the low bits after adding
+    // (SIMD_BLOCK - 1) to round up.
+    (dim + SIMD_BLOCK - 1) & !(SIMD_BLOCK - 1)
+}
+
 /// Per-query state cached once per HNSW search invocation.
 ///
 /// Built by [`Self::prepare`] from the f32 query and the segment-level
@@ -48,8 +68,11 @@ use crate::vector::core::quantization::{PqParams, QuantizedVectorMeta, ScalarQua
 /// `norm_query` precomputed here).
 #[derive(Debug, Clone)]
 pub struct QuantizedQuery {
-    /// Query elements quantized with the segment's `(offset, scale)`.
-    /// Length equals the vector dimension.
+    /// Query elements quantized with the segment's `(offset, scale)`,
+    /// zero-padded to [`Self::pad_dim`]. The first [`Self::dim`] bytes
+    /// are the real quantized values; the rest are zero so the padded
+    /// lanes contribute 0 to every kernel (matching the candidate's
+    /// zero padding in the pool).
     pub q_data: Vec<u8>,
     /// `Σ q_data[i]`, used in the affine dot-product reconstruction.
     pub sum_q: u32,
@@ -63,8 +86,14 @@ pub struct QuantizedQuery {
     pub scale: f32,
     /// Cached `params.offset`.
     pub offset: f32,
-    /// Vector dimension. Equal to `q_data.len()`.
+    /// True vector dimension (number of meaningful query elements). Used
+    /// for the `N·offset²` term of the affine dot-product reconstruction,
+    /// which must count real dimensions only, not the zero padding.
     pub dim: usize,
+    /// Padded length of `q_data`, equal to [`padded_dim`]`(dim)`. This is
+    /// also the length of every candidate int8 slice the kernels receive,
+    /// so both operands are the same multiple-of-32 length.
+    pub pad_dim: usize,
 }
 
 impl QuantizedQuery {
@@ -78,7 +107,12 @@ impl QuantizedQuery {
     /// * `params` - Segment-level quantization params recovered from
     ///   the segment header at search time.
     pub fn prepare(query: &[f32], params: &ScalarQuantParams) -> Self {
-        let q_data = params.quantize_slice(query);
+        let dim = query.len();
+        let mut q_data = params.quantize_slice(query);
+        // `sum_q` and `norm_query` are computed over the real `dim`
+        // elements only, before padding. (Zero padding would not change
+        // `sum_q`, but it *would* corrupt `norm_query` because
+        // `dequantize_value(0)` is `offset`, not 0.)
         let sum_q: u32 = q_data.iter().map(|&x| x as u32).sum();
         // Compute the norm of the *dequantized* query so it lives in
         // the same basis as `cand_meta.norm_q` (which is the norm of
@@ -93,13 +127,20 @@ impl QuantizedQuery {
             })
             .sum::<f32>()
             .sqrt();
+        // Zero-pad the quantized query to a multiple of `SIMD_BLOCK` so
+        // the distance kernels run over whole 32-byte blocks with no
+        // scalar tail, matching the candidate padding in
+        // `QuantizedVectorPool`.
+        let pad_dim = padded_dim(dim);
+        q_data.resize(pad_dim, 0);
         Self {
             q_data,
             sum_q,
             norm_query,
             scale: params.scale,
             offset: params.offset,
-            dim: query.len(),
+            dim,
+            pad_dim,
         }
     }
 }
@@ -120,15 +161,17 @@ impl QuantizedQuery {
 ///
 /// # Panics
 ///
-/// In debug mode, panics if `cand.len() != query.dim`. The caller (HNSW
-/// searcher) guarantees this invariant in release mode.
+/// In debug mode, panics if `cand.len() != query.pad_dim`. The candidate
+/// is the zero-padded int8 slice from the pool (length `pad_dim`), and
+/// the query is padded to the same length, so the kernels see matching
+/// multiple-of-32 operands. The caller guarantees this in release mode.
 pub fn distance_quantized(
     metric: DistanceMetric,
     query: &QuantizedQuery,
     cand: &[u8],
     cand_meta: QuantizedVectorMeta,
 ) -> f32 {
-    debug_assert_eq!(cand.len(), query.dim);
+    debug_assert_eq!(cand.len(), query.pad_dim);
     match metric {
         DistanceMetric::Cosine => {
             let approx_dot = approx_dot_product(query, cand, cand_meta.sum_q);
@@ -713,6 +756,39 @@ mod tests {
         );
     }
 
+    /// Padding invariant end-to-end: for a dim that is *not* a multiple
+    /// of 32, the query is zero-padded by `prepare` and the candidate is
+    /// zero-padded exactly as `QuantizedVectorPool` does. The result must
+    /// still match the f32 cosine distance, proving the padded lanes
+    /// contribute 0 and `sum_q` / `norm_query` / `N` are unaffected.
+    #[test]
+    fn cosine_matches_f32_for_non_block_dim_with_padding() {
+        let dim = 100; // padded_dim(100) == 128
+        let a_f32 = pseudo_random_f32(31, dim, -1.0, 1.0);
+        let b_f32 = pseudo_random_f32(32, dim, -1.0, 1.0);
+        let params =
+            ScalarQuantParams::train(&[Vector::new(a_f32.clone()), Vector::new(b_f32.clone())])
+                .unwrap();
+
+        // `meta_a` is derived from the UNPADDED candidate (real dim), as
+        // the writer does; then the candidate is zero-padded to pad_dim,
+        // as the in-memory pool does.
+        let mut q_a = params.quantize_slice(&a_f32);
+        let meta_a = QuantizedVectorMeta::from_quantized(&q_a, &params);
+        q_a.resize(padded_dim(dim), 0);
+
+        let prepared = QuantizedQuery::prepare(&b_f32, &params);
+        assert_eq!(prepared.pad_dim, 128);
+        assert_eq!(q_a.len(), prepared.pad_dim);
+
+        let approx = distance_quantized(DistanceMetric::Cosine, &prepared, &q_a, meta_a);
+        let exact = DistanceMetric::Cosine.distance(&a_f32, &b_f32).unwrap();
+        assert!(
+            (approx - exact).abs() < 0.02,
+            "padded cosine: quantized = {approx}, f32 = {exact}"
+        );
+    }
+
     #[test]
     fn euclidean_quantized_matches_f32_within_tolerance() {
         let dim = 128;
@@ -814,8 +890,10 @@ mod tests {
             offset: 0.0,
             scale: 1.0,
         };
-        let a: Vec<u8> = (0..dim as u8).collect();
+        let mut a: Vec<u8> = (0..dim as u8).collect();
         let meta_a = QuantizedVectorMeta::from_quantized(&a, &params);
+        // Pad the candidate to pad_dim as the in-memory pool does.
+        a.resize(padded_dim(dim), 0);
         let zero_query = vec![0.0_f32; dim];
         let prepared = QuantizedQuery::prepare(&zero_query, &params);
 
@@ -842,7 +920,11 @@ mod tests {
         assert_eq!(prepared.dim, dim);
         assert_eq!(prepared.offset, params.offset);
         assert_eq!(prepared.scale, params.scale);
-        assert_eq!(prepared.q_data.len(), dim);
+        // q_data is zero-padded to pad_dim (dim 8 -> 32).
+        assert_eq!(prepared.pad_dim, padded_dim(dim));
+        assert_eq!(prepared.q_data.len(), prepared.pad_dim);
+        // sum_q counts the real dim only; the zero padding adds nothing,
+        // so summing the whole padded buffer yields the same value.
         let expected_sum: u32 = prepared.q_data.iter().map(|&x| x as u32).sum();
         assert_eq!(prepared.sum_q, expected_sum);
     }

--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -338,7 +338,7 @@ impl VectorIndexReader for FlatVectorIndexReader {
     fn stats(&self) -> VectorStats {
         let _memory_usage = match &self.vectors {
             VectorStorage::Owned(vectors) => vectors.len() * (8 + self.dimension * 4),
-            VectorStorage::OwnedQuantized(pool) => pool.data.len(),
+            VectorStorage::OwnedQuantized(pool) => pool.heap_size(),
             VectorStorage::OwnedPq(pool) => pool.data.len() + pool.codebook.len() * 4,
             #[cfg(feature = "pq-fastscan")]
             VectorStorage::OwnedPqFastScan(_) => {

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -627,16 +627,16 @@ impl HnswIndexReader {
             }
             VectorStorage::OwnedQuantized(pool) => {
                 let mut idx: HashMap<String, HashMap<u64, usize>> = HashMap::new();
-                let record_size = QuantizedVectorPool::record_size(pool.dim);
-                let base = pool.data.as_ptr();
+                let stride = pool.pad_dim;
+                let base = pool.int8_data.as_ptr();
                 for (field_name, doc_map) in pool.field_index.iter() {
                     let entry = idx.entry(field_name.clone()).or_default();
                     for (&doc_id, &pos) in doc_map.iter() {
                         // SAFETY: pool is held alive by self.vectors
                         // (Arc) for the lifetime of self; pos is in
-                        // bounds because it was populated from data.len()
-                        // / record_size at build time.
-                        let addr = unsafe { base.add(pos as usize * record_size) } as usize;
+                        // bounds because it was populated from
+                        // int8_data.len() / pad_dim at build time.
+                        let addr = unsafe { base.add(pos as usize * stride) } as usize;
                         entry.insert(doc_id, addr);
                     }
                 }
@@ -881,7 +881,7 @@ impl VectorIndexReader for HnswIndexReader {
     fn stats(&self) -> VectorStats {
         let memory_usage = match &self.vectors {
             VectorStorage::Owned(vectors) => vectors.len() * (8 + self.dimension * 4),
-            VectorStorage::OwnedQuantized(pool) => pool.data.len(),
+            VectorStorage::OwnedQuantized(pool) => pool.heap_size(),
             VectorStorage::OwnedPq(pool) => pool.data.len() + pool.codebook.len() * 4,
             #[cfg(feature = "pq-fastscan")]
             VectorStorage::OwnedPqFastScan(pool) => pool.packed.len() + pool.codebook.len() * 4,

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -541,11 +541,13 @@ impl HnswSearcher {
         // Retrieve the per-field prefetch index once per search call (O(1), no allocation).
         // `None` for on-demand (disk-backed) storage; the prefetch loop is skipped entirely.
         let field_prefetch = reader.field_prefetch_index(field_name);
-        // Prefetch payload size: int8 record (dim + 8 bytes meta) for
-        // the SQ hot path; M bytes for PQ; legacy f32 size otherwise.
+        // Prefetch payload size: the padded int8 record (`pad_dim`
+        // bytes) for the SQ hot path; M bytes for PQ; legacy f32 size
+        // otherwise. The meta now lives in separate SoA arrays, so the
+        // int8 stride alone is what the hot loop streams.
         let prefetch_n_bytes = match &quant_ctx {
             Some(QuantizedSearchCtx::Scalar8Bit { .. }) => {
-                QuantizedVectorPool::record_size(reader.dimension())
+                QuantizedVectorPool::padded_dim(reader.dimension())
             }
             Some(QuantizedSearchCtx::Pq { pool, .. }) => PqVectorPool::record_size(pool.params.m),
             #[cfg(feature = "pq-fastscan")]

--- a/laurus/src/vector/index/quantized_storage.rs
+++ b/laurus/src/vector/index/quantized_storage.rs
@@ -2,15 +2,34 @@
 //! of HNSW / Flat / IVF (Issue #481 Stage 1, Step 6 onward).
 //!
 //! Replaces the per-index `Arc<HashMap<(u64, String), Vector>>` that
-//! held f32 vectors until Step 5. Vectors are kept as int8 in one
-//! tightly-packed AoS buffer plus a per-field doc_id -> position
-//! index. The search hot loop pulls `(int8 slice,
-//! QuantizedVectorMeta)` directly out of this buffer and feeds it to
+//! held f32 vectors until Step 5. Vectors are kept as int8 in a
+//! Structure-of-Arrays (SoA) layout (Issue #837): one contiguous int8
+//! payload buffer with each vector padded to a 32-byte boundary, plus
+//! two parallel meta arrays (`sum_q`, `norm_q`). The search hot loop
+//! pulls `(padded int8 slice, QuantizedVectorMeta)` directly out of this
+//! pool and feeds it to
 //! [`crate::vector::core::distance_quantized::distance_quantized`].
 //!
-//! Memory footprint: `dim + 8` bytes per vector (int8 payload +
-//! `sum_q` u32 + `norm_q` f32) plus `O(field_count + vector_count)`
-//! for the lookup tables.
+//! # Why SoA + padding
+//!
+//! - **SoA** keeps `sum_q` / `norm_q` in their own `Vec<u32>` / `Vec<f32>`,
+//!   so the per-candidate meta read is a plain indexed load instead of a
+//!   `try_into`-decode of inline bytes.
+//! - **Padding** each vector's int8 payload to `pad_dim =
+//!   next multiple of 32` means the SIMD kernels
+//!   ([`crate::vector::core::distance_quantized::dot_u8_to_i32`] et al.)
+//!   process a whole number of 32-byte blocks with **no scalar tail**.
+//!   The padded lanes are zero on both the query and the candidate, so
+//!   each padded pair contributes 0 to dot / squared-diff / abs-diff and
+//!   the result is identical to the unpadded computation. `sum_q` is a
+//!   sum over the same zero-padded bytes and is therefore unchanged, and
+//!   the affine dot-product reconstruction uses the *true* `dim` for its
+//!   `N·offset²` term (see
+//!   [`crate::vector::core::distance_quantized::QuantizedQuery`]).
+//!
+//! Memory footprint: `pad_dim` bytes of int8 payload per vector plus 8
+//! bytes of meta (`sum_q` u32 + `norm_q` f32) held in the parallel
+//! arrays, plus `O(field_count + vector_count)` for the lookup tables.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -28,56 +47,79 @@ use crate::vector::core::vector::Vector;
 pub struct QuantizedVectorPool {
     /// Per-segment quantization params (`offset`, `scale`).
     pub params: ScalarQuantParams,
-    /// Vector dimension.
+    /// True vector dimension (number of meaningful int8 values).
     pub dim: usize,
-    /// Tightly-packed AoS payload: for vector index `i`,
-    /// `data[i * record_size .. i * record_size + dim]` is the int8
-    /// payload and the next 8 bytes are the meta (`sum_q` u32 LE +
-    /// `norm_q` f32 LE).
-    pub data: Vec<u8>,
+    /// Padded per-vector stride in [`Self::int8_data`], equal to
+    /// `dim` rounded up to the 32-byte SIMD block (see
+    /// [`Self::padded_dim`]). The bytes in `[dim, pad_dim)` of each
+    /// record are zero.
+    pub pad_dim: usize,
+    /// Contiguous int8 payload buffer, SoA-style. For vector index `i`
+    /// the payload is `int8_data[i * pad_dim .. i * pad_dim + pad_dim]`,
+    /// whose first `dim` bytes are the real quantized values and the
+    /// remaining `pad_dim - dim` bytes are zero padding.
+    pub int8_data: Vec<u8>,
+    /// Per-vector `sum_q` (`Σ` of the quantized bytes), parallel to
+    /// [`Self::int8_data`] records: `sum_q[i]` belongs to vector `i`.
+    pub sum_q: Vec<u32>,
+    /// Per-vector `norm_q` (f32 norm of the dequantized vector),
+    /// parallel to [`Self::sum_q`].
+    pub norm_q: Vec<f32>,
     /// Per-field doc_id -> vector position.
     ///
     /// `field_index[field][doc_id] = i` such that the int8 payload
-    /// for `(doc_id, field)` lives at `i * record_size`. The outer
+    /// for `(doc_id, field)` lives at `i * pad_dim`. The outer
     /// `String` key allocation only happens on the first lookup per
     /// search; the inner `u64` lookup is the per-candidate hot-path
     /// op.
     pub field_index: HashMap<String, Arc<HashMap<u64, u32>>>,
-    /// Total vector count (matches `data.len() / record_size`).
+    /// Total vector count (matches `int8_data.len() / pad_dim` and the
+    /// length of the `sum_q` / `norm_q` arrays).
     pub vector_count: usize,
 }
 
 impl QuantizedVectorPool {
-    /// Bytes occupied by one vector record (int8 + meta).
+    /// Padded per-vector int8 stride for a given `dim`: `dim` rounded up
+    /// to the SIMD block size (32). Exposed so callers that only know the
+    /// dimension (e.g. the HNSW prefetch-address builder) can compute the
+    /// stride without a pool instance. Delegates to the canonical
+    /// [`crate::vector::core::distance_quantized::padded_dim`] so the pool
+    /// and the per-query padding always agree.
     #[inline]
-    pub const fn record_size(dim: usize) -> usize {
-        dim + QuantizedVectorMeta::SERIALIZED_SIZE
+    pub const fn padded_dim(dim: usize) -> usize {
+        crate::vector::core::distance_quantized::padded_dim(dim)
     }
 
     /// Build from a sequence of `(doc_id, field_name, int8_data, meta)`
     /// records and the per-segment quantization params.
     ///
     /// The records may be in any order; the field index is built from
-    /// the iteration order, and the int8 payload is written at the
-    /// position equal to the iteration index.
+    /// the iteration order, and each int8 payload is written at the
+    /// position equal to the iteration index, zero-padded to
+    /// [`Self::pad_dim`].
     pub fn build(
         params: ScalarQuantParams,
         dim: usize,
         records: impl IntoIterator<Item = (u64, String, Vec<u8>, QuantizedVectorMeta)>,
     ) -> Self {
-        let mut data = Vec::new();
+        let pad_dim = Self::padded_dim(dim);
+        let mut int8_data: Vec<u8> = Vec::new();
+        let mut sum_q: Vec<u32> = Vec::new();
+        let mut norm_q: Vec<f32> = Vec::new();
         let mut by_field: HashMap<String, HashMap<u64, u32>> = HashMap::new();
-        let record_size = Self::record_size(dim);
 
         for (doc_id, field, int8, meta) in records {
-            let pos = (data.len() / record_size) as u32;
-            data.extend_from_slice(&int8);
-            data.extend_from_slice(&meta.sum_q.to_le_bytes());
-            data.extend_from_slice(&meta.norm_q.to_le_bytes());
+            debug_assert_eq!(int8.len(), dim, "int8 payload length must equal dim");
+            let pos = sum_q.len() as u32;
+            int8_data.extend_from_slice(&int8);
+            // Zero-fill the padding tail up to the next pad_dim boundary.
+            int8_data.resize((pos as usize + 1) * pad_dim, 0);
+            sum_q.push(meta.sum_q);
+            norm_q.push(meta.norm_q);
             by_field.entry(field).or_default().insert(doc_id, pos);
         }
 
-        let vector_count = data.len() / record_size;
+        let vector_count = sum_q.len();
         let field_index: HashMap<String, Arc<HashMap<u64, u32>>> = by_field
             .into_iter()
             .map(|(field, map)| (field, Arc::new(map)))
@@ -86,36 +128,41 @@ impl QuantizedVectorPool {
         Self {
             params,
             dim,
-            data,
+            pad_dim,
+            int8_data,
+            sum_q,
+            norm_q,
             field_index,
             vector_count,
         }
     }
 
-    /// Borrow the int8 payload + decoded meta for `(doc_id, field)`.
+    /// Borrow the padded int8 payload + decoded meta for `(doc_id, field)`.
     ///
     /// Returns `None` if the key is not present in this segment.
-    /// The int8 slice has length [`Self::dim`].
+    /// The int8 slice has length [`Self::pad_dim`]; its first
+    /// [`Self::dim`] bytes are the real quantized values and the rest
+    /// are zero padding.
     #[inline]
     pub fn get_record(&self, doc_id: u64, field: &str) -> Option<(&[u8], QuantizedVectorMeta)> {
         let pos = self.field_index.get(field)?.get(&doc_id).copied()?;
         Some(self.record_at(pos))
     }
 
-    /// Borrow the int8 payload + meta at vector position `pos`.
+    /// Borrow the padded int8 payload + meta at vector position `pos`.
     ///
     /// Lower-level than [`Self::get_record`]; useful when the caller
     /// has already cached the per-field doc_id -> position map (the
     /// search hot loop does this once per search via
-    /// [`Self::field_position_index`]).
+    /// [`Self::field_position_index`]). The returned int8 slice has
+    /// length [`Self::pad_dim`] (zero-padded); the meta is read from the
+    /// parallel `sum_q` / `norm_q` arrays with no byte decode.
     #[inline]
     pub fn record_at(&self, pos: u32) -> (&[u8], QuantizedVectorMeta) {
-        let record_size = Self::record_size(self.dim);
-        let start = (pos as usize) * record_size;
-        let int8 = &self.data[start..start + self.dim];
-        let meta_bytes = &self.data[start + self.dim..start + record_size];
-        let sum_q = u32::from_le_bytes(meta_bytes[0..4].try_into().expect("4 bytes"));
-        let norm_q = f32::from_le_bytes(meta_bytes[4..8].try_into().expect("4 bytes"));
+        let start = (pos as usize) * self.pad_dim;
+        let int8 = &self.int8_data[start..start + self.pad_dim];
+        let sum_q = self.sum_q[pos as usize];
+        let norm_q = self.norm_q[pos as usize];
         (int8, QuantizedVectorMeta { sum_q, norm_q })
     }
 
@@ -150,9 +197,12 @@ impl QuantizedVectorPool {
     /// `Vector` (f32). Used by the legacy
     /// [`crate::vector::reader::VectorIndexReader::get_vector`] API
     /// path; the search hot loop never calls this.
+    ///
+    /// Only the first [`Self::dim`] bytes are dequantized; the zero
+    /// padding is dropped.
     pub fn dequantize_to_vector(&self, doc_id: u64, field: &str) -> Option<Vector> {
         let (int8, _meta) = self.get_record(doc_id, field)?;
-        let data: Vec<f32> = int8
+        let data: Vec<f32> = int8[..self.dim]
             .iter()
             .map(|&b| self.params.dequantize_value(b))
             .collect();
@@ -181,6 +231,14 @@ impl QuantizedVectorPool {
         let mut ids: Vec<u64> = map.keys().copied().collect();
         ids.sort_unstable();
         Arc::<[u64]>::from(ids)
+    }
+
+    /// Approximate resident size in bytes (int8 payload + meta arrays).
+    /// Used for reader memory-footprint reporting; excludes the lookup
+    /// tables.
+    #[inline]
+    pub fn heap_size(&self) -> usize {
+        self.int8_data.len() + self.sum_q.len() * 4 + self.norm_q.len() * 4
     }
 }
 
@@ -216,17 +274,39 @@ mod tests {
         );
         assert_eq!(q.vector_count, 2);
         assert_eq!(q.dim, 4);
-        assert_eq!(q.data.len(), 2 * QuantizedVectorPool::record_size(4));
+        // dim 4 pads up to one 32-byte block.
+        assert_eq!(q.pad_dim, 32);
+        assert_eq!(q.int8_data.len(), 2 * q.pad_dim);
 
         let (int8_0, meta_0) = q.get_record(10, "embedding").unwrap();
-        assert_eq!(int8_0, &[0u8, 1, 2, 3]);
+        assert_eq!(int8_0.len(), 32);
+        assert_eq!(&int8_0[..4], &[0u8, 1, 2, 3]);
+        assert!(int8_0[4..].iter().all(|&b| b == 0), "padding is zero");
         assert_eq!(meta_0.sum_q, 6);
         assert_eq!(meta_0.norm_q, 1.0);
 
         let (int8_1, meta_1) = q.get_record(20, "embedding").unwrap();
-        assert_eq!(int8_1, &[10u8, 20, 30, 40]);
+        assert_eq!(&int8_1[..4], &[10u8, 20, 30, 40]);
         assert_eq!(meta_1.sum_q, 100);
         assert_eq!(meta_1.norm_q, 2.0);
+    }
+
+    #[test]
+    fn build_pads_non_multiple_of_32_dim() {
+        // dim 100 -> pad_dim 128 (next multiple of 32).
+        let int8: Vec<u8> = (0..100).map(|i| (i % 256) as u8).collect();
+        let q = QuantizedVectorPool::build(
+            sample_params(),
+            100,
+            vec![(1, "f".to_string(), int8.clone(), meta(42, 1.0))],
+        );
+        assert_eq!(q.pad_dim, 128);
+        assert_eq!(q.int8_data.len(), 128);
+        let (payload, m) = q.record_at(0);
+        assert_eq!(payload.len(), 128);
+        assert_eq!(&payload[..100], &int8[..]);
+        assert!(payload[100..].iter().all(|&b| b == 0), "tail padding zero");
+        assert_eq!(m.sum_q, 42);
     }
 
     #[test]
@@ -255,7 +335,7 @@ mod tests {
         assert_eq!(idx.len(), 2);
         let pos = *idx.get(&2).unwrap();
         let (int8, meta_back) = q.record_at(pos);
-        assert_eq!(int8, &[7u8, 8]);
+        assert_eq!(&int8[..2], &[7u8, 8]);
         assert_eq!(meta_back.sum_q, 15);
     }
 
@@ -267,6 +347,8 @@ mod tests {
             vec![(1, "f".to_string(), vec![0, 128, 255], meta(383, 1.0))],
         );
         let v = q.dequantize_to_vector(1, "f").unwrap();
+        // Padding must not leak into the dequantized vector.
+        assert_eq!(v.data.len(), 3);
         // offset = -1.0, scale = 2/255
         // u8 = 0   -> -1.0
         // u8 = 128 -> -1.0 + 128 * 2/255 = ~0.0039
@@ -323,9 +405,13 @@ mod tests {
     }
 
     #[test]
-    fn record_size_matches_dim_plus_eight() {
-        assert_eq!(QuantizedVectorPool::record_size(0), 8);
-        assert_eq!(QuantizedVectorPool::record_size(128), 136);
+    fn padded_dim_rounds_up_to_block() {
+        assert_eq!(QuantizedVectorPool::padded_dim(0), 0);
+        assert_eq!(QuantizedVectorPool::padded_dim(1), 32);
+        assert_eq!(QuantizedVectorPool::padded_dim(32), 32);
+        assert_eq!(QuantizedVectorPool::padded_dim(33), 64);
+        assert_eq!(QuantizedVectorPool::padded_dim(100), 128);
+        assert_eq!(QuantizedVectorPool::padded_dim(128), 128);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reshape the in-memory `QuantizedVectorPool` (`VectorStorage::OwnedQuantized` — the Eager int8 search hot path) from AoS to **Structure-of-Arrays + 32-byte padding**:

- one contiguous `int8_data` buffer, each vector zero-padded to a 32-byte boundary (`pad_dim = next multiple of 32`);
- parallel `sum_q: Vec<u32>` / `norm_q: Vec<f32>` meta arrays.

`record_at` now reads meta via a plain indexed load instead of a per-candidate `try_into` byte decode, and the padded stride removes the SIMD kernel's scalar tail.

## Scope correction vs #837

The issue body assumed an **on-disk format change + backward-compat shim**. Investigation showed that is unnecessary: the int8 SIMD hot path runs **only** on the Eager in-memory pool. Lazy/mmap `OnDemand` dequantizes to f32 (never touches the int8 kernel), and the merge engine round-trips vectors through f32 and re-quantizes via the writer. So the **disk records stay `dim+8` AoS**, there is **no version bump / compat shim**, and **no binding changes** are needed. The remaining #837 acceptance criteria (SoA/padding on disk) are dropped as unnecessary.

## Correctness

Integer-only arithmetic ⇒ zero-padding both operands makes each padded pair contribute 0 to dot / sq_diff / abs_diff, so results are unchanged:

- the query is zero-padded to `pad_dim` in `QuantizedQuery::prepare` (both operands same multiple-of-32 length);
- `sum_q` is unchanged by zero padding;
- `norm_query` is computed over the **true `dim`** (`dequantize_value(0) = offset ≠ 0`, so padded lanes must be excluded);
- `approx_dot_product` keeps using the true `dim` for its `N·offset²` term.

New tests cover a non-multiple-of-32 dim (100→128) roundtrip in the pool and an end-to-end cosine match through `distance_quantized` with padding.

## Benchmark — `bench_flat_search_int8_kernel` (Flat int8 end-to-end, dim=128)

A/B of SoA (this branch) vs AoS (`main`, measured by `git stash` on the same tree; the on-disk cache is format-unchanged and shared):

| metric | main (AoS) | branch (SoA) | speedup |
| --- | ---: | ---: | ---: |
| cosine (dot) | 2.147 ms | 1.668 ms | 1.29× (−22%) |
| euclidean (sq_diff) | 2.564 ms | 1.712 ms | 1.50× (−33%) |
| manhattan (abs_diff) | 2.011 ms | 1.622 ms | 1.24× (−19%) |

The delta is 6–10× the vector-bench noise floor. dim=128 is already a multiple of 32 (padding is a no-op here) and euclidean/manhattan never read the meta, yet they improve the most — so the win is dominated by the **cache-line-aligned 128-byte contiguous int8 layout** replacing the 136-byte meta-interleaved AoS stride. Once the SIMD kernels landed (#652/#838), memory layout became the bottleneck.

## Testing

- `cargo fmt --check` clean; `cargo clippy -p laurus --lib --benches -- -D warnings` clean.
- `cargo test -p laurus --lib`: 1183/1183 pass (vector:: 266).

## Related

- Refs #837 (kernel SIMD was #652/#838)
- Umbrella: #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
