### PR TITLE
chore(lexical/query): fix clippy 1.97 question_mark lint in next_block_boundary (#851)

### DIFF
--- a/laurus/src/lexical/query/scorer.rs
+++ b/laurus/src/lexical/query/scorer.rs
@@ -958,15 +958,11 @@ impl Scorer for BooleanScorer {
         let clauses = self.clauses.borrow();
         let mut min_boundary: Option<u64> = None;
         for (scorer, _) in clauses.iter() {
-            match scorer.next_block_boundary(doc_id) {
-                None => return None,
-                Some(b) => {
-                    min_boundary = Some(match min_boundary {
-                        None => b,
-                        Some(m) => m.min(b),
-                    });
-                }
-            }
+            let b = scorer.next_block_boundary(doc_id)?;
+            min_boundary = Some(match min_boundary {
+                None => b,
+                Some(m) => m.min(b),
+            });
         }
         min_boundary
     }


### PR DESCRIPTION
## Summary

Rust 1.97.0 (on the CI runners since 2026-07-09) broadened `clippy::question_mark`, which now fires on the match-with-early-`None` in `BooleanScorer::next_block_boundary` (`laurus/src/lexical/query/scorer.rs:961`) and fails every clippy gate repo-wide. First seen on PR #850's `Test laurus-wasm` job; the repo-level Clippy job passed there only because it still resolved the previous stable at run time.

One-line-class fix: replace the match with the `?` operator, exactly as clippy suggests. Behavior-identical — the early `None` return is preserved, so the conservative "any clause without block info disables the skip" semantics are unchanged.

## Testing

- `cargo +1.97.0 clippy --workspace --all-targets --features laurus/embeddings-all -- -D warnings` — clean
- `cargo +1.97.0 clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings` — clean (reproduces the CI failure before the fix)
- `cargo fmt --check` clean; boolean scorer tests 36/36 green

Closes #851
