### PR TITLE
perf(vector/index): parallelize IVF k-means and PQ training; fix O(n*k^2*d) k-means++ init (#622)

### DIFF
--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -173,6 +173,10 @@ name = "nrt_active_search_bench"
 harness = false
 
 [[bench]]
+name = "pq_train_bench"
+harness = false
+
+[[bench]]
 name = "vector_multi_query_bench"
 harness = false
 

--- a/laurus/benches/pq_train_bench.rs
+++ b/laurus/benches/pq_train_bench.rs
@@ -1,0 +1,82 @@
+//! PQ codebook training benchmark (Issue #622).
+//!
+//! PQ is HNSW-only, and training runs inside the writer's `write()`
+//! (not `finalize()`): `quantize_segment_pq` → `pq_train_codebook`
+//! trains M per-sub-vector k-means codebooks (M = 16, K = 256,
+//! `PQ_KMEANS_ITERATIONS` = 25). The bench builds and finalizes one
+//! HNSW+PQ index per case in setup, then measures repeated `write()`
+//! calls — each call retrains the codebook and re-serializes to
+//! in-memory storage, so training dominates the measured op. This is
+//! the designated A/B gate metric for #622's PQ-side changes
+//! (parallel sub-vector training + SIMD L2 kernel).
+//!
+//! Setup is in-memory and deterministic via `common::DEFAULT_SEED`.
+
+mod common;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use common::{DEFAULT_SEED, SAMPLE_SIZE_SLOW, lcg_vec_unit, select_storage};
+use laurus::vector::Vector;
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::quantization::QuantizationMethod;
+use laurus::vector::index::ManagedVectorIndex;
+use laurus::vector::index::config::{HnswIndexConfig, VectorIndexTypeConfig};
+
+/// Vector dimension (matches the other vector benches; M = 16 gives
+/// `sub_dim` = 8).
+const DIM: usize = 128;
+
+/// Deterministic corpus for one bench case.
+fn generate_vectors(count: usize, dim: usize) -> Vec<(u64, String, Vector)> {
+    let mut state = DEFAULT_SEED;
+    (0..count)
+        .map(|i| {
+            (
+                i as u64,
+                "field".to_string(),
+                Vector::new(lcg_vec_unit(&mut state, dim)),
+            )
+        })
+        .collect()
+}
+
+/// Repeated `write()` on a finalized HNSW+PQ index: PQ codebook
+/// training (M seeded k-means runs) plus the comparatively cheap
+/// encode + serialization passes.
+fn bench_pq_train(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PQ Train");
+    group.sample_size(SAMPLE_SIZE_SLOW); // slow training path
+
+    for &count in &[2048usize, 8192] {
+        // One-time setup: build + finalize the graph so the measured
+        // op is write() = PQ training + serialization only.
+        let config = HnswIndexConfig {
+            dimension: DIM,
+            m: 16,
+            ef_construction: 200,
+            distance_metric: DistanceMetric::Cosine,
+            quantization_method: QuantizationMethod::ProductQuantization {
+                subvector_count: 16,
+            },
+            ..Default::default()
+        };
+        let mut index = ManagedVectorIndex::new(
+            VectorIndexTypeConfig::HNSW(config),
+            select_storage(),
+            "bench",
+        )
+        .unwrap();
+        index.add_vectors(generate_vectors(count, DIM)).unwrap();
+        index.finalize().unwrap();
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| index.write().unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_pq_train);
+criterion_main!(benches);

--- a/laurus/src/vector/core/quantization.rs
+++ b/laurus/src/vector/core/quantization.rs
@@ -239,7 +239,9 @@ pub fn pq_train_codebook(
         }
     }
 
-    let m = params.m as usize;
+    // `m` is implicit below: the codebook holds exactly `m` chunks of
+    // `k * sub_dim` floats, so `chunks_mut(k * sub_dim)` yields one
+    // task per sub-vector.
     let k = params.k as usize;
     let sub_dim = params.sub_dim as usize;
     let n = vectors.len();
@@ -250,34 +252,53 @@ pub fn pq_train_codebook(
 
     let mut codebook = vec![0.0_f32; params.codebook_len()];
 
-    // Reusable scratch buffer to avoid per-sub-vector reallocations.
-    let mut sub_data: Vec<f32> = Vec::with_capacity(n * sub_dim);
-
-    for sub in 0..m {
-        // Project corpus onto this sub-vector stride.
-        sub_data.clear();
+    // Train one sub-vector's codebook slot: project the corpus onto
+    // the sub-vector stride, run seeded k-means, and write the
+    // centroids into `codebook[sub][..]`. When `effective_k < k` the
+    // remaining slots are left zero-filled — they will never be
+    // selected by the encoder because `pq_encode` only picks from the
+    // seeded set, but the codebook is sized to `k` so the on-disk
+    // format stays uniform. The seed is derived from `sub` so two runs
+    // over the same input produce the same codebook regardless of
+    // scheduling (Issue #622: the sub-vectors are trained in parallel
+    // on native targets and stay byte-identical because each
+    // sub-vector's arithmetic is untouched).
+    let train_sub = |(sub, slot): (usize, &mut [f32])| {
+        let mut sub_data: Vec<f32> = Vec::with_capacity(n * sub_dim);
         for v in vectors {
             sub_data.extend_from_slice(&v.data[sub * sub_dim..(sub + 1) * sub_dim]);
         }
 
-        // Deterministic seed derived from `sub` so two runs over the
-        // same input produce the same codebook.
         let seed: u64 =
             0xCAFE_F00D_DEAD_BEEF_u64 ^ ((sub as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
 
         let centroids = kmeans_train(&sub_data, sub_dim, effective_k, PQ_KMEANS_ITERATIONS, seed);
 
-        // Write centroids into codebook[sub][..]. When `effective_k < k`
-        // the remaining slots are left zero-filled — they will never
-        // be selected by the encoder because `pq_encode` only picks
-        // from the seeded set, but the codebook is sized to `k` so the
-        // on-disk format stays uniform.
-        let dst_base = sub * k * sub_dim;
         let src_len = effective_k * sub_dim;
-        codebook[dst_base..dst_base + src_len].copy_from_slice(&centroids[..src_len]);
+        slot[..src_len].copy_from_slice(&centroids[..src_len]);
+    };
+
+    // The m sub-quantizers are independent (embarrassingly parallel);
+    // `par_chunks_mut(k * sub_dim)` hands each task exactly its own
+    // codebook slot. Serial fallback when rayon is unavailable (wasm).
+    #[cfg(feature = "native")]
+    {
+        use rayon::prelude::*;
+        codebook
+            .par_chunks_mut(k * sub_dim)
+            .enumerate()
+            .for_each(train_sub);
+        Ok(codebook)
     }
 
-    Ok(codebook)
+    #[cfg(not(feature = "native"))]
+    {
+        codebook
+            .chunks_mut(k * sub_dim)
+            .enumerate()
+            .for_each(train_sub);
+        Ok(codebook)
+    }
 }
 
 /// Encode one full-dimensional vector into `m` byte codes using a
@@ -296,11 +317,8 @@ pub fn pq_encode(vector: &[f32], params: PqParams, codebook: &[f32]) -> Vec<u8> 
         let mut best_d = f32::INFINITY;
         for ki in 0..k {
             let c = &codebook[base + ki * sub_dim..base + (ki + 1) * sub_dim];
-            let mut sum = 0.0_f32;
-            for d in 0..sub_dim {
-                let diff = q_sub[d] - c[d];
-                sum += diff * diff;
-            }
+            // Shared SIMD kernel (Issue #622) — was an identical scalar loop.
+            let sum = l2_squared_slice(q_sub, c);
             if sum < best_d {
                 best_d = sum;
                 best_k = ki as u8;
@@ -432,12 +450,40 @@ fn kmeans_train(data: &[f32], sub_dim: usize, k: usize, iters: usize, seed: u64)
     centroids
 }
 
+/// SIMD `Σ (a[i] - b[i])²` over f32 slices (Issue #622).
+///
+/// Mirrors `distance.rs`'s `simd_euclidean_sq`: 8-wide [`wide::f32x8`]
+/// accumulation with a scalar tail. The 8-lane regrouping changes the
+/// f32 summation order relative to the previous scalar loop, so
+/// codebooks trained by the new build differ from old ones in
+/// low-order bits; within one build the result is fully deterministic.
+///
+/// # Arguments
+///
+/// * `a`, `b` - Equal-length f32 slices.
+///
+/// # Returns
+///
+/// The squared Euclidean distance between `a` and `b`.
 #[inline]
 fn l2_squared_slice(a: &[f32], b: &[f32]) -> f32 {
+    use wide::f32x8;
+
     debug_assert_eq!(a.len(), b.len());
-    let mut sum = 0.0_f32;
-    for i in 0..a.len() {
-        let d = a[i] - b[i];
+    let mut acc = f32x8::ZERO;
+    let chunks_a = a.chunks_exact(8);
+    let chunks_b = b.chunks_exact(8);
+    let rem_a = chunks_a.remainder();
+    let rem_b = chunks_b.remainder();
+
+    for (ca, cb) in chunks_a.zip(chunks_b) {
+        let diff = f32x8::from(ca) - f32x8::from(cb);
+        acc += diff * diff;
+    }
+
+    let mut sum: f32 = acc.reduce_add();
+    for (x, y) in rem_a.iter().zip(rem_b.iter()) {
+        let d = x - y;
         sum += d * d;
     }
     sum
@@ -1128,5 +1174,44 @@ mod tests {
     #[test]
     fn meta_serialized_size_is_eight() {
         assert_eq!(QuantizedVectorMeta::SERIALIZED_SIZE, 8);
+    }
+
+    /// Issue #622: `pq_train_codebook` must be deterministic — two runs
+    /// on the same input produce byte-identical codebooks. Today this
+    /// holds because each sub-vector's k-means uses a seed derived from
+    /// its index; the parallelization of the outer `m` loop must keep
+    /// it holding (per-sub arithmetic untouched, only scheduling
+    /// changes).
+    #[test]
+    fn pq_train_codebook_is_byte_identical_across_runs() {
+        let dim = 16usize;
+        let m = 4usize;
+        let params = PqParams::from_dim_and_m(dim, m).unwrap();
+
+        // Deterministic pseudo-random corpus, large enough that every
+        // sub-vector's k-means does real multi-cluster work.
+        let mut state: u64 = 0x5EED_1234_ABCD_9876;
+        let mut next = move || {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+        };
+        let vectors: Vec<Vector> = (0..512)
+            .map(|_| Vector::new((0..dim).map(|_| next()).collect()))
+            .collect();
+
+        let a = pq_train_codebook(dim, params, &vectors).expect("train a");
+        let b = pq_train_codebook(dim, params, &vectors).expect("train b");
+        assert_eq!(a.len(), b.len());
+        // Bitwise comparison (not approximate): the seeded LCG makes
+        // training fully deterministic, so any difference means a
+        // scheduling-dependent arithmetic change slipped in.
+        let a_bits: Vec<u32> = a.iter().map(|f| f.to_bits()).collect();
+        let b_bits: Vec<u32> = b.iter().map(|f| f.to_bits()).collect();
+        assert_eq!(
+            a_bits, b_bits,
+            "two pq_train_codebook runs must be byte-identical"
+        );
     }
 }

--- a/laurus/src/vector/index/ivf/writer.rs
+++ b/laurus/src/vector/index/ivf/writer.rs
@@ -385,23 +385,34 @@ impl IvfIndexWriter {
         let first_idx = rng.random_range(0..self.vectors.len());
         self.centroids.push(self.vectors[first_idx].2.clone());
 
+        // Running minimum distance from each vector to its nearest
+        // chosen centroid (Issue #622). The textbook k-means++
+        // formulation folds only the NEWEST centroid into the running
+        // minimum on each pick — O(n·d) per pick, O(n·k·d) total —
+        // replacing the previous full recompute over all chosen
+        // centroids per pick, which was O(n·k²·d). `f32::min` over the
+        // same distance values is exact, so the per-pick weights (and
+        // therefore the RNG sampling sequence and the chosen centroids)
+        // are bit-identical to the previous implementation.
+        let mut min_dists: Vec<f32> = vec![f32::INFINITY; self.vectors.len()];
+
         // Choose remaining centroids with probability proportional to squared distance
         for _ in 1..self.index_config.n_clusters {
+            // Fold the most recently chosen centroid into the running
+            // minima (the only centroid the previous minima have not
+            // seen yet).
+            let newest = self
+                .centroids
+                .last()
+                .expect("k-means++ always has at least the first centroid")
+                .clone();
+            self.fold_min_dists(&newest, &mut min_dists);
+
+            // Weights are accumulated serially in vector order so the
+            // floating-point sums match the previous implementation.
             let mut distances = Vec::with_capacity(self.vectors.len());
             let mut total_weight = 0.0;
-
-            for (_, _, vector) in &self.vectors {
-                let min_dist = self
-                    .centroids
-                    .iter()
-                    .map(|centroid| {
-                        self.index_config
-                            .distance_metric
-                            .distance(&vector.data, &centroid.data)
-                            .unwrap_or(f32::INFINITY)
-                    })
-                    .fold(f32::INFINITY, f32::min);
-
+            for &min_dist in &min_dists {
                 let weight = min_dist * min_dist;
                 distances.push(weight);
                 total_weight += weight;
@@ -436,6 +447,43 @@ impl IvfIndexWriter {
         }
 
         Ok(())
+    }
+
+    /// Fold `centroid` into the per-vector running minimum distances
+    /// used by k-means++ initialization (Issue #622).
+    ///
+    /// Runs the per-vector scan in parallel under the same gate as
+    /// [`Self::assign_vectors_to_clusters`] (`parallel_build` and more
+    /// than 1000 buffered vectors; always serial on wasm32). Each
+    /// element update is independent, so the parallel result is
+    /// bit-identical to the serial one.
+    ///
+    /// # Arguments
+    ///
+    /// * `centroid` - The newest chosen centroid.
+    /// * `min_dists` - Per-vector running minima, updated in place.
+    fn fold_min_dists(&self, centroid: &Vector, min_dists: &mut [f32]) {
+        let metric = self.index_config.distance_metric;
+        // Distance errors contribute `INFINITY`, which leaves the
+        // running minimum unchanged — the same effect the previous
+        // implementation's `unwrap_or(f32::INFINITY)` had.
+        let fold = |(min_dist, (_, _, vector)): (&mut f32, &(u64, String, Vector))| {
+            let dist = metric
+                .distance(&vector.data, &centroid.data)
+                .unwrap_or(f32::INFINITY);
+            *min_dist = min_dist.min(dist);
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if self.writer_config.parallel_build && self.vectors.len() as u64 > 1000 {
+            min_dists
+                .par_iter_mut()
+                .zip(self.vectors.par_iter())
+                .for_each(fold);
+            return;
+        }
+
+        min_dists.iter_mut().zip(self.vectors.iter()).for_each(fold);
     }
 
     /// Assign each vector to its nearest cluster.
@@ -477,19 +525,7 @@ impl IvfIndexWriter {
 
     /// Update centroids based on cluster assignments.
     fn update_centroids(&mut self, assignments: &[usize]) -> Result<()> {
-        let mut cluster_sums =
-            vec![vec![0.0; self.index_config.dimension]; self.index_config.n_clusters];
-        let mut cluster_counts = vec![0; self.index_config.n_clusters];
-
-        // Sum vectors in each cluster
-        for (i, (_, _, vector)) in self.vectors.iter().enumerate() {
-            let cluster = assignments[i];
-            cluster_counts[cluster] += 1;
-
-            for (j, &value) in vector.data.iter().enumerate() {
-                cluster_sums[cluster][j] += value;
-            }
-        }
+        let (cluster_sums, cluster_counts) = self.accumulate_cluster_sums(assignments);
 
         // Compute new centroids as averages
         for (i, (sum, count)) in cluster_sums.iter().zip(cluster_counts.iter()).enumerate() {
@@ -504,6 +540,84 @@ impl IvfIndexWriter {
         }
 
         Ok(())
+    }
+
+    /// Accumulate per-cluster `(sums, counts)` over the buffered
+    /// vectors (Issue #622).
+    ///
+    /// Runs a rayon `fold`/`reduce` with per-thread partial sums under
+    /// the same gate as [`Self::assign_vectors_to_clusters`]
+    /// (`parallel_build` and more than 1000 buffered vectors; always
+    /// serial on wasm32). The parallel path regroups f32 additions, so
+    /// centroid low-order bits may differ from the serial order —
+    /// acceptable because k-means++ initialization is already
+    /// RNG-nondeterministic across runs.
+    ///
+    /// # Arguments
+    ///
+    /// * `assignments` - Cluster index per buffered vector (parallel
+    ///   array to `self.vectors`).
+    ///
+    /// # Returns
+    ///
+    /// `(cluster_sums, cluster_counts)`: per-cluster component sums
+    /// (`n_clusters × dimension`) and member counts.
+    fn accumulate_cluster_sums(&self, assignments: &[usize]) -> (Vec<Vec<f32>>, Vec<usize>) {
+        let dim = self.index_config.dimension;
+        let n_clusters = self.index_config.n_clusters;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if self.writer_config.parallel_build && self.vectors.len() as u64 > 1000 {
+            return self
+                .vectors
+                .par_iter()
+                .zip(assignments.par_iter())
+                .fold(
+                    || {
+                        (
+                            vec![vec![0.0_f32; dim]; n_clusters],
+                            vec![0_usize; n_clusters],
+                        )
+                    },
+                    |(mut sums, mut counts), ((_, _, vector), &cluster)| {
+                        counts[cluster] += 1;
+                        for (j, &value) in vector.data.iter().enumerate() {
+                            sums[cluster][j] += value;
+                        }
+                        (sums, counts)
+                    },
+                )
+                .reduce(
+                    || {
+                        (
+                            vec![vec![0.0_f32; dim]; n_clusters],
+                            vec![0_usize; n_clusters],
+                        )
+                    },
+                    |(mut sums_a, mut counts_a), (sums_b, counts_b)| {
+                        for (sum_a, sum_b) in sums_a.iter_mut().zip(sums_b) {
+                            for (a, b) in sum_a.iter_mut().zip(sum_b) {
+                                *a += b;
+                            }
+                        }
+                        for (a, b) in counts_a.iter_mut().zip(counts_b) {
+                            *a += b;
+                        }
+                        (sums_a, counts_a)
+                    },
+                );
+        }
+
+        let mut cluster_sums = vec![vec![0.0_f32; dim]; n_clusters];
+        let mut cluster_counts = vec![0_usize; n_clusters];
+        for (i, (_, _, vector)) in self.vectors.iter().enumerate() {
+            let cluster = assignments[i];
+            cluster_counts[cluster] += 1;
+            for (j, &value) in vector.data.iter().enumerate() {
+                cluster_sums[cluster][j] += value;
+            }
+        }
+        (cluster_sums, cluster_counts)
     }
 
     /// Compute convergence metric between old and new centroids.


### PR DESCRIPTION
## Summary

Parallelizes the serial phases of IVF k-means training and PQ codebook training (Refs #622), and fixes an **O(n·k²·d) k-means++ initialization** along the way.

### IVF (`ivf/writer.rs`)

- **Algorithmic fix**: `init_centroids_kmeans_plus_plus` recomputed the min-distance over *all* chosen centroids for *every* point on *each* of the k−1 picks — O(n·k²·d). Rewritten to the textbook running-min formulation (fold only the newest centroid into per-vector minima): **O(n·k·d)** total. **Bit-identical** — identical distance values feed identical weights, so the RNG sampling sequence and the chosen centroids are unchanged.
- The per-pick min-distance fold and the `update_centroids` accumulation (rayon `fold`/`reduce`, per-thread partial sums) are parallelized behind the existing `parallel_build && n > 1000` gate (serial on wasm32). The `update_centroids` f32 regrouping may shift centroid low-order bits — acceptable: IVF training is already RNG-nondeterministic.

### PQ (`core/quantization.rs`)

- The `m` sub-vector codebooks train **in parallel** (`par_chunks_mut` over codebook slots, per-task scratch), gated on the `native` feature. **Byte-identical**: each sub-vector keeps its deterministic seed and arithmetic order — pinned by a new test asserting two-run bitwise equality (added before parallelizing, green before and after).
- `l2_squared_slice` is now `wide::f32x8` SIMD (mirrors `distance.rs`), and `pq_encode`'s previously duplicated scalar loop reuses it. Codebooks trained by new builds differ from old ones in low-order bits (summation order); run-to-run determinism is preserved.

### New benchmark

PQ turned out to be HNSW-only with training inside the writer's `write()` (not `finalize()`), so `pq_train_bench` isolates repeated `write()` on a pre-finalized HNSW+PQ index.

## A/B vs `main` (src-only `git stash` baseline, 2 samples/side)

| bench | main | branch | speedup (worst pairing) |
| --- | ---: | ---: | ---: |
| PQ Train/2048 | 704.7 / 744.0 ms | 399.8 / 402.8 ms | **1.75×** |
| PQ Train/8192 | 2.896 / 2.917 s | 1.631 / 1.575 s | **1.78×** |
| IVF Construction/1000 | 10.88 / 11.51 ms | 9.25 / 9.28 ms | 1.17–1.24× |
| IVF Construction/5000 | 58.94 / 46.14 ms | 53.56 / 53.23 ms | inconclusive (main ±12% run-to-run) |

Honest notes: at the bench default k=10, many Lloyd iterations make the already-parallel assignment step dominate, so the quadratic-init removal shows only modestly there; its cost grows as O(k²), so the effect is largest at large cluster counts (512–2048). The init rewrite needs no benchmark to justify — it is a bit-identical strict work reduction.

## Testing

- `cargo test -p laurus --lib`: 1185/1185 (incl. the new PQ byte-identity test); IVF 20/20.
- `cargo fmt --check` / `cargo clippy -p laurus --lib --benches --tests -- -D warnings`: clean.

## Out of scope (noted on the issue)

- Seeding IVF's unseeded `rand::rng()` sites (#842-class, behavior change).
- Parallelizing `kmeans_train`'s internal loops (the m-way outer parallelism already saturates cores for PQ).

Refs #622
