### PR TITLE
fix(lexical/search): rewrite multi-term queries once at the searcher; fix 0 hits on multi-segment indexes (#613)

### DIFF
--- a/laurus/benches/lexical_search_bench.rs
+++ b/laurus/benches/lexical_search_bench.rs
@@ -122,7 +122,9 @@ use common::{SAMPLE_SIZE_FAST, SAMPLE_SIZE_SLOW};
 use laurus::analysis::analyzer::analyzer::Analyzer;
 use laurus::analysis::analyzer::standard::StandardAnalyzer;
 use laurus::lexical::core::field::IntegerOption;
-use laurus::lexical::{BooleanQuery, FuzzyQuery, PhraseQuery, TermQuery, TextOption};
+use laurus::lexical::{
+    BooleanQuery, FuzzyQuery, PhraseQuery, TermQuery, TextOption, WildcardQuery,
+};
 use laurus::storage::Storage;
 use laurus::storage::file::FileStorageConfig;
 use laurus::storage::{StorageConfig, StorageFactory};
@@ -1066,6 +1068,49 @@ fn bench_fuzzy_query(c: &mut Criterion) {
     group.finish();
 }
 
+/// Wildcard search latency (Issue #613): like [`bench_fuzzy_query`],
+/// exercises the multi-term enumeration path — the query is lowered to a
+/// Boolean-of-TermQuery via one term-dictionary enumeration per request
+/// (previously two: matcher and scorer re-enumerated independently).
+fn bench_wildcard_query(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("lexical/wildcard_query");
+    group.sample_size(SAMPLE_SIZE_FAST);
+
+    for &n in &[100, 1000, 5000] {
+        let engine = cached_engine(&rt, EngineShape::Uniform, n, 1);
+
+        // Sanity check: the probe must match `programming`-family terms.
+        let probe = rt.block_on(async {
+            let query = Box::new(WildcardQuery::new("body", "program*").unwrap());
+            let request = SearchRequestBuilder::new()
+                .lexical_query(LexicalSearchQuery::Obj(query))
+                .limit(10)
+                .build();
+            engine.search(request).await.unwrap()
+        });
+        assert!(
+            !probe.is_empty(),
+            "wildcard_query probe must return at least one hit at n={n}"
+        );
+
+        group.bench_with_input(BenchmarkId::new("prefix_star", n), &n, |b, _| {
+            b.to_async(&rt).iter(|| {
+                let engine = &engine;
+                async move {
+                    let query = Box::new(WildcardQuery::new("body", "program*").unwrap());
+                    let request = SearchRequestBuilder::new()
+                        .lexical_query(LexicalSearchQuery::Obj(query))
+                        .limit(10)
+                        .build();
+                    black_box(engine.search(request).await.unwrap())
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
 fn bench_dsl_query(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let engine = cached_engine(&rt, EngineShape::Uniform, 5000, 1);
@@ -1142,6 +1187,7 @@ criterion_group!(
     bench_seek_skewed,
     bench_phrase_query,
     bench_fuzzy_query,
+    bench_wildcard_query,
     bench_dsl_query,
 );
 criterion_main!(benches);

--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -167,6 +167,23 @@ impl InvertedIndexSearcher {
         parallel: bool,
         deadline: Option<Deadline>,
     ) -> Result<C> {
+        // Query rewrite (Issue #613): lower multi-term queries (prefix /
+        // wildcard / fuzzy / regexp) into Boolean-of-TermQuery ONCE,
+        // against the top-level reader, before any gating below. This
+        // (a) halves the term-dictionary enumerations (matcher and
+        // scorer used to re-enumerate independently), and (b) hands the
+        // per-segment fanout a query it can execute — the fanout's
+        // `PerSegmentReaderView` cannot enumerate the term dictionary,
+        // which previously made raw multi-term queries return 0 hits on
+        // multi-segment indexes. `None` (nothing to rewrite, or the
+        // reader is itself a per-segment view) keeps the original query;
+        // an already-lowered query rewrites to `None`, so the fanout's
+        // recursion back into this method is a cheap no-op.
+        let query = match query.rewrite(self.reader.as_ref())? {
+            Some(rewritten) => rewritten,
+            None => query,
+        };
+
         // For BooleanQuery with multiple clauses, try to execute sub-queries in parallel
         if parallel && let Some(boolean_query) = query.as_any().downcast_ref::<BooleanQuery>() {
             return self.search_boolean_query_parallel(boolean_query, collector, deadline);

--- a/laurus/src/lexical/query.rs
+++ b/laurus/src/lexical/query.rs
@@ -148,6 +148,34 @@ pub trait Query: Send + Sync + Debug {
     /// Get the estimated cost of executing this query.
     fn cost(&self, reader: &dyn LexicalIndexReader) -> Result<u64>;
 
+    /// Rewrite this query against the reader (Issue #613).
+    ///
+    /// Called once by the searcher at the top of query execution,
+    /// against the top-level reader — before the per-segment fanout and
+    /// BMW gates. Multi-term queries (prefix / wildcard / fuzzy /
+    /// regexp) override this to lower themselves into a `BooleanQuery`
+    /// of `TermQuery` clauses via one term-dictionary enumeration, so
+    /// the subsequent `matcher` + `scorer` construction (and every
+    /// per-segment execution) reuses the lowered form instead of
+    /// re-enumerating. [`crate::lexical::query::boolean::BooleanQuery`]
+    /// recurses into its scoring clauses.
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - The index reader the query will execute against.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(query))` with the rewritten query, or `Ok(None)` when
+    /// this query has nothing to rewrite (the default — zero cost for
+    /// term / phrase / range queries) or the reader does not support
+    /// term enumeration (the caller keeps the original query, whose
+    /// `matcher` / `scorer` fallback behavior is unchanged).
+    fn rewrite(&self, reader: &dyn LexicalIndexReader) -> Result<Option<Box<dyn Query>>> {
+        let _ = reader;
+        Ok(None)
+    }
+
     /// Get this query as Any for downcasting.
     fn as_any(&self) -> &dyn Any;
 

--- a/laurus/src/lexical/query/boolean.rs
+++ b/laurus/src/lexical/query/boolean.rs
@@ -472,6 +472,39 @@ impl Query for BooleanQuery {
         Ok(total_cost)
     }
 
+    fn rewrite(&self, reader: &dyn LexicalIndexReader) -> Result<Option<Box<dyn Query>>> {
+        // Lower multi-term subqueries once at the searcher level
+        // (Issue #613). Only scoring clauses (Should / Must) are
+        // rewritten: Filter and MustNot clauses are matched through the
+        // cached doc-id path keyed by the ORIGINAL clause's
+        // `cache_key`, which a rewrite would invalidate.
+        let mut rewritten_any = false;
+        let mut clauses = Vec::with_capacity(self.clauses.len());
+        for clause in &self.clauses {
+            let lowered = match clause.occur {
+                Occur::Should | Occur::Must => clause.query.rewrite(reader)?,
+                Occur::MustNot | Occur::Filter => None,
+            };
+            match lowered {
+                Some(query) => {
+                    rewritten_any = true;
+                    clauses.push(BooleanClause::new(query, clause.occur));
+                }
+                None => clauses.push(clause.clone()),
+            }
+        }
+        if !rewritten_any {
+            return Ok(None);
+        }
+        let mut rewritten =
+            BooleanQuery::new().with_minimum_should_match(self.minimum_should_match);
+        rewritten.set_boost(self.boost);
+        for clause in clauses {
+            rewritten.add_clause(clause);
+        }
+        Ok(Some(Box::new(rewritten)))
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/laurus/src/lexical/query/fuzzy.rs
+++ b/laurus/src/lexical/query/fuzzy.rs
@@ -179,12 +179,12 @@ impl MultiTermQuery for FuzzyQuery {
 
 impl Query for FuzzyQuery {
     fn matcher(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Matcher>> {
-        let rewritten = self.rewrite(reader)?;
+        let rewritten = MultiTermQuery::rewrite(self, reader)?;
         rewritten.matcher(reader)
     }
 
     fn scorer(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Scorer>> {
-        let rewritten = self.rewrite(reader)?;
+        let rewritten = MultiTermQuery::rewrite(self, reader)?;
         rewritten.scorer(reader)
     }
 
@@ -214,6 +214,21 @@ impl Query for FuzzyQuery {
     fn cost(&self, reader: &dyn LexicalIndexReader) -> Result<u64> {
         // Rough estimate
         Ok(reader.doc_count())
+    }
+
+    fn rewrite(&self, reader: &dyn LexicalIndexReader) -> Result<Option<Box<dyn Query>>> {
+        // Lower once at the searcher level (Issue #613). When the reader
+        // cannot enumerate terms (e.g. the per-segment fanout view), keep
+        // the original query so the matcher/scorer fallback stays in
+        // charge; probing via the downcast costs nothing extra.
+        if reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .is_none()
+        {
+            return Ok(None);
+        }
+        Ok(Some(MultiTermQuery::rewrite(self, reader)?))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/laurus/src/lexical/query/prefix.rs
+++ b/laurus/src/lexical/query/prefix.rs
@@ -120,12 +120,12 @@ impl MultiTermQuery for PrefixQuery {
 
 impl Query for PrefixQuery {
     fn matcher(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Matcher>> {
-        let rewritten = self.rewrite(reader)?;
+        let rewritten = MultiTermQuery::rewrite(self, reader)?;
         rewritten.matcher(reader)
     }
 
     fn scorer(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Scorer>> {
-        let rewritten = self.rewrite(reader)?;
+        let rewritten = MultiTermQuery::rewrite(self, reader)?;
         rewritten.scorer(reader)
     }
 
@@ -155,6 +155,21 @@ impl Query for PrefixQuery {
     fn cost(&self, reader: &dyn LexicalIndexReader) -> Result<u64> {
         // Rough estimate
         Ok(reader.doc_count())
+    }
+
+    fn rewrite(&self, reader: &dyn LexicalIndexReader) -> Result<Option<Box<dyn Query>>> {
+        // Lower once at the searcher level (Issue #613). When the reader
+        // cannot enumerate terms (e.g. the per-segment fanout view), keep
+        // the original query so the matcher/scorer fallback stays in
+        // charge; probing via the downcast costs nothing extra.
+        if reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .is_none()
+        {
+            return Ok(None);
+        }
+        Ok(Some(MultiTermQuery::rewrite(self, reader)?))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/laurus/src/lexical/query/regexp.rs
+++ b/laurus/src/lexical/query/regexp.rs
@@ -120,12 +120,12 @@ impl MultiTermQuery for RegexpQuery {
 
 impl Query for RegexpQuery {
     fn matcher(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Matcher>> {
-        let rewritten = self.rewrite(reader)?;
+        let rewritten = MultiTermQuery::rewrite(self, reader)?;
         rewritten.matcher(reader)
     }
 
     fn scorer(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Scorer>> {
-        let rewritten = self.rewrite(reader)?;
+        let rewritten = MultiTermQuery::rewrite(self, reader)?;
         rewritten.scorer(reader)
     }
 
@@ -154,6 +154,21 @@ impl Query for RegexpQuery {
 
     fn cost(&self, reader: &dyn LexicalIndexReader) -> Result<u64> {
         Ok(reader.doc_count())
+    }
+
+    fn rewrite(&self, reader: &dyn LexicalIndexReader) -> Result<Option<Box<dyn Query>>> {
+        // Lower once at the searcher level (Issue #613). When the reader
+        // cannot enumerate terms (e.g. the per-segment fanout view), keep
+        // the original query so the matcher/scorer fallback stays in
+        // charge; probing via the downcast costs nothing extra.
+        if reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .is_none()
+        {
+            return Ok(None);
+        }
+        Ok(Some(MultiTermQuery::rewrite(self, reader)?))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/laurus/src/lexical/query/wildcard.rs
+++ b/laurus/src/lexical/query/wildcard.rs
@@ -202,12 +202,12 @@ impl MultiTermQuery for WildcardQuery {
 
 impl Query for WildcardQuery {
     fn matcher(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Matcher>> {
-        let rewritten = self.rewrite(reader)?;
+        let rewritten = MultiTermQuery::rewrite(self, reader)?;
         rewritten.matcher(reader)
     }
 
     fn scorer(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Scorer>> {
-        let rewritten = self.rewrite(reader)?;
+        let rewritten = MultiTermQuery::rewrite(self, reader)?;
         rewritten.scorer(reader)
     }
 
@@ -237,6 +237,21 @@ impl Query for WildcardQuery {
     fn cost(&self, reader: &dyn LexicalIndexReader) -> Result<u64> {
         // Wildcard queries can be expensive
         Ok(reader.doc_count())
+    }
+
+    fn rewrite(&self, reader: &dyn LexicalIndexReader) -> Result<Option<Box<dyn Query>>> {
+        // Lower once at the searcher level (Issue #613). When the reader
+        // cannot enumerate terms (e.g. the per-segment fanout view), keep
+        // the original query so the matcher/scorer fallback stays in
+        // charge; probing via the downcast costs nothing extra.
+        if reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .is_none()
+        {
+            return Ok(None);
+        }
+        Ok(Some(MultiTermQuery::rewrite(self, reader)?))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/laurus/tests/lexical_multi_term_query_test.rs
+++ b/laurus/tests/lexical_multi_term_query_test.rs
@@ -1,0 +1,129 @@
+//! Index-backed end-to-end tests for the multi-term query types
+//! (Prefix / Wildcard / Fuzzy / Regexp) — Issue #613.
+//!
+//! These are the first hit-level tests for these query types (prior
+//! coverage was structural only). The multi-segment cases pin the
+//! Issue #613 bug: before the searcher-level rewrite, the per-segment
+//! fanout handed each segment a `PerSegmentReaderView`, which cannot
+//! enumerate the term dictionary, so a raw multi-term query against a
+//! ≥2-segment index silently returned 0 hits.
+
+use std::sync::Arc;
+
+use laurus::Document;
+use laurus::lexical::query::Query;
+use laurus::lexical::query::fuzzy::FuzzyQuery;
+use laurus::lexical::query::prefix::PrefixQuery;
+use laurus::lexical::query::regexp::RegexpQuery;
+use laurus::lexical::query::wildcard::WildcardQuery;
+use laurus::lexical::{LexicalIndexConfig, LexicalSearchRequest, LexicalStore};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+fn doc(body: &str) -> Document {
+    Document::builder().add_text("body", body).build()
+}
+
+/// Corpus with distinctive stems. Expected matches:
+/// - prefix/wildcard/regexp `program…`: docs 1, 2, 3
+/// - fuzzy "programing" (1 edit): doc 1 ("programming")
+const CORPUS: [(u64, &str); 4] = [
+    (1, "programming in rust"),
+    (2, "a programmer at work"),
+    (3, "program notes for the concert"),
+    (4, "python coding session"),
+];
+
+/// Build a store with the corpus split across `n_segments` commits
+/// (one commit per chunk; auto-merge disabled via a high threshold).
+fn store_with_segments(n_segments: usize) -> (LexicalStore, Arc<dyn Storage>) {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let config = LexicalIndexConfig::builder().max_segments(1000).build();
+    let store = LexicalStore::new(storage.clone(), config).unwrap();
+
+    let chunk = CORPUS.len().div_ceil(n_segments);
+    for group in CORPUS.chunks(chunk) {
+        for (id, body) in group {
+            store.upsert_document(*id, doc(body)).unwrap();
+        }
+        store.commit().unwrap();
+    }
+    (store, storage)
+}
+
+fn search_ids(store: &LexicalStore, query: Box<dyn Query>) -> Vec<u64> {
+    let mut ids: Vec<u64> = store
+        .search(LexicalSearchRequest::new(query).limit(10))
+        .unwrap()
+        .hits
+        .iter()
+        .map(|h| h.doc_id)
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// Run the four query types against a store and assert hit sets.
+fn assert_multi_term_hits(store: &LexicalStore, label: &str) {
+    assert_eq!(
+        search_ids(store, Box::new(PrefixQuery::new("body", "program"))),
+        vec![1, 2, 3],
+        "{label}: PrefixQuery(body, program)"
+    );
+    assert_eq!(
+        search_ids(
+            store,
+            Box::new(WildcardQuery::new("body", "program*").unwrap())
+        ),
+        vec![1, 2, 3],
+        "{label}: WildcardQuery(body, program*)"
+    );
+    assert_eq!(
+        search_ids(
+            store,
+            Box::new(FuzzyQuery::new("body", "programing").max_edits(1))
+        ),
+        vec![1],
+        "{label}: FuzzyQuery(body, programing, 1 edit)"
+    );
+    assert_eq!(
+        search_ids(
+            store,
+            Box::new(RegexpQuery::new("body", "program.*").unwrap())
+        ),
+        vec![1, 2, 3],
+        "{label}: RegexpQuery(body, program.*)"
+    );
+}
+
+/// Single segment: all four multi-term query types return the expected
+/// hits (this passed before #613's fix as well).
+#[test]
+fn multi_term_queries_hit_on_single_segment() {
+    let (store, storage) = store_with_segments(1);
+    let segs = storage
+        .list_files()
+        .unwrap()
+        .iter()
+        .filter(|f| f.starts_with("segment_") && f.ends_with(".meta"))
+        .count();
+    assert_eq!(segs, 1, "harness must produce exactly 1 segment");
+    assert_multi_term_hits(&store, "single-segment");
+}
+
+/// Multi-segment: the same queries over a 2-segment index. Before the
+/// Issue #613 searcher-level rewrite this returned 0 hits (the fanout's
+/// `PerSegmentReaderView` cannot enumerate terms); it must return the
+/// same hits as the single-segment case.
+#[test]
+fn multi_term_queries_hit_on_multi_segment() {
+    let (store, storage) = store_with_segments(2);
+    let segs = storage
+        .list_files()
+        .unwrap()
+        .iter()
+        .filter(|f| f.starts_with("segment_") && f.ends_with(".meta"))
+        .count();
+    assert_eq!(segs, 2, "harness must produce exactly 2 segments");
+    assert_multi_term_hits(&store, "multi-segment");
+}


### PR DESCRIPTION
## Summary

Adds the Lucene-style **query-rewrite step** #613 asks for, and in doing so fixes a **correctness bug**: a raw multi-term query (Prefix / Wildcard / Fuzzy / Regexp) against a **≥2-segment index silently returned 0 hits**.

### The bug (test-proven)

The per-segment fanout (#476) hands each segment a `PerSegmentReaderView`, which cannot enumerate the term dictionary; every multi-term query's enumeration is gated on `downcast_ref::<InvertedIndexReader>`, so the per-segment rewrite produced an empty query. The new `lexical_multi_term_query_test.rs` — the **first index-backed hit-level coverage for these four query types** — proved it red (`PrefixQuery` → `[]` instead of `[1,2,3]` on 2 segments) and now passes on both single- and multi-segment indexes.

### The fix / design

- **`Query::rewrite(&self, reader) -> Result<Option<Box<dyn Query>>>`** trait hook, default `None` (zero cost for term/phrase/range queries).
- The four multi-term queries override it, delegating to the existing `MultiTermQuery::rewrite` (one term-dictionary enumeration → Boolean-of-TermQuery). They return `None` when the reader can't enumerate, keeping the original query and its matcher/scorer fallback (facet path unchanged).
- **`BooleanQuery::rewrite`** recurses into **Should/Must clauses only** — Filter/MustNot clauses stay untouched so their `cache_key`-based doc-id caching keeps working. Boost and `minimum_should_match` are preserved.
- **One searcher integration point** at the top of `search_with_collector_deadline`, before the parallel-boolean / fanout / BMW gates — covers `search`, `count`, and boolean-parallel paths. The fanout's per-segment recursion re-rewrites to `None` (cheap no-op). The lowered all-`TermQuery` Boolean is also BMW-eligible.

### Perf (matcher and scorer no longer re-enumerate independently: 2 → 1 enumerations/request)

A/B vs `main` (src-only `git stash` baseline, 2 samples/side, worst-case pairing — every branch sample beat every main sample in all 9 cases):

| bench | main | branch | speedup |
| --- | ---: | ---: | ---: |
| fuzzy edit1/1000 | 394/397 µs | 196/212 µs | **1.86×** |
| fuzzy edit2/5000 | 1725/1483 µs | 694/801 µs | **1.85×** |
| wildcard/100 | 696/581 µs | 372/360 µs | 1.56× |
| wildcard/1000 | 816/788 µs | 488/474 µs | 1.61× |
| wildcard/5000 | 1672/1567 µs | 967/973 µs | **1.61×** |

(~1.85× at n=5000 ⇒ enumeration was ~85–90% of query time.) Adds `bench_wildcard_query` alongside the existing fuzzy bench.

## Testing

- New e2e tests: 4 query types × {1, 2} segments (red-before/green-after for multi-segment).
- `cargo test -p laurus --lib`: 1185/1185; all lexical/engine integration suites green; fmt/clippy clean.

## Follow-ups (documented on the issue, not pursued here)

- Cross-request caching of rewritten queries (`cache_key` integration).
- Lazy `InvertedIndexTermsEnum` (it still clones the full dictionary once per request — the remaining enumeration cost).

Closes #613
