### PR TITLE
feat(bindings): `put_documents` / `add_documents` across python, nodejs, wasm, ruby, php (#866)

### DIFF
--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -28,6 +28,8 @@ class Index {
 | :--- | :--- |
 | `putDocument(id, doc)` | ドキュメントを上書き保存。 |
 | `addDocument(id, doc)` | 既存バージョンを残してチャンクを追記。 |
+| `putDocuments(docs)` | バッチ upsert。`docs` は `Array<[id, doc]>` で、バッチごとに WAL fsync 1 回で順に適用（重複 ID はデデュープ、最後が勝ち）。最初の不正エントリで fail-fast し、適用済みの prefix はロールバックされません。 |
+| `addDocuments(docs)` | バッチチャンク追記。`putDocuments` と同様ですが、繰り返した ID は別バージョンとして蓄積されます。 |
 | `getDocuments(id)` | 指定 ID の全バージョンを取得。 |
 | `deleteDocuments(id)` | 指定 ID の全バージョンを削除。 |
 | `commit()` | 書き込みをフラッシュし変更を検索可能にする。 |

--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -22,6 +22,8 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $
 | :--- | :--- |
 | `putDocument(string $id, array $doc): void` | ドキュメントをアップサート（upsert）します。同じ ID の既存バージョンをすべて置換します。 |
 | `addDocument(string $id, array $doc): void` | 既存バージョンを削除せずにドキュメントチャンクを追記します。 |
+| `putDocuments(array $docs): void` | バッチ upsert。`$docs` は `[$id, $doc]` ペアの配列で、バッチごとに WAL fsync 1 回で順に適用します（重複 ID はデデュープ、最後が勝ち）。最初の不正エントリで fail-fast し、適用済みの prefix はロールバックされません。 |
+| `addDocuments(array $docs): void` | バッチチャンク追記。`putDocuments` と同様ですが、繰り返した ID は別バージョンとして蓄積されます。 |
 | `getDocuments(string $id): array` | 指定 ID の全保存バージョンを返します。 |
 | `deleteDocuments(string $id): void` | 指定 ID の全バージョンを削除します。 |
 | `commit(): void` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |

--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -28,6 +28,8 @@ class Index:
 | :--- | :--- |
 | `put_document(id, doc)` | ドキュメントをアップサート（upsert）します。同じ ID の既存バージョンをすべて置換します。 |
 | `add_document(id, doc)` | 既存バージョンを削除せずにドキュメントチャンクを追記します。 |
+| `put_documents(docs)` | バッチ upsert。`docs` は `(id, dict)` ペアのイテラブルで、バッチごとに WAL fsync 1 回で順に適用します（重複 ID はデデュープ、最後が勝ち）。最初の不正エントリで fail-fast し、適用済みの prefix はロールバックされません。 |
+| `add_documents(docs)` | バッチチャンク追記。`put_documents` と同様ですが、繰り返した ID は別バージョンとして蓄積されます。 |
 | `get_documents(id) -> list[dict]` | 指定 ID の全保存バージョンを返します。 |
 | `delete_documents(id)` | 指定 ID の全バージョンを削除します。 |
 | `commit()` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |

--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -22,6 +22,8 @@ Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil)
 | :--- | :--- |
 | `put_document(id, doc)` | ドキュメントをアップサート（upsert）します。同じ ID の既存バージョンをすべて置換します。 |
 | `add_document(id, doc)` | 既存バージョンを削除せずにドキュメントチャンクを追記します。 |
+| `put_documents(docs)` | バッチ upsert。`docs` は `[id, hash]` ペアの `Array` で、バッチごとに WAL fsync 1 回で順に適用します（重複 ID はデデュープ、最後が勝ち）。最初の不正エントリで fail-fast し、適用済みの prefix はロールバックされません。 |
+| `add_documents(docs)` | バッチチャンク追記。`put_documents` と同様ですが、繰り返した ID は別バージョンとして蓄積されます。 |
 | `get_documents(id) -> Array<Hash>` | 指定 ID の全保存バージョンを返します。 |
 | `delete_documents(id)` | 指定 ID の全バージョンを削除します。 |
 | `commit` | バッファリングされた書き込みをフラッシュし、すべての保留中の変更を検索可能にします。 |

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -46,6 +46,20 @@ OPFS で永続化されたインデックスを開くか、新規作成します
 
 - **引数・戻り値:** `putDocument` と同じ
 
+#### `putDocuments(docs)`
+
+バッチ upsert。ペアをバッチ全体で WAL fsync 1 回で順に適用します。1 バッチ内で重複した ID はデデュープされます（最後が勝ち）。最初の不正エントリで fail-fast し、適用済みの prefix はロールバックされません（再試行は冪等）。
+
+- **引数:**
+  - `docs` (`Array<[string, object]>`) -- `[id, document]` ペアの配列
+- **戻り値:** `Promise<void>`
+
+#### `addDocuments(docs)`
+
+バッチチャンク追記。`putDocuments` と同様ですが、繰り返した ID は別バージョンとして蓄積されます。
+
+- **引数・戻り値:** `putDocuments` と同じ
+
 #### `getDocuments(id)`
 
 ドキュメントの全バージョンを取得します。

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -28,6 +28,8 @@ class Index {
 | :--- | :--- |
 | `putDocument(id, doc)` | Upsert a document. Replaces all existing versions. |
 | `addDocument(id, doc)` | Append a document chunk without removing existing versions. |
+| `putDocuments(docs)` | Batched upsert. `docs` is an `Array<[id, doc]>` applied in order with one WAL fsync per batch (duplicate ids dedup, last wins). Fails fast at the first bad entry; the applied prefix is not rolled back. |
+| `addDocuments(docs)` | Batched chunk append. Like `putDocuments` but repeated ids accumulate as separate versions. |
 | `getDocuments(id)` | Return all stored versions for the given ID. |
 | `deleteDocuments(id)` | Delete all versions for the given ID. |
 | `commit()` | Flush writes and make pending changes searchable. |

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -22,6 +22,8 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $
 | :--- | :--- |
 | `putDocument(string $id, array $doc): void` | Upsert a document. Replaces all existing versions with the same ID. |
 | `addDocument(string $id, array $doc): void` | Append a document chunk without removing existing versions. |
+| `putDocuments(array $docs): void` | Batched upsert. `$docs` is an array of `[$id, $doc]` pairs, applied in order with one WAL fsync per batch (duplicate ids dedup, last wins). Fails fast at the first bad entry; the applied prefix is not rolled back. |
+| `addDocuments(array $docs): void` | Batched chunk append. Like `putDocuments` but repeated ids accumulate as separate versions. |
 | `getDocuments(string $id): array` | Return all stored versions for the given ID. |
 | `deleteDocuments(string $id): void` | Delete all versions for the given ID. |
 | `commit(): void` | Flush buffered writes and make all pending changes searchable. |

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -28,6 +28,8 @@ class Index:
 | :--- | :--- |
 | `put_document(id, doc)` | Upsert a document. Replaces all existing versions with the same ID. |
 | `add_document(id, doc)` | Append a document chunk without removing existing versions. |
+| `put_documents(docs)` | Batched upsert. `docs` is an iterable of `(id, dict)` pairs, applied in order with one WAL fsync per batch (duplicate ids dedup, last wins). Fails fast at the first bad entry; the applied prefix is not rolled back. |
+| `add_documents(docs)` | Batched chunk append. Like `put_documents` but repeated ids accumulate as separate versions. |
 | `get_documents(id) -> list[dict]` | Return all stored versions for the given ID. |
 | `delete_documents(id)` | Delete all versions for the given ID. |
 | `commit()` | Flush buffered writes and make all pending changes searchable. |

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -22,6 +22,8 @@ Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil)
 | :--- | :--- |
 | `put_document(id, doc)` | Upsert a document. Replaces all existing versions with the same ID. |
 | `add_document(id, doc)` | Append a document chunk without removing existing versions. |
+| `put_documents(docs)` | Batched upsert. `docs` is an `Array` of `[id, hash]` pairs, applied in order with one WAL fsync per batch (duplicate ids dedup, last wins). Fails fast at the first bad entry; the applied prefix is not rolled back. |
+| `add_documents(docs)` | Batched chunk append. Like `put_documents` but repeated ids accumulate as separate versions. |
 | `get_documents(id) -> Array<Hash>` | Return all stored versions for the given ID. |
 | `delete_documents(id)` | Delete all versions for the given ID. |
 | `commit` | Flush buffered writes and make all pending changes searchable. |

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -46,6 +46,20 @@ Append a document version (multi-version RAG pattern).
 
 - **Parameters / Returns:** Same as `putDocument`.
 
+#### `putDocuments(docs)`
+
+Batched upsert. Applies the pairs in order with one WAL fsync for the whole batch; duplicate ids within one batch dedup (last occurrence wins). Fails fast at the first bad entry, and the applied prefix is not rolled back (retrying is idempotent).
+
+- **Parameters:**
+  - `docs` (`Array<[string, object]>`) -- An array of `[id, document]` pairs.
+- **Returns:** `Promise<void>`
+
+#### `addDocuments(docs)`
+
+Batched chunk append. Like `putDocuments` but repeated ids accumulate as separate versions.
+
+- **Parameters / Returns:** Same as `putDocuments`.
+
 #### `getDocuments(id)`
 
 Retrieve all versions of a document.

--- a/laurus-nodejs/__tests__/batch_ingest.spec.mjs
+++ b/laurus-nodejs/__tests__/batch_ingest.spec.mjs
@@ -1,0 +1,56 @@
+/**
+ * Integration tests for `Index.putDocuments` / `Index.addDocuments` (#866).
+ *
+ * Covers:
+ * - Empty batch is a no-op.
+ * - `putDocuments` applies the batch and deduplicates duplicate ids within
+ *   one batch (last occurrence wins).
+ * - `addDocuments` accumulates repeated ids as separate versions.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Index, Schema } from "../index.js";
+
+async function createTextIndex() {
+  const schema = new Schema();
+  schema.addTextField("title");
+  schema.setDefaultFields(["title"]);
+  return await Index.create(null, schema);
+}
+
+describe("putDocuments / addDocuments", () => {
+  it("empty batch is a no-op", async () => {
+    const index = await createTextIndex();
+    await index.putDocuments([]);
+    await index.addDocuments([]);
+    await index.commit();
+    expect(index.stats().documentCount).toBe(0);
+  });
+
+  it("putDocuments applies the batch and dedups duplicate ids", async () => {
+    const index = await createTextIndex();
+    await index.putDocuments([
+      ["doc1", { title: "One" }],
+      ["doc2", { title: "Two" }],
+      ["doc1", { title: "One v2" }],
+    ]);
+    await index.commit();
+
+    expect(index.stats().documentCount).toBe(2);
+    const docs = await index.getDocuments("doc1");
+    expect(docs.length).toBe(1);
+    expect(docs[0].title).toBe("One v2");
+  });
+
+  it("addDocuments accumulates repeated ids as chunks", async () => {
+    const index = await createTextIndex();
+    await index.addDocuments([
+      ["doc", { title: "chunk 0" }],
+      ["doc", { title: "chunk 1" }],
+    ]);
+    await index.commit();
+
+    const docs = await index.getDocuments("doc");
+    expect(docs.length).toBe(2);
+  });
+});

--- a/laurus-nodejs/src/index.rs
+++ b/laurus-nodejs/src/index.rs
@@ -139,6 +139,46 @@ impl JsIndex {
             .map_err(laurus_err)
     }
 
+    /// Index many documents in one call, replacing existing documents by id.
+    ///
+    /// Batched form of `putDocument`: the `[id, doc]` pairs are applied
+    /// sequentially, in order, with one WAL fsync for the whole batch.
+    /// Duplicate ids within one batch deduplicate exactly like the same puts
+    /// issued one by one (the last occurrence wins). Fails fast at the first
+    /// document that cannot be indexed; documents applied before the failure
+    /// are **not** rolled back (retrying the batch is idempotent).
+    ///
+    /// # Arguments
+    ///
+    /// * `docs` - An array of `[id, doc]` pairs.
+    #[napi]
+    pub async fn put_documents(&self, docs: Vec<(String, Value)>) -> Result<()> {
+        let batch = pairs_to_documents(docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        self.engine.put_documents(batch).await.map_err(laurus_err)
+    }
+
+    /// Append many document versions in one call, without removing existing
+    /// versions.
+    ///
+    /// Batched form of `addDocument`. Ordering, single-fsync durability, and
+    /// fail-fast error semantics match `putDocuments`, but repeated ids
+    /// accumulate as separate versions instead of deduplicating.
+    ///
+    /// # Arguments
+    ///
+    /// * `docs` - An array of `[id, doc]` pairs.
+    #[napi]
+    pub async fn add_documents(&self, docs: Vec<(String, Value)>) -> Result<()> {
+        let batch = pairs_to_documents(docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        self.engine.add_documents(batch).await.map_err(laurus_err)
+    }
+
     /// Retrieve all document versions stored under `id`.
     ///
     /// # Arguments
@@ -424,6 +464,25 @@ impl JsIndex {
             "vectorFields": vector_fields,
         }))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Batch-ingestion helper
+// ---------------------------------------------------------------------------
+
+/// Convert an array of `(id, doc)` pairs into the engine's
+/// `(String, Document)` batch, naming the offending position on any entry
+/// whose document cannot be converted.
+fn pairs_to_documents(docs: Vec<(String, Value)>) -> Result<Vec<(String, laurus::Document)>> {
+    docs.into_iter()
+        .enumerate()
+        .map(|(index, (id, doc))| {
+            let document = json_to_document(&doc)
+                .map_err(|e| laurus::LaurusError::other(format!("documents[{index}]: {e}")))
+                .map_err(laurus_err)?;
+            Ok((id, document))
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/laurus-php/src/index.rs
+++ b/laurus-php/src/index.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use ext_php_rs::convert::FromZval;
 use ext_php_rs::prelude::*;
 use ext_php_rs::types::{ZendHashTable, Zval};
 use laurus::{
@@ -246,6 +247,50 @@ impl PhpIndex {
             .map_err(laurus_err)
     }
 
+    /// Index many documents in one call, replacing existing documents by id.
+    ///
+    /// Batched form of `putDocument()`: the `[id, doc]` pairs are applied
+    /// sequentially, in order, with one WAL fsync for the whole batch.
+    /// Duplicate ids within one batch deduplicate exactly like the same puts
+    /// issued one by one (the last occurrence wins). Fails fast at the first
+    /// document that cannot be indexed; documents applied before the failure
+    /// are **not** rolled back (retrying the batch is idempotent).
+    ///
+    /// # Arguments
+    ///
+    /// * `docs` - An array of `[id, doc]` pairs.
+    pub fn put_documents(&self, docs: &Zval) -> PhpResult<()> {
+        let batch = pairs_to_documents(docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let engine = self.engine.clone();
+        self.rt
+            .block_on(engine.put_documents(batch))
+            .map_err(laurus_err)
+    }
+
+    /// Append many document versions in one call, without removing existing
+    /// versions.
+    ///
+    /// Batched form of `addDocument()`. Ordering, single-fsync durability, and
+    /// fail-fast error semantics match `putDocuments()`, but repeated ids
+    /// accumulate as separate versions instead of deduplicating.
+    ///
+    /// # Arguments
+    ///
+    /// * `docs` - An array of `[id, doc]` pairs.
+    pub fn add_documents(&self, docs: &Zval) -> PhpResult<()> {
+        let batch = pairs_to_documents(docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let engine = self.engine.clone();
+        self.rt
+            .block_on(engine.add_documents(batch))
+            .map_err(laurus_err)
+    }
+
     /// Retrieve all document versions stored under `id`.
     ///
     /// # Arguments
@@ -478,6 +523,40 @@ impl PhpIndex {
 // ---------------------------------------------------------------------------
 
 /// Create a storage backend from an optional path.
+/// Convert an array of `[id, doc]` pairs into the engine's
+/// `(String, Document)` batch, raising an exception that names the offending
+/// position on any entry that is not a two-element `[string, array]` pair.
+///
+/// # Arguments
+///
+/// * `docs` - A PHP array of `[id, doc]` pairs.
+fn pairs_to_documents(docs: &Zval) -> PhpResult<Vec<(String, laurus::Document)>> {
+    let arr = docs
+        .array()
+        .ok_or_else(|| PhpException::from("expected an array of [id, doc] pairs".to_string()))?;
+
+    let mut batch = Vec::with_capacity(arr.len());
+    for (index, (_, pair_zv)) in arr.iter().enumerate() {
+        let pair = pair_zv.array().ok_or_else(|| {
+            PhpException::from(format!("documents[{index}]: expected an [id, doc] pair"))
+        })?;
+        let values: Vec<&Zval> = pair.iter().map(|(_, v)| v).collect();
+        if values.len() != 2 {
+            return Err(PhpException::from(format!(
+                "documents[{index}]: expected a 2-element [id, doc] pair"
+            )));
+        }
+        let id = String::from_zval(values[0]).ok_or_else(|| {
+            PhpException::from(format!("documents[{index}]: id must be a string"))
+        })?;
+        let doc = values[1].array().ok_or_else(|| {
+            PhpException::from(format!("documents[{index}]: document must be an array"))
+        })?;
+        batch.push((id, hashtable_to_document(doc)?));
+    }
+    Ok(batch)
+}
+
 ///
 /// # Arguments
 ///

--- a/laurus-php/tests/LaurusTest.php
+++ b/laurus-php/tests/LaurusTest.php
@@ -138,6 +138,45 @@ class LaurusTest extends TestCase
         $this->assertCount(0, $docs);
     }
 
+    // ── Batch ingestion (#866) ───────────────────────────────────────────
+
+    public function testPutDocumentsEmptyBatchIsNoop(): void
+    {
+        $idx = new Laurus\Index();
+        $idx->putDocuments([]);
+        $idx->addDocuments([]);
+        $idx->commit();
+        $this->assertEquals(0, $idx->stats()["documentCount"]);
+    }
+
+    public function testPutDocumentsAppliesAndDedupes(): void
+    {
+        $idx = new Laurus\Index();
+        $idx->putDocuments([
+            ["doc1", ["title" => "One"]],
+            ["doc2", ["title" => "Two"]],
+            ["doc1", ["title" => "One v2"]], // duplicate id: last wins
+        ]);
+        $idx->commit();
+
+        $this->assertEquals(2, $idx->stats()["documentCount"]);
+        $docs = $idx->getDocuments("doc1");
+        $this->assertCount(1, $docs);
+        $this->assertEquals("One v2", $docs[0]["title"]);
+    }
+
+    public function testAddDocumentsAccumulatesChunks(): void
+    {
+        $idx = new Laurus\Index();
+        $idx->addDocuments([
+            ["doc", ["title" => "chunk 0"]],
+            ["doc", ["title" => "chunk 1"]],
+        ]);
+        $idx->commit();
+
+        $this->assertCount(2, $idx->getDocuments("doc"));
+    }
+
     // ── Statistics ───────────────────────────────────────────────────────
 
     public function testDocumentCount(): void

--- a/laurus-python/src/index.rs
+++ b/laurus-python/src/index.rs
@@ -261,6 +261,51 @@ impl PyIndex {
             .map_err(laurus_err)
     }
 
+    /// Index many documents in one call, replacing existing documents by id.
+    ///
+    /// Batched form of [`put_document`]: the `(id, dict)` pairs are applied
+    /// sequentially, in order, with a single WAL fsync for the whole batch.
+    /// Duplicate ids within one batch deduplicate exactly like the same puts
+    /// issued one by one (the last occurrence wins).
+    ///
+    /// Args:
+    ///     docs: An iterable of `(id, dict)` pairs.
+    ///
+    /// Fails fast at the first document that cannot be indexed; the raised
+    /// error names the failing position and id. Documents applied before the
+    /// failure are **not** rolled back (retrying the batch is idempotent).
+    /// Call [`commit`] to make the changes visible to searches.
+    pub fn put_documents(&self, py: Python, docs: &Bound<PyAny>) -> PyResult<()> {
+        let batch = pairs_to_documents(py, docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let engine = self.engine.clone();
+        self.rt
+            .block_on(engine.put_documents(batch))
+            .map_err(laurus_err)
+    }
+
+    /// Append many document versions in one call, without removing existing
+    /// versions.
+    ///
+    /// Batched form of [`add_document`]. Ordering, single-fsync durability,
+    /// and fail-fast error semantics match [`put_documents`], but repeated
+    /// ids accumulate as separate versions instead of deduplicating.
+    ///
+    /// Args:
+    ///     docs: An iterable of `(id, dict)` pairs.
+    pub fn add_documents(&self, py: Python, docs: &Bound<PyAny>) -> PyResult<()> {
+        let batch = pairs_to_documents(py, docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let engine = self.engine.clone();
+        self.rt
+            .block_on(engine.add_documents(batch))
+            .map_err(laurus_err)
+    }
+
     /// Retrieve all document versions stored under `id`.
     ///
     /// Returns a list of dicts, one per indexed version.
@@ -449,6 +494,36 @@ impl PyIndex {
     fn __repr__(&self) -> String {
         "Index()".to_string()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Batch-ingestion helper
+// ---------------------------------------------------------------------------
+
+/// Convert a Python iterable of `(id, dict)` pairs into the engine's
+/// `(String, Document)` batch, naming the offending position on any entry
+/// that is not a two-element `(str, dict)` pair.
+fn pairs_to_documents(
+    py: Python,
+    docs: &Bound<PyAny>,
+) -> PyResult<Vec<(String, laurus::Document)>> {
+    let iter = docs.try_iter().map_err(|_| {
+        PyRuntimeError::new_err(
+            "expected an iterable of (id, dict) pairs, e.g. [(\"doc1\", {\"title\": \"...\"}), ...]",
+        )
+    })?;
+
+    let mut batch = Vec::new();
+    for (index, item) in iter.enumerate() {
+        let item = item?;
+        let (id, doc): (String, Bound<PyDict>) = item.extract().map_err(|_| {
+            PyRuntimeError::new_err(format!(
+                "documents[{index}]: expected a (id: str, doc: dict) pair"
+            ))
+        })?;
+        batch.push((id, dict_to_document(py, &doc)?));
+    }
+    Ok(batch)
 }
 
 // ---------------------------------------------------------------------------

--- a/laurus-python/tests/test_batch_ingest.py
+++ b/laurus-python/tests/test_batch_ingest.py
@@ -1,0 +1,61 @@
+"""Integration tests for ``Index.put_documents`` / ``Index.add_documents`` (#866).
+
+These tests cover the Python-facing batched ingestion API:
+
+- Empty batch is a no-op.
+- ``put_documents`` applies the batch and deduplicates duplicate ids
+  within one batch (last occurrence wins), matching a sequence of
+  ``put_document`` calls.
+- ``add_documents`` accumulates repeated ids as separate versions.
+- A malformed entry (not an ``(id, dict)`` pair) is rejected naming its
+  position.
+"""
+
+import pytest
+import laurus
+
+
+def test_put_documents_empty_batch_is_noop():
+    idx = laurus.Index()
+    idx.put_documents([])
+    idx.add_documents([])
+    idx.commit()
+    assert idx.stats()["document_count"] == 0
+
+
+def test_put_documents_applies_and_dedupes():
+    idx = laurus.Index()
+    idx.put_documents(
+        [
+            ("doc1", {"title": "One"}),
+            ("doc2", {"title": "Two"}),
+            ("doc1", {"title": "One v2"}),  # duplicate id: last wins
+        ]
+    )
+    idx.commit()
+
+    assert idx.stats()["document_count"] == 2
+    docs = idx.get_documents("doc1")
+    assert len(docs) == 1
+    assert docs[0]["title"] == "One v2"
+
+
+def test_add_documents_accumulates_chunks():
+    idx = laurus.Index()
+    idx.add_documents(
+        [
+            ("doc", {"title": "chunk 0"}),
+            ("doc", {"title": "chunk 1"}),
+        ]
+    )
+    idx.commit()
+
+    docs = idx.get_documents("doc")
+    assert len(docs) == 2
+
+
+def test_put_documents_rejects_malformed_entry():
+    idx = laurus.Index()
+    with pytest.raises(Exception) as excinfo:
+        idx.put_documents([("ok", {"title": "fine"}), "not-a-pair"])
+    assert "documents[1]" in str(excinfo.value)

--- a/laurus-ruby/src/index.rs
+++ b/laurus-ruby/src/index.rs
@@ -135,6 +135,52 @@ impl RbIndex {
             .map_err(laurus_err)
     }
 
+    /// Index many documents in one call, replacing existing documents by id.
+    ///
+    /// Batched form of `put_document`: the `[id, hash]` pairs are applied
+    /// sequentially, in order, with one WAL fsync for the whole batch.
+    /// Duplicate ids within one batch deduplicate exactly like the same puts
+    /// issued one by one (the last occurrence wins). Fails fast at the first
+    /// document that cannot be indexed; documents applied before the failure
+    /// are **not** rolled back (retrying the batch is idempotent).
+    ///
+    /// # Arguments
+    ///
+    /// * `docs` - An Array of `[id, hash]` pairs.
+    fn put_documents(&self, docs: RArray) -> Result<(), Error> {
+        let ruby = Ruby::get().expect("called from Ruby thread");
+        let batch = pairs_to_documents(&ruby, docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let engine = self.engine.clone();
+        self.rt
+            .block_on(engine.put_documents(batch))
+            .map_err(laurus_err)
+    }
+
+    /// Append many document versions in one call, without removing existing
+    /// versions.
+    ///
+    /// Batched form of `add_document`. Ordering, single-fsync durability, and
+    /// fail-fast error semantics match `put_documents`, but repeated ids
+    /// accumulate as separate versions instead of deduplicating.
+    ///
+    /// # Arguments
+    ///
+    /// * `docs` - An Array of `[id, hash]` pairs.
+    fn add_documents(&self, docs: RArray) -> Result<(), Error> {
+        let ruby = Ruby::get().expect("called from Ruby thread");
+        let batch = pairs_to_documents(&ruby, docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let engine = self.engine.clone();
+        self.rt
+            .block_on(engine.add_documents(batch))
+            .map_err(laurus_err)
+    }
+
     /// Retrieve all document versions stored under `id`.
     ///
     /// # Arguments
@@ -365,6 +411,50 @@ impl RbIndex {
 ///
 /// # Arguments
 ///
+/// Convert an Array of `[id, hash]` pairs into the engine's
+/// `(String, Document)` batch, raising an ArgumentError that names the
+/// offending position on any entry that is not a two-element `[String, Hash]`
+/// pair.
+///
+/// # Arguments
+///
+/// * `ruby` - The current Ruby interpreter handle.
+/// * `docs` - An Array of `[id, hash]` pairs.
+fn pairs_to_documents(
+    ruby: &Ruby,
+    docs: RArray,
+) -> Result<Vec<(String, laurus::Document)>, Error> {
+    let mut batch = Vec::with_capacity(docs.len());
+    for (index, item) in docs.into_iter().enumerate() {
+        let pair: RArray = TryConvert::try_convert(item).map_err(|_| {
+            Error::new(
+                ruby.exception_arg_error(),
+                format!("documents[{index}]: expected an [id, hash] pair"),
+            )
+        })?;
+        if pair.len() != 2 {
+            return Err(Error::new(
+                ruby.exception_arg_error(),
+                format!("documents[{index}]: expected a 2-element [id, hash] pair"),
+            ));
+        }
+        let id: String = TryConvert::try_convert(pair.entry(0)?).map_err(|_| {
+            Error::new(
+                ruby.exception_arg_error(),
+                format!("documents[{index}]: id must be a String"),
+            )
+        })?;
+        let hash: RHash = TryConvert::try_convert(pair.entry(1)?).map_err(|_| {
+            Error::new(
+                ruby.exception_arg_error(),
+                format!("documents[{index}]: document must be a Hash"),
+            )
+        })?;
+        batch.push((id, hash_to_document(ruby, hash)?));
+    }
+    Ok(batch)
+}
+
 /// * `path` - Optional directory path. `None` means in-memory storage.
 ///
 /// # Returns
@@ -396,6 +486,8 @@ pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     class.define_singleton_method("new", magnus::function!(RbIndex::new, -1))?;
     class.define_method("put_document", magnus::method!(RbIndex::put_document, 2))?;
     class.define_method("add_document", magnus::method!(RbIndex::add_document, 2))?;
+    class.define_method("put_documents", magnus::method!(RbIndex::put_documents, 1))?;
+    class.define_method("add_documents", magnus::method!(RbIndex::add_documents, 1))?;
     class.define_method("get_documents", magnus::method!(RbIndex::get_documents, 1))?;
     class.define_method(
         "delete_documents",

--- a/laurus-ruby/src/index.rs
+++ b/laurus-ruby/src/index.rs
@@ -420,10 +420,7 @@ impl RbIndex {
 ///
 /// * `ruby` - The current Ruby interpreter handle.
 /// * `docs` - An Array of `[id, hash]` pairs.
-fn pairs_to_documents(
-    ruby: &Ruby,
-    docs: RArray,
-) -> Result<Vec<(String, laurus::Document)>, Error> {
+fn pairs_to_documents(ruby: &Ruby, docs: RArray) -> Result<Vec<(String, laurus::Document)>, Error> {
     let mut batch = Vec::with_capacity(docs.len());
     for (index, item) in docs.into_iter().enumerate() {
         let pair: RArray = TryConvert::try_convert(item).map_err(|_| {

--- a/laurus-ruby/test/test_batch_ingest.rb
+++ b/laurus-ruby/test/test_batch_ingest.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Integration tests for Laurus::Index#put_documents / #add_documents (#866).
+class TestBatchIngest < Minitest::Test
+  def test_put_documents_empty_batch_is_noop
+    idx = Laurus::Index.new
+    idx.put_documents([])
+    idx.add_documents([])
+    idx.commit
+    assert_equal 0, idx.stats["document_count"]
+  end
+
+  def test_put_documents_applies_and_dedupes
+    idx = Laurus::Index.new
+    idx.put_documents([
+                        ["doc1", { "title" => "One" }],
+                        ["doc2", { "title" => "Two" }],
+                        ["doc1", { "title" => "One v2" }] # duplicate id: last wins
+                      ])
+    idx.commit
+
+    assert_equal 2, idx.stats["document_count"]
+    docs = idx.get_documents("doc1")
+    assert_equal 1, docs.length
+    assert_equal "One v2", docs[0]["title"]
+  end
+
+  def test_add_documents_accumulates_chunks
+    idx = Laurus::Index.new
+    idx.add_documents([
+                        ["doc", { "title" => "chunk 0" }],
+                        ["doc", { "title" => "chunk 1" }]
+                      ])
+    idx.commit
+
+    assert_equal 2, idx.get_documents("doc").length
+  end
+
+  def test_put_documents_rejects_malformed_entry
+    idx = Laurus::Index.new
+    error = assert_raises(ArgumentError) do
+      idx.put_documents([["ok", { "title" => "fine" }], "not-a-pair"])
+    end
+    assert_includes error.message, "documents[1]"
+  end
+end

--- a/laurus-wasm/src/index.rs
+++ b/laurus-wasm/src/index.rs
@@ -75,14 +75,19 @@ fn documents_to_js(docs: Vec<laurus::Document>) -> Result<JsValue, JsValue> {
 /// `(String, Document)` batch, naming the offending position on any entry
 /// that is not a `[string, object]` pair.
 fn pairs_to_documents(docs: JsValue) -> Result<Vec<(String, laurus::Document)>, JsValue> {
-    let pairs: Vec<(String, serde_json::Value)> = serde_wasm_bindgen::from_value(docs)
-        .map_err(|e| JsValue::from_str(&format!("Invalid documents: expected an array of [id, doc] pairs: {e}")))?;
+    let pairs: Vec<(String, serde_json::Value)> =
+        serde_wasm_bindgen::from_value(docs).map_err(|e| {
+            JsValue::from_str(&format!(
+                "Invalid documents: expected an array of [id, doc] pairs: {e}"
+            ))
+        })?;
     pairs
         .into_iter()
         .enumerate()
         .map(|(index, (id, doc))| {
-            let document = json_to_document(&doc)
-                .map_err(|e| JsValue::from_str(&format!("documents[{index}]: {}", js_error_string(&e))))?;
+            let document = json_to_document(&doc).map_err(|e| {
+                JsValue::from_str(&format!("documents[{index}]: {}", js_error_string(&e)))
+            })?;
             Ok((id, document))
         })
         .collect()

--- a/laurus-wasm/src/index.rs
+++ b/laurus-wasm/src/index.rs
@@ -71,6 +71,28 @@ fn documents_to_js(docs: Vec<laurus::Document>) -> Result<JsValue, JsValue> {
     js_sys::JSON::parse(&json_str)
 }
 
+/// Convert a JS array of `[id, doc]` pairs into the engine's
+/// `(String, Document)` batch, naming the offending position on any entry
+/// that is not a `[string, object]` pair.
+fn pairs_to_documents(docs: JsValue) -> Result<Vec<(String, laurus::Document)>, JsValue> {
+    let pairs: Vec<(String, serde_json::Value)> = serde_wasm_bindgen::from_value(docs)
+        .map_err(|e| JsValue::from_str(&format!("Invalid documents: expected an array of [id, doc] pairs: {e}")))?;
+    pairs
+        .into_iter()
+        .enumerate()
+        .map(|(index, (id, doc))| {
+            let document = json_to_document(&doc)
+                .map_err(|e| JsValue::from_str(&format!("documents[{index}]: {}", js_error_string(&e))))?;
+            Ok((id, document))
+        })
+        .collect()
+}
+
+/// Best-effort string form of a `JsValue` error for message composition.
+fn js_error_string(e: &JsValue) -> String {
+    e.as_string().unwrap_or_else(|| format!("{e:?}"))
+}
+
 /// Build a [`PerFieldEmbedder`] from JS callback embedders and the schema.
 ///
 /// Reads the schema to find which vector fields reference which embedder name,
@@ -279,6 +301,46 @@ impl WasmIndex {
             .add_document(&id, document)
             .await
             .map_err(laurus_err)
+    }
+
+    /// Index many documents in one call, replacing existing documents by id.
+    ///
+    /// Batched form of `putDocument`: the `[id, doc]` pairs are applied
+    /// sequentially, in order, with one WAL fsync for the whole batch.
+    /// Duplicate ids within one batch deduplicate exactly like the same puts
+    /// issued one by one (the last occurrence wins). Fails fast at the first
+    /// document that cannot be indexed; documents applied before the failure
+    /// are **not** rolled back (retrying the batch is idempotent).
+    ///
+    /// # Arguments
+    ///
+    /// * `docs` - A JS array of `[id, doc]` pairs.
+    #[wasm_bindgen(js_name = "putDocuments")]
+    pub async fn put_documents(&self, docs: JsValue) -> Result<(), JsValue> {
+        let batch = pairs_to_documents(docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        self.engine.put_documents(batch).await.map_err(laurus_err)
+    }
+
+    /// Append many document versions in one call, without removing existing
+    /// versions.
+    ///
+    /// Batched form of `addDocument`. Ordering, single-fsync durability, and
+    /// fail-fast error semantics match `putDocuments`, but repeated ids
+    /// accumulate as separate versions instead of deduplicating.
+    ///
+    /// # Arguments
+    ///
+    /// * `docs` - A JS array of `[id, doc]` pairs.
+    #[wasm_bindgen(js_name = "addDocuments")]
+    pub async fn add_documents(&self, docs: JsValue) -> Result<(), JsValue> {
+        let batch = pairs_to_documents(docs)?;
+        if batch.is_empty() {
+            return Ok(());
+        }
+        self.engine.add_documents(batch).await.map_err(laurus_err)
     }
 
     /// Retrieve all document versions stored under `id`.


### PR DESCRIPTION
## Summary

Exposes the batch ingestion API (#551 PR-4, the campaign's final PR) in all five language bindings, on top of the merged `Engine::put_documents` / `add_documents`.

Each binding gains `put_documents` / `add_documents` (`putDocuments` / `addDocuments` in the camelCase hosts), taking a **list of `(id, document)` pairs** — the most direct mirror of the core `Vec<(String, Document)>` signature and the natural batched form of each binding's existing singular `put_document(id, doc)`. Semantics carry through from the core: sequential in-order application, one WAL fsync per batch, duplicate-id dedup within a `put` batch (last wins), chunk accumulation for `add`, and fail-fast with the applied prefix left in place (retrying is idempotent). Each binding's converter names the offending position on a malformed entry, and an empty batch is a no-op.

| Binding | Method shape | Notes |
|---|---|---|
| Python | `put_documents([(id, dict), ...])` | iterable of `(str, dict)` pairs |
| Node.js | `putDocuments([[id, obj], ...])` | `Vec<(String, Value)>` napi tuple marshalling; `index.d.ts` regenerated |
| wasm | `putDocuments([[id, obj], ...])` | JS array via `serde_wasm_bindgen`; `.d.ts` regenerated |
| Ruby | `put_documents([[id, hash], ...])` | manual `define_method` registration added |
| PHP | `putDocuments([[$id, $doc], ...])` | nested-array marshalling |

The `BatchIngest` error surfaces message-only through each binding's existing error mapper (the message already carries `failed_index` / `failed_id` / `applied` via `Display`); no new host exception types.

## Verification (real runtime tests, not just compile)

- **Python** — `maturin develop` + pytest: 4/4 (`test_batch_ingest.py`: empty no-op, apply+dedup, chunk accumulation, malformed-entry position).
- **Node.js** — `napi build` + vitest: 58/58 (3 new in `batch_ingest.spec.mjs`); regenerated `index.d.ts` carries both methods.
- **Ruby** — `rake compile` + minitest: 4/4 (`test_batch_ingest.rb`, incl. `ArgumentError` naming `documents[1]`).
- **PHP** — `cargo build --release` + phpunit: batch tests green (`LaurusTest.php`).
- **wasm** — `cargo build --target wasm32-unknown-unknown` and `wasm-pack build --target web` succeed; `putDocuments` / `addDocuments` present in the regenerated `pkg/*.d.ts`. (This binding has no runtime test harness — build-test only, consistent with the rest of the wasm suite.)
- fmt / clippy 1.95 + 1.97 across all four host bindings + wasm-target clippy clean; markdownlint clean on all 10 updated `api_reference.md` (en+ja × 5).

Generated artifacts (`laurus-nodejs/index.d.ts`, `laurus-wasm/pkg/`) are git-ignored, so they are regenerated by each binding's build rather than committed.

## Docs

`docs/{src,ja/src}/laurus-{python,nodejs,wasm,ruby,php}/api_reference.md`: `put_documents` / `add_documents` rows (or headings for wasm) with the pair-list shape and fail-fast/no-rollback semantics.

Closes #866. Refs #551 (final PR of the batch-ingestion campaign; the #551 umbrella is closed during wrap-up once PR-3 (#865) and this PR are both merged).
