### PR TITLE
fix(vector/hnsw): restore seed-then-bulk-load recall parity (#872)

### DIFF
--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -895,9 +895,24 @@ impl HnswIndexWriter {
         // build, threaded through the serial level-assignment loops below.
         let mut level_rng = rand::rngs::StdRng::seed_from_u64(LEVEL_RNG_SEED);
 
+        // Rebuild from scratch instead of appending when the loaded base is
+        // too small to serve as a routing hierarchy for the new nodes (Issue
+        // #872). A base below `ef_construction` has a near-flat hierarchy (max
+        // level ~0-1), so appending many higher-level nodes onto it can only
+        // route through that low-level core and fragments the graph. Since
+        // `self.vectors` already holds the existing + new vectors and such a
+        // base is by definition small, discarding it and doing a full build is
+        // both correct and cheap — and yields fresh-build quality. A larger
+        // base keeps the incremental path (its hierarchy is real and a rebuild
+        // would be wasteful).
+        let existing = self
+            .graph
+            .take()
+            .filter(|g| g.node_count() >= ef_construction);
+
         // Check if we have an existing graph to append to
-        let (graph, entry_point, max_level, search_entry_point) =
-            if let Some(existing_graph) = self.graph.take() {
+        let (graph, entry_point, max_level, search_entry_point, promoted_ep) =
+            if let Some(existing_graph) = existing {
                 // Identify new vectors
                 for (doc_id, _, _) in &self.vectors {
                     if !existing_graph.contains_node(doc_id) {
@@ -919,13 +934,21 @@ impl HnswIndexWriter {
                 let old_ep = existing_graph.entry_point;
                 let mut ep = old_ep;
 
-                // If we have new nodes with higher level, update entry point
-                if new_max_level > current_max_level {
-                    ep = new_node_levels
+                // If new nodes reach a higher level than the loaded graph, the
+                // entry point is promoted to one of them. `promoted_ep` records
+                // that new top-level node so it can be inserted first and used
+                // as the build search start (Issue #872) — otherwise searches
+                // start from the low-level `old_ep` and can't route through the
+                // upper layers, funneling every insert through the small base.
+                let mut promoted_ep = None;
+                if new_max_level > current_max_level
+                    && let Some(new_top) = new_node_levels
                         .iter()
                         .find(|(_, l)| *l == total_max_level)
                         .map(|(id, _)| *id)
-                        .or(ep);
+                {
+                    ep = Some(new_top);
+                    promoted_ep = Some(new_top);
                 }
 
                 // Convert to ConcurrentHnswGraph and extend
@@ -933,9 +956,19 @@ impl HnswIndexWriter {
                     ConcurrentHnswGraph::from_hnsw_graph(existing_graph, total_max_level);
                 concurrent_graph.add_nodes(new_node_levels.clone());
 
+                // Insert searches start from the loaded graph's entry point so
+                // new nodes connect to the existing component; the promoted top
+                // node (if any) is inserted first from here, then becomes the
+                // start (see the loop below).
                 let search_ep = old_ep.or(ep);
 
-                (concurrent_graph, ep, total_max_level, search_ep)
+                (
+                    concurrent_graph,
+                    ep,
+                    total_max_level,
+                    search_ep,
+                    promoted_ep,
+                )
             } else {
                 // Full build
                 let mut doc_ids_in_order: Vec<u64> =
@@ -956,7 +989,9 @@ impl HnswIndexWriter {
                 new_doc_ids_in_order = doc_ids_in_order;
 
                 let concurrent_graph = ConcurrentHnswGraph::new(new_node_levels.clone(), max_level);
-                (concurrent_graph, ep, max_level, ep)
+                // Full build: the seed `ep` is already the max-level node, so
+                // the search start needs no promotion.
+                (concurrent_graph, ep, max_level, ep, None)
             };
 
         // 3. Concurrent insertion (Issues #868 / #621).
@@ -977,34 +1012,25 @@ impl HnswIndexWriter {
         // guarantees full reachability regardless of interleaving.
         let writer_ref = &*self;
 
-        // The search-start node must be visible before any worker runs so
-        // traversals that reach it are not filtered out. For an incremental
+        // The initial search-start node must be visible before any worker runs
+        // so traversals that reach it are not filtered out. For an incremental
         // build it is the (already-linked) old entry point; for a full build
         // it is the seed, which has no edges yet but is a valid, linked start.
         if let Some(sp) = search_entry_point {
             graph.mark_linked(sp);
         }
 
-        let insert_one = |doc_id: u64| -> Result<()> {
+        let insert_one = |doc_id: u64, start_node: u64| -> Result<()> {
+            // Skip insertion of the search start node itself (the seed / entry
+            // point — other nodes link TO it via bidirectional edges).
+            if start_node == doc_id {
+                return Ok(());
+            }
+
             let doc_vector_idx = *writer_ref.doc_id_map.get(&doc_id).ok_or_else(|| {
                 LaurusError::internal(format!("Doc ID {} not found in doc_id_map", doc_id))
             })?;
             let vector = &writer_ref.vectors[doc_vector_idx].2;
-
-            // Determine the starting node for search.
-            // For incremental builds `search_entry_point` is the OLD entry
-            // point so new nodes (including a promoted EP) always get
-            // connected to the existing graph.
-            let start_node = match search_entry_point {
-                Some(sp) => sp,
-                None => return Ok(()), // No existing node to search from
-            };
-
-            // Skip insertion of the search start node itself (full-build
-            // seed node — other nodes will link TO it via bidirectional edges).
-            if start_node == doc_id {
-                return Ok(());
-            }
 
             // Determine the assigned level from the pre-populated graph
             let layers_len = graph
@@ -1096,23 +1122,42 @@ impl HnswIndexWriter {
         // pattern also suffers from a low-level entry point, handled (as a
         // quality follow-up) in Issue #872; the connectivity repair below is
         // the correctness backstop for it regardless.
-        const BOOTSTRAP_FLOOR: usize = 32;
-        let new_count = new_doc_ids_in_order.len();
-        let existing_linked = graph.nodes.len().saturating_sub(new_count);
-        let bootstrap_count = ef_construction
-            .max(BOOTSTRAP_FLOOR)
-            .saturating_sub(existing_linked)
-            .min(new_count);
-        let parallel_ids: Vec<u64> = new_doc_ids_in_order.split_off(bootstrap_count);
-        for doc_id in new_doc_ids_in_order {
-            insert_one(doc_id)?;
-        }
+        //
+        // The `effective_start` is the node every insert searches from. When
+        // the append promoted the entry point to a new top-level node (#872),
+        // that node is inserted FIRST (searching from the low-level `old_ep`,
+        // so it joins the existing component) and then becomes the start —
+        // matching the full-build regime where searches descend from the
+        // max-level node. Otherwise it stays the loaded/seed entry point.
+        if let Some(start) = search_entry_point {
+            let effective_start = match promoted_ep {
+                Some(pep) => {
+                    insert_one(pep, start)?;
+                    pep
+                }
+                None => start,
+            };
 
-        #[cfg(not(target_arch = "wasm32"))]
-        parallel_ids.into_par_iter().try_for_each(insert_one)?;
-        #[cfg(target_arch = "wasm32")]
-        for doc_id in parallel_ids {
-            insert_one(doc_id)?;
+            const BOOTSTRAP_FLOOR: usize = 32;
+            let new_count = new_doc_ids_in_order.len();
+            let existing_linked = graph.nodes.len().saturating_sub(new_count);
+            let bootstrap_count = ef_construction
+                .max(BOOTSTRAP_FLOOR)
+                .saturating_sub(existing_linked)
+                .min(new_count);
+            let parallel_ids: Vec<u64> = new_doc_ids_in_order.split_off(bootstrap_count);
+            for doc_id in new_doc_ids_in_order {
+                insert_one(doc_id, effective_start)?;
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            parallel_ids
+                .into_par_iter()
+                .try_for_each(|doc_id| insert_one(doc_id, effective_start))?;
+            #[cfg(target_arch = "wasm32")]
+            for doc_id in parallel_ids {
+                insert_one(doc_id, effective_start)?;
+            }
         }
 
         // 4. Convert ConcurrentGraph to HnswGraph

--- a/laurus/tests/hnsw_coldstart_recall_test.rs
+++ b/laurus/tests/hnsw_coldstart_recall_test.rs
@@ -1,0 +1,159 @@
+//! Regression tests for #872 — seed/incremental bulk-load recall parity.
+//!
+//! Appending a large batch onto a small HNSW base used to funnel every parallel
+//! insert through the base's low-level entry point, fragmenting the graph:
+//! reachability was still guaranteed (by the #868 connectivity repair), but the
+//! appended nodes had far fewer/worse in-edges, so their search recall collapsed
+//! to roughly half of a fresh full build of the same total size.
+//!
+//! The #872 fix has two regimes, and there is one test per regime:
+//!   * base `< ef_construction` — the base is too shallow to navigate, so the
+//!     append discards it and does a full rebuild (fresh quality). Covered by
+//!     [`seed_then_bulk_load_recall_matches_fresh_build`] (base = 1).
+//!   * base `>= ef_construction` — the incremental path is kept, but if the
+//!     append promotes the entry point to a new top-level node, that node is
+//!     inserted first and used as the build search start so inserts descend from
+//!     the top layer instead of funneling through `old_ep`. Covered by
+//!     [`incremental_append_recall_matches_fresh_build`] (base = 200).
+//!
+//! The gate is **self-recall@10**: query each node with its own vector and check
+//! it appears in its own top-10. A well-built graph is ~1.0; a fragmented one is
+//! much lower. Each test compares the appended nodes' self-recall against a fresh
+//! full build of the same corpus — deterministic and independent of any fixed
+//! absolute threshold (both builds see the identical vectors and query set).
+
+use std::sync::Arc;
+
+use laurus::storage::file::{FileStorage, FileStorageConfig};
+use laurus::vector::index::hnsw::searcher::HnswSearcher;
+use laurus::vector::search::searcher::{VectorIndexQuery, VectorIndexSearcher};
+use laurus::vector::{
+    DistanceMetric, HnswIndexConfig, HnswIndexReader, HnswIndexWriter, Vector, VectorIndexWriter,
+    VectorIndexWriterConfig,
+};
+use tempfile::tempdir;
+
+fn doc_vec(i: u64) -> Vector {
+    let mut v = vec![0.0f32; 16];
+    let t = i as f32 * 0.001;
+    v[0] = t.cos();
+    v[1] = t.sin();
+    v[2] = (t * 2.0).cos();
+    v[3] = (t * 3.0).sin();
+    Vector::new(v)
+}
+fn config() -> HnswIndexConfig {
+    HnswIndexConfig {
+        dimension: 16,
+        m: 16,
+        ef_construction: 100,
+        normalize_vectors: false,
+        distance_metric: DistanceMetric::Cosine,
+        ..Default::default()
+    }
+}
+fn writer_config() -> VectorIndexWriterConfig {
+    VectorIndexWriterConfig {
+        parallel_build: true,
+        ..Default::default()
+    }
+}
+
+/// Fraction of ids in `[lo, hi)` that appear in their own vector's top-10.
+fn self_recall_at_10(path: &std::path::Path, name: &str, lo: u64, hi: u64) -> f32 {
+    let storage = Arc::new(FileStorage::new(path, FileStorageConfig::new(path)).unwrap());
+    let reader = HnswIndexReader::load(storage, name, DistanceMetric::Cosine).unwrap();
+    let mut searcher = HnswSearcher::new(Arc::new(reader)).unwrap();
+    searcher.set_ef_search(200);
+    let mut hits = 0u64;
+    for id in lo..hi {
+        let req = VectorIndexQuery::new(doc_vec(id))
+            .top_k(10)
+            .field_name("v".to_string());
+        if searcher
+            .search(&req)
+            .unwrap()
+            .results
+            .iter()
+            .any(|r| r.doc_id == id)
+        {
+            hits += 1;
+        }
+    }
+    hits as f32 / (hi - lo) as f32
+}
+
+/// Fresh full build of ids `0..n` in one shot.
+fn fresh_build(path: &std::path::Path, name: &str, n: u64) {
+    let storage = Arc::new(FileStorage::new(path, FileStorageConfig::new(path)).unwrap());
+    let mut w = HnswIndexWriter::with_storage(config(), writer_config(), name, storage).unwrap();
+    let v: Vec<_> = (0..n).map(|i| (i, "v".to_string(), doc_vec(i))).collect();
+    w.add_vectors(v).unwrap();
+    w.finalize().unwrap();
+    w.write().unwrap();
+}
+
+/// Build `0..base` first, commit, then append `base..n` in a second commit.
+fn seed_then_append(path: &std::path::Path, name: &str, base: u64, n: u64) {
+    {
+        let storage = Arc::new(FileStorage::new(path, FileStorageConfig::new(path)).unwrap());
+        let mut w =
+            HnswIndexWriter::with_storage(config(), writer_config(), name, storage).unwrap();
+        let v: Vec<_> = (0..base)
+            .map(|i| (i, "v".to_string(), doc_vec(i)))
+            .collect();
+        w.add_vectors(v).unwrap();
+        w.finalize().unwrap();
+        w.write().unwrap();
+    }
+    {
+        let storage = Arc::new(FileStorage::new(path, FileStorageConfig::new(path)).unwrap());
+        let mut w = HnswIndexWriter::load(config(), writer_config(), storage, name).unwrap();
+        let v: Vec<_> = (base..n)
+            .map(|i| (i, "v".to_string(), doc_vec(i)))
+            .collect();
+        w.add_vectors(v).unwrap();
+        w.finalize().unwrap();
+        w.write().unwrap();
+    }
+}
+
+/// Assert the appended nodes' self-recall matches a fresh full build's over the
+/// same id range, within a small tolerance (pre-#872 the append was ~0.5x).
+fn assert_append_matches_fresh(base: u64, n: u64) {
+    let fresh_dir = tempdir().unwrap();
+    fresh_build(fresh_dir.path(), "fresh", n);
+    let fresh = self_recall_at_10(fresh_dir.path(), "fresh", base, n);
+
+    let cold_dir = tempdir().unwrap();
+    seed_then_append(cold_dir.path(), "cold", base, n);
+    let cold = self_recall_at_10(cold_dir.path(), "cold", base, n);
+
+    // Sanity: the fresh build must itself be well-connected.
+    assert!(
+        fresh > 0.9,
+        "fresh full-build self-recall@10 should be high, got {fresh:.4}"
+    );
+    // Absolute-difference tolerance so a marginally-higher cold value (it can
+    // slightly exceed fresh) also passes.
+    assert!(
+        cold >= fresh - 0.05,
+        "base={base} seed-then-bulk-load self-recall@10 ({cold:.4}) must match the \
+         fresh build ({fresh:.4}) within tolerance (#872)",
+    );
+}
+
+/// #872, base `< ef_construction`: a seed-1-then-bulk-append build is rebuilt
+/// fresh, so it must reach the same self-recall as a fresh full build.
+#[test]
+fn seed_then_bulk_load_recall_matches_fresh_build() {
+    assert_append_matches_fresh(1, 5000);
+}
+
+/// #872, base `>= ef_construction`: appending onto a real (non-trivial) base
+/// keeps the incremental path; the promoted-entry-point-first fix must still
+/// give the appended nodes fresh-build recall (pre-fix ~0.73 vs ~0.98).
+#[test]
+fn incremental_append_recall_matches_fresh_build() {
+    assert_append_matches_fresh(200, 5000);
+}


### PR DESCRIPTION
## Summary

Appending a large batch onto a **small** HNSW base funneled every parallel insert through the base's low-level entry point, fragmenting the graph. Reachability stayed 100% (via the #868 connectivity repair), but the appended nodes had far fewer/worse in-edges, so their search recall collapsed to roughly **half** of a fresh full build of the same total size. This is the quality follow-on of #868/#873.

## Fix

`build_hnsw_graph` (`laurus/src/vector/index/hnsw/writer.rs`) now handles the incremental append path in **two regimes** — both measured to be load-bearing:

- **base `< ef_construction`** — a shallow base has a near-flat hierarchy, so appending many higher-level nodes can only route through its low-level core. Since `self.vectors` already holds all existing+new vectors and such a base is small by definition, we discard it and full-rebuild — correct, cheap, and fresh-build quality.

  ```rust
  let existing = self.graph.take().filter(|g| g.node_count() >= ef_construction);
  ```

- **base `>= ef_construction`** — the incremental path is kept. When the append promotes the entry point to a new top-level node (`new_max_level > current_max_level`), that node is inserted **first** (searching from the low-level `old_ep`, so it joins the existing component) and then becomes the build search start. Inserts then descend from the top layer, matching the full-build regime, instead of funneling through `old_ep`. The full-build path returns `promoted_ep = None` and is unchanged.

## Verification — deterministic self-recall@10 gate

New test `laurus/tests/hnsw_coldstart_recall_test.rs` (one test per regime, n=5000). Each node is queried with its own vector; the gate is whether it appears in its own top-10, compared to a fresh full build over the same id range.

| Regime | Case | Pre-fix | Post-fix (fresh) |
|---|---|---|---|
| base < ef_construction | seed=1 → append 4999 | 0.78 (rebuild disabled) | 0.98 (parity) |
| base >= ef_construction | base=200 → append 4800 | 0.73 (promoted-ep disabled) | 0.98 |

A negative test confirms the red/green gate: disabling the rebuild filter fails the seed=1 test; disabling promoted-ep-first drops base=200 to 0.73. Both fixes are load-bearing in their own regime.

## Regression + static checks (all green)

- `hnsw_reachability_test` (#868 BFS reachability = 100%): 4 passed
- vector regression net (append / auto_compaction / soft_delete / deletion_aware / recall / retention / merge / deletion): 40 passed
- `cargo fmt --all --check` on 1.95 and 1.97: clean
- `cargo clippy -p laurus --all-targets` on 1.95 and 1.97: zero warnings
- `cargo build`/`clippy -p laurus-wasm --target wasm32-unknown-unknown`: clean

## Adversarial review

An 8-agent adversarial review (3 dimensions × verify) surfaced 5 findings; **all 5 were refuted** — the one real behavioral change (a sub-`ef_construction` base full-rebuilds every commit) is by design and negligible (the base is < `ef_construction` nodes, so the rebuild is microseconds).

## Scope

Internal build-algorithm change only; public API unchanged, so no language-binding changes are needed.

Closes #872
Refs #868, #621
