### PR TITLE
perf(vector/search): prepared query + parallel scan + partial top-k in NRT active-segment search (#640)

### DIFF
--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -169,6 +169,10 @@ name = "vector_search_bench"
 harness = false
 
 [[bench]]
+name = "nrt_active_search_bench"
+harness = false
+
+[[bench]]
 name = "vector_multi_query_bench"
 harness = false
 

--- a/laurus/benches/nrt_active_search_bench.rs
+++ b/laurus/benches/nrt_active_search_bench.rs
@@ -1,0 +1,126 @@
+//! NRT active-segment (unflushed) vector search benchmark (Issue #640).
+//!
+//! Measures `SegmentedVectorField::search` when every vector still sits
+//! in the active (unflushed) segment, so the whole query is the
+//! brute-force scan in `search_active_segment`. This is the designated
+//! A/B gate metric for #640 (prepared query + `parallel_scan` + partial
+//! top-k selection in the active path).
+//!
+//! Corpus sizes straddle `PARALLEL_SCAN_THRESHOLD` (2048):
+//! - `1000` — serial path (prepared-query + partial-select effect only)
+//! - `10000` / `50000` — rayon path on top of the above
+//!
+//! Setup is pure in-memory (`MemoryStorage`, no disk cache, no flush),
+//! deterministic via `common::DEFAULT_SEED`.
+
+mod common;
+
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use common::{DEFAULT_SEED, SAMPLE_SIZE_FAST, lcg_vec_unit};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::index::field::{FieldSearchInput, VectorFieldReader, VectorFieldWriter};
+use laurus::vector::index::hnsw::segment::manager::{SegmentManager, SegmentManagerConfig};
+use laurus::vector::index::segmented_field::SegmentedVectorField;
+use laurus::vector::store::request::QueryVector;
+use laurus::vector::{
+    DistanceMetric, FieldOption, HnswOption, StoredVector, Vector, VectorFieldConfig,
+};
+
+/// Vector dimension for all cases (matches the other vector benches).
+const DIM: usize = 128;
+
+/// Build a Cosine `SegmentedVectorField` over in-memory storage and load
+/// `count` deterministic vectors into its ACTIVE segment (no flush).
+///
+/// # Arguments
+///
+/// * `count` - Number of vectors buffered in the active segment.
+///
+/// # Returns
+///
+/// The field, ready for unflushed searches (the backing manager is kept
+/// alive inside the field via `Arc`).
+fn active_field_with(count: usize) -> SegmentedVectorField {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let manager = Arc::new(
+        SegmentManager::new(SegmentManagerConfig::default(), storage.clone())
+            .expect("segment manager"),
+    );
+    let field_config = VectorFieldConfig {
+        vector: Some(FieldOption::Hnsw(HnswOption {
+            dimension: DIM,
+            distance: DistanceMetric::Cosine,
+            m: 16,
+            ef_construction: 200,
+            default_ef_search: None,
+            base_weight: 1.0,
+            quantizer: Default::default(),
+            rerank_storage: None,
+            embedder: None,
+        })),
+        lexical: None,
+    };
+    let field = SegmentedVectorField::create("embedding", field_config, manager, storage, None)
+        .expect("create segmented field");
+
+    // `add_stored_vector` is async; drive it on a small runtime for setup.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("tokio runtime");
+    let mut state = DEFAULT_SEED;
+    rt.block_on(async {
+        for doc_id in 0..count as u64 {
+            let v = StoredVector::new(lcg_vec_unit(&mut state, DIM));
+            field
+                .add_stored_vector(doc_id, &v, 0)
+                .await
+                .expect("buffer vector");
+        }
+    });
+    field
+}
+
+/// Deterministic query distinct from every corpus vector.
+fn query_input(limit: usize) -> FieldSearchInput {
+    let mut state = DEFAULT_SEED.wrapping_add(1);
+    FieldSearchInput {
+        field: "embedding".to_string(),
+        query_vectors: vec![QueryVector {
+            vector: Vector::new(lcg_vec_unit(&mut state, DIM)),
+            weight: 1.0,
+            fields: None,
+        }],
+        limit,
+        allowed_ids: None,
+    }
+}
+
+/// Unflushed top-10 search across corpus sizes straddling the
+/// parallel-scan threshold.
+fn bench_nrt_active_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("NRT Active Search");
+    group.sample_size(SAMPLE_SIZE_FAST);
+
+    for &count in &[1_000usize, 10_000, 50_000] {
+        let field = active_field_with(count);
+
+        // Sanity: unflushed top-10 must return hits from the active scan.
+        let probe = field.search(query_input(10)).expect("probe search");
+        assert!(
+            !probe.hits.is_empty(),
+            "unflushed probe must hit the active segment at count={count}"
+        );
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::new("top10", count), &count, |b, _| {
+            b.iter(|| field.search(query_input(10)).expect("search"));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_nrt_active_search);
+criterion_main!(benches);

--- a/laurus/src/vector/index/segmented_field.rs
+++ b/laurus/src/vector/index/segmented_field.rs
@@ -316,12 +316,37 @@ impl VectorFieldWriter for SegmentedVectorField {
 }
 
 impl SegmentedVectorField {
+    /// Brute-force top-`limit` search over the active (unflushed)
+    /// segment's buffered vectors (Issue #640).
+    ///
+    /// Mirrors the Flat searcher's scan: the query is prepared once per
+    /// call (`prepare_query` caches `‖query‖²`, so Cosine / Angular run
+    /// two SIMD accumulator chains per candidate instead of three), the
+    /// per-candidate distance runs through
+    /// [`crate::vector::search::searcher::parallel_scan`] (rayon when the
+    /// buffer holds ≥ 2048 vectors, serial below), and top-`limit`
+    /// selection uses `select_nth_unstable_by` instead of sorting the
+    /// whole buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The f32 query vector.
+    /// * `limit` - Maximum number of hits to return.
+    /// * `weight` - Query weight multiplied into each hit's score.
+    ///
+    /// # Returns
+    ///
+    /// Up to `limit` hits ranked by similarity descending; empty when
+    /// there is no active segment (or `limit == 0`).
     fn search_active_segment(
         &self,
         query: &[f32],
         limit: usize,
         weight: f32,
     ) -> Result<Vec<FieldHit>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
         let active_opt = self.active_segment.read();
         let writer = match active_opt.as_ref() {
             Some((_, w)) => w,
@@ -335,20 +360,27 @@ impl SegmentedVectorField {
         };
 
         let vectors = writer.vectors();
-        let mut candidates = Vec::with_capacity(vectors.len());
+        // Prepare once per query: caches the query norm for Cosine /
+        // Angular; the other metrics pass through unchanged.
+        let prepared = distance_metric.prepare_query(query);
 
-        for (doc_id, _field, vector) in vectors {
-            let distance = distance_metric.distance(query, &vector.data)?;
-            let similarity = distance_metric.distance_to_similarity(distance);
-            candidates.push((*doc_id, similarity, distance));
+        let mut candidates: Vec<(u64, f32, f32)> =
+            crate::vector::search::searcher::parallel_scan(vectors, |(doc_id, _field, vector)| {
+                let distance = distance_metric.distance_with_prepared(&prepared, &vector.data)?;
+                let similarity = distance_metric.distance_to_similarity(distance);
+                Ok(Some((*doc_id, similarity, distance)))
+            })?;
+
+        // Partial top-`limit` selection, then sort only the survivors
+        // (same pattern as the store-level search).
+        if candidates.len() > limit {
+            candidates.select_nth_unstable_by(limit - 1, |a, b| b.1.total_cmp(&a.1));
+            candidates.truncate(limit);
         }
-
-        // Sort by similarity descending
         candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
 
         let hits = candidates
             .into_iter()
-            .take(limit)
             .map(|(doc_id, similarity, distance)| FieldHit {
                 doc_id,
                 field: self.name.clone(),

--- a/laurus/tests/vector_merge_test.rs
+++ b/laurus/tests/vector_merge_test.rs
@@ -562,3 +562,160 @@ async fn segmented_merge_preserves_rerank_sidecar_f32_losslessly()
 
     Ok(())
 }
+
+/// Build a Cosine-metric `SegmentedVectorField` over in-memory storage
+/// for the active-segment (NRT, unflushed) search tests (Issue #640).
+///
+/// # Arguments
+///
+/// * `dimension` - Vector dimension for the field.
+///
+/// # Returns
+///
+/// The field plus its backing `SegmentManager` (kept alive by the caller).
+fn cosine_field(
+    dimension: usize,
+) -> Result<(SegmentedVectorField, Arc<SegmentManager>), Box<dyn std::error::Error>> {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let manager = Arc::new(SegmentManager::new(
+        SegmentManagerConfig {
+            max_segments: 8,
+            merge_factor: 2,
+            min_vectors_per_segment: 1,
+            ..Default::default()
+        },
+        storage.clone(),
+    )?);
+    let field_config = VectorFieldConfig {
+        vector: Some(FieldOption::Hnsw(HnswOption {
+            dimension,
+            distance: DistanceMetric::Cosine,
+            m: 16,
+            ef_construction: 200,
+            default_ef_search: None,
+            base_weight: 1.0,
+            quantizer: Default::default(),
+            rerank_storage: None,
+            embedder: None,
+        })),
+        lexical: None,
+    };
+    let field = SegmentedVectorField::create(
+        "embedding",
+        field_config,
+        manager.clone(),
+        storage.clone(),
+        None,
+    )?;
+    Ok((field, manager))
+}
+
+/// One-query search helper for the active-segment tests.
+fn top_k_input(query: Vec<f32>, limit: usize) -> FieldSearchInput {
+    FieldSearchInput {
+        field: "embedding".to_string(),
+        query_vectors: vec![QueryVector {
+            vector: Vector::new(query),
+            weight: 1.0,
+            fields: None,
+        }],
+        limit,
+        allowed_ids: None,
+    }
+}
+
+/// Issue #640: searching BEFORE any flush must return correctly ranked
+/// hits from the active (unflushed) segment. Prior to this test the
+/// active brute-force path had no direct coverage — every existing test
+/// flushed before searching.
+#[tokio::test]
+async fn search_before_flush_returns_active_hits() -> Result<(), Box<dyn std::error::Error>> {
+    let (field, _manager) = cosine_field(4)?;
+
+    // Cosine similarities against query [1, 0, 0, 0]:
+    // doc 1 -> 1.0 (identical direction)
+    // doc 2 -> 0.8 ([0.8, 0.6] direction)
+    // doc 3 -> 0.0 (orthogonal)
+    field
+        .add_stored_vector(1, &StoredVector::new(vec![1.0, 0.0, 0.0, 0.0]), 0)
+        .await?;
+    field
+        .add_stored_vector(2, &StoredVector::new(vec![0.8, 0.6, 0.0, 0.0]), 0)
+        .await?;
+    field
+        .add_stored_vector(3, &StoredVector::new(vec![0.0, 1.0, 0.0, 0.0]), 0)
+        .await?;
+
+    // NO flush: hits must come from the active segment scan.
+    let results = field.search(top_k_input(vec![1.0, 0.0, 0.0, 0.0], 2))?;
+    let ids: Vec<u64> = results.hits.iter().map(|h| h.doc_id).collect();
+    assert_eq!(
+        ids,
+        vec![1, 2],
+        "top-2 must be doc 1 (cos 1.0) then doc 2 (cos 0.8), got {ids:?}"
+    );
+    assert!(
+        results.hits[0].score > results.hits[1].score,
+        "scores must be ranked descending: {} vs {}",
+        results.hits[0].score,
+        results.hits[1].score
+    );
+    Ok(())
+}
+
+/// Issue #640: hits from the active (unflushed) segment must merge with
+/// hits from managed (flushed) segments in one search.
+#[tokio::test]
+async fn search_merges_active_and_managed_hits() -> Result<(), Box<dyn std::error::Error>> {
+    let (field, _manager) = cosine_field(4)?;
+
+    // doc 1 goes to a managed segment via flush...
+    field
+        .add_stored_vector(1, &StoredVector::new(vec![1.0, 0.0, 0.0, 0.0]), 0)
+        .await?;
+    field.flush().await?;
+    // ...doc 2 stays in the active segment (no flush).
+    field
+        .add_stored_vector(2, &StoredVector::new(vec![0.9, 0.1, 0.0, 0.0]), 0)
+        .await?;
+
+    let results = field.search(top_k_input(vec![1.0, 0.0, 0.0, 0.0], 3))?;
+    let mut ids: Vec<u64> = results.hits.iter().map(|h| h.doc_id).collect();
+    ids.sort_unstable();
+    assert_eq!(
+        ids,
+        vec![1, 2],
+        "search must merge managed (doc 1) and active (doc 2) hits, got {ids:?}"
+    );
+    Ok(())
+}
+
+/// Issue #640: the active-segment scan must stay correct above the
+/// parallel-scan threshold (2048 candidates), where the rayon path runs.
+/// A single distinguished best match keeps the assertion tie-free.
+#[tokio::test]
+async fn search_active_segment_above_parallel_threshold() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (field, _manager) = cosine_field(4)?;
+
+    // 2500 vectors (> PARALLEL_SCAN_THRESHOLD = 2048), all orthogonal to
+    // the query except doc 777, the unique best match.
+    for doc_id in 1..=2500u64 {
+        let v = if doc_id == 777 {
+            vec![1.0, 0.0, 0.0, 0.0]
+        } else {
+            vec![0.0, 1.0, 0.0, 0.0]
+        };
+        field
+            .add_stored_vector(doc_id, &StoredVector::new(v), 0)
+            .await?;
+    }
+
+    let results = field.search(top_k_input(vec![1.0, 0.0, 0.0, 0.0], 1))?;
+    assert_eq!(results.hits.len(), 1, "top-1 must return exactly one hit");
+    assert_eq!(
+        results.hits[0].doc_id, 777,
+        "the unique aligned vector must win the unflushed scan"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Rewrite `SegmentedVectorField::search_active_segment` — the brute-force scan behind NRT (unflushed) vector search — using the three building blocks the flat/hnsw/ivf searchers already use, none of which the active path used:

1. **`prepare_query` + `distance_with_prepared`**: the query norm is computed once per query instead of once per candidate; Cosine/Angular drop from 3 SIMD MAC chains per candidate to 2 (other metrics pass through unchanged).
2. **`parallel_scan`** (#662 utility): rayon scan when the active buffer holds ≥ 2048 vectors, serial below.
3. **Partial top-k** via `select_nth_unstable_by` + truncate + sort (the store-level pattern) instead of full-sorting the whole buffer.

Lock scope, public API, and on-disk format are unchanged.

## Correctness net (added first)

There was previously **no direct test coverage of search-before-flush** (every existing test flushed first). This PR adds three tests — ranked-order assertion, active+managed merge, and an above-parallel-threshold case (N=2500, unique best match) — written and verified passing against the OLD implementation before the rewrite, then re-verified on the new one (behavior-preserving).

## Benchmark — `nrt_active_search_bench` (new; unflushed top-10, dim 128, Cosine)

A/B vs `main` (src-only `git stash` on the same tree; 2 samples/side):

| N | main | branch | speedup |
| --- | ---: | ---: | ---: |
| 1,000 (serial path) | 56.1 / 54.4 µs | 40.6 / 37.0 µs | 1.3–1.5× |
| 10,000 | 679 / 721 µs | 459 / 278 µs | 1.5–2.6× |
| 50,000 | 4.07 / 3.90 ms | 1.72 / 1.33 ms | **2.3–3.1×** |

Worst-case pairing (branch-worst vs main-best) wins ≥1.3× at every size; main-side same-code variance is ±2–3%.

## Testing

- `cargo fmt --check` clean; `cargo clippy -p laurus --lib --benches --tests -- -D warnings` clean
- `cargo test -p laurus --lib`: 1183/1183; `cargo test --test vector_merge_test`: 8/8

## Scope notes

- The issue's heavier "quantized pool snapshot" direction is unnecessary at these numbers and stays out of scope.
- The outer multi-segment merge (HashMap + full sort) is untouched.

Refs #640
