### PR TITLE
perf(vector/index): segment-per-commit becomes the default HNSW layout (#882)

### DIFF
--- a/laurus-server/tests/grpc_rerank_sidecar_test.rs
+++ b/laurus-server/tests/grpc_rerank_sidecar_test.rs
@@ -21,8 +21,9 @@ use laurus::{DataValue, DistanceMetric, Document, Engine, FieldOption, HnswOptio
 use laurus_server::convert::schema::{from_proto, to_proto};
 
 /// Sidecar file name as it lands under the engine's vector storage
-/// prefix (`PrefixedStorage("vector", ..)`, index file `vector_index`).
-const SIDECAR_NAME: &str = "vector/vector_index.hnsw.f32";
+/// prefix (`PrefixedStorage("vector", ..)`): the first sealed segment of
+/// the (default, #882) segmented layout is `segment_000000.hnsw`.
+const SIDECAR_NAME: &str = "vector/segment_000000.hnsw.f32";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn grpc_schema_with_rerank_storage_emits_sidecar_on_commit() -> laurus::Result<()> {

--- a/laurus/src/vector/index/config.rs
+++ b/laurus/src/vector/index/config.rs
@@ -398,6 +398,12 @@ impl std::fmt::Debug for FlatIndexConfig {
     }
 }
 
+/// Serde default for [`HnswIndexConfig::segmented`] — `true` since #882
+/// (configs serialized before the field existed open in the segmented
+/// layout and are migrated zero-copy).
+fn default_segmented() -> bool {
+    true
+}
 /// Configuration specific to HNSW index.
 ///
 /// These settings control the behavior of the HNSW (Hierarchical Navigable Small World)
@@ -442,14 +448,14 @@ pub struct HnswIndexConfig {
 
     /// Whether this index uses the segment-per-commit layout (Issue #634).
     ///
-    /// When `true`, each commit seals the newly added vectors as an
-    /// immutable per-segment `.hnsw` file registered in an atomic
-    /// `segments.json` manifest, instead of rewriting one monolithic file —
-    /// turning the per-commit cost from O(index) to O(new docs). Defaults to
-    /// `false` (the monolithic layout). Introduced dark in #881; the
-    /// production default flips in #882 together with the zero-copy legacy
-    /// migration.
-    #[serde(default)]
+    /// When `true` (the default since #882), each commit seals the newly
+    /// added vectors as an immutable per-segment `.hnsw` file registered in
+    /// an atomic `segments.json` manifest, instead of rewriting one
+    /// monolithic file — turning the per-commit cost from O(index) to
+    /// O(new docs). An existing monolithic index is migrated zero-copy on
+    /// first open (its `.hnsw` becomes segment 0 of the manifest). Set to
+    /// `false` to keep the monolithic layout.
+    #[serde(default = "default_segmented")]
     pub segmented: bool,
 
     /// Maximum number of vectors per segment.
@@ -525,7 +531,7 @@ impl Default for HnswIndexConfig {
             m: 16,
             ef_construction: 200,
             default_ef_search: None,
-            segmented: false,
+            segmented: true,
             max_vectors_per_segment: 1000000,
             write_buffer_size: 1024 * 1024, // 1MB
             quantization_method: quantization::QuantizationMethod::Scalar8Bit,

--- a/laurus/src/vector/index/factory.rs
+++ b/laurus/src/vector/index/factory.rs
@@ -84,25 +84,55 @@ impl VectorIndexFactory {
                 Ok(Box::new(index))
             }
             VectorIndexTypeConfig::HNSW(hnsw_config) => {
-                if hnsw_config.segmented {
-                    // Segment-per-commit layout (#634 / #881), introduced
-                    // dark: `segmented` defaults to false.
-                    let index =
-                        crate::vector::index::hnsw::segmented::SegmentedHnswIndex::open_or_create(
-                            storage,
-                            name,
-                            hnsw_config,
-                        )?;
-                    return Ok(Box::new(index));
-                }
-                let index = HnswIndex::create(storage, name, hnsw_config)?;
-                Ok(Box::new(index))
+                Self::dispatch_hnsw(storage, name, hnsw_config, false)
             }
             VectorIndexTypeConfig::IVF(ivf_config) => {
                 let index = IvfIndex::create(storage, name, ivf_config)?;
                 Ok(Box::new(index))
             }
         }
+    }
+
+    /// Dispatch an HNSW config to the segmented or monolithic implementation
+    /// (#634 / #882).
+    ///
+    /// The `segmented` flag (the default since #882) routes to
+    /// [`SegmentedHnswIndex::open_or_create`], which handles create, open,
+    /// AND the zero-copy migration of a legacy monolithic index — so BOTH
+    /// factory arms must come through here: a legacy index always has a
+    /// `metadata.json` and therefore always takes the *open* arm, which is
+    /// exactly where the migration must fire (#882 review).
+    ///
+    /// With the flag off, opening a directory that contains a segment
+    /// manifest is rejected: the monolithic index would silently serve only
+    /// the migrated segment-0 data and hide every later segment.
+    fn dispatch_hnsw(
+        storage: Arc<dyn Storage>,
+        name: &str,
+        hnsw_config: crate::vector::index::config::HnswIndexConfig,
+        open_only: bool,
+    ) -> Result<Box<dyn VectorIndex>> {
+        use crate::vector::index::hnsw::segmented::SegmentedHnswIndex;
+
+        if hnsw_config.segmented {
+            let index = SegmentedHnswIndex::open_or_create(storage, name, hnsw_config)?;
+            return Ok(Box::new(index));
+        }
+        // Reverse guard (#882 review): a segmented directory must not be
+        // opened monolithically — the single-file view would silently hide
+        // every segment sealed after the migration.
+        if storage.file_exists("segments.json") {
+            return Err(crate::error::LaurusError::invalid_config(format!(
+                "index '{name}' uses the segmented layout (segments.json exists) but \
+                 `segmented` is disabled; enable it to open this index"
+            )));
+        }
+        let index = if open_only {
+            HnswIndex::open(storage, name, hnsw_config)?
+        } else {
+            HnswIndex::create(storage, name, hnsw_config)?
+        };
+        Ok(Box::new(index))
     }
 
     /// Open an existing index or create a new one if it doesn't exist.
@@ -168,8 +198,11 @@ impl VectorIndexFactory {
                 Ok(Box::new(index))
             }
             VectorIndexTypeConfig::HNSW(hnsw_config) => {
-                let index = HnswIndex::open(storage, name, hnsw_config)?;
-                Ok(Box::new(index))
+                // Same dispatch as `create` (#882): the segmented path's
+                // `open_or_create` opens existing manifests and migrates
+                // legacy monolithic indexes; the flag-off path is
+                // reverse-guarded against segmented directories.
+                Self::dispatch_hnsw(storage, name, hnsw_config, true)
             }
             VectorIndexTypeConfig::IVF(ivf_config) => {
                 let index = IvfIndex::open(storage, name, ivf_config)?;

--- a/laurus/src/vector/index/hnsw/segment/manager.rs
+++ b/laurus/src/vector/index/hnsw/segment/manager.rs
@@ -49,12 +49,14 @@ struct SegmentManifest {
     /// re-issues an ID even if the highest-numbered segment was merged away.
     next_segment_id: u64,
 
-    /// Last WAL sequence number applied to the segments in this manifest.
+    /// Last WAL sequence number whose effects are fully durable in this
+    /// manifest's segments and the index deletion bitmap (#882).
     ///
-    /// Reserved for the segment-per-commit recovery pivot (#634 PR-4): the
-    /// vector side persists no WAL checkpoint today, so this stays 0 until
-    /// the wiring lands. Persisting it here keeps the manifest format stable
-    /// across the campaign.
+    /// Published by the segmented index's `persist_deletions` — the last
+    /// vector step of the store's commit ladder, before the engine
+    /// truncates the WAL — so recovery can safely skip records at or below
+    /// it. Intermediate manifest saves (segment seals) carry the previous
+    /// value.
     last_wal_seq: u64,
 
     /// The registered segments.
@@ -447,12 +449,16 @@ impl SegmentManager {
         self.save_state_locked(&segments)
     }
 
-    /// Sum the on-storage sizes of a segment's file and sidecars.
+    /// Sum the on-storage sizes of a segment's file and rerank sidecar.
+    ///
+    /// `.delmap` is deliberately excluded (#882): per-segment deletion
+    /// bitmaps do not exist — the bitmap is index-level — and for a
+    /// legacy-migrated segment (whose id equals the index name) including
+    /// it would misattribute the index bitmap's size to the segment.
     fn measure_segment_size(&self, segment_id: &str) -> u64 {
         [
             format!("{segment_id}.hnsw"),
             format!("{segment_id}.hnsw.f32"),
-            format!("{segment_id}.delmap"),
         ]
         .iter()
         .filter_map(|name| self.storage.file_size(name).ok())
@@ -471,13 +477,19 @@ impl SegmentManager {
     }
 
     /// Delete physical files associated with a segment, including its
-    /// rerank sidecar (`.hnsw.f32`) and deletion bitmap (`.delmap`) —
-    /// leaving them behind orphans storage after every merge (#879).
+    /// rerank sidecar (`.hnsw.f32`) — leaving it behind orphans storage
+    /// after every merge (#879).
+    ///
+    /// Deliberately does NOT touch `{segment_id}.delmap` (#882): the
+    /// segmented index keeps ONE index-level deletion bitmap named
+    /// `{index_name}.delmap` — per-segment bitmaps do not exist — and a
+    /// legacy-migrated segment's id EQUALS the index name, so deleting the
+    /// segment's "delmap" here would destroy live deletion state when a
+    /// merge consumes that segment.
     pub fn delete_segment_files(&self, segment_id: &str) -> Result<()> {
         // Best effort deletion - ignore if a file doesn't exist
         let _ = self.storage.delete_file(&format!("{segment_id}.hnsw"));
         let _ = self.storage.delete_file(&format!("{segment_id}.hnsw.f32"));
-        let _ = self.storage.delete_file(&format!("{segment_id}.delmap"));
         Ok(())
     }
 
@@ -1018,8 +1030,11 @@ mod tests {
         assert!(storage.file_exists("not_a_segment.hnsw"), "foreign spared");
     }
 
-    /// #879: deleting a segment's files removes the rerank sidecar and the
-    /// deletion bitmap along with the index file.
+    /// #879/#882: deleting a segment's files removes the rerank sidecar
+    /// along with the index file — but never a `.delmap`: the deletion
+    /// bitmap is index-level, and a legacy-migrated segment shares the
+    /// index's name (#882), so touching it would destroy live deletion
+    /// state.
     #[test]
     fn test_delete_segment_files_includes_sidecars() {
         let config = SegmentManagerConfig::default();
@@ -1042,7 +1057,11 @@ mod tests {
             !storage.file_exists("segment_000001.hnsw.f32"),
             "sidecar GC"
         );
-        assert!(!storage.file_exists("segment_000001.delmap"), "delmap GC");
+        assert!(
+            storage.file_exists("segment_000001.delmap"),
+            "a .delmap must never be deleted with segment files — the \
+             deletion bitmap is index-level (#882)"
+        );
     }
 
     /// #879: `add_segment` stamps a zero generation with max+1 and measures a

--- a/laurus/src/vector/index/hnsw/segmented.rs
+++ b/laurus/src/vector/index/hnsw/segmented.rs
@@ -21,11 +21,13 @@
 //! bitmap is doc-scoped, which is consistent here because a document's
 //! fields always land in the same segment.
 //!
-//! Introduced dark: [`HnswIndexConfig::segmented`] defaults to `false` and
-//! the factory keeps dispatching to the monolithic index. The default flips
-//! in #882 together with the zero-copy legacy migration (an existing
-//! monolithic `.hnsw` becomes segment 0 of the manifest); until then,
-//! opening a legacy index with the flag on is rejected explicitly.
+//! Since #882 this is the DEFAULT HNSW layout ([`HnswIndexConfig::segmented`]
+//! defaults to `true`): a legacy monolithic index is migrated zero-copy on
+//! first open (its `.hnsw` becomes segment 0 of the manifest, no data
+//! movement), and the manifest's `last_wal_seq` is published with the
+//! durability ordering the engine's recovery relies on (data before
+//! checkpoint, checkpoint before WAL truncate). Set the flag to `false` to
+//! keep the monolithic layout.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -84,6 +86,12 @@ struct SegmentedShared {
     /// enough, because a concurrent build could repopulate it with
     /// bitmap-less readers after the clear.
     bitmap_epoch: std::sync::atomic::AtomicU64,
+
+    /// Highest WAL sequence number applied to this index but NOT yet
+    /// published to the manifest (#882). Published (and persisted) by
+    /// [`VectorIndex::persist_deletions`] at the end of the store's commit
+    /// ladder, once every covered mutation is durable.
+    pending_wal_seq: std::sync::atomic::AtomicU64,
 }
 
 impl SegmentedShared {
@@ -189,30 +197,76 @@ impl SegmentedHnswIndex {
     /// * `config` - HNSW configuration (with [`HnswIndexConfig::segmented`]
     ///   set).
     ///
+    /// A legacy monolithic index is migrated **zero-copy** (#882): the
+    /// existing `{name}.hnsw` is registered verbatim as the first segment —
+    /// its segment id is the index name, which every reader treats as a
+    /// plain path prefix — with a single atomic manifest write and no data
+    /// movement. A crash before the manifest save leaves the legacy layout
+    /// intact, so the migration simply re-runs on the next open. The
+    /// pre-existing `{name}.delmap` keeps its meaning: it is the index-level
+    /// deletion bitmap in both layouts (and `delete_segment_files` never
+    /// touches `.delmap` files for exactly this reason).
+    ///
     /// # Errors
     ///
     /// Returns an error when the manifest fails to load (corruption fails
-    /// loudly, #879), or when a legacy monolithic `{name}.hnsw` exists
-    /// without a manifest — the zero-copy migration lands in #882, so until
-    /// then the flag must not silently shadow existing data.
+    /// loudly, #879), or when reading the legacy file's header during
+    /// migration fails.
     pub fn open_or_create(
         storage: Arc<dyn Storage>,
         name: &str,
         config: HnswIndexConfig,
     ) -> Result<Self> {
-        let legacy_file = format!("{name}.hnsw");
-        if storage.file_exists(&legacy_file) && !storage.file_exists("segments.json") {
+        // The generated-segment namespace is reserved: an index named like
+        // a generated id would collide with sealed segments (same file
+        // names, orphan-sweep patterns, and merge GC) — reject it loudly
+        // (#882 review).
+        if let Some(ordinal) = name.strip_prefix("segment_")
+            && !ordinal.is_empty()
+            && ordinal.bytes().all(|b| b.is_ascii_digit())
+        {
             return Err(LaurusError::invalid_config(format!(
-                "index '{name}' has a monolithic {legacy_file} but no segment manifest; \
-                 the segmented layout cannot open it yet (migration lands with #882) — \
-                 disable `segmented` for this index"
+                "index name '{name}' collides with the reserved segment-id \
+                 namespace (segment_<digits>)"
             )));
         }
 
+        let legacy_file = format!("{name}.hnsw");
+        let migrate = storage.file_exists(&legacy_file) && !storage.file_exists("segments.json");
+
+        // The manager's orphan sweep only touches `segment_NNNNNN.*` names,
+        // so an unmigrated `{name}.hnsw` is never swept.
         let manager = Arc::new(SegmentManager::new(
             SegmentManagerConfig::default(),
             storage.clone(),
         )?);
+
+        if migrate {
+            // Read the committed vector count from the leading u64 of the
+            // legacy file (same header every reader loads).
+            let vector_count = {
+                use std::io::Read;
+                let mut input = storage.open_input(&legacy_file)?;
+                let mut buf = [0u8; 8];
+                input.read_exact(&mut buf)?;
+                u64::from_le_bytes(buf)
+            };
+            // `add_segment` stamps generation 1, measures the on-storage
+            // size, and saves the manifest atomically (#879) — the moment it
+            // returns, the index is segmented; before that, it is still a
+            // valid legacy index. A legacy delmap (same file in both
+            // layouts) means the segment carries deletions.
+            let mut info = ManagedSegmentInfo::new(name.to_string(), vector_count, 0, 0);
+            info.has_deletions = storage.file_exists(&format!("{name}.delmap"));
+            manager.add_segment(info)?;
+
+            // Drop the monolithic index's now-stale `metadata.json` so the
+            // factory's open/create routing can never again mistake this
+            // directory for a monolithic index (#882 review: a stale
+            // metadata.json flipped a migrated index back to the monolithic
+            // view, silently hiding every post-migration segment).
+            let _ = storage.delete_file("metadata.json");
+        }
 
         Ok(Self {
             shared: Arc::new(SegmentedShared {
@@ -222,6 +276,7 @@ impl SegmentedHnswIndex {
                 reader_cache: Arc::new(SegmentedReaderCache::new()),
                 deletion: RwLock::new(None),
                 bitmap_epoch: std::sync::atomic::AtomicU64::new(0),
+                pending_wal_seq: std::sync::atomic::AtomicU64::new(0),
             }),
             config,
             closed: AtomicBool::new(false),
@@ -242,6 +297,46 @@ impl SegmentedHnswIndex {
         self.config
             .default_ef_search
             .unwrap_or_else(|| self.config.ef_construction.max(50) * 2)
+    }
+
+    /// Merge one policy-selected window of segments (#882).
+    ///
+    /// Uses the generation-contiguous `SimpleMergePolicy` (#880) through
+    /// the deletion-filtering, duplicate-collapsing merge engine; source
+    /// readers are invalidated afterwards. A no-op when the policy finds no
+    /// candidate.
+    fn merge_once(&self) -> Result<()> {
+        use crate::vector::index::hnsw::segment::merge_policy::SimpleMergePolicy;
+
+        let Some(candidate) = self.shared.manager.check_merge(&SimpleMergePolicy::new()) else {
+            return Ok(());
+        };
+
+        let mut engine = MergeEngine::new(
+            MergeConfig::default(),
+            self.shared.storage.clone(),
+            self.config.clone(),
+            VectorIndexWriterConfig::default(),
+        );
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(false)? {
+            engine.set_deletion_bitmap(bitmap);
+        }
+
+        let new_segment_id = self.shared.manager.generate_segment_id();
+        let result = engine.merge_segments(candidate.segments.clone(), new_segment_id)?;
+
+        let source_ids: Vec<String> = candidate
+            .segments
+            .iter()
+            .map(|s| s.segment_id.clone())
+            .collect();
+        self.shared
+            .manager
+            .apply_merge(candidate, result.merged_segment)?;
+        for id in &source_ids {
+            self.shared.reader_cache.invalidate(id);
+        }
+        Ok(())
     }
 
     /// Drop the deletion state after a compaction physically reclaimed the
@@ -403,13 +498,27 @@ impl VectorIndex for SegmentedHnswIndex {
         Arc::clone(&self.config.embedder)
     }
 
-    // `last_wal_seq` / `set_last_wal_seq` intentionally keep their trait
-    // defaults (0 / no-op): reporting a persisted checkpoint without the
-    // #882 ordering guarantees (manifest durable BEFORE the WAL truncate)
-    // would let recovery skip records whose effects never became durable.
-    // With the defaults, recovery replays the whole WAL idempotently — the
-    // monolithic index's behavior. #882 wires the manifest's `last_wal_seq`
-    // field together with the ordering.
+    fn last_wal_seq(&self) -> u64 {
+        // The PUBLISHED checkpoint: the value loaded from (or last saved to)
+        // the manifest — never the pending one, which may not be durable
+        // yet. Recovery skips WAL records at or below this seq, so it must
+        // only ever reflect state that is already on storage (#882).
+        self.shared.manager.last_wal_seq()
+    }
+
+    fn set_last_wal_seq(&self, seq: u64) -> Result<()> {
+        // Recorded as PENDING only. It is published into the manifest at the
+        // end of `persist_deletions` — the last vector step of the store's
+        // commit ladder — at which point the sealed segment files AND the
+        // deletion bitmap for every record up to `seq` are durable, and the
+        // engine has not yet truncated the WAL (#882 ordering; the #875
+        // lesson: a checkpoint must never outrun the durability of the state
+        // it covers).
+        self.shared
+            .pending_wal_seq
+            .fetch_max(seq, Ordering::Release);
+        Ok(())
+    }
 
     fn supports_soft_delete(&self) -> bool {
         true
@@ -453,10 +562,38 @@ impl VectorIndex for SegmentedHnswIndex {
                 self.shared.storage.delete_file(&file)?;
             }
         }
+        drop(guard);
+
+        // Publish the WAL checkpoint (#882). This is the last vector step of
+        // the store's commit ladder: the sealed segment files (fsynced +
+        // manifest-registered by `writer.commit()`) and the deletion bitmap
+        // (written above) are durable for every record up to the pending
+        // seq, and `Engine::commit` truncates the WAL only after all stores
+        // finish — so a crash on either side of this save is safe: before
+        // it, recovery replays idempotently from the old checkpoint; after
+        // it, everything skipped is already on storage.
+        let pending = self.shared.pending_wal_seq.load(Ordering::Acquire);
+        if pending > self.shared.manager.last_wal_seq() {
+            self.shared.manager.set_last_wal_seq(pending);
+            self.shared.manager.save_state()?;
+        }
         Ok(())
     }
 
     fn maybe_auto_compact(&self) -> Result<bool> {
+        // Segment-count bound (#882): pure-append workloads never take the
+        // deletion-ratio branch below, so without this the segment count —
+        // and with it every search fan-out and the manifest size — would
+        // grow unboundedly, one segment per commit. Merge one
+        // generation-contiguous window (#880 policy) when the manager's
+        // threshold is exceeded; the tiered policy lands with #883. Runs
+        // regardless of `auto_compaction`, which gates deletion
+        // *reclamation*, not the structural segment bound.
+        if self.shared.manager.needs_merge() {
+            self.merge_once()?;
+            return Ok(true);
+        }
+
         if !self.config.auto_compaction {
             return Ok(false);
         }
@@ -611,6 +748,13 @@ impl VectorIndexWriter for SegmentedHnswWriter {
     }
 
     fn rollback(&mut self) -> Result<()> {
+        // Rolled-back mutations are discarded, so the pending WAL
+        // checkpoint must not keep covering their sequence numbers (#882):
+        // roll it back to the published value; their WAL records then stay
+        // replayable.
+        self.shared
+            .pending_wal_seq
+            .store(self.shared.manager.last_wal_seq(), Ordering::Release);
         self.inner.rollback()
     }
 
@@ -631,6 +775,24 @@ impl VectorIndexWriter for SegmentedHnswWriter {
 
     fn build_reader(&self) -> Result<Arc<dyn VectorIndexReader>> {
         self.inner.build_reader()
+    }
+}
+
+impl Drop for SegmentedHnswWriter {
+    fn drop(&mut self) {
+        // Backstop (#882 review): dropping a writer whose buffered
+        // mutations were never sealed discards the only in-process copy,
+        // while the pending WAL checkpoint may already cover their
+        // sequence numbers — publishing it later would hide the loss from
+        // recovery. Roll the pending value back to the published
+        // checkpoint so those records stay replayable. The store never
+        // drops a dirty writer (its commit/optimize/add_field paths retain
+        // it on failure), so this fires only on direct API use.
+        if self.has_pending_changes() {
+            self.shared
+                .pending_wal_seq
+                .store(self.shared.manager.last_wal_seq(), Ordering::Release);
+        }
     }
 }
 

--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -1989,8 +1989,13 @@ impl VectorIndexWriter for HnswIndexWriter {
         let content_crc = output.checksum();
         output.write_all(&crate::vector::index::hnsw::HNSW_FOOTER_MAGIC.to_le_bytes())?;
         output.write_all(&content_crc.to_le_bytes())?;
-        output.flush()?;
-        drop(output);
+        // Close with an fsync BEFORE the rename (#882 review): the rename
+        // publishes the segment (and, in the segmented layout, a manifest
+        // whose WAL checkpoint covers it may follow) — a flush alone leaves
+        // the content in the page cache, so a power loss could surface a
+        // published-but-hollow segment file.
+        let mut inner = output.into_inner();
+        inner.close()?;
         storage.rename_file(&tmp_name, &file_name)?;
 
         // Stage 2 (Issue #481): emit the optional LRS1 rerank sidecar

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -365,7 +365,20 @@ impl VectorStore {
             Some(writer) if writer.has_pending_changes() => writer.commit(),
             _ => Ok(()),
         };
-        let ladder_result = flush_result
+        // A FAILED flush must keep the writer cached (#882 review, the #875
+        // lesson): its buffered mutations are the only in-process copy, and
+        // the segmented index's pending WAL checkpoint may already cover
+        // their sequence numbers — dropping the writer while a later
+        // successful commit publishes that checkpoint would let recovery
+        // skip records whose effects were silently discarded. The seal is
+        // atomic (tmp+rename before manifest registration), so a retry from
+        // the retained writer is sound.
+        if let Err(e) = flush_result {
+            drop(writer_guard);
+            *self.searcher_cache.write() = None;
+            return Err(e);
+        }
+        let ladder_result = Ok(())
             // Persist any pending logical deletions (Issue #624) so the
             // deletion bitmap survives restarts. The WAL also records
             // deletions, so this is a durability optimization rather than the
@@ -432,11 +445,14 @@ impl VectorStore {
             Some(writer) if writer.has_pending_changes() => writer.commit(),
             _ => Ok(()),
         };
-        // Always drop the cache — optimize() rewrites the index through a
-        // fresh writer and clears the deletion bitmap — and drop it on the
-        // flush error path too, where the writer/disk agreement is unknown.
-        *writer_guard = None;
+        // A failed flush keeps the writer cached (#882 review / #875): its
+        // buffered mutations are the only in-process copy and their WAL
+        // records may already be inside the pending checkpoint's range.
         flush_result?;
+        // Drop the cache on success — optimize() rewrites the index through
+        // a fresh writer and clears the deletion bitmap, so a retained
+        // writer would resurrect reclaimed vectors (#864).
+        *writer_guard = None;
         self.index.optimize()?;
         drop(writer_guard);
         *self.searcher_cache.write() = None;
@@ -965,7 +981,24 @@ impl VectorStore {
         }
 
         // Invalidate caches so the next writer/searcher uses updated config.
-        *self.writer_cache.lock().await = None;
+        // Commit the cached writer first and KEEP it on failure (#882
+        // review / #875): its buffered mutations are the only in-process
+        // copy, and the segmented pending WAL checkpoint may already cover
+        // them — a bare drop would let a later successful commit's
+        // checkpoint hide the loss from recovery. This method cannot
+        // propagate the error (its signature returns `()`); leaving the
+        // writer cached makes the next `commit()` retry and surface it.
+        {
+            let mut writer_guard = self.writer_cache.lock().await;
+            if let Some(writer) = writer_guard.as_mut()
+                && writer.has_pending_changes()
+                && writer.commit().is_err()
+            {
+                *self.searcher_cache.write() = None;
+                return;
+            }
+            *writer_guard = None;
+        }
         *self.searcher_cache.write() = None;
     }
 
@@ -989,7 +1022,20 @@ impl VectorStore {
         }
 
         // Invalidate caches so the next writer/searcher uses updated config.
-        *self.writer_cache.lock().await = None;
+        // Same commit-then-drop-on-success guard as `add_field` (#882
+        // review): never rely on a bare drop while buffered mutations are
+        // the only in-process copy.
+        {
+            let mut writer_guard = self.writer_cache.lock().await;
+            if let Some(writer) = writer_guard.as_mut()
+                && writer.has_pending_changes()
+                && writer.commit().is_err()
+            {
+                *self.searcher_cache.write() = None;
+                return;
+            }
+            *writer_guard = None;
+        }
         *self.searcher_cache.write() = None;
     }
 }

--- a/laurus/tests/vector_hnsw_atomic_write_test.rs
+++ b/laurus/tests/vector_hnsw_atomic_write_test.rs
@@ -1,11 +1,13 @@
 //! Integration tests for crash-safe atomic writes of the production HNSW
-//! index files (issue #784).
+//! index files (issue #784; segmented layout since #882).
 //!
-//! `HnswIndexWriter::write` / `HnswIndex::write_metadata` /
-//! `HnswIndex::persist_deletions` now write to a `.tmp` file and atomically
-//! `rename_file` it into place. A crash between writing the temp file and the
-//! rename therefore leaves the previously committed file intact, and a
-//! successful commit leaves no temp file behind.
+//! Every on-disk artifact — per-segment `.hnsw` files (written by
+//! `HnswIndexWriter::write`), the `segments.json` manifest (#879), and the
+//! deletion bitmap — is written to a `.tmp` file and atomically
+//! `rename_file`d into place. A crash between writing a temp file and the
+//! rename therefore leaves the previously committed state intact (the
+//! orphaned temp is ignored and swept on reopen), and a successful commit
+//! leaves no temp file behind.
 
 use async_trait::async_trait;
 use std::any::Any;
@@ -32,8 +34,10 @@ use laurus::{LaurusError, Result};
 const DIM: usize = 16;
 const N: u64 = 50;
 const STEP: f32 = 0.01;
-const HNSW_FILE: &str = "vector_index.hnsw";
-const HNSW_TMP: &str = "vector_index.hnsw.tmp";
+/// First sealed segment of the (default, #882) segmented layout.
+const HNSW_FILE: &str = "segment_000000.hnsw";
+/// An orphaned staging file from a simulated crashed segment write.
+const HNSW_TMP: &str = "segment_000001.hnsw.tmp";
 
 #[derive(Debug)]
 struct MockEmbedder {
@@ -148,12 +152,19 @@ async fn commit_leaves_no_temp_file() {
     let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
     let store = build_committed(storage.clone()).await;
 
-    // After a successful commit the segment is in place and the temp file has
-    // been renamed away.
-    assert!(storage.file_exists(HNSW_FILE), "committed .hnsw must exist");
+    // After a successful commit the sealed segment and the manifest are in
+    // place, and every temp file has been renamed away.
+    assert!(storage.file_exists(HNSW_FILE), "sealed segment must exist");
+    assert!(storage.file_exists("segments.json"), "manifest must exist");
+    let temps: Vec<String> = storage
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .filter(|f| f.ends_with(".tmp"))
+        .collect();
     assert!(
-        !storage.file_exists(HNSW_TMP),
-        "a successful commit must not leave a .hnsw.tmp behind"
+        temps.is_empty(),
+        "a successful commit must not leave any .tmp behind, got {temps:?}"
     );
     assert_eq!(hit_ids(&store.search(request()).unwrap()).len(), 10);
 }
@@ -166,8 +177,9 @@ async fn orphaned_temp_from_crashed_write_is_ignored() {
     assert_eq!(before.len(), 10);
     drop(store);
 
-    // Simulate a crash *during* a later write: the temp file was created but
-    // the atomic rename never happened. The committed `.hnsw` must be untouched.
+    // Simulate a crash *during* a later segment write: the temp file was
+    // created but the atomic rename never happened. The committed segment
+    // must be untouched.
     {
         let mut out = storage.create_output(HNSW_TMP).unwrap();
         out.write_all(b"partially-written-garbage-from-a-crashed-commit")
@@ -176,15 +188,19 @@ async fn orphaned_temp_from_crashed_write_is_ignored() {
     }
     assert!(
         storage.file_exists(HNSW_FILE),
-        "committed .hnsw still present"
+        "committed segment still present"
     );
 
-    // Reopening reads the valid committed segment and ignores the orphaned
-    // temp file — same results as before the simulated crash.
+    // Reopening reads the valid committed segment, ignores the orphaned
+    // temp (the #879 sweep removes it), and returns the same results.
     let reopened = laurus::vector::VectorStore::new(storage.clone(), make_config()).unwrap();
     let after = hit_ids(&reopened.search(request()).unwrap());
     assert_eq!(
         after, before,
         "the committed index must survive an orphaned temp file from a crashed write"
+    );
+    assert!(
+        !storage.file_exists(HNSW_TMP),
+        "the orphaned staging file must be swept on reopen (#879)"
     );
 }

--- a/laurus/tests/vector_hnsw_checksum_test.rs
+++ b/laurus/tests/vector_hnsw_checksum_test.rs
@@ -29,8 +29,12 @@ use laurus::{LaurusError, Result};
 const DIM: usize = 16;
 const N: u64 = 50;
 const STEP: f32 = 0.01;
-const HNSW_FILE: &str = "vector_index.hnsw";
-const METADATA_FILE: &str = "metadata.json";
+/// First sealed segment of the (default, #882) segmented layout — the
+/// same LVS file format (and CRC footer semantics) as the monolithic file.
+const HNSW_FILE: &str = "segment_000000.hnsw";
+/// The segmented layout's commit pivot (#879): CRC-framed and
+/// atomically replaced, so corruption must fail the open loudly.
+const METADATA_FILE: &str = "segments.json";
 
 #[derive(Debug)]
 struct MockEmbedder {
@@ -204,17 +208,18 @@ async fn corrupted_metadata_is_rejected() {
     let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
     build_committed(storage.clone()).await;
 
-    // Flip a byte in the CRC-framed metadata content.
+    // Flip a byte in the CRC-framed manifest content (#879): a corrupted
+    // segment registry must fail the open loudly, never silently start
+    // empty (which would orphan every live segment).
     let mut bytes = read_all(&storage, METADATA_FILE);
     let mid = bytes.len() / 2;
     bytes[mid] ^= 0xff;
     write_all(&storage, METADATA_FILE, &bytes);
 
-    // Opening the index reads (and now verifies) metadata.json.
     let result = laurus::vector::VectorStore::new(storage.clone(), make_config());
     assert!(
         result.is_err(),
-        "a corrupted metadata.json must be rejected on open"
+        "a corrupted segments.json must be rejected on open"
     );
 }
 

--- a/laurus/tests/vector_rerank_engine_test.rs
+++ b/laurus/tests/vector_rerank_engine_test.rs
@@ -27,9 +27,10 @@ use laurus::{FieldOption, QueryVector, Schema, VectorSearchQuery};
 use std::sync::Arc;
 
 /// Sidecar name as seen by the engine's outer storage: the vector
-/// store works behind `PrefixedStorage("vector", ..)`, and the HNSW
-/// index file is `vector_index.hnsw`.
-const SIDECAR_NAME: &str = "vector/vector_index.hnsw.f32";
+/// store works behind `PrefixedStorage("vector", ..)`, and the first
+/// sealed segment of the (default, #882) segmented layout is
+/// `segment_000000.hnsw`.
+const SIDECAR_NAME: &str = "vector/segment_000000.hnsw.f32";
 
 /// Build a search request for `query`, optionally asking for Stage-2
 /// rerank with the given factor.
@@ -96,15 +97,18 @@ async fn engine_search_with_rerank_factor_succeeds_on_stage2_field() -> laurus::
 
     // Stronger, deterministic guard: reopen the committed segment the
     // way the vector store does (behind `PrefixedStorage("vector", ..)`,
-    // index file `vector_index`) and assert the sidecar actually loads
-    // into the rerank pool. A fresh `PrefixedStorage` reports Eager
-    // loading (the trait default), so the pool is populated on load —
-    // this proves "the f32 pool exists and is populated", independent
-    // of the score comparison below.
+    // first sealed segment `segment_000000`, #882) and assert the sidecar
+    // actually loads into the rerank pool. A fresh `PrefixedStorage`
+    // reports Eager loading (the trait default), so the pool is populated
+    // on load — this proves "the f32 pool exists and is populated",
+    // independent of the score comparison below.
     let vector_storage: Arc<dyn Storage> =
         Arc::new(PrefixedStorage::new("vector", storage.clone()));
-    let reader =
-        HnswIndexReader::load(vector_storage, "vector_index", VectorDistanceMetric::Cosine)?;
+    let reader = HnswIndexReader::load(
+        vector_storage,
+        "segment_000000",
+        VectorDistanceMetric::Cosine,
+    )?;
     let pool = reader
         .rerank_storage()
         .expect("the committed Stage-2 segment must load its rerank pool");

--- a/laurus/tests/vector_segmented_index_test.rs
+++ b/laurus/tests/vector_segmented_index_test.rs
@@ -128,10 +128,12 @@ fn config_off_keeps_monolithic_layout() {
     assert!(storage.file_exists("vector_index.hnsw"));
 }
 
-/// #881: opening a legacy monolithic index with the flag ON is rejected —
-/// the zero-copy migration lands with #882.
+/// #882: a legacy monolithic index is migrated ZERO-COPY on first segmented
+/// open — the existing `.hnsw` becomes segment 0 verbatim (no data
+/// movement), search results are identical, and later commits append new
+/// segments without ever touching the legacy file.
 #[test]
-fn flag_on_rejects_legacy_monolithic_index() {
+fn legacy_monolithic_index_migrates_zero_copy() {
     let storage = storage();
     {
         let index = HnswIndex::create(
@@ -140,17 +142,97 @@ fn flag_on_rejects_legacy_monolithic_index() {
             config(false),
         )
         .unwrap();
-        commit_batch(&index, 0..10);
+        commit_batch(&index, 0..100);
     }
-    let err = SegmentedHnswIndex::open_or_create(
+    let legacy_size = storage.file_size("vector_index.hnsw").unwrap();
+
+    let index = SegmentedHnswIndex::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    // Migration wrote only the manifest; the legacy file is untouched.
+    assert!(storage.file_exists("segments.json"), "manifest created");
+    assert_eq!(
+        storage.file_size("vector_index.hnsw").unwrap(),
+        legacy_size,
+        "zero-copy: the legacy file must not be rewritten (#882)"
+    );
+
+    // The migrated data is searchable...
+    let searcher = index.searcher().unwrap();
+    let results = searcher.search(&query(42, 1)).unwrap();
+    assert_eq!(results.results[0].doc_id, 42);
+
+    // ...and a later commit appends a NEW segment, still leaving the legacy
+    // file untouched.
+    commit_batch(&index, 100..101);
+    assert_eq!(storage.file_size("vector_index.hnsw").unwrap(), legacy_size);
+    let searcher = index.searcher().unwrap();
+    assert_eq!(
+        searcher.search(&query(100, 1)).unwrap().results[0].doc_id,
+        100
+    );
+    assert_eq!(
+        searcher.search(&query(42, 1)).unwrap().results[0].doc_id,
+        42
+    );
+
+    // Re-open: the migration must not re-run (idempotent — the manifest
+    // already exists) and everything stays searchable.
+    drop(index);
+    let index = SegmentedHnswIndex::open_or_create(
         storage as Arc<dyn Storage>,
         "vector_index",
         config(true),
+    )
+    .unwrap();
+    let searcher = index.searcher().unwrap();
+    assert_eq!(
+        searcher.search(&query(42, 1)).unwrap().results[0].doc_id,
+        42
     );
-    assert!(
-        err.is_err(),
-        "a legacy monolithic index must be rejected until the #882 migration"
+    assert_eq!(
+        searcher.search(&query(100, 1)).unwrap().results[0].doc_id,
+        100
     );
+}
+
+/// #882: the WAL checkpoint is published only by `persist_deletions` (the
+/// end of the store's commit ladder) — never by intermediate manifest saves
+/// — so recovery can only skip records whose effects are already durable.
+#[test]
+fn wal_checkpoint_publishes_only_after_persist_deletions() {
+    let storage = storage();
+    let index = SegmentedHnswIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    index.set_last_wal_seq(7).unwrap();
+    assert_eq!(
+        index.last_wal_seq(),
+        0,
+        "a pending seq must not be visible before persist_deletions (#882)"
+    );
+
+    // Sealing a segment saves the manifest, but must NOT publish the
+    // pending checkpoint (the deletion bitmap for seq<=7 may not be
+    // durable yet).
+    commit_batch(&index, 0..5);
+    assert_eq!(
+        index.last_wal_seq(),
+        0,
+        "sealing must not publish the pending checkpoint (#882)"
+    );
+
+    // persist_deletions publishes and persists it.
+    index.persist_deletions().unwrap();
+    assert_eq!(index.last_wal_seq(), 7);
 }
 
 /// #881: self-recall@10 of a 5-segment index matches a monolithic build of
@@ -390,4 +472,172 @@ fn count_excludes_soft_deleted_docs() {
     let searcher = index.searcher().unwrap();
     let count = searcher.count(query(0, 1)).unwrap();
     assert_eq!(count, 9, "count must exclude soft-deleted docs (#881)");
+}
+
+/// #882 (CRITICAL review find): the migration must fire through the
+/// PRODUCTION factory path. A legacy index always has a `metadata.json`, so
+/// it always takes the factory's OPEN arm — which previously had no
+/// segmented dispatch, leaving every existing deployment monolithic forever
+/// and (worse) flipping an already-migrated directory back to a monolithic
+/// view that silently hid post-migration segments.
+#[test]
+fn factory_open_path_migrates_legacy_index_and_stays_segmented() {
+    use laurus::vector::index::config::VectorIndexTypeConfig;
+    use laurus::vector::index::factory::VectorIndexFactory;
+
+    let storage = storage();
+    {
+        let index = HnswIndex::create(
+            storage.clone() as Arc<dyn Storage>,
+            "vector_index",
+            config(false),
+        )
+        .unwrap();
+        commit_batch(&index, 0..50);
+    }
+    assert!(storage.file_exists("metadata.json"), "legacy precondition");
+
+    // The exact production call (VectorStore::with_index_type_config).
+    let index = VectorIndexFactory::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        VectorIndexTypeConfig::HNSW(config(true)),
+    )
+    .unwrap();
+    assert!(
+        storage.file_exists("segments.json"),
+        "the factory OPEN arm must migrate a legacy index (#882)"
+    );
+    assert!(
+        !storage.file_exists("metadata.json"),
+        "the stale monolithic metadata.json must be removed so factory \
+         routing can never regress to the monolithic view (#882)"
+    );
+
+    // Commit through the migrated index, then reopen through the factory
+    // again: the segmented view must persist and serve ALL data.
+    commit_batch(index.as_ref(), 50..51);
+    drop(index);
+    let index = VectorIndexFactory::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        VectorIndexTypeConfig::HNSW(config(true)),
+    )
+    .unwrap();
+    let searcher = index.searcher().unwrap();
+    assert_eq!(
+        searcher.search(&query(42, 1)).unwrap().results[0].doc_id,
+        42
+    );
+    assert_eq!(
+        searcher.search(&query(50, 1)).unwrap().results[0].doc_id,
+        50
+    );
+}
+
+/// #882: opening a segmented directory with `segmented: false` must be
+/// rejected loudly — the monolithic view would silently hide every sealed
+/// segment.
+#[test]
+fn factory_rejects_segmented_directory_with_flag_off() {
+    use laurus::vector::index::config::VectorIndexTypeConfig;
+    use laurus::vector::index::factory::VectorIndexFactory;
+
+    let storage = storage();
+    {
+        let index = SegmentedHnswIndex::open_or_create(
+            storage.clone() as Arc<dyn Storage>,
+            "vector_index",
+            config(true),
+        )
+        .unwrap();
+        commit_batch(&index, 0..10);
+    }
+
+    let result = VectorIndexFactory::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        VectorIndexTypeConfig::HNSW(config(false)),
+    );
+    assert!(
+        result.is_err(),
+        "a segmented directory must not open monolithically (#882)"
+    );
+}
+
+/// #882: pure-append workloads must not grow the segment count unboundedly
+/// — `maybe_auto_compact` merges a policy window once the manager's
+/// threshold is exceeded (tiered policy lands with #883).
+#[test]
+fn append_only_segment_count_is_bounded_by_auto_merge() {
+    let storage = storage();
+    let index = SegmentedHnswIndex::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    // 101 one-doc commits exceed the default max_segments (100).
+    for i in 0..101u64 {
+        commit_batch(&index, i..i + 1);
+    }
+    let before = storage
+        .list_files()
+        .unwrap()
+        .iter()
+        .filter(|f| f.ends_with(".hnsw"))
+        .count();
+    assert!(before > 100, "precondition: {before} segments");
+
+    let compacted = index.maybe_auto_compact().unwrap();
+    assert!(compacted, "the segment-count bound must trigger a merge");
+    let after = storage
+        .list_files()
+        .unwrap()
+        .iter()
+        .filter(|f| f.ends_with(".hnsw"))
+        .count();
+    assert!(
+        after < before,
+        "the merge must reduce the segment count ({before} -> {after})"
+    );
+
+    // Every doc is still searchable through the merged layout.
+    let searcher = index.searcher().unwrap();
+    for id in [0u64, 50, 100] {
+        assert_eq!(
+            searcher.search(&query(id, 1)).unwrap().results[0].doc_id,
+            id
+        );
+    }
+}
+
+/// #882: serde behavior of the flipped default — a config missing the field
+/// deserializes to `true`; an explicit `false` is preserved.
+#[test]
+fn segmented_flag_serde_default_and_explicit_false() {
+    // A pre-#882 config = today's config with the `segmented` key removed.
+    let mut value: serde_json::Value = serde_json::to_value(HnswIndexConfig::default()).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .remove("segmented")
+        .expect("the flag must serialize");
+    let config: HnswIndexConfig = serde_json::from_value(value).unwrap();
+    assert!(
+        config.segmented,
+        "a config serialized before the field existed must open segmented (#882)"
+    );
+
+    let explicit_false = serde_json::to_string(&HnswIndexConfig {
+        segmented: false,
+        ..HnswIndexConfig::default()
+    })
+    .unwrap();
+    let config: HnswIndexConfig = serde_json::from_str(&explicit_false).unwrap();
+    assert!(
+        !config.segmented,
+        "an explicit `segmented: false` must be preserved (#882)"
+    );
 }

--- a/laurus/tests/vector_writer_retention_test.rs
+++ b/laurus/tests/vector_writer_retention_test.rs
@@ -544,7 +544,7 @@ async fn optimize_flushes_writer_emptied_by_deletions() {
 /// writer/disk agreement is unknown after a partial failure, so the next
 /// upsert must reload ground truth from storage.
 #[tokio::test(flavor = "multi_thread")]
-async fn failed_commit_drops_retained_writer() {
+async fn failed_commit_retains_writer_for_retry() {
     let counting = Arc::new(CountingStorage::new());
     let storage: Arc<dyn Storage> = counting.clone();
     let store = laurus::vector::VectorStore::new(storage, make_config(false, 0.5)).unwrap();
@@ -569,30 +569,27 @@ async fn failed_commit_drops_retained_writer() {
         .expect_err("the injected create_output failure must fail the commit");
     counting.set_fail_create_matching(None);
 
-    // The failed writer must be gone: the next upsert reloads the intact
-    // on-disk index (observable as a fresh .hnsw open) instead of reusing a
-    // writer in an unknown state.
-    let opens_before = counting.open_count(HNSW_FILE);
+    // #882 review (the #875 lesson): a FAILED flush keeps the writer — its
+    // buffered doc 5 is the only in-process copy, and the pending WAL
+    // checkpoint may already cover its sequence number; dropping it would
+    // let a later successful commit's checkpoint hide the loss from
+    // recovery. The sealed segments were never touched by the failed
+    // commit, so the retry from the retained writer is sound.
     store
         .upsert_document_by_internal_id(6, vec_doc(6))
         .await
         .unwrap();
-    assert!(
-        counting.open_count(HNSW_FILE) > opens_before,
-        "after a failed commit the cache must be empty, forcing a reload"
-    );
 
-    // And the store recovers fully: doc 5 was lost with the failed writer
-    // (it is WAL-replayable at engine level), docs 0-4 + 6 are intact.
+    // The retry commits BOTH the previously failed doc 5 and the new doc 6.
     store.commit().await.unwrap();
     let ids = hit_ids(&store, 10);
     assert!(
-        ids.contains(&6),
-        "post-recovery upsert must be live: {ids:?}"
+        ids.contains(&5) && ids.contains(&6),
+        "the retained writer must carry the failed doc through the retry: {ids:?}"
     );
     assert_eq!(
         store.stats().unwrap().document_count,
-        6,
-        "the intact on-disk docs (0-4) plus the post-recovery doc (6)"
+        7,
+        "docs 0-4 plus the retried doc 5 and the new doc 6"
     );
 }


### PR DESCRIPTION
## Summary

PR-4 of the #634 segment-per-commit campaign: **the segmented layout becomes the default HNSW layout**, with zero-copy legacy migration and the WAL checkpoint ordering wired. Hardened by an adversarial review — **13 confirmed findings (1 critical) fixed**. Full details in the [implementation report on #882](https://github.com/mosuka/laurus/issues/882#issuecomment-5016470334).

## Changes

- **Default flip**: `HnswIndexConfig::segmented` defaults to `true` (Default impl + serde default fn; explicit `false` preserved — serde-pinned). The monolithic layout remains supported for direct index users via the flag.
- **Zero-copy migration**: on first open, an existing monolithic `{name}.hnsw` is registered verbatim as the first segment — one atomic manifest write, no data movement, idempotent across crashes; a legacy `.delmap` marks `has_deletions`; the stale `metadata.json` is removed.
- **Factory dispatch unified (review-critical)**: both the create AND open arms route through one segmented dispatcher. A legacy index always has a `metadata.json`, so it always takes the *open* arm — which previously had no dispatch: the migration was unreachable through `VectorStore` (the default flip would have been a production no-op), and a migrated directory could silently reopen as a monolithic view hiding newer segments. The gate test now drives the exact production factory call (migrate → commit → reopen).
- **WAL checkpoint ordering** (the #875 lesson, made structural): `set_last_wal_seq` records a pending value; `persist_deletions` — the last vector step of the commit ladder, before the engine truncates the WAL — publishes it into the manifest once the sealed segments and deletion bitmap are durable. Intermediate manifest saves never publish (gate-tested). Every writer-discard path (commit/optimize flush failure, `add_field`/`delete_field`, `rollback`, `Drop`) either retains the writer for retry or rolls the pending value back, so a checkpoint can never cover discarded mutations.
- **Hardening**: reverse guard (segmented directory + flag off → loud error); segment temp files fsynced before the publishing rename; `.delmap` excluded from segment-file GC and size accounting (the migrated segment shares the index name); `segment_<digits>` index names rejected; a generation-contiguous auto-merge bounds pure-append segment growth (tiered policy lands with #883).

## Verification

- 13 gate tests (factory-path migration, reverse guard, checkpoint publish timing, append-only segment bound, zero-copy invariants, upsert/soft-delete semantics, …) plus the layout-pinned tests updated (atomic-write, checksum, rerank sidecar, laurus-server sidecar, retention-retry — the retention test now pins the *retain-on-failure* contract).
- **1243 lib + 1441 integration + 1575 `--features pq-fastscan` + 43 laurus-server tests green**; fmt + clippy on 1.95/1.97 + fastscan + wasm clean. (Server tests are now part of the local verification set — the review caught a failing server assertion my earlier runs never compiled.)

Handoff to #883 (PR-5): tiered merge policy, adaptive refill, bytes/commit benches, comprehensive docs EN/JA.

Refs #634
Closes #882
