### PR TITLE
fix(vector/hnsw): seed the level RNG and harden the flaky rerank engine test (#841)

### DIFF
--- a/laurus/src/vector/index/hnsw/tests.rs
+++ b/laurus/src/vector/index/hnsw/tests.rs
@@ -919,3 +919,78 @@ fn eager_load_rejects_corrupted_pq_fastscan_segment() -> Result<()> {
     );
     Ok(())
 }
+
+/// Issue #841: HNSW **level assignment** must be deterministic — the
+/// level RNG is seeded with a fixed constant ([`LEVEL_RNG_SEED`] in the
+/// writer), so building the same vector set twice yields the same entry
+/// point, max level, and per-node layer counts.
+///
+/// Neighbor lists are deliberately NOT compared: graph insertion runs in
+/// parallel (`ConcurrentHnswGraph` + rayon), so neighbor selection still
+/// depends on thread interleaving. That residual nondeterminism is
+/// documented on #841; this test pins exactly the invariant the seeded
+/// RNG guarantees.
+#[test]
+fn graph_build_levels_are_deterministic_across_writers() -> Result<()> {
+    /// Loaded level shape: `(entry_point, max_level, per-node layer counts)`.
+    type LevelShape = (Option<u64>, usize, Vec<(u64, usize)>);
+
+    /// Build one segment from a fixed 64-vector set and return its
+    /// loaded [`LevelShape`].
+    fn build(name: &str) -> Result<LevelShape> {
+        let storage =
+            StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+        let config = HnswIndexConfig {
+            dimension: 4,
+            m: 4,
+            ef_construction: 16,
+            distance_metric: DistanceMetric::Cosine,
+            ..Default::default()
+        };
+        let mut writer = HnswIndexWriter::with_storage(
+            config,
+            VectorIndexWriterConfig::default(),
+            name,
+            Arc::clone(&storage),
+        )?;
+        // Deterministic non-trivial vectors; 64 nodes give the level
+        // RNG room to produce multiple layers.
+        let vectors: Vec<(u64, String, Vector)> = (0..64u64)
+            .map(|i| {
+                let t = i as f32;
+                (
+                    i,
+                    "f".to_string(),
+                    Vector::new(vec![
+                        (t * 0.37).sin(),
+                        (t * 0.73).cos(),
+                        (t * 0.11).sin(),
+                        (t * 0.53).cos(),
+                    ]),
+                )
+            })
+            .collect();
+        writer.add_vectors(vectors)?;
+        writer.finalize()?;
+        writer.write()?;
+
+        let reader = HnswIndexReader::load(storage, name, DistanceMetric::Cosine)?;
+        let graph = reader.graph.as_ref().expect("segment must carry a graph");
+        let levels = graph
+            .sorted_nodes()
+            .into_iter()
+            .map(|(id, layers)| (id, layers.len()))
+            .collect();
+        Ok((graph.entry_point, graph.max_level, levels))
+    }
+
+    let a = build("determinism_a")?;
+    let b = build("determinism_b")?;
+    assert_eq!(a.0, b.0, "entry point must be identical across builds");
+    assert_eq!(a.1, b.1, "max level must be identical across builds");
+    assert_eq!(
+        a.2, b.2,
+        "every node's layer count must be identical across builds"
+    );
+    Ok(())
+}

