### PR TITLE
feat(engine): auto-commit policy (CommitPolicy::EveryDocs) (#890)

### DIFF
--- a/docs/ja/src/laurus/engine.md
+++ b/docs/ja/src/laurus/engine.md
@@ -52,6 +52,8 @@ let engine = Engine::builder(storage, schema)
 | `analyzer()` | `Arc<dyn Analyzer>` | `StandardAnalyzer` | Lexicalフィールド用のテキスト解析パイプライン |
 | `embedder()` | `Arc<dyn Embedder>` | None | Vectorフィールド用のEmbeddingモデル |
 | `embedding_cache_capacity()` | `usize` | None（無効） | 最大 N 件のクエリEmbeddingをLRUキャッシュする |
+| `wal_sync_policy()` | `WalSyncPolicy` | `PerRecord` | WAL fsync の耐久性（per-record か group commit か） |
+| `commit_policy()` | `CommitPolicy` | `Manual` | 自動コミットのタイミング — 例: `EveryDocs(n)` は `n` 件ごとにコミット |
 | `build()` | -- | -- | Engineを構築（非同期） |
 
 ### クエリEmbeddingキャッシュ

--- a/docs/ja/src/laurus/persistence.md
+++ b/docs/ja/src/laurus/persistence.md
@@ -116,6 +116,37 @@ engine.add_document("doc-3", doc3).await?;
 
 > **ヒント:** コミットはセグメントをストレージにフラッシュするため比較的コストが高い操作です。バルクインデキシングでは、`commit()` を呼び出す前に多数のドキュメントをバッチ処理してください。
 
+### 自動コミットポリシー（Auto-commit Policy）
+
+自分で `commit()` を呼ぶ代わりに、ビルダーで `CommitPolicy` を設定して、インジェスト駆動のタイミングでエンジンにコミットラダーを自動実行させることができます。
+
+```rust
+use laurus::CommitPolicy;
+
+let engine = Engine::builder(storage, schema)
+    // 適用ドキュメント 1,000 件ごとに自動コミット。
+    .commit_policy(CommitPolicy::EveryDocs(1000))
+    .build()
+    .await?;
+
+// 明示的な commit() は不要 — 1,000 件目ごとにコミットが発火する。
+engine.put_documents(one_thousand_docs).await?;
+```
+
+| ポリシー | 挙動 |
+| :--- | :--- |
+| `Manual`（既定） | 自動コミットしない。すべての `commit()` を自分で駆動する。従来と同一の挙動。 |
+| `EveryDocs(n)` | 単数・バッチ両 API を通じて、適用ドキュメント `n` 件ごとにコミットラダーを実行。`EveryDocs(0)` は自動コミット無効（`Manual` と同じ）。 |
+
+主なセマンティクス:
+
+- **group-commit を維持**: 各自動コミットは WAL フラッシュ 1 回 + materialization ラダー 1 回であり、ドキュメントごとのコミットには決してならない。1 回の `put_documents` / `add_documents` 呼び出し内でも自動コミットは **`n` 件ごと**（チャンク単位）に発火するため、大きなバッチは最後にまとめて 1 回ではなく逐次 materialize される。末尾の `< n` 件の端数は次の境界か明示 `commit()` まで WAL durable のまま残る。
+- **`WalSyncPolicy` と直交**: `CommitPolicy` は *ストアがいつ materialize するか* を、`WalSyncPolicy` は *WAL fsync の耐久性* を決める。`commit()` は必ず WAL フラッシュから始まるため、自動コミットは任意の WAL ポリシー下で機能する。
+- **クラッシュ意味論は不変**: 自動コミットは通常のコミットであり、クラッシュ時は未コミットの tail が手動コミットとまったく同じように再生される。
+- **並行性**: 正確なタイミングと「ack した書き込みは durable」という保証は、**単一 writer のインジェスト**（エンジンの書き込みパスが前提とするモデル。CLI・バインディングもこれに従う）で成立する。共有エンジン上の並行 writer 下では auto-commit は best-effort となる: commit ラダーは他スレッドの in-flight write に対してアトミックでないため、並行 auto-commit の実行中に ack された書き込みが次のコミットまで durable にならず、タイミングもドリフトしうる（並行の手動 `commit()` も同じ race を持つ — auto-commit はそれを ingest 経路から誘発するだけ）。並行下でこれらの保証が必要な場合は、明示コミットか単一インジェストタスクを使うこと。
+
+> **注:** 時間ベースの `Interval` ポリシー（*T* 秒ごとにコミット）は計画中です。背景コミットタイマーが必要で、既存コードを壊さずに追加されます。
+
 ## バッチインジェスト
 
 `put_documents` / `add_documents` は `put_document` / `add_document` のバッチ形式です。`(id, doc)` ペアを**入力順に逐次適用**し、既定の `PerRecord` ポリシー下ではレコードごとではなく**バッチ末尾の 1 回の WAL fsync** でバッチ全体を durable にします。

--- a/docs/src/laurus/engine.md
+++ b/docs/src/laurus/engine.md
@@ -52,6 +52,8 @@ let engine = Engine::builder(storage, schema)
 | `analyzer()` | `Arc<dyn Analyzer>` | `StandardAnalyzer` | Text analysis pipeline for lexical fields |
 | `embedder()` | `Arc<dyn Embedder>` | None | Embedding model for vector fields |
 | `embedding_cache_capacity()` | `usize` | None (disabled) | Enable an LRU cache of up to N query embeddings |
+| `wal_sync_policy()` | `WalSyncPolicy` | `PerRecord` | WAL fsync durability (per-record vs group commit) |
+| `commit_policy()` | `CommitPolicy` | `Manual` | Auto-commit cadence — e.g. `EveryDocs(n)` commits every `n` documents |
 | `build()` | -- | -- | Create the Engine (async) |
 
 ### Query embedding cache

--- a/docs/src/laurus/persistence.md
+++ b/docs/src/laurus/persistence.md
@@ -110,6 +110,37 @@ engine.add_document("doc-3", doc3).await?;
 
 > **Tip:** Commits are relatively expensive because they flush segments to storage. For bulk indexing, batch many documents before calling `commit()`.
 
+### Auto-commit Policy
+
+Instead of calling `commit()` yourself, you can let the engine run the commit ladder automatically at an ingestion-driven cadence via `CommitPolicy`, configured on the builder:
+
+```rust
+use laurus::CommitPolicy;
+
+let engine = Engine::builder(storage, schema)
+    // Commit automatically after every 1,000 applied documents.
+    .commit_policy(CommitPolicy::EveryDocs(1000))
+    .build()
+    .await?;
+
+// No explicit commit() needed — every 1,000th document triggers one.
+engine.put_documents(one_thousand_docs).await?;
+```
+
+| Policy | Behavior |
+| :--- | :--- |
+| `Manual` (default) | Never auto-commits; you drive every `commit()`. Identical to the historical behavior. |
+| `EveryDocs(n)` | Runs the commit ladder after every `n` applied documents, across the singular and batch APIs. `EveryDocs(0)` disables auto-commit (same as `Manual`). |
+
+Key semantics:
+
+- **Group-commit preserved.** Each auto-commit is one WAL flush plus one materialization ladder — never one commit per document. Within a single `put_documents` / `add_documents` call the auto-commit fires **every `n` documents** (chunked), so a large batch materializes incrementally rather than in one final ladder; the trailing `< n` remainder stays WAL-durable until the next boundary or an explicit `commit()`.
+- **Orthogonal to `WalSyncPolicy`.** `CommitPolicy` decides *when the stores materialize*; `WalSyncPolicy` decides *WAL fsync durability*. Auto-commit works under any WAL policy because `commit()` always begins with a WAL flush.
+- **Crash semantics unchanged.** An auto-commit is a normal commit; a crash replays the uncommitted tail exactly as it would under manual commits.
+- **Concurrency.** The exact cadence and the usual "acknowledged write is durable" guarantee hold for **single-writer ingestion** (the model the engine's write path — and the CLI/bindings — are built around). Under concurrent writers on a shared engine, auto-commit is best-effort: because the commit ladder is not atomic with respect to another thread's in-flight write, a write acknowledged while a concurrent auto-commit runs may only become durable at the following commit, and the cadence may drift. (A concurrent manual `commit()` races the same way — auto-commit merely triggers it from the ingest path.) Use explicit commits, or a single ingest task, if you need these guarantees under concurrency.
+
+> **Note:** A time-based `Interval` policy (commit every *T* seconds) is planned; it needs a background commit timer and will be added without breaking existing code.
+
 ## Batch Ingestion
 
 `put_documents` / `add_documents` are the batched forms of `put_document` / `add_document`. They apply their `(id, doc)` pairs **sequentially, in input order**, and under the default `PerRecord` policy they make the whole batch durable with a **single WAL fsync at batch end** instead of one per record:

--- a/laurus-cli/src/commands/bulk.rs
+++ b/laurus-cli/src/commands/bulk.rs
@@ -88,7 +88,21 @@ pub async fn run(
         bail!("--batch-size must be greater than 0");
     }
 
-    let engine = context::open_index(index_dir).await?;
+    // Hand the commit cadence to the engine's auto-commit policy (Issue #890):
+    // `--commit-every n` opens the engine with `CommitPolicy::EveryDocs(n)`, so
+    // the engine commits every n documents (including within a single
+    // `put_documents` call) instead of the client committing in this loop.
+    // `--commit-every 0` (the default) keeps manual control: only the final
+    // commit below runs.
+    let engine = if commit_every > 0 {
+        context::open_index_with_commit_policy(
+            index_dir,
+            laurus::CommitPolicy::EveryDocs(commit_every),
+        )
+        .await?
+    } else {
+        context::open_index(index_dir).await?
+    };
     let reader = std::io::BufReader::new(
         std::fs::File::open(file)
             .with_context(|| format!("failed to open JSONL file '{}'", file.display()))?,
@@ -98,7 +112,6 @@ pub async fn run(
     // 1-based input line number of each entry in `batch`, for error reports.
     let mut batch_lines: Vec<usize> = Vec::with_capacity(batch_size);
     let mut applied: usize = 0;
-    let mut since_commit: usize = 0;
 
     let flush = async |batch: Vec<(String, Document)>,
                        lines: Vec<usize>,
@@ -150,15 +163,17 @@ pub async fn run(
             let lines = std::mem::take(&mut batch_lines);
             let flushed = flush(docs, lines, applied).await?;
             applied += flushed;
-            since_commit += flushed;
-            if commit_every > 0 && since_commit >= commit_every {
-                engine.commit().await?;
-                since_commit = 0;
-                println!("... {applied} documents applied (committed)");
+            // The engine auto-commits every `commit_every` docs when set; report
+            // ingest progress per batch.
+            if commit_every > 0 {
+                println!("... {applied} documents applied");
             }
         }
     }
     applied += flush(batch, batch_lines, applied).await?;
+    // Final commit flushes the trailing remainder (the last < commit_every docs
+    // that did not reach an auto-commit boundary, or the whole run when
+    // --commit-every is 0).
     engine.commit().await?;
 
     let verb = match mode {

--- a/laurus-cli/src/context.rs
+++ b/laurus-cli/src/context.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result, bail};
 use laurus::storage::file::FileStorageConfig;
-use laurus::{Engine, Schema, StorageConfig, StorageFactory};
+use laurus::{CommitPolicy, Engine, Schema, StorageConfig, StorageFactory};
 
 /// File name used to persist the schema inside the index directory.
 const SCHEMA_FILE: &str = "schema.toml";
@@ -160,6 +160,31 @@ async fn init_index(index_dir: &Path, schema: Schema) -> Result<()> {
 /// - The storage backend cannot be opened (or created) or the engine cannot
 ///   be initialised.
 pub async fn open_index(index_dir: &Path) -> Result<Engine> {
+    open_index_with_commit_policy(index_dir, CommitPolicy::Manual).await
+}
+
+/// Open an existing index with an explicit auto-commit policy (Issue #890).
+///
+/// Identical to [`open_index`] but builds the engine with the given
+/// [`CommitPolicy`], so a bulk ingest can hand commit cadence to the engine
+/// (e.g. `EveryDocs(n)`) instead of committing client-side.
+///
+/// # Arguments
+///
+/// * `index_dir` - Path to the index directory that contains an existing index.
+/// * `commit_policy` - The engine auto-commit policy.
+///
+/// # Returns
+///
+/// Returns the opened [`Engine`] on success.
+///
+/// # Errors
+///
+/// Same as [`open_index`].
+pub async fn open_index_with_commit_policy(
+    index_dir: &Path,
+    commit_policy: CommitPolicy,
+) -> Result<Engine> {
     let schema_path = index_dir.join(SCHEMA_FILE);
     if !schema_path.exists() {
         bail!(
@@ -181,7 +206,10 @@ pub async fn open_index(index_dir: &Path) -> Result<Engine> {
     } else {
         StorageFactory::create(storage_config)?
     };
-    let engine = Engine::new(storage, schema).await?;
+    let engine = Engine::builder(storage, schema)
+        .commit_policy(commit_policy)
+        .build()
+        .await?;
 
     Ok(engine)
 }

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -7,6 +7,7 @@ pub mod type_inference;
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use parking_lot::RwLock;
 
@@ -27,6 +28,54 @@ use crate::vector::store::VectorStore;
 use crate::vector::store::config::VectorIndexConfig;
 
 use self::schema::Schema;
+
+/// Policy controlling when the engine automatically runs the commit ladder
+/// during ingestion (Issue #890).
+///
+/// The commit ladder ([`Engine::commit`]) materializes and fsyncs the lexical,
+/// vector, and document stores and truncates the WAL. By default it runs only
+/// when the caller invokes [`Engine::commit`] explicitly; a non-`Manual` policy
+/// makes the engine run it automatically at an ingestion-driven cadence, one
+/// full ladder per auto-commit (group-commit semantics are preserved).
+///
+/// This is orthogonal to [`WalSyncPolicy`]: that governs *WAL fsync
+/// durability*, while `CommitPolicy` governs *when the stores materialize*. An
+/// auto-commit works under any `WalSyncPolicy` because [`Engine::commit`] always
+/// begins with a WAL flush.
+///
+/// The enum is `#[non_exhaustive]`: a time-based `Interval` variant is planned
+/// (it needs a background commit timer) and will be added without breaking
+/// exhaustive matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum CommitPolicy {
+    /// Never auto-commit; the caller drives every commit explicitly. This is
+    /// the default and preserves the historical behavior.
+    #[default]
+    Manual,
+    /// Auto-commit after every `n` applied documents, across the singular
+    /// ([`Engine::put_document`] / [`Engine::add_document`]) and batch
+    /// ([`Engine::put_documents`] / [`Engine::add_documents`]) APIs. Within a
+    /// batch the commit fires every `n` documents (chunked), so a large batch
+    /// materializes incrementally rather than in one final ladder.
+    ///
+    /// The exact cadence, and the usual "acknowledged write is durable"
+    /// guarantee, hold for **single-writer ingestion** (the model the engine's
+    /// write path is built around — the CLI and language bindings drive a
+    /// single ingest task). Under **concurrent writers on a shared engine**,
+    /// auto-commit is best-effort: the commit ladder is not atomic with respect
+    /// to another thread's in-flight write, so a write acknowledged while a
+    /// concurrent auto-commit is running may only become durable at the
+    /// following commit, and the cadence may drift. This is a property of
+    /// commit-vs-concurrent-write in general (a concurrent manual `commit()`
+    /// races the same way); auto-commit merely triggers it from inside the
+    /// ingest path. Use explicit commits, or a single ingest task, when you
+    /// need these guarantees under concurrency.
+    ///
+    /// `EveryDocs(0)` disables auto-commit (equivalent to
+    /// [`CommitPolicy::Manual`]).
+    EveryDocs(usize),
+}
 
 /// Combined statistics from both the lexical and vector stores.
 #[derive(Debug, Clone, Default)]
@@ -132,6 +181,16 @@ pub struct Engine {
     /// built in [`Self::unified_query_parser`], so both the direct
     /// `Payloads` path and the DSL path hit the same cache.
     embedding_cache: Option<Arc<EmbeddingCache>>,
+    /// Auto-commit policy (Issue #890). `Manual` by default; a non-`Manual`
+    /// policy runs the commit ladder automatically during ingestion.
+    commit_policy: CommitPolicy,
+    /// Documents applied since the last commit, tracking progress toward the
+    /// [`CommitPolicy::EveryDocs`] threshold. Incremented once per applied
+    /// document in [`Self::index_internal`] and reset to `0` by
+    /// [`Self::commit`], so both manual and auto commits keep the count
+    /// consistent. Lock-free (mirrors [`DocumentLog`]'s counters); exact for
+    /// serial ingestion, best-effort under concurrent writers.
+    docs_since_commit: AtomicU64,
     /// Background WAL flush timer for a [`WalSyncPolicy::Group`] configured with
     /// a `max_interval`. `None` when no interval is set. Held only to keep the
     /// timer thread alive for the engine's lifetime; dropping the engine stops
@@ -304,6 +363,8 @@ impl Engine {
         // sync-deferral scope, which would otherwise leave this acknowledged
         // write unsynced. A no-op when the append already self-synced.
         self.log.ensure_per_record_durability()?;
+        // Auto-commit if the CommitPolicy threshold was reached (#890).
+        self.maybe_auto_commit().await?;
         Ok(())
     }
 
@@ -334,6 +395,8 @@ impl Engine {
         // sync-deferral scope, which would otherwise leave this acknowledged
         // write unsynced. A no-op when the append already self-synced.
         self.log.ensure_per_record_durability()?;
+        // Auto-commit if the CommitPolicy threshold was reached (#890).
+        self.maybe_auto_commit().await?;
         Ok(())
     }
 
@@ -445,6 +508,17 @@ impl Engine {
                     source: Box::new(e),
                 });
             }
+            // Auto-commit every `n` documents *within* the batch (#890). The
+            // commit's own `flush_wal` is deferral-independent, so each chunk
+            // becomes durable in one fsync + one ladder (group-commit per
+            // chunk), leaving the sync-deferral scope intact for the rest of
+            // the loop. A commit failure is distinct from a per-document
+            // failure: surface it directly (the applied prefix stays in the
+            // WAL and replays on recovery) rather than as a `BatchIngest`.
+            if let Err(e) = self.maybe_auto_commit().await {
+                drop(deferral);
+                return Err(e);
+            }
         }
         drop(deferral);
         self.log.flush_wal()
@@ -499,7 +573,36 @@ impl Engine {
         self.lexical.set_last_wal_seq(seq)?;
         self.vector.set_last_wal_seq(seq);
 
+        // 7. Count the applied document toward the auto-commit threshold. The
+        // trigger itself lives at the API boundary (see `maybe_auto_commit`),
+        // not here, so this method's `Ok` keeps meaning "document applied" —
+        // a commit failure never masquerades as a per-document index failure.
+        self.docs_since_commit.fetch_add(1, Ordering::AcqRel);
+
         Ok(doc_id)
+    }
+
+    /// Run the commit ladder if the [`CommitPolicy`] threshold has been reached.
+    ///
+    /// A no-op under [`CommitPolicy::Manual`] and [`CommitPolicy::EveryDocs`]
+    /// with a zero count. Under `EveryDocs(n)` with `n > 0` it commits once the
+    /// documents applied since the last commit reach `n`; [`Self::commit`]
+    /// resets the counter. Called at ingestion API boundaries (after each
+    /// singular put/add, and after each document inside a batch), never inside
+    /// [`Self::index_internal`], so its error is reported as a commit error
+    /// rather than a document-index failure.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Self::commit`].
+    async fn maybe_auto_commit(&self) -> Result<()> {
+        let CommitPolicy::EveryDocs(n) = self.commit_policy else {
+            return Ok(());
+        };
+        if n > 0 && self.docs_since_commit.load(Ordering::Acquire) >= n as u64 {
+            self.commit().await?;
+        }
+        Ok(())
     }
 
     /// Apply the schema's [`DynamicFieldPolicy`](schema::DynamicFieldPolicy)
@@ -755,6 +858,9 @@ impl Engine {
         self.log.commit_documents()?;
         // After successful commit to all stores, truncate the log
         self.log.truncate()?;
+        // Reset the auto-commit counter so a manual commit and an
+        // `EveryDocs` auto-commit keep the same cadence going forward (#890).
+        self.docs_since_commit.store(0, Ordering::Release);
         Ok(())
     }
 
@@ -1942,6 +2048,7 @@ pub struct EngineBuilder {
     runtime_analyzers: HashMap<String, Arc<dyn Analyzer>>,
     embedding_cache_capacity: Option<usize>,
     wal_sync_policy: WalSyncPolicy,
+    commit_policy: CommitPolicy,
 }
 
 impl EngineBuilder {
@@ -1955,6 +2062,7 @@ impl EngineBuilder {
             runtime_analyzers: HashMap::new(),
             embedding_cache_capacity: None,
             wal_sync_policy: WalSyncPolicy::default(),
+            commit_policy: CommitPolicy::default(),
         }
     }
 
@@ -2041,6 +2149,25 @@ impl EngineBuilder {
         self
     }
 
+    /// Set the auto-commit policy (Issue #890).
+    ///
+    /// Defaults to [`CommitPolicy::Manual`] — the engine commits only when the
+    /// caller invokes [`Engine::commit`]. Use [`CommitPolicy::EveryDocs`] to
+    /// run the commit ladder automatically every `n` applied documents (across
+    /// the singular and batch ingest APIs, and every `n` documents *within* a
+    /// batch). Orthogonal to [`Self::wal_sync_policy`]: an auto-commit works
+    /// under any WAL sync policy because [`Engine::commit`] always begins with
+    /// a WAL flush.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy` - The auto-commit policy. `EveryDocs(0)` disables auto-commit
+    ///   (equivalent to `Manual`).
+    pub fn commit_policy(mut self, policy: CommitPolicy) -> Self {
+        self.commit_policy = policy;
+        self
+    }
+
     /// Build the [`Engine`].
     ///
     /// Creates the lexical store, vector store, and document log (WAL),
@@ -2095,6 +2222,8 @@ impl EngineBuilder {
             log,
             runtime_analyzers: self.runtime_analyzers,
             embedding_cache,
+            commit_policy: self.commit_policy,
+            docs_since_commit: AtomicU64::new(0),
             #[cfg(not(target_arch = "wasm32"))]
             _wal_flush_timer: wal_flush_timer,
         };
@@ -3509,6 +3638,182 @@ mod tests {
              got {} (regression: either #480 fanout BKD or #400 \
              per-segment deletion filter)",
             hits.len()
+        );
+    }
+
+    // ---- #890 CommitPolicy (auto-commit) gates ----
+
+    /// Build a `title`-only engine with the given auto-commit policy, returning
+    /// the engine plus a handle to the root storage so tests can observe the
+    /// WAL file directly. The WAL lives at `engine.wal` on the root storage;
+    /// the commit ladder truncates it to zero bytes, so [`wal_bytes`] is a
+    /// side-effect-free "are there uncommitted records?" probe.
+    async fn commit_policy_engine(policy: CommitPolicy) -> (Engine, Arc<dyn Storage>) {
+        use crate::engine::schema::FieldOption;
+        use crate::lexical::core::field::TextOption;
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field("title", FieldOption::Text(TextOption::default()))
+            .build();
+        let engine = Engine::builder(storage.clone(), schema)
+            .commit_policy(policy)
+            .build()
+            .await
+            .unwrap();
+        (engine, storage)
+    }
+
+    /// Bytes in the WAL file: `0` right after a commit (the ladder truncates
+    /// the WAL) or before the first append; `> 0` while uncommitted records are
+    /// buffered.
+    fn wal_bytes(storage: &Arc<dyn Storage>) -> u64 {
+        storage.file_size("engine.wal").unwrap_or(0)
+    }
+
+    fn title_doc(title: &str) -> Document {
+        Document::builder().add_text("title", title).build()
+    }
+
+    /// #890: `EveryDocs(n)` auto-commits after exactly every n-th applied
+    /// document — the WAL is truncated right after each n-th put and non-empty
+    /// in between (a deterministic commit-boundary counter).
+    #[tokio::test]
+    async fn every_docs_commits_at_exact_multiples() {
+        let (engine, storage) = commit_policy_engine(CommitPolicy::EveryDocs(3)).await;
+        for i in 1..=7u64 {
+            engine
+                .put_document(&format!("d{i}"), title_doc("x"))
+                .await
+                .unwrap();
+            if i % 3 == 0 {
+                assert_eq!(
+                    wal_bytes(&storage),
+                    0,
+                    "an auto-commit must truncate the WAL at doc {i}"
+                );
+            } else {
+                assert!(
+                    wal_bytes(&storage) > 0,
+                    "docs between commit points stay uncommitted (doc {i})"
+                );
+            }
+        }
+    }
+
+    /// #890: within a batch the auto-commit fires every n documents *inside*
+    /// the call (chunked), not once at the end. `EveryDocs(3)` over 7 docs
+    /// commits at docs 3 and 6, leaving exactly the 1-document remainder
+    /// uncommitted — a single end-of-batch commit would empty the WAL entirely.
+    #[tokio::test]
+    async fn every_docs_commits_within_batch() {
+        let (engine, storage) = commit_policy_engine(CommitPolicy::EveryDocs(3)).await;
+        let docs: Vec<_> = (1..=7u64)
+            .map(|i| batch_entry(&format!("d{i}"), "x"))
+            .collect();
+        engine.put_documents(docs).await.unwrap();
+        assert!(
+            wal_bytes(&storage) > 0,
+            "chunked auto-commit must leave the 1-doc remainder uncommitted; \
+             an empty WAL would mean a single end-of-batch commit instead"
+        );
+
+        // A clean multiple leaves nothing uncommitted (both chunks committed).
+        let (engine2, storage2) = commit_policy_engine(CommitPolicy::EveryDocs(3)).await;
+        let docs2: Vec<_> = (1..=6u64)
+            .map(|i| batch_entry(&format!("d{i}"), "x"))
+            .collect();
+        engine2.put_documents(docs2).await.unwrap();
+        assert_eq!(
+            wal_bytes(&storage2),
+            0,
+            "6 docs at EveryDocs(3) commits both chunks, leaving an empty WAL"
+        );
+    }
+
+    /// #890: `EveryDocs(0)` disables auto-commit (equivalent to `Manual`).
+    #[tokio::test]
+    async fn every_docs_zero_is_manual() {
+        let (engine, storage) = commit_policy_engine(CommitPolicy::EveryDocs(0)).await;
+        for i in 1..=5u64 {
+            engine
+                .put_document(&format!("d{i}"), title_doc("x"))
+                .await
+                .unwrap();
+        }
+        assert!(wal_bytes(&storage) > 0, "EveryDocs(0) must not auto-commit");
+        engine.commit().await.unwrap();
+        assert_eq!(
+            wal_bytes(&storage),
+            0,
+            "an explicit commit still truncates the WAL"
+        );
+    }
+
+    /// #890: the default policy is `Manual` — no auto-commit until the caller
+    /// commits explicitly.
+    #[tokio::test]
+    async fn manual_default_no_autocommit() {
+        assert_eq!(CommitPolicy::default(), CommitPolicy::Manual);
+        let (engine, storage) = commit_policy_engine(CommitPolicy::Manual).await;
+        for i in 1..=5u64 {
+            engine
+                .put_document(&format!("d{i}"), title_doc("x"))
+                .await
+                .unwrap();
+        }
+        assert!(wal_bytes(&storage) > 0, "Manual must never auto-commit");
+    }
+
+    /// #890: a manual commit between auto-commits resets the counter, so the
+    /// next auto-commit lands n documents after the reset — not at a stale
+    /// offset carried over from before the manual commit.
+    #[tokio::test]
+    async fn commit_resets_autocommit_counter() {
+        let (engine, storage) = commit_policy_engine(CommitPolicy::EveryDocs(3)).await;
+        // 2 docs, then a manual commit resets the counter to 0.
+        for i in 1..=2u64 {
+            engine
+                .put_document(&format!("d{i}"), title_doc("x"))
+                .await
+                .unwrap();
+        }
+        engine.commit().await.unwrap();
+        assert_eq!(wal_bytes(&storage), 0);
+
+        // The next auto-commit must be 3 docs after the reset (at d5), not 1
+        // (which would happen if the counter still held its pre-commit value 2).
+        engine.put_document("d3", title_doc("x")).await.unwrap();
+        assert!(
+            wal_bytes(&storage) > 0,
+            "1 doc after a manual commit must not auto-commit (counter was reset)"
+        );
+        engine.put_document("d4", title_doc("x")).await.unwrap();
+        assert!(wal_bytes(&storage) > 0);
+        engine.put_document("d5", title_doc("x")).await.unwrap();
+        assert_eq!(
+            wal_bytes(&storage),
+            0,
+            "auto-commit lands exactly 3 docs after the manual-commit reset"
+        );
+    }
+
+    /// #890: an auto-committed document is durably searchable without any
+    /// explicit commit from the caller (end-to-end wiring through the ladder).
+    #[tokio::test]
+    async fn every_docs_autocommit_is_searchable_without_explicit_commit() {
+        let (engine, _storage) = commit_policy_engine(CommitPolicy::EveryDocs(2)).await;
+        engine.put_document("a", title_doc("alpha")).await.unwrap();
+        engine.put_document("b", title_doc("bravo")).await.unwrap();
+        // No explicit commit — the 2nd put reached the threshold and committed.
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:alpha"))
+            .limit(10)
+            .build();
+        assert_eq!(
+            engine.search(request).await.unwrap().len(),
+            1,
+            "an auto-committed doc must be searchable without an explicit commit"
         );
     }
 }

--- a/laurus/src/lib.rs
+++ b/laurus/src/lib.rs
@@ -81,6 +81,7 @@ pub use embedding::embedder::{EmbedInput, EmbedInputType, Embedder};
 pub use embedding::openai_embedder::OpenAIEmbedder;
 pub use embedding::per_field::PerFieldEmbedder;
 pub use embedding::precomputed::PrecomputedEmbedder;
+pub use engine::CommitPolicy;
 pub use engine::Engine;
 pub use engine::EngineBuilder;
 pub use engine::EngineStats;

--- a/laurus/tests/wal_recovery_test.rs
+++ b/laurus/tests/wal_recovery_test.rs
@@ -6,8 +6,8 @@ use laurus::lexical::TextOption;
 use laurus::storage::file::FileStorageConfig;
 use laurus::storage::{StorageConfig, StorageFactory};
 use laurus::vector::FlatOption;
+use laurus::{CommitPolicy, FieldOption, LexicalSearchQuery, Schema, WalSyncPolicy};
 use laurus::{DataValue, Document};
-use laurus::{FieldOption, LexicalSearchQuery, Schema, WalSyncPolicy};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wal_recovery_uncommitted() -> laurus::Result<()> {
@@ -119,6 +119,63 @@ async fn test_wal_recovery_group_commit_flush_wal() -> laurus::Result<()> {
             search_results.len(),
             1,
             "flush_wal'd group-commit record should recover from WAL"
+        );
+    }
+
+    Ok(())
+}
+
+/// #890: an engine with `CommitPolicy::EveryDocs` must keep the exact same
+/// crash/recovery semantics as manual commits. Ingesting a number of documents
+/// that is not a multiple of the threshold leaves an uncommitted tail in the
+/// WAL; a crash (drop without an explicit final commit) followed by a reopen
+/// must recover every document — the auto-committed prefix from the stores and
+/// the uncommitted tail from WAL replay — with no loss or duplication.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_commit_policy_every_docs_crash_recovery() -> laurus::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_config = StorageConfig::File(FileStorageConfig::new(temp_dir.path()));
+    let storage = StorageFactory::create(storage_config)?;
+
+    let config = Schema::builder()
+        .add_field("title", FieldOption::Text(TextOption::default()))
+        .add_field("embedding", FieldOption::Flat(FlatOption::default()))
+        .build();
+
+    // Round 1: ingest 5 docs under EveryDocs(3). Doc 3 auto-commits (docs 1-3
+    // durable in the stores); docs 4-5 remain uncommitted in the WAL. Drop the
+    // engine WITHOUT an explicit final commit — the crash.
+    {
+        let engine = Engine::builder(storage.clone(), config.clone())
+            .commit_policy(CommitPolicy::EveryDocs(3))
+            .build()
+            .await?;
+
+        for i in 0..5 {
+            let doc = Document::builder()
+                .add_field("title", DataValue::Text(format!("rust doc {i}")))
+                .add_field("embedding", DataValue::Vector(vec![0.1; 128]))
+                .build();
+            engine.put_document(&format!("doc{i}"), doc).await?;
+        }
+        // Drop without commit — docs 4-5 are only in the WAL.
+    }
+
+    // Round 2: reopen on the same storage. Recovery replays the uncommitted
+    // tail; all 5 documents must be present.
+    {
+        let engine = Engine::new(storage.clone(), config.clone()).await?;
+        let query = Box::new(TermQuery::new("title", "rust"));
+        let search_request = laurus::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::Obj(query))
+            .limit(10)
+            .build();
+        let results = engine.search(search_request).await?;
+        assert_eq!(
+            results.len(),
+            5,
+            "all 5 docs must survive a crash under EveryDocs: the auto-committed \
+             prefix from the stores plus the uncommitted tail from WAL replay"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds an engine-level **auto-commit policy** so ingestion can hand commit cadence to the engine instead of the caller driving every `commit()`. Deferred during #551 because, with the monolithic vector layout, committing every *c* docs cost O(N²/c) cumulative bytes; #634 (segment-per-commit) removed that blocker, making each commit O(new docs).

Scope for this PR (approved): `CommitPolicy::{ Manual, EveryDocs(usize) }` in the engine + the CLI switch + docs. A time-based `Interval` and bindings/server exposure are follow-ups.

Refs #551, #634
Closes #890

## What changed

- **`CommitPolicy`** (`#[non_exhaustive]`, re-exported from the crate root): `Manual` (default, unchanged behavior) and `EveryDocs(usize)`. Wired via `EngineBuilder::commit_policy()`, cloning the `wal_sync_policy` pattern. `EveryDocs(0)` disables auto-commit.
- **Counter + trigger**: `docs_since_commit: AtomicU64` is bumped in `index_internal` after both stores apply a document; `maybe_auto_commit()` runs `commit()` at the API boundary — after each singular put/add, and **after each document inside a batch loop**, so a large `put_documents` commits every *n* docs (chunked). `commit()` resets the counter, keeping manual and auto commits on the same cadence.
- **Group-commit preserved**: `flush_wal`/`truncate` are independent of the batch `defer_sync` scope, so a mid-batch commit makes the chunk durable in one fsync + one ladder while the deferral stays intact for the rest of the batch; the `< n` remainder is left WAL-durable until the next boundary or an explicit commit.
- **Recovery untouched**: `recover()` replays via direct store calls, not `index_internal`, so auto-commit never mis-fires during replay (the terminal recovery `commit()` runs over a zero counter).
- **CLI**: `--commit-every n` now opens the engine with `CommitPolicy::EveryDocs(n)` (new `context::open_index_with_commit_policy`, existing callers unchanged) and drops its client-side commit loop; cadence is now exactly every *n*.
- **Docs (EN + JA)**: a new "Auto-commit Policy" section in `persistence.md` and a builder-method row in `engine.md`.

## Tests

- **6 engine unit gates** using WAL truncation as a side-effect-free commit signal (a commit truncates `engine.wal` to 0 bytes):
  - `every_docs_commits_at_exact_multiples` — WAL empty only right after each *n*-th doc.
  - `every_docs_commits_within_batch` — `put_documents(7)` at `EveryDocs(3)` leaves a 1-doc remainder uncommitted (proves chunking; a single end-of-batch commit would empty the WAL). **Verified RED/GREEN** — disabling the batch-loop auto-commit fails this test.
  - `every_docs_zero_is_manual`, `manual_default_no_autocommit`, `commit_resets_autocommit_counter`, `every_docs_autocommit_is_searchable_without_explicit_commit`.
- **Crash-recovery integration** (`test_commit_policy_every_docs_crash_recovery`): `EveryDocs(3)` ingests 5 docs, drops without a final commit, reopens → all 5 recover (auto-committed prefix from the stores + uncommitted tail from WAL replay) — identical to manual crash semantics.

## Adversarial review

Ran a focused adversarial review of six failure modes (recovery mis-fire, counter reset race, `BatchIngest` contract, group-commit preservation, `EveryDocs(0)`/cast, CLI). **All six refuted** for the single-writer contract the feature targets. One substantive finding — the docstring **understated** the concurrent-writer worst case (a write acknowledged during another thread's auto-commit may only become durable at the next commit; the underlying commit-vs-write race is pre-existing, but #890 triggers it from the ingest path). **Fixed** by stating the single-writer scope and the concurrency caveat honestly in the docstring and the EN/JA docs.

## Verification

fmt clean · clippy 1.95 + 1.97 (`-D warnings`) 0 · lib 1249 · integration 1451 · laurus-cli 6 · laurus-server 2 · `laurus-wasm` clippy (wasm32) clean · markdownlint (EN + JA) 0.

## Follow-ups

- #892 — `CommitPolicy::Interval(Duration)` (time-based; needs a background commit timer — `Arc<EngineInner>` extraction or `Weak`+`build()->Arc<Engine>`, tokio task, wasm no-op).
- #893 — expose `CommitPolicy` in the 5 bindings + the gRPC server config.