--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -18,11 +18,22 @@ use crate::vector::index::quantized_io::{
 use crate::vector::index::rerank_sidecar::{read_sidecar, write_sidecar};
 use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
 use parking_lot::RwLock;
-use rand::RngExt;
+use rand::{RngExt, SeedableRng};
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
+
+/// Fixed seed for the HNSW level-selection RNG (Issue #841).
+///
+/// Level selection needs no secret randomness — what matters is the
+/// geometric level distribution, not its unpredictability — so the
+/// build uses a deterministic generator seeded with this constant.
+/// This makes graph topology reproducible for a given insertion order:
+/// segment builds, merges, and topology-sensitive tests all become
+/// deterministic instead of flaking on unlucky layouts. Precedent:
+/// Lucene's `HnswGraphBuilder` builds with `DEFAULT_RAND_SEED = 42`.
+const LEVEL_RNG_SEED: u64 = 42;
 
 /// Abstract trait to allow reading from both HnswGraph (serial) and ConcurrentHnswGraph (parallel)
 trait GraphView {
@@ -569,9 +580,19 @@ impl HnswIndexWriter {
     }
 
     /// Calculate the layer for a new vector.
-    fn select_layer(&self) -> usize {
+    ///
+    /// # Arguments
+    ///
+    /// * `rng` - The build-scoped level RNG, seeded with
+    ///   [`LEVEL_RNG_SEED`] so graph topology is deterministic for a
+    ///   given insertion order (Issue #841).
+    ///
+    /// # Returns
+    ///
+    /// The layer index, geometrically distributed with ratio `_ml` and
+    /// capped at 16.
+    fn select_layer(&self, rng: &mut impl RngExt) -> usize {
         let mut layer = 0;
-        let mut rng = rand::rng();
 
         while rng.random_range(0.0..1.0) < self._ml && layer < 16 {
             layer += 1;
@@ -680,6 +701,10 @@ impl HnswIndexWriter {
         let mut new_node_levels = Vec::new(); // (doc_id, level)
         let mut new_doc_ids_in_order = Vec::new();
 
+        // Deterministic level RNG (Issue #841): one seeded generator per
+        // build, threaded through the serial level-assignment loops below.
+        let mut level_rng = rand::rngs::StdRng::seed_from_u64(LEVEL_RNG_SEED);
+
         // Check if we have an existing graph to append to
         let (graph, entry_point, max_level, search_entry_point) =
             if let Some(existing_graph) = self.graph.take() {
@@ -693,7 +718,7 @@ impl HnswIndexWriter {
 
                 // Assign levels to new vectors
                 for doc_id in &new_doc_ids_in_order {
-                    let level = self.select_layer();
+                    let level = self.select_layer(&mut level_rng);
                     new_node_levels.push((*doc_id, level));
                 }
 
@@ -728,7 +753,7 @@ impl HnswIndexWriter {
                 doc_ids_in_order.sort_unstable();
 
                 for doc_id in &doc_ids_in_order {
-                    let level = self.select_layer();
+                    let level = self.select_layer(&mut level_rng);
                     new_node_levels.push((*doc_id, level));
                 }
 

--- a/laurus/tests/vector_rerank_engine_test.rs
+++ b/laurus/tests/vector_rerank_engine_test.rs
@@ -119,7 +119,14 @@ async fn engine_search_with_rerank_factor_succeeds_on_stage2_field() -> laurus::
 
     let query = [0.87, 0.36, 0.21, 0.09];
 
-    let with_rerank = engine.search(vector_request(&query, Some(3))).await?;
+    // rerank_factor = 4 rescans ALL 4 docs against the exact f32 pool
+    // (rerank_count = limit × factor = 4), so the doc1-wins assertion
+    // below cannot depend on which candidates survive the int8 Stage-1
+    // cut under an unlucky (parallel-build) graph topology — the flake
+    // #841 hit with factor 3, where doc1 once fell outside the rescored
+    // top-3. The Stage-2 wiring this test guards (sidecar emitted, pool
+    // loaded, score changed by rerank) is unaffected by the factor.
+    let with_rerank = engine.search(vector_request(&query, Some(4))).await?;
     assert_eq!(with_rerank.len(), 1, "expected exactly 1 hit");
     assert_eq!(
         with_rerank[0].id, "doc1",


### PR DESCRIPTION
## Summary

Fixes the flaky `engine_search_with_rerank_factor_succeeds_on_stage2_field` (one CI failure on PR #840) at two levels:

1. **Seeded HNSW level RNG** (`LEVEL_RNG_SEED = 42`, following Lucene's `HnswGraphBuilder.DEFAULT_RAND_SEED`): `select_layer` now takes a build-scoped `StdRng` threaded through the two serial level-assignment loops, replacing a fresh unseeded `rand::rng()` per call. Per-node level assignment is now deterministic for a given insertion order. **No public-API, binding, or on-disk change.**
2. **Topology-robust test assertion**: the observed failure mode was doc1 falling outside the rescored stage-1 top-3 under an unlucky graph topology. `rerank_factor` 3 → 4 rescores **all four** docs against the exact f32 pool, so the doc1-wins assertion no longer depends on topology. The Stage-2 wiring the test guards (sidecar emitted, pool loaded, score changed by rerank) is unaffected.

## Finding: residual nondeterminism (documented, out of scope)

A first version of the determinism test compared full neighbor lists across two identical builds — and **failed**: graph insertion runs in parallel (`ConcurrentHnswGraph` + rayon), so neighbor selection still depends on thread interleaving even with seeded levels. The shipped test (`graph_build_levels_are_deterministic_across_writers`) pins exactly the invariant the seed guarantees (entry point, max level, per-node layer counts) and documents the residual source in its comment. Fully deterministic parallel insertion would be a separate, larger change.

## Verification

- **Stress: 100/100 runs** of the previously flaky test pass (acceptance criterion on #841).
- `cargo test -p laurus --lib`: 1184/1184 (incl. the new determinism test); integration: rerank 2/2, merge 8/8.
- `cargo fmt --check` / `cargo clippy -p laurus --lib --tests -- -D warnings`: clean.

Closes #841
