### PR TITLE
feat(bindings,server): expose CommitPolicy (5 bindings + gRPC server config) (#893)

### DIFF
--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -10,6 +10,7 @@ class Index {
     path?: string | null,
     schema?: Schema,
     walSyncPolicy?: WalSyncPolicy,
+    commitPolicy?: CommitPolicy,
   ): Promise<Index>;
 }
 ```
@@ -21,6 +22,7 @@ class Index {
 | `path` | `string \| null` | `null` | 永続化ストレージのディレクトリ。`null` でインメモリ。 |
 | `schema` | `Schema` | 空 | スキーマ定義。 |
 | `walSyncPolicy` | `WalSyncPolicy` | レコードごと | WAL の永続性ポリシー。省略するとデフォルトのレコードごとの `fsync` を使用します。[WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照。 |
+| `commitPolicy` | `CommitPolicy` | 手動 | 自動コミットポリシー。省略するとデフォルトの手動ポリシー（呼び出し側がすべての `commit()` を駆動）を使用します。[コミットポリシー / 自動コミット](#コミットポリシー--自動コミット)を参照。 |
 
 ### メソッド
 
@@ -117,6 +119,55 @@ await index.commit(); // WAL もフラッシュされます
 
 `walSyncPolicy` を省略する（または `WalSyncPolicy.perRecord()` を渡す）と、
 デフォルトの完全に永続的な動作が維持されます。
+
+### コミットポリシー / 自動コミット
+
+デフォルトでは呼び出し側がすべての `commit()` を駆動するため、保留中の変更は
+明示的に呼び出したときにのみ検索可能になります。`Index.create` はオプションの
+`commitPolicy` を受け付け、代わりに取り込み駆動のタイミングでエンジンに自動
+コミットさせることができます。これにより明示的な `commit()` なしで書き込みが
+実体化されます。
+
+```typescript
+class CommitPolicy {
+  static manual(): CommitPolicy;
+  static everyDocs(n: number): CommitPolicy;
+}
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `CommitPolicy.manual()` | デフォルト。自動コミットなし。呼び出し側がすべての `commit()` を駆動します。 |
+| `CommitPolicy.everyDocs(n)` | 適用されたドキュメント `n` 件ごとに自動コミットします。 |
+
+`everyDocs(n)` では、エンジンは適用されたドキュメント `n` 件ごとにコミットし、
+その件数は単発・バッチ両方の取り込みにまたがって数えられます — 1 つのバッチ
+**内部**でもドキュメント `n` 件ごとにコミットされます。`everyDocs(0)` は有効で
+自動コミットを無効化し、`CommitPolicy.manual()` と等価です。
+
+`commitPolicy` は `walSyncPolicy` と直交します。`walSyncPolicy` は WAL の
+`fsync` 永続性を制御するのに対し、`commitPolicy` は保留中の変更を検索可能な
+コミットへ**いつ**実体化するかを制御します。両者は自由に組み合わせられます。
+
+```javascript
+import { Index, CommitPolicy } from "laurus-nodejs";
+
+// 適用されたドキュメント 1000 件ごとに自動コミットします。
+const index = await Index.create(
+  null,
+  schema,
+  undefined,
+  CommitPolicy.everyDocs(1000),
+);
+
+for (let i = 0; i < 10000; i++) {
+  await index.putDocument(`doc${i}`, { title: `Document ${i}` });
+}
+// エンジンはすでに 10 回コミット済みです。明示的な commit() は不要です。
+```
+
+`commitPolicy` を省略する（または `CommitPolicy.manual()` を渡す）と、
+デフォルトの呼び出し側駆動のコミット動作が維持されます。
 
 ---
 

--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -5,7 +5,7 @@
 Laurus 検索エンジンをラップするメインクラスです。
 
 ```php
-new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $wal_sync_policy = null)
+new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $wal_sync_policy = null, ?CommitPolicy $commit_policy = null)
 ```
 
 ### コンストラクタ
@@ -15,6 +15,7 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $
 | `$path` | `string\|null` | `null` | 永続ストレージのディレクトリパス。`null` の場合はインメモリインデックスを作成します。 |
 | `$schema` | `Schema\|null` | `null` | スキーマ定義。省略時は空のスキーマが使用されます。 |
 | `$wal_sync_policy` | `WalSyncPolicy\|null` | `null` | 先行書き込みログ（WAL）の耐久性ポリシー。`null` の場合はデフォルトのレコードごと fsync を維持します。[WAL 同期ポリシーと耐久性](#wal-同期ポリシーと耐久性) を参照。 |
+| `$commit_policy` | `CommitPolicy\|null` | `null` | 自動コミットポリシー。`null` の場合はデフォルトの manual ポリシー（呼び出し側がすべての `commit()` を駆動）を維持します。[コミットポリシーと自動コミット](#コミットポリシーと自動コミット) を参照。 |
 
 ### メソッド
 
@@ -92,6 +93,51 @@ $index = new \Laurus\Index("./myindex", null, $policy);
 
 $index->putDocument("doc1", ["title" => "Hello"]);
 $index->flushWal(); // group バッチが満杯でなくてもレコードが永続化される
+```
+
+### コミットポリシーと自動コミット
+
+コミットは、バッファリングされた書き込みを Lexical ストアと Vector ストアに
+実体化（materialise）し、保留中の変更を検索可能にします。デフォルトでは
+Laurus が自動でコミットすることはなく、呼び出し側がすべての `commit()` を
+駆動します。代わりに、適用したドキュメント数が一定に達するたびにエンジンに
+**自動コミット（auto-commit）**させることもできます。
+
+#### CommitPolicy
+
+`Laurus\CommitPolicy` はエンジンがいつコミットするかを記述するイミュータブルな
+値オブジェクトです。`Index` コンストラクタの `$commit_policy` 引数に渡します。
+
+```php
+// デフォルト: 自動コミットなし — 呼び出し側がすべての commit() を駆動。
+\Laurus\CommitPolicy::manual(): CommitPolicy
+
+// 適用したドキュメント N 件ごとに自動コミット。
+\Laurus\CommitPolicy::everyDocs(
+    int $n,   // このドキュメント数を適用するたびにコミット
+): CommitPolicy
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `CommitPolicy::manual()` | デフォルト。エンジンは自動でコミットせず、呼び出し側がすべての `commit()` を駆動します。 |
+| `CommitPolicy::everyDocs($n)` | 適用したドキュメント `$n` 件ごとに自動コミットします。カウントは単一 ingest とバッチ ingest の両方にまたがり、バッチ **内** でも `$n` 件ごとにトリガーされます。 |
+
+`CommitPolicy::everyDocs(0)` は有効で、自動コミットを無効化します。
+`CommitPolicy::manual()` と等価です。
+
+コミットポリシーは WAL 同期ポリシーと**直交（orthogonal）**しています。
+`WalSyncPolicy` は耐久性のために WAL をいつ `fsync` するかを制御するのに対し、
+`CommitPolicy` はストアをいつ実体化し、保留中の変更をいつ検索可能にするかを
+制御します。両者は独立して設定します。
+
+```php
+// 適用したドキュメント 1000 件ごとに自動コミットし、WAL ポリシーはデフォルトを維持。
+$index = new \Laurus\Index(null, $schema, null, \Laurus\CommitPolicy::everyDocs(1000));
+
+foreach ($docs as $id => $doc) {
+    $index->putDocument($id, $doc); // エンジンが 1000 件ごとに自動でコミットする
+}
 ```
 
 ---

--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -11,6 +11,7 @@ class Index:
         path: str | None = None,
         schema: Schema | None = None,
         wal_sync_policy: WalSyncPolicy | None = None,
+        commit_policy: CommitPolicy | None = None,
     ) -> None: ...
 ```
 
@@ -21,6 +22,7 @@ class Index:
 | `path` | `str \| None` | `None` | 永続ストレージのディレクトリパス。`None` の場合はインメモリインデックスを作成します。 |
 | `schema` | `Schema \| None` | `None` | スキーマ定義。省略時は空のスキーマが使用されます。 |
 | `wal_sync_policy` | `WalSyncPolicy \| None` | `None` | WAL の永続性ポリシー。`None` の場合はデフォルトのレコードごとの `fsync` を使用します。[WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照してください。 |
+| `commit_policy` | `CommitPolicy \| None` | `None` | 自動コミットポリシー。`None` の場合はデフォルトの手動コミット（自動コミットなし）を使用します。[コミットポリシー / 自動コミット](#コミットポリシー--自動コミット)を参照してください。 |
 
 ### メソッド
 
@@ -112,6 +114,55 @@ index.commit()  # WAL もフラッシュされます
 
 `wal_sync_policy` を省略する（または `WalSyncPolicy.per_record()` を渡す）と、
 デフォルトの完全に永続的な動作が維持されます。
+
+### コミットポリシー / 自動コミット
+
+コミットはバッファリングされた書き込みをストアへ materialize し、すべての
+保留中の変更を検索可能にします。デフォルトでは `Index` は自動コミットを
+行わないため、呼び出し側がすべての `commit()` を明示的に実行します。
+コンストラクタはオプションの `commit_policy` を受け付け、一定件数の
+ドキュメントを適用するごとにエンジンが自動的にコミットするようにできます。
+
+```python
+class CommitPolicy:
+    @staticmethod
+    def manual() -> CommitPolicy: ...
+    @staticmethod
+    def every_docs(n: int) -> CommitPolicy: ...
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `CommitPolicy.manual()` | デフォルト。自動コミットなし。呼び出し側がすべての `commit()` を実行します。 |
+| `CommitPolicy.every_docs(n)` | `n` 件のドキュメントを適用するごとに自動コミットします。 |
+
+`every_docs(n)` は、単体（`put_document`、`add_document`）とバッチ
+（`put_documents`、`add_documents`）の両方の取り込みにまたがって適用済み
+ドキュメントを数え、`n` 件ごとに自動コミットします — 1 つのバッチの
+**内部**でも同様です。`every_docs(0)` も有効で、自動コミットを無効化するため
+`manual()` と等価になります。
+
+`commit_policy` は `wal_sync_policy` と直交します。`wal_sync_policy` は WAL の
+`fsync` 永続性を制御するのに対し、`commit_policy` はストアが保留中の変更を
+検索可能な状態へ materialize するタイミングを制御します。一方を設定しても
+他方には影響しません。
+
+```python
+import laurus
+
+# 100 件のドキュメントを適用するごとに自動コミットします。
+index = laurus.Index(
+    path="./myindex",
+    commit_policy=laurus.CommitPolicy.every_docs(100),
+)
+
+for i in range(1_000):
+    index.put_document(f"doc{i}", {"title": f"Document {i}"})
+# エンジンはすでに 10 回コミットしています（100 件ごとに 1 回）。
+```
+
+`commit_policy` を省略する（または `CommitPolicy.manual()` を渡す）と、
+デフォルトの手動コミットの動作が維持されます。
 
 ---
 

--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -5,7 +5,7 @@
 Laurus 検索エンジンをラップするメインクラスです。
 
 ```ruby
-Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil)
+Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil, commit_policy: nil)
 ```
 
 ### コンストラクタ
@@ -15,6 +15,7 @@ Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil)
 | `path:` | `String \| nil` | `nil` | 永続ストレージのディレクトリパス。`nil` の場合はインメモリインデックスを作成します。 |
 | `schema:` | `Schema \| nil` | `nil` | スキーマ定義。省略時は空のスキーマが使用されます。 |
 | `wal_sync_policy:` | `WalSyncPolicy \| nil` | `nil` | 先行書き込みログ（WAL）の耐久性ポリシー。`nil` の場合はデフォルトのレコードごと fsync を維持します。[WAL 同期ポリシーと耐久性](#wal-同期ポリシーと耐久性) を参照。 |
+| `commit_policy:` | `CommitPolicy \| nil` | `nil` | 自動コミットポリシー。`nil` の場合はデフォルトの manual モード（呼び出し側がすべての `commit` を駆動）を維持します。[コミットポリシーと自動コミット](#コミットポリシーと自動コミット) を参照。 |
 
 ### メソッド
 
@@ -92,6 +93,46 @@ index = Laurus::Index.new(path: "./myindex", wal_sync_policy: policy)
 
 index.put_document("doc1", { "title" => "Hello" })
 index.flush_wal  # group バッチが満杯でなくてもレコードが永続化される
+```
+
+### コミットポリシーと自動コミット
+
+デフォルトでは、すべてのコミットは呼び出し側が駆動します。バッファリング
+された書き込みは、明示的に `commit` を呼び出したときにのみ検索可能になり
+ます。**自動コミットポリシー（auto-commit policy）** を使うと、その責務を
+エンジンに委ねられ、一定数のドキュメントを適用するたびに自動でコミットされ
+ます。
+
+#### CommitPolicy
+
+`Laurus::CommitPolicy` は、エンジンがバッファリングされた書き込みをいつ
+ストアへ実体化するかを記述するイミュータブルな値オブジェクトです。
+`Index.new(commit_policy:)` に渡します。
+
+```ruby
+# デフォルト: manual — すべてのコミットは呼び出し側が駆動。
+Laurus::CommitPolicy.manual
+
+# 自動コミット: N ドキュメント適用ごとにコミット。
+Laurus::CommitPolicy.every_docs(1000)
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `CommitPolicy.manual` | デフォルト。自動コミットなし。すべての `commit` は呼び出し側が駆動します。 |
+| `CommitPolicy.every_docs(n)` | `n` ドキュメント適用ごとに自動コミットします。単発・バッチ両方の取り込みを通してカウントされ、単一バッチ **内** でも `n` ドキュメントごとにコミットされます。 |
+
+`every_docs(0)` は有効で、自動コミットを無効化します（`manual` と等価）。
+
+コミットポリシーは [WalSyncPolicy](#wal-同期ポリシーと耐久性) と直交して
+います。`WalSyncPolicy` が WAL の `fsync` 耐久性を制御するのに対し、
+`CommitPolicy` はストアがバッファリングされた書き込みをいつ実体化するかを
+制御します。両者は独立して設定します。
+
+```ruby
+# 1000 ドキュメント適用ごとに自動コミット。
+policy = Laurus::CommitPolicy.every_docs(1000)
+index = Laurus::Index.new(path: "./myindex", commit_policy: policy)
 ```
 
 ---

--- a/docs/ja/src/laurus-server/configuration.md
+++ b/docs/ja/src/laurus-server/configuration.md
@@ -46,6 +46,10 @@ sync_policy = "group"          # "per_record"（デフォルト） | "group"
 group_max_records = 1024       # オプション; デフォルト 1024
 group_max_bytes = 1048576      # オプション; デフォルト 1 MiB
 group_max_interval_ms = 1000   # オプション; 未設定時は background timer なし（native のみ）
+
+[index.commit]
+policy = "every_docs"          # "manual"（デフォルト） | "every_docs"
+every_docs = 1000              # オプション; N 件ごとに commit（0/未設定で無効）
 ```
 
 ログの詳細度は設定ファイルではなく、`RUST_LOG` 環境変数で制御します（デフォルト: `info`）。
@@ -87,6 +91,25 @@ WAL は **per-record** fsync を使用します（各書き込みは返る前に
 無条件で flush します。クラッシュ時には未 sync の最終バッチまで失う可能性があります
 （SQLite `synchronous = NORMAL` に相当）。途中で切れた末尾レコードはリカバリ時に
 破棄されるため、復旧後のログにはギャップが生じません。
+
+#### `[index.commit]` セクション
+
+自動コミットポリシーを制御します。セクション全体を省略した場合、エンジンは
+**manual** — サーバーがインデックスを materialize するときのみ commit します
+（インジェスト中の自動コミットはありません）。このポリシーは、起動時に開かれる
+インデックスと、後から `CreateIndex` で作成されるインデックスの両方に適用されます。
+セマンティクスは
+[永続化と WAL → 自動コミットポリシー](../laurus/persistence.md#自動コミットポリシーauto-commit-policy)
+を参照してください。
+
+| フィールド | 型 | デフォルト | 説明 |
+| :--- | :--- | :--- | :--- |
+| `policy` | String | `"manual"` | 自動コミットポリシー: `"manual"`（呼び出し側が commit を駆動）または `"every_docs"`（`every_docs` 件ごとに commit） |
+| `every_docs` | Integer | -- | `every_docs` ポリシーのみ。適用ドキュメント数がこの値に達するごとに commit。未設定（または `0`）で自動コミット無効（`"manual"` と同等） |
+
+`CommitPolicy` は `[index.wal]` と直交します。WAL セクションは *append がいつ fsync
+されるか* を、このセクションは *ストアがいつ materialize するか* を制御します。commit は
+必ず WAL flush から始まるため、自動コミットは任意の WAL ポリシー下で機能します。
 
 ## 環境変数
 

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -6,7 +6,7 @@
 
 ### 静的メソッド
 
-#### `Index.create(schema?, walSyncPolicy?)`
+#### `Index.create(schema?, walSyncPolicy?, commitPolicy?)`
 
 新しいインメモリ（一時）インデックスを作成します。
 
@@ -15,9 +15,12 @@
   - `walSyncPolicy` (WalSyncPolicy, 省略可) -- WAL の永続性ポリシー。省略すると
     デフォルトのレコードごとの同期を使用します。
     [WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照してください。
+  - `commitPolicy` (CommitPolicy, 省略可) -- 自動コミットポリシー。省略すると
+    デフォルト（manual: 呼び出し側がコミットを駆動）を使用します。
+    [コミットポリシー / 自動コミット](#コミットポリシー--自動コミット)を参照してください。
 - **戻り値:** `Promise<Index>`
 
-#### `Index.open(name, schema?, walSyncPolicy?)`
+#### `Index.open(name, schema?, walSyncPolicy?, commitPolicy?)`
 
 OPFS で永続化されたインデックスを開くか、新規作成します。
 
@@ -27,6 +30,9 @@ OPFS で永続化されたインデックスを開くか、新規作成します
   - `walSyncPolicy` (WalSyncPolicy, 省略可) -- WAL の永続性ポリシー。省略すると
     デフォルトのレコードごとの同期を使用します。
     [WAL 同期ポリシー / 永続性](#wal-同期ポリシー--永続性)を参照してください。
+  - `commitPolicy` (CommitPolicy, 省略可) -- 自動コミットポリシー。省略すると
+    デフォルト（manual: 呼び出し側がコミットを駆動）を使用します。
+    [コミットポリシー / 自動コミット](#コミットポリシー--自動コミット)を参照してください。
 - **戻り値:** `Promise<Index>`
 
 ### インスタンスメソッド
@@ -244,6 +250,63 @@ for (let i = 0; i < 10000; i++) {
 
 await index.flushWal(); // エンジン WAL をフラッシュ（OPFS ではない）
 await index.commit();   // 変更を検索可能にし、かつ OPFS に永続化する
+```
+
+## コミットポリシー / 自動コミット
+
+コミットはバッファされた書き込みを検索可能なストアに反映します。
+`Index.create` と `Index.open` はオプションの `commitPolicy` を受け付け、
+エンジンが代わりにコミットするかどうかを制御します。デフォルト（引数を省略）は
+manual で、すべての `commit()` を自分で駆動します。
+
+```typescript
+class CommitPolicy {
+  static manual(): CommitPolicy;
+  static everyDocs(n: number): CommitPolicy;
+}
+```
+
+| コンストラクタ | 説明 |
+| :--- | :--- |
+| `CommitPolicy.manual()` | デフォルト。自動コミットなし。呼び出し側がすべての `commit()` を駆動します。 |
+| `CommitPolicy.everyDocs(n)` | `n` 件のドキュメントを適用するたびに自動コミットします。 |
+
+`everyDocs(n)` では、エンジンは `n` 件のドキュメントを適用するたびに 1 回
+コミットします。カウンタは単発とバッチの両方の取り込みにまたがり、バッチの
+**内部**でも発火します — `n` より大きい `putDocuments` 呼び出しはバッチの
+途中で 1 回以上のコミットを引き起こします。`everyDocs(0)` は有効で、自動
+コミットを無効化します。これは `CommitPolicy.manual()` と等価です。
+
+`commitPolicy` は `walSyncPolicy` と**直交**します: `walSyncPolicy` は永続性の
+ために WAL をどの頻度で fsync するかを制御し、`commitPolicy` はバッファされた
+書き込みをいつ検索可能な状態へ反映するかを制御します。両者は独立して設定
+できます。
+
+### WASM の注意点
+
+`walSyncPolicy` の `maxIntervalMs` バックグラウンドタイマー（wasm では no-op）
+とは異なり、`everyDocs` はバックグラウンドスレッドを**必要としません** —
+ドキュメントカウンタは取り込み中にインラインでチェックされます — そのため
+自動コミットは WebAssembly 上でも完全に動作します。
+
+```javascript
+import { Index, Schema, CommitPolicy } from "./pkg/laurus_wasm.js";
+
+const schema = new Schema();
+schema.addTextField("title");
+
+// 1000 件のドキュメントを適用するたびに自動コミット。
+const index = await Index.open(
+  "my-index",
+  schema,
+  undefined,
+  CommitPolicy.everyDocs(1000),
+);
+
+for (let i = 0; i < 10000; i++) {
+  await index.putDocument(`doc${i}`, { title: `Document ${i}` });
+}
+// エンジンは 10 回自動コミット済み。明示的な commit() は不要。
 ```
 
 ## Schema

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -10,6 +10,7 @@ class Index {
     path?: string | null,
     schema?: Schema,
     walSyncPolicy?: WalSyncPolicy,
+    commitPolicy?: CommitPolicy,
   ): Promise<Index>;
 }
 ```
@@ -21,6 +22,7 @@ class Index {
 | `path` | `string \| null` | `null` | Directory for persistent storage. `null` creates an in-memory index. |
 | `schema` | `Schema` | empty | Schema definition. |
 | `walSyncPolicy` | `WalSyncPolicy` | per-record | WAL durability policy. Omit to keep the default per-record `fsync`. See [WAL sync policy / durability](#wal-sync-policy--durability). |
+| `commitPolicy` | `CommitPolicy` | manual | Auto-commit policy. Omit to keep the default manual policy (the caller drives every `commit()`). See [Commit policy / auto-commit](#commit-policy--auto-commit). |
 
 ### Methods
 
@@ -115,6 +117,55 @@ await index.commit(); // also flushes the WAL
 
 Omit `walSyncPolicy` (or pass `WalSyncPolicy.perRecord()`) to keep the
 default, fully durable behaviour.
+
+### Commit policy / auto-commit
+
+By default the caller drives every `commit()`, so pending changes become
+searchable only when you call it explicitly. `Index.create` accepts an
+optional `commitPolicy` to let the engine auto-commit on an ingestion-driven
+cadence instead, so writes are materialized without an explicit `commit()`.
+
+```typescript
+class CommitPolicy {
+  static manual(): CommitPolicy;
+  static everyDocs(n: number): CommitPolicy;
+}
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `CommitPolicy.manual()` | Default. No auto-commit; the caller drives every `commit()`. |
+| `CommitPolicy.everyDocs(n)` | Auto-commit after every `n` applied documents. |
+
+With `everyDocs(n)` the engine commits after every `n` applied documents,
+counted across both singular and batch ingest — including every `n`
+documents **within** a single batch. Passing `everyDocs(0)` is valid and
+disables auto-commit, which is equivalent to `CommitPolicy.manual()`.
+
+`commitPolicy` is orthogonal to `walSyncPolicy`: `walSyncPolicy` governs WAL
+`fsync` durability, while `commitPolicy` governs **when** the stores
+materialize pending changes into a searchable commit. You can combine them
+freely.
+
+```javascript
+import { Index, CommitPolicy } from "laurus-nodejs";
+
+// Auto-commit after every 1000 applied documents.
+const index = await Index.create(
+  null,
+  schema,
+  undefined,
+  CommitPolicy.everyDocs(1000),
+);
+
+for (let i = 0; i < 10000; i++) {
+  await index.putDocument(`doc${i}`, { title: `Document ${i}` });
+}
+// The engine has already committed ten times; no explicit commit() needed.
+```
+
+Omit `commitPolicy` (or pass `CommitPolicy.manual()`) to keep the default,
+caller-driven commit behaviour.
 
 ---
 

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -5,7 +5,7 @@
 The primary entry point. Wraps the Laurus search engine.
 
 ```php
-new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $wal_sync_policy = null)
+new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $wal_sync_policy = null, ?CommitPolicy $commit_policy = null)
 ```
 
 ### Constructor
@@ -15,6 +15,7 @@ new \Laurus\Index(?string $path = null, ?Schema $schema = null, ?WalSyncPolicy $
 | `$path` | `string\|null` | `null` | Directory path for persistent storage. `null` creates an in-memory index. |
 | `$schema` | `Schema\|null` | `null` | Schema definition. An empty schema is used when omitted. |
 | `$wal_sync_policy` | `WalSyncPolicy\|null` | `null` | Write-ahead log (WAL) durability policy. `null` keeps the default per-record fsync. See [WAL sync policy & durability](#wal-sync-policy--durability). |
+| `$commit_policy` | `CommitPolicy\|null` | `null` | Auto-commit policy. `null` keeps the default manual policy (the caller drives every `commit()`). See [Commit policy & auto-commit](#commit-policy--auto-commit). |
 
 ### Methods
 
@@ -91,6 +92,50 @@ $index = new \Laurus\Index("./myindex", null, $policy);
 
 $index->putDocument("doc1", ["title" => "Hello"]);
 $index->flushWal(); // records persisted even though the group batch is not full
+```
+
+### Commit policy & auto-commit
+
+A commit materialises buffered writes into the lexical and vector stores and
+makes pending changes searchable. By default Laurus never commits on your
+behalf — the caller drives every `commit()`. You can instead let the engine
+**auto-commit** after a fixed number of applied documents.
+
+#### CommitPolicy
+
+`Laurus\CommitPolicy` is an immutable value object describing when the engine
+commits. Pass it to the `Index` constructor's `$commit_policy` argument.
+
+```php
+// Default: no auto-commit — the caller drives every commit().
+\Laurus\CommitPolicy::manual(): CommitPolicy
+
+// Auto-commit after every N applied documents.
+\Laurus\CommitPolicy::everyDocs(
+    int $n,   // commit after this many applied documents
+): CommitPolicy
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `CommitPolicy::manual()` | Default. The engine never commits on its own; the caller drives every `commit()`. |
+| `CommitPolicy::everyDocs($n)` | Auto-commit after every `$n` applied documents. Counting spans both singular and batch ingest, and triggers every `$n` documents **within** a batch. |
+
+`CommitPolicy::everyDocs(0)` is valid and disables auto-commit — it is
+equivalent to `CommitPolicy::manual()`.
+
+The commit policy is **orthogonal** to the WAL sync policy: `WalSyncPolicy`
+governs when the WAL is `fsync`ed for durability, whereas `CommitPolicy`
+governs when the stores materialise and pending changes become searchable. The
+two are configured independently.
+
+```php
+// Auto-commit every 1000 applied documents; keep the default WAL policy.
+$index = new \Laurus\Index(null, $schema, null, \Laurus\CommitPolicy::everyDocs(1000));
+
+foreach ($docs as $id => $doc) {
+    $index->putDocument($id, $doc); // engine commits automatically every 1000 docs
+}
 ```
 
 ---

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -11,6 +11,7 @@ class Index:
         path: str | None = None,
         schema: Schema | None = None,
         wal_sync_policy: WalSyncPolicy | None = None,
+        commit_policy: CommitPolicy | None = None,
     ) -> None: ...
 ```
 
@@ -21,6 +22,7 @@ class Index:
 | `path` | `str \| None` | `None` | Directory path for persistent storage. `None` creates an in-memory index. |
 | `schema` | `Schema \| None` | `None` | Schema definition. An empty schema is used when omitted. |
 | `wal_sync_policy` | `WalSyncPolicy \| None` | `None` | WAL durability policy. `None` keeps the default per-record `fsync`. See [WAL sync policy / durability](#wal-sync-policy--durability). |
+| `commit_policy` | `CommitPolicy \| None` | `None` | Auto-commit policy. `None` keeps the default manual commit (no auto-commit). See [Commit policy / auto-commit](#commit-policy--auto-commit). |
 
 ### Methods
 
@@ -110,6 +112,55 @@ index.commit()  # also flushes the WAL
 
 Omit `wal_sync_policy` (or pass `WalSyncPolicy.per_record()`) to keep the
 default, fully durable behaviour.
+
+### Commit policy / auto-commit
+
+A commit materializes buffered writes into the stores and makes all pending
+changes searchable. By default an `Index` never auto-commits, so the caller
+drives every `commit()` explicitly. The constructor accepts an optional
+`commit_policy` to instead let the engine auto-commit after a fixed number of
+applied documents.
+
+```python
+class CommitPolicy:
+    @staticmethod
+    def manual() -> CommitPolicy: ...
+    @staticmethod
+    def every_docs(n: int) -> CommitPolicy: ...
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `CommitPolicy.manual()` | Default. No auto-commit; the caller drives every `commit()`. |
+| `CommitPolicy.every_docs(n)` | Auto-commit after every `n` applied documents. |
+
+`every_docs(n)` counts applied documents across both singular (`put_document`,
+`add_document`) and batch (`put_documents`, `add_documents`) ingest, and
+auto-commits after every `n` documents — including *within* a single batch.
+`every_docs(0)` is valid and disables auto-commit, making it equivalent to
+`manual()`.
+
+`commit_policy` is orthogonal to `wal_sync_policy`: `wal_sync_policy` governs
+WAL `fsync` durability, whereas `commit_policy` governs when the stores
+materialize pending changes into searchable state. Setting one does not affect
+the other.
+
+```python
+import laurus
+
+# Auto-commit after every 100 applied documents.
+index = laurus.Index(
+    path="./myindex",
+    commit_policy=laurus.CommitPolicy.every_docs(100),
+)
+
+for i in range(1_000):
+    index.put_document(f"doc{i}", {"title": f"Document {i}"})
+# The engine has already committed 10 times (once per 100 documents).
+```
+
+Omit `commit_policy` (or pass `CommitPolicy.manual()`) to keep the default,
+manual-commit behaviour.
 
 ---
 

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -5,7 +5,7 @@
 The primary entry point. Wraps the Laurus search engine.
 
 ```ruby
-Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil)
+Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil, commit_policy: nil)
 ```
 
 ### Constructor
@@ -15,6 +15,7 @@ Laurus::Index.new(path: nil, schema: nil, wal_sync_policy: nil)
 | `path:` | `String \| nil` | `nil` | Directory path for persistent storage. `nil` creates an in-memory index. |
 | `schema:` | `Schema \| nil` | `nil` | Schema definition. An empty schema is used when omitted. |
 | `wal_sync_policy:` | `WalSyncPolicy \| nil` | `nil` | Write-ahead log (WAL) durability policy. `nil` keeps the default per-record fsync. See [WAL sync policy & durability](#wal-sync-policy--durability). |
+| `commit_policy:` | `CommitPolicy \| nil` | `nil` | Auto-commit policy. `nil` keeps the default manual mode (the caller drives every `commit`). See [Commit policy & auto-commit](#commit-policy--auto-commit). |
 
 ### Methods
 
@@ -91,6 +92,45 @@ index = Laurus::Index.new(path: "./myindex", wal_sync_policy: policy)
 
 index.put_document("doc1", { "title" => "Hello" })
 index.flush_wal  # records persisted even though the group batch is not full
+```
+
+### Commit policy & auto-commit
+
+By default the caller drives every commit: buffered writes only become
+searchable once you call `commit` explicitly. You can hand that responsibility
+to the engine with an **auto-commit policy**, which commits automatically after
+a fixed number of applied documents.
+
+#### CommitPolicy
+
+`Laurus::CommitPolicy` is an immutable value object describing when the engine
+materialises buffered writes into the stores. Pass it to
+`Index.new(commit_policy:)`.
+
+```ruby
+# Default: manual — the caller drives every commit.
+Laurus::CommitPolicy.manual
+
+# Auto-commit: commit after every N applied documents.
+Laurus::CommitPolicy.every_docs(1000)
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `CommitPolicy.manual` | Default. No auto-commit — the caller drives every `commit`. |
+| `CommitPolicy.every_docs(n)` | Auto-commit after every `n` applied documents. Counted across both singular and batch ingest, including every `n` documents **within** a single batch. |
+
+`every_docs(0)` is valid and disables auto-commit, making it equivalent to
+`manual`.
+
+Commit policy is orthogonal to [WalSyncPolicy](#wal-sync-policy--durability):
+`WalSyncPolicy` governs WAL `fsync` durability, whereas `CommitPolicy` governs
+when the stores materialise buffered writes. Set them independently.
+
+```ruby
+# Auto-commit after every 1000 applied documents.
+policy = Laurus::CommitPolicy.every_docs(1000)
+index = Laurus::Index.new(path: "./myindex", commit_policy: policy)
 ```
 
 ---

--- a/docs/src/laurus-server/configuration.md
+++ b/docs/src/laurus-server/configuration.md
@@ -46,6 +46,10 @@ sync_policy = "group"          # "per_record" (default) | "group"
 group_max_records = 1024       # optional; default 1024
 group_max_bytes = 1048576      # optional; default 1 MiB
 group_max_interval_ms = 1000   # optional; no background timer when unset (native only)
+
+[index.commit]
+policy = "every_docs"          # "manual" (default) | "every_docs"
+every_docs = 1000              # optional; commit every N docs (0/unset disables)
 ```
 
 Log verbosity is controlled by the `RUST_LOG` environment variable (default: `info`), not through the config file.
@@ -87,6 +91,25 @@ records **or** `group_max_bytes` bytes have accumulated since the last sync
 (whichever comes first), and unconditionally on commit. A crash can lose up to
 the last unsynced batch (comparable to SQLite `synchronous = NORMAL`); a torn
 trailing record is dropped on recovery, so the recovered log is gap-free.
+
+#### `[index.commit]` Section
+
+Controls the auto-commit policy. When the whole section is omitted, the engine
+is **manual** — it commits only when the server materializes an index (there is
+no automatic commit during ingestion). The policy applies to both an index
+opened at boot and any index created later through `CreateIndex`. See
+[Persistence & WAL → Auto-commit Policy](../laurus/persistence.md#auto-commit-policy)
+for the semantics.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `policy` | String | `"manual"` | Auto-commit policy: `"manual"` (caller-driven commits) or `"every_docs"` (commit every `every_docs` applied documents) |
+| `every_docs` | Integer | -- | `every_docs` policy only. Commit after this many applied documents. Unset (or `0`) disables auto-commit, equivalent to `"manual"` |
+
+`CommitPolicy` is orthogonal to `[index.wal]`: the WAL section governs *when
+appends are fsync'd*, while this section governs *when the stores materialize*.
+An auto-commit works under any WAL policy because a commit always begins with a
+WAL flush.
 
 ## Environment Variables
 

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -6,7 +6,7 @@ The main entry point for creating and querying search indexes.
 
 ### Static Methods
 
-#### `Index.create(schema?, walSyncPolicy?)`
+#### `Index.create(schema?, walSyncPolicy?, commitPolicy?)`
 
 Create a new in-memory (ephemeral) index.
 
@@ -15,9 +15,12 @@ Create a new in-memory (ephemeral) index.
   - `walSyncPolicy` (WalSyncPolicy, optional) -- WAL durability policy. Omit
     to keep the default per-record sync. See
     [WAL sync policy / durability](#wal-sync-policy--durability).
+  - `commitPolicy` (CommitPolicy, optional) -- Auto-commit policy. Omit to keep
+    the default (manual; caller-driven commits). See
+    [Commit policy / auto-commit](#commit-policy--auto-commit).
 - **Returns:** `Promise<Index>`
 
-#### `Index.open(name, schema?, walSyncPolicy?)`
+#### `Index.open(name, schema?, walSyncPolicy?, commitPolicy?)`
 
 Open or create a persistent index backed by OPFS.
 
@@ -27,6 +30,9 @@ Open or create a persistent index backed by OPFS.
   - `walSyncPolicy` (WalSyncPolicy, optional) -- WAL durability policy. Omit
     to keep the default per-record sync. See
     [WAL sync policy / durability](#wal-sync-policy--durability).
+  - `commitPolicy` (CommitPolicy, optional) -- Auto-commit policy. Omit to keep
+    the default (manual; caller-driven commits). See
+    [Commit policy / auto-commit](#commit-policy--auto-commit).
 - **Returns:** `Promise<Index>`
 
 ### Instance Methods
@@ -244,6 +250,62 @@ for (let i = 0; i < 10000; i++) {
 
 await index.flushWal(); // flushes the engine WAL (not OPFS)
 await index.commit();   // makes changes searchable AND persists to OPFS
+```
+
+## Commit policy / auto-commit
+
+A commit materializes buffered writes into the searchable stores.
+`Index.create` and `Index.open` accept an optional `commitPolicy` that controls
+whether the engine commits on your behalf. The default (omit the argument) is
+manual: you drive every `commit()` yourself.
+
+```typescript
+class CommitPolicy {
+  static manual(): CommitPolicy;
+  static everyDocs(n: number): CommitPolicy;
+}
+```
+
+| Constructor | Description |
+| :--- | :--- |
+| `CommitPolicy.manual()` | Default. No auto-commit; the caller drives every `commit()`. |
+| `CommitPolicy.everyDocs(n)` | Auto-commit after every `n` applied documents. |
+
+With `everyDocs(n)` the engine commits once every `n` applied documents. The
+counter spans both singular and batch ingest, and it also fires **within** a
+batch — a `putDocuments` call larger than `n` triggers one or more commits mid
+batch. `everyDocs(0)` is valid and disables auto-commit, which is equivalent to
+`CommitPolicy.manual()`.
+
+`commitPolicy` is **orthogonal** to `walSyncPolicy`: `walSyncPolicy` governs how
+often the WAL is fsynced for durability, while `commitPolicy` governs when the
+stores materialize buffered writes into searchable state. They are configured
+independently.
+
+### WASM note
+
+Unlike `walSyncPolicy`'s `maxIntervalMs` background timer (a no-op on wasm),
+`everyDocs` needs **no** background thread — the document counter is checked
+inline during ingestion — so auto-commit works fully under WebAssembly.
+
+```javascript
+import { Index, Schema, CommitPolicy } from "./pkg/laurus_wasm.js";
+
+const schema = new Schema();
+schema.addTextField("title");
+
+// Auto-commit after every 1000 applied documents.
+const index = await Index.open(
+  "my-index",
+  schema,
+  undefined,
+  CommitPolicy.everyDocs(1000),
+);
+
+for (let i = 0; i < 10000; i++) {
+  await index.putDocument(`doc${i}`, { title: `Document ${i}` });
+}
+// The engine has auto-committed 10 times; no explicit commit() required.
 ```
 
 ## Schema

--- a/laurus-nodejs/__tests__/index.spec.mjs
+++ b/laurus-nodejs/__tests__/index.spec.mjs
@@ -22,6 +22,7 @@ import {
   WhitespaceTokenizer,
   SynonymGraphFilter,
   WalSyncPolicy,
+  CommitPolicy,
 } from "../index.js";
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,39 @@ describe("WAL sync policy", () => {
     await index.commit();
     const docs = await index.getDocuments("doc1");
     expect(docs).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Commit policy (auto-commit)
+// ---------------------------------------------------------------------------
+
+describe("Commit policy", () => {
+  it("accepts manual() and everyDocs(n) factories", () => {
+    expect(CommitPolicy.manual()).toBeDefined();
+    expect(CommitPolicy.everyDocs(100)).toBeDefined();
+    // everyDocs(0) is valid — it disables auto-commit (equivalent to manual).
+    expect(CommitPolicy.everyDocs(0)).toBeDefined();
+  });
+
+  it("creates an index with an EveryDocs policy and retrieves a doc", async () => {
+    const schema = new Schema();
+    schema.addTextField("title");
+    const index = await Index.create(
+      null,
+      schema,
+      undefined,
+      CommitPolicy.everyDocs(1),
+    );
+    await index.putDocument("d1", { title: "Auto" });
+    // No explicit commit — the binding path is wired end-to-end.
+    const docs = await index.getDocuments("d1");
+    expect(docs).toHaveLength(1);
+  });
+
+  it("defaults to manual when no commit policy is given", async () => {
+    const index = await Index.create(null, undefined, undefined, CommitPolicy.manual());
+    expect(index).toBeDefined();
   });
 });
 

--- a/laurus-nodejs/src/commit.rs
+++ b/laurus-nodejs/src/commit.rs
@@ -1,0 +1,84 @@
+//! Node.js wrapper for the auto-commit policy.
+//!
+//! Exposes [`laurus::CommitPolicy`] to JavaScript as the `CommitPolicy` value
+//! object, mirroring the same factory-method surface used by the other
+//! language bindings and by [`crate::wal::JsWalSyncPolicy`].
+
+use laurus::CommitPolicy;
+use napi_derive::napi;
+
+// ---------------------------------------------------------------------------
+// CommitPolicy
+// ---------------------------------------------------------------------------
+
+/// Auto-commit policy — controls when the engine automatically runs the commit
+/// ladder during ingestion.
+///
+/// By default the engine commits only when `commit()` is called explicitly; a
+/// non-`manual` policy makes it commit automatically at an ingestion-driven
+/// cadence (one full ladder per auto-commit). This is orthogonal to
+/// `WalSyncPolicy`.
+///
+/// Construct one of the variants with the static factory methods and pass it to
+/// `Index.create(path, schema, walSyncPolicy, commitPolicy)`.
+///
+/// ## Example
+///
+/// ```javascript
+/// const { Index, Schema, CommitPolicy } = require("laurus-nodejs");
+///
+/// const schema = new Schema();
+/// schema.addTextField("title");
+///
+/// // Auto-commit after every 1000 applied documents.
+/// const index = await Index.create("./idx", schema, undefined, CommitPolicy.everyDocs(1000));
+///
+/// // Manual (the default if no policy is supplied): the caller drives commit().
+/// const manual = CommitPolicy.manual();
+/// ```
+#[napi(js_name = "CommitPolicy")]
+#[derive(Clone, Copy)]
+pub struct JsCommitPolicy {
+    /// The wrapped Laurus auto-commit policy.
+    pub(crate) inner: CommitPolicy,
+}
+
+#[napi]
+impl JsCommitPolicy {
+    /// Create a manual (no auto-commit) policy.
+    ///
+    /// The engine commits only when `Index.commit()` is called explicitly. This
+    /// is the default policy when no policy is passed to `Index.create`.
+    ///
+    /// # Returns
+    ///
+    /// A `CommitPolicy` representing `Manual`.
+    #[napi(factory)]
+    pub fn manual() -> Self {
+        Self {
+            inner: CommitPolicy::Manual,
+        }
+    }
+
+    /// Create an auto-commit-every-`n`-documents policy.
+    ///
+    /// The engine runs the commit ladder after every `n` applied documents,
+    /// across the singular and batch ingest APIs (and every `n` documents
+    /// within a single batch). `everyDocs(0)` disables auto-commit, which is
+    /// equivalent to `CommitPolicy.manual()`.
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - Commit after this many applied documents. `0` disables
+    ///   auto-commit.
+    ///
+    /// # Returns
+    ///
+    /// A `CommitPolicy` representing `EveryDocs(n)`.
+    #[napi(factory)]
+    pub fn every_docs(n: u32) -> Self {
+        Self {
+            inner: CommitPolicy::EveryDocs(n as usize),
+        }
+    }
+}

--- a/laurus-nodejs/src/index.rs
+++ b/laurus-nodejs/src/index.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::commit::JsCommitPolicy;
 use crate::convert::{data_value_to_json, json_to_document};
 use crate::errors::laurus_err;
 use crate::query::{JsQuery, JsTermQuery, JsVectorQuery, JsVectorQueryInner, JsVectorTextQuery};
@@ -78,6 +79,9 @@ impl JsIndex {
     /// * `wal_sync_policy` - Optional WAL durability policy (see
     ///     `WalSyncPolicy`). When omitted, the default per-record policy is
     ///     used, where every append is fsync'd before it returns.
+    /// * `commit_policy` - Optional auto-commit policy (see `CommitPolicy`).
+    ///     When omitted, the engine is manual — the caller drives every
+    ///     `commit()`.
     ///
     /// # Returns
     ///
@@ -87,6 +91,7 @@ impl JsIndex {
         path: Option<String>,
         schema: Option<&JsSchema>,
         wal_sync_policy: Option<&JsWalSyncPolicy>,
+        commit_policy: Option<&JsCommitPolicy>,
     ) -> Result<Self> {
         let storage = create_storage(path.as_deref())?;
         let schema = schema.map(|s| s.inner.clone()).unwrap_or_default();
@@ -94,6 +99,9 @@ impl JsIndex {
         let mut builder = Engine::builder(storage, schema);
         if let Some(policy) = wal_sync_policy {
             builder = builder.wal_sync_policy(policy.inner);
+        }
+        if let Some(policy) = commit_policy {
+            builder = builder.commit_policy(policy.inner);
         }
         let engine = builder.build().await.map_err(laurus_err)?;
 

--- a/laurus-nodejs/src/lib.rs
+++ b/laurus-nodejs/src/lib.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::enum_variant_names)]
 
 mod analysis;
+mod commit;
 mod convert;
 mod errors;
 mod index;

--- a/laurus-php/src/index.rs
+++ b/laurus-php/src/index.rs
@@ -7,7 +7,7 @@ use ext_php_rs::convert::FromZval;
 use ext_php_rs::prelude::*;
 use ext_php_rs::types::{ZendHashTable, Zval};
 use laurus::{
-    DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, Engine, EngineStats, Storage,
+    CommitPolicy, DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, Engine, EngineStats, Storage,
     StorageConfig, StorageFactory, WalSyncPolicy,
 };
 
@@ -137,6 +137,87 @@ impl PhpWalSyncPolicy {
 }
 
 // ---------------------------------------------------------------------------
+// CommitPolicy
+// ---------------------------------------------------------------------------
+
+/// Auto-commit policy controlling when the engine automatically runs the commit
+/// ladder during ingestion.
+///
+/// By default the engine commits only when `commit()` is called explicitly; a
+/// non-`manual` policy makes it commit automatically at an ingestion-driven
+/// cadence. This is orthogonal to [`PhpWalSyncPolicy`].
+///
+/// ```php
+/// use Laurus\CommitPolicy;
+/// use Laurus\Index;
+///
+/// // Manual (the default): the caller drives every commit().
+/// $policy = CommitPolicy::manual();
+///
+/// // Auto-commit after every 1000 applied documents.
+/// $policy = CommitPolicy::everyDocs(1000);
+///
+/// $index = new Index(null, null, null, $policy);
+/// ```
+#[php_class]
+#[php(name = "Laurus\\CommitPolicy")]
+#[derive(Clone, Copy)]
+pub struct PhpCommitPolicy {
+    /// The wrapped Rust auto-commit policy passed to the engine builder.
+    pub inner: CommitPolicy,
+}
+
+#[php_impl]
+impl PhpCommitPolicy {
+    /// Create a manual (no auto-commit) policy.
+    ///
+    /// The engine commits only when `commit()` is called explicitly. This is
+    /// the engine default when no `commit_policy` is supplied to
+    /// [`PhpIndex::__construct`].
+    ///
+    /// # Returns
+    ///
+    /// A `CommitPolicy` wrapping [`CommitPolicy::Manual`].
+    pub fn manual() -> Self {
+        Self {
+            inner: CommitPolicy::Manual,
+        }
+    }
+
+    /// Create an auto-commit-every-`n`-documents policy.
+    ///
+    /// The engine runs the commit ladder after every `n` applied documents,
+    /// across the singular and batch ingest APIs (and every `n` documents
+    /// within a single batch). `everyDocs(0)` disables auto-commit, which is
+    /// equivalent to [`PhpCommitPolicy::manual`].
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - Commit after this many applied documents. `0` disables
+    ///   auto-commit.
+    ///
+    /// # Returns
+    ///
+    /// A `CommitPolicy` wrapping [`CommitPolicy::EveryDocs`].
+    pub fn every_docs(n: i64) -> Self {
+        Self {
+            inner: CommitPolicy::EveryDocs(n.max(0) as usize),
+        }
+    }
+
+    /// Return a string representation.
+    pub fn __to_string(&self) -> String {
+        match self.inner {
+            CommitPolicy::Manual => "CommitPolicy.manual()".to_string(),
+            CommitPolicy::EveryDocs(n) => format!("CommitPolicy.everyDocs({n})"),
+            // `CommitPolicy` is #[non_exhaustive]; render a future variant
+            // generically rather than failing to compile.
+            _ => "CommitPolicy(<unknown>)".to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Index
 // ---------------------------------------------------------------------------
 
@@ -184,10 +265,15 @@ impl PhpIndex {
     ///   write-ahead log is forced durable. Defaults to per-record durability
     ///   ([`WalSyncPolicy::PerRecord`]) when null. Use
     ///   [`PhpWalSyncPolicy::group`] for higher-throughput group commit.
+    /// * `commit_policy` - Optional [`PhpCommitPolicy`] controlling automatic
+    ///   commits during ingestion. Defaults to manual (caller-driven commits)
+    ///   when null. Use [`PhpCommitPolicy::every_docs`] to auto-commit every
+    ///   `n` documents.
     pub fn __construct(
         path: Option<String>,
         schema: Option<&PhpSchema>,
         wal_sync_policy: Option<&PhpWalSyncPolicy>,
+        commit_policy: Option<&PhpCommitPolicy>,
     ) -> PhpResult<Self> {
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| ext_php_rs::exception::PhpException::default(e.to_string()))?;
@@ -202,6 +288,9 @@ impl PhpIndex {
         let mut builder = Engine::builder(storage, schema_val);
         if let Some(policy) = wal_sync_policy {
             builder = builder.wal_sync_policy(policy.inner);
+        }
+        if let Some(policy) = commit_policy {
+            builder = builder.commit_policy(policy.inner);
         }
 
         let engine = rt.block_on(builder.build()).map_err(laurus_err)?;

--- a/laurus-php/src/lib.rs
+++ b/laurus-php/src/lib.rs
@@ -29,6 +29,7 @@ pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
         // Core
         .class::<index::PhpIndex>()
         .class::<index::PhpWalSyncPolicy>()
+        .class::<index::PhpCommitPolicy>()
         .class::<schema::PhpSchema>()
         // Search result & request, fusion algorithms
         .class::<search::PhpRRF>()

--- a/laurus-php/tests/LaurusTest.php
+++ b/laurus-php/tests/LaurusTest.php
@@ -799,4 +799,39 @@ class LaurusTest extends TestCase
         $idx->commit();
         $this->assertCount(1, $idx->getDocuments("doc1"));
     }
+
+    // ── Auto-commit / CommitPolicy (#893) ─────────────────────────────────
+
+    public function testCommitPolicyFactoriesAccepted(): void
+    {
+        // Both factories build a value object that the Index constructor
+        // accepts as the 4th argument. everyDocs(0) is valid (== manual).
+        $manual = Laurus\CommitPolicy::manual();
+        $this->assertNotNull($manual);
+
+        $auto = Laurus\CommitPolicy::everyDocs(100);
+        $this->assertNotNull($auto);
+
+        $this->assertNotNull(Laurus\CommitPolicy::everyDocs(0));
+
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+
+        $idx1 = new Laurus\Index(null, $schema, null, $manual);
+        $this->assertNotNull($idx1);
+
+        $idx2 = new Laurus\Index(null, $schema, null, $auto);
+        $this->assertNotNull($idx2);
+    }
+
+    public function testEveryDocsAutoCommitEndToEnd(): void
+    {
+        // An index built with everyDocs(1) is wired end-to-end: a document is
+        // retrievable with no explicit commit() from the caller.
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+        $idx = new Laurus\Index(null, $schema, null, Laurus\CommitPolicy::everyDocs(1));
+        $idx->putDocument("d1", ["title" => "Auto"]);
+        $this->assertCount(1, $idx->getDocuments("d1"));
+    }
 }

--- a/laurus-python/src/index.rs
+++ b/laurus-python/src/index.rs
@@ -8,7 +8,7 @@ use crate::errors::laurus_err;
 use crate::schema::PySchema;
 use crate::search::{PySearchResult, build_request_from_py, to_py_search_result};
 use laurus::{
-    DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, Engine, EngineStats, Storage,
+    CommitPolicy, DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, Engine, EngineStats, Storage,
     StorageConfig, StorageFactory, WalSyncPolicy,
 };
 use pyo3::exceptions::PyRuntimeError;
@@ -133,6 +133,86 @@ impl PyWalSyncPolicy {
 }
 
 // ---------------------------------------------------------------------------
+// CommitPolicy
+// ---------------------------------------------------------------------------
+
+/// Auto-commit policy that controls when the engine automatically runs the
+/// commit ladder during ingestion.
+///
+/// This is a value object wrapping the Rust [`laurus::CommitPolicy`]. It is
+/// passed to [`Index`] at construction time via the `commit_policy` keyword
+/// argument. By default the engine commits only when [`Index.commit`] is
+/// called explicitly; a non-`manual` policy makes it commit automatically at
+/// an ingestion-driven cadence. This is orthogonal to `wal_sync_policy`.
+///
+/// ## Constructing a policy
+///
+/// ```python
+/// import laurus
+///
+/// # Manual (the default): the caller drives every commit().
+/// policy = laurus.CommitPolicy.manual()
+///
+/// # Auto-commit after every 1000 applied documents.
+/// policy = laurus.CommitPolicy.every_docs(1000)
+///
+/// index = laurus.Index(commit_policy=policy)
+/// ```
+#[pyclass(name = "CommitPolicy", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyCommitPolicy {
+    /// The wrapped Rust auto-commit policy.
+    pub inner: CommitPolicy,
+}
+
+#[pymethods]
+impl PyCommitPolicy {
+    /// Create a manual (no auto-commit) policy.
+    ///
+    /// The engine commits only when [`Index.commit`] is called explicitly.
+    /// This is the default when no `commit_policy` is supplied to [`Index`].
+    ///
+    /// Returns:
+    ///     A `CommitPolicy` wrapping `CommitPolicy::Manual`.
+    #[staticmethod]
+    pub fn manual() -> Self {
+        Self {
+            inner: CommitPolicy::Manual,
+        }
+    }
+
+    /// Create an auto-commit-every-`n`-documents policy.
+    ///
+    /// The engine runs the commit ladder after every `n` applied documents,
+    /// across the singular and batch ingest APIs (and every `n` documents
+    /// within a single batch). `every_docs(0)` disables auto-commit, which is
+    /// equivalent to [`CommitPolicy.manual`].
+    ///
+    /// Args:
+    ///     n: Commit after this many applied documents. `0` disables
+    ///         auto-commit.
+    ///
+    /// Returns:
+    ///     A `CommitPolicy` wrapping `CommitPolicy::EveryDocs(n)`.
+    #[staticmethod]
+    pub fn every_docs(n: usize) -> Self {
+        Self {
+            inner: CommitPolicy::EveryDocs(n),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        match self.inner {
+            CommitPolicy::Manual => "CommitPolicy.manual()".to_string(),
+            CommitPolicy::EveryDocs(n) => format!("CommitPolicy.every_docs({n})"),
+            // `CommitPolicy` is #[non_exhaustive]; a future variant renders
+            // generically rather than failing to compile.
+            _ => "CommitPolicy(<unknown>)".to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Index
 // ---------------------------------------------------------------------------
 
@@ -200,12 +280,16 @@ impl PyIndex {
     ///           appends are fsync'd. When `None` (the default), laurus uses
     ///           per-record durability (every append is fsync'd before it
     ///           returns).
+    ///     commit_policy: Optional [`CommitPolicy`] controlling automatic
+    ///           commits during ingestion. When `None` (the default), the
+    ///           engine is manual — the caller drives every `commit()`.
     #[new]
-    #[pyo3(signature = (path=None, schema=None, wal_sync_policy=None))]
+    #[pyo3(signature = (path=None, schema=None, wal_sync_policy=None, commit_policy=None))]
     pub fn new(
         path: Option<String>,
         schema: Option<&PySchema>,
         wal_sync_policy: Option<&PyWalSyncPolicy>,
+        commit_policy: Option<&PyCommitPolicy>,
     ) -> PyResult<Self> {
         let rt =
             tokio::runtime::Runtime::new().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
@@ -216,6 +300,9 @@ impl PyIndex {
         let mut builder = Engine::builder(storage, schema);
         if let Some(p) = wal_sync_policy {
             builder = builder.wal_sync_policy(p.inner);
+        }
+        if let Some(p) = commit_policy {
+            builder = builder.commit_policy(p.inner);
         }
 
         let engine = rt.block_on(builder.build()).map_err(laurus_err)?;

--- a/laurus-python/src/lib.rs
+++ b/laurus-python/src/lib.rs
@@ -17,7 +17,7 @@ mod schema;
 mod search;
 
 use analysis::{PySynonymDictionary, PySynonymGraphFilter, PyToken, PyWhitespaceTokenizer};
-use index::{PyIndex, PyWalSyncPolicy};
+use index::{PyCommitPolicy, PyIndex, PyWalSyncPolicy};
 use pyo3::prelude::*;
 use query::{
     PyBooleanQuery, PyFuzzyQuery, PyGeo3dBoundingBoxQuery, PyGeo3dDistanceQuery,
@@ -54,6 +54,7 @@ fn laurus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyIndex>()?;
     m.add_class::<PySchema>()?;
     m.add_class::<PyWalSyncPolicy>()?;
+    m.add_class::<PyCommitPolicy>()?;
 
     // ── Search result & request ───────────────────────────────────────────
     m.add_class::<PySearchResult>()?;

--- a/laurus-python/tests/test_index.py
+++ b/laurus-python/tests/test_index.py
@@ -140,6 +140,33 @@ def test_flush_wal_per_record_is_noop():
     assert len(docs) == 1
 
 
+def test_commit_policy_constructors():
+    """All CommitPolicy constructors build without error."""
+    assert laurus.CommitPolicy.manual() is not None
+    assert laurus.CommitPolicy.every_docs(100) is not None
+    # every_docs(0) is valid — it disables auto-commit (equivalent to manual).
+    assert laurus.CommitPolicy.every_docs(0) is not None
+    assert "every_docs(100)" in repr(laurus.CommitPolicy.every_docs(100))
+
+
+def test_index_accepts_commit_policies():
+    """Index construction accepts every CommitPolicy variant, and the default."""
+    assert laurus.Index(commit_policy=laurus.CommitPolicy.manual()) is not None
+    assert laurus.Index(commit_policy=laurus.CommitPolicy.every_docs(100)) is not None
+    assert laurus.Index(commit_policy=laurus.CommitPolicy.every_docs(0)) is not None
+    # Omitting commit_policy keeps the default (manual).
+    assert laurus.Index() is not None
+
+
+def test_index_auto_commit_end_to_end():
+    """An index built with EveryDocs is usable; a doc is retrievable with no
+    explicit commit (the binding path is wired end-to-end)."""
+    idx = laurus.Index(commit_policy=laurus.CommitPolicy.every_docs(1))
+    idx.put_document("d1", {"title": "Auto"})
+    # No explicit idx.commit() here.
+    assert len(idx.get_documents("d1")) == 1
+
+
 # ---------------------------------------------------------------------------
 # Stats
 # ---------------------------------------------------------------------------

--- a/laurus-ruby/src/commit_policy.rs
+++ b/laurus-ruby/src/commit_policy.rs
@@ -1,0 +1,115 @@
+//! Ruby wrapper for the Laurus [`laurus::CommitPolicy`] value object.
+//!
+//! Exposes `Laurus::CommitPolicy` with the two construction class methods
+//! `manual` and `every_docs`, mirroring the auto-commit policy plumbed through
+//! [`laurus::EngineBuilder::commit_policy`]. The resulting value object is
+//! passed to `Laurus::Index.new(commit_policy: ...)`.
+
+use laurus::CommitPolicy;
+use magnus::prelude::*;
+use magnus::{Error, RModule, Ruby};
+
+// ---------------------------------------------------------------------------
+// CommitPolicy
+// ---------------------------------------------------------------------------
+
+/// Ruby value object wrapping a [`laurus::CommitPolicy`].
+///
+/// A commit policy controls when the engine automatically runs the commit
+/// ladder during ingestion:
+///
+/// * `Laurus::CommitPolicy.manual` — the default. The caller drives every
+///   `commit`. Identical to omitting `commit_policy:`.
+/// * `Laurus::CommitPolicy.every_docs(n)` — auto-commit after every `n` applied
+///   documents, across the singular and batch ingest APIs (and every `n`
+///   documents within a single batch). `every_docs(0)` disables auto-commit
+///   (equivalent to `manual`).
+///
+/// This is orthogonal to `Laurus::WalSyncPolicy`.
+///
+/// # Examples
+///
+/// ```ruby
+/// require "laurus"
+///
+/// # Default manual commits.
+/// policy = Laurus::CommitPolicy.manual
+///
+/// # Auto-commit every 1000 applied documents.
+/// policy = Laurus::CommitPolicy.every_docs(1000)
+///
+/// index = Laurus::Index.new(commit_policy: policy)
+/// ```
+#[magnus::wrap(class = "Laurus::CommitPolicy")]
+pub struct RbCommitPolicy {
+    /// The wrapped core policy, forwarded verbatim to the engine builder.
+    pub inner: CommitPolicy,
+}
+
+impl RbCommitPolicy {
+    /// Build the manual (no auto-commit) policy
+    /// ([`laurus::CommitPolicy::Manual`]).
+    ///
+    /// The engine commits only when `Laurus::Index#commit` is called
+    /// explicitly. This is the engine default and matches the behavior when
+    /// `commit_policy:` is omitted from `Laurus::Index.new`.
+    ///
+    /// # Returns
+    ///
+    /// A `Laurus::CommitPolicy` wrapping [`laurus::CommitPolicy::Manual`].
+    fn manual() -> Self {
+        Self {
+            inner: CommitPolicy::Manual,
+        }
+    }
+
+    /// Build the auto-commit-every-`n`-documents policy
+    /// ([`laurus::CommitPolicy::EveryDocs`]).
+    ///
+    /// # Arguments
+    ///
+    /// * `n` (Integer): Commit after this many applied documents. `0` disables
+    ///   auto-commit (equivalent to `manual`).
+    ///
+    /// # Returns
+    ///
+    /// A `Laurus::CommitPolicy` wrapping [`laurus::CommitPolicy::EveryDocs`].
+    fn every_docs(n: usize) -> Self {
+        Self {
+            inner: CommitPolicy::EveryDocs(n),
+        }
+    }
+
+    /// Human-readable representation for `inspect` / `to_s`.
+    fn inspect(&self) -> String {
+        match self.inner {
+            CommitPolicy::Manual => "CommitPolicy(Manual)".to_string(),
+            CommitPolicy::EveryDocs(n) => format!("CommitPolicy(EveryDocs {n})"),
+            // `CommitPolicy` is #[non_exhaustive]; render a future variant
+            // generically rather than failing to compile.
+            _ => "CommitPolicy(<unknown>)".to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class registration
+// ---------------------------------------------------------------------------
+
+/// Register the `Laurus::CommitPolicy` class and its methods.
+///
+/// # Arguments
+///
+/// * `ruby` - Ruby interpreter handle.
+/// * `module` - The `Laurus` module.
+pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("CommitPolicy", ruby.class_object())?;
+    class.define_singleton_method("manual", magnus::function!(RbCommitPolicy::manual, 0))?;
+    class.define_singleton_method(
+        "every_docs",
+        magnus::function!(RbCommitPolicy::every_docs, 1),
+    )?;
+    class.define_method("inspect", magnus::method!(RbCommitPolicy::inspect, 0))?;
+    class.define_method("to_s", magnus::method!(RbCommitPolicy::inspect, 0))?;
+    Ok(())
+}

--- a/laurus-ruby/src/index.rs
+++ b/laurus-ruby/src/index.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::commit_policy::RbCommitPolicy;
 use crate::convert::{document_to_hash, hash_to_document};
 use crate::errors::laurus_err;
 use crate::schema::RbSchema;
@@ -59,6 +60,10 @@ impl RbIndex {
     ///     Defaults to per-record fsync (highest durability). Pass
     ///     `Laurus::WalSyncPolicy.group(...)` to enable group commit for higher
     ///     write throughput; use `flush_wal` to force durability on demand.
+    ///   - `commit_policy:` (CommitPolicy, optional): auto-commit policy.
+    ///     Defaults to manual (the caller drives every commit). Pass
+    ///     `Laurus::CommitPolicy.every_docs(n)` to auto-commit every `n`
+    ///     applied documents.
     fn new(args: &[Value]) -> Result<Self, Error> {
         let ruby = Ruby::get().expect("called from Ruby thread");
         let args = scan_args::<(), (), (), (), RHash, ()>(args)?;
@@ -69,13 +74,19 @@ impl RbIndex {
                 Option<Option<String>>,
                 Option<Option<&RbSchema>>,
                 Option<Option<&RbWalSyncPolicy>>,
+                Option<Option<&RbCommitPolicy>>,
             ),
             (),
-        >(args.keywords, &[], &["path", "schema", "wal_sync_policy"])?;
-        let (path, schema, wal_sync_policy) = kwargs.optional;
+        >(
+            args.keywords,
+            &[],
+            &["path", "schema", "wal_sync_policy", "commit_policy"],
+        )?;
+        let (path, schema, wal_sync_policy, commit_policy) = kwargs.optional;
         let path = path.flatten();
         let schema_ref = schema.flatten();
         let wal_sync_policy = wal_sync_policy.flatten();
+        let commit_policy = commit_policy.flatten();
 
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| Error::new(ruby.exception_runtime_error(), e.to_string()))?;
@@ -88,6 +99,9 @@ impl RbIndex {
         let mut builder = Engine::builder(storage, schema);
         if let Some(policy) = wal_sync_policy {
             builder = builder.wal_sync_policy(policy.inner);
+        }
+        if let Some(policy) = commit_policy {
+            builder = builder.commit_policy(policy.inner);
         }
 
         let engine = rt.block_on(builder.build()).map_err(laurus_err)?;

--- a/laurus-ruby/src/lib.rs
+++ b/laurus-ruby/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(dead_code)]
 
 mod analysis;
+mod commit_policy;
 mod convert;
 mod errors;
 mod index;
@@ -31,6 +32,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     index::define(ruby, &module)?;
     schema::define(ruby, &module)?;
     wal::define(ruby, &module)?;
+    commit_policy::define(ruby, &module)?;
 
     // Search result & request, fusion algorithms
     search::define(ruby, &module)?;

--- a/laurus-ruby/test/test_index.rb
+++ b/laurus-ruby/test/test_index.rb
@@ -71,6 +71,27 @@ class TestIndex < Minitest::Test
     assert_equal 1, docs.length
   end
 
+  def test_commit_policy_constructors
+    # Both constructors build accepted value objects.
+    refute_nil Laurus::CommitPolicy.manual
+    refute_nil Laurus::CommitPolicy.every_docs(100)
+    # every_docs(0) is valid — it disables auto-commit (equivalent to manual).
+    refute_nil Laurus::CommitPolicy.every_docs(0)
+
+    # Every variant, and the default (omitted kwarg), is accepted by Index.new.
+    refute_nil Laurus::Index.new(commit_policy: Laurus::CommitPolicy.manual)
+    refute_nil Laurus::Index.new(commit_policy: Laurus::CommitPolicy.every_docs(100))
+    refute_nil Laurus::Index.new(commit_policy: Laurus::CommitPolicy.every_docs(0))
+  end
+
+  def test_index_with_every_docs_auto_commit
+    idx = Laurus::Index.new(commit_policy: Laurus::CommitPolicy.every_docs(1))
+    idx.put_document("d1", { "title" => "Auto" })
+    # No explicit commit — the binding path is wired end-to-end.
+    docs = idx.get_documents("d1")
+    assert_equal 1, docs.length
+  end
+
   # ---------------------------------------------------------------------------
   # Document CRUD
   # ---------------------------------------------------------------------------

--- a/laurus-server/src/config.rs
+++ b/laurus-server/src/config.rs
@@ -4,7 +4,7 @@
 //! index storage, and logging. All sections have sensible defaults so that
 //! a minimal (or even empty) TOML file produces a working configuration.
 
-use laurus::{DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, WalSyncPolicy};
+use laurus::{CommitPolicy, DEFAULT_GROUP_MAX_BYTES, DEFAULT_GROUP_MAX_RECORDS, WalSyncPolicy};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -54,6 +54,9 @@ pub struct IndexConfig {
     /// Write-ahead log durability settings. Defaults to per-record fsync.
     #[serde(default)]
     pub wal: WalConfig,
+    /// Auto-commit settings. Defaults to manual (caller/server-driven commits).
+    #[serde(default)]
+    pub commit: CommitConfig,
 }
 
 impl Default for IndexConfig {
@@ -61,6 +64,7 @@ impl Default for IndexConfig {
         Self {
             data_dir: default_data_dir(),
             wal: WalConfig::default(),
+            commit: CommitConfig::default(),
         }
     }
 }
@@ -123,6 +127,57 @@ impl WalConfig {
                 max_bytes: self.group_max_bytes.unwrap_or(DEFAULT_GROUP_MAX_BYTES),
                 max_interval: self.group_max_interval_ms.map(Duration::from_millis),
             },
+        }
+    }
+}
+
+/// The auto-commit policy selector deserialized from the config file.
+///
+/// Mirrors the variants of [`laurus::CommitPolicy`] without their parameters;
+/// the [`CommitConfig::every_docs`] threshold is applied when the policy is
+/// [`CommitPolicyKind::EveryDocs`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitPolicyKind {
+    /// Never auto-commit (default); maps to [`CommitPolicy::Manual`].
+    #[default]
+    Manual,
+    /// Commit every `every_docs` applied documents; maps to
+    /// [`CommitPolicy::EveryDocs`].
+    EveryDocs,
+}
+
+/// Auto-commit configuration.
+///
+/// Selects the [`laurus::CommitPolicy`] used for the index. The default is
+/// [`CommitPolicyKind::Manual`], preserving caller-driven commits. When
+/// `policy = "every_docs"`, the optional `every_docs` threshold sets the
+/// document count between commits; an unset (or `0`) threshold disables
+/// auto-commit, matching [`CommitPolicy::EveryDocs`]`(0)`.
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+pub struct CommitConfig {
+    /// Which auto-commit policy to use. Defaults to `manual`.
+    #[serde(default)]
+    pub policy: CommitPolicyKind,
+    /// Commit after this many applied documents (`every_docs` policy only).
+    /// Unset (or `0`) disables auto-commit.
+    #[serde(default)]
+    pub every_docs: Option<usize>,
+}
+
+impl CommitConfig {
+    /// Convert this configuration into a [`laurus::CommitPolicy`].
+    ///
+    /// # Returns
+    ///
+    /// [`CommitPolicy::Manual`] when `policy` is `manual`, or
+    /// [`CommitPolicy::EveryDocs`] with the configured threshold (`0` when
+    /// unset, which the engine treats as disabled) when `policy` is
+    /// `every_docs`.
+    pub fn to_policy(&self) -> CommitPolicy {
+        match self.policy {
+            CommitPolicyKind::Manual => CommitPolicy::Manual,
+            CommitPolicyKind::EveryDocs => CommitPolicy::EveryDocs(self.every_docs.unwrap_or(0)),
         }
     }
 }
@@ -210,5 +265,40 @@ mod tests {
                 max_interval: Some(Duration::from_millis(500)),
             }
         );
+    }
+
+    #[test]
+    fn default_commit_policy_is_manual() {
+        // An empty config (no [index.commit] section) must keep manual commits.
+        let config: Config = toml::from_str("").unwrap();
+        assert_eq!(config.index.commit.policy, CommitPolicyKind::Manual);
+        assert_eq!(config.index.commit.to_policy(), CommitPolicy::Manual);
+    }
+
+    #[test]
+    fn every_docs_policy_maps_threshold() {
+        let toml = r#"
+            [index.commit]
+            policy = "every_docs"
+            every_docs = 1000
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.index.commit.policy, CommitPolicyKind::EveryDocs);
+        assert_eq!(
+            config.index.commit.to_policy(),
+            CommitPolicy::EveryDocs(1000)
+        );
+    }
+
+    #[test]
+    fn every_docs_policy_defaults_threshold_to_zero_when_omitted() {
+        // policy = "every_docs" without a threshold maps to EveryDocs(0), which
+        // the engine treats as disabled (equivalent to Manual).
+        let toml = r#"
+            [index.commit]
+            policy = "every_docs"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.index.commit.to_policy(), CommitPolicy::EveryDocs(0));
     }
 }

--- a/laurus-server/src/context.rs
+++ b/laurus-server/src/context.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use anyhow::{Context, bail};
 use laurus::storage::file::FileStorageConfig;
-use laurus::{Engine, Schema, StorageConfig, StorageFactory, WalSyncPolicy};
+use laurus::{CommitPolicy, Engine, Schema, StorageConfig, StorageFactory, WalSyncPolicy};
 
 /// Filename used to persist the index schema inside the data directory.
 const SCHEMA_FILE: &str = "schema.toml";
@@ -27,6 +27,7 @@ const STORE_DIR: &str = "store";
 /// * `data_dir`  - Root directory where the index files will be stored.
 /// * `schema`    - The schema definition describing the index fields.
 /// * `wal_policy` - WAL durability policy threaded into the engine builder.
+/// * `commit_policy` - Auto-commit policy threaded into the engine builder.
 ///
 /// # Returns
 ///
@@ -40,6 +41,7 @@ pub async fn create_index(
     data_dir: &Path,
     schema: &Schema,
     wal_policy: WalSyncPolicy,
+    commit_policy: CommitPolicy,
 ) -> anyhow::Result<Engine> {
     let schema_path = data_dir.join(SCHEMA_FILE);
     if schema_path.exists() {
@@ -64,6 +66,7 @@ pub async fn create_index(
     let storage = StorageFactory::create(storage_config)?;
     let engine = Engine::builder(storage, schema.clone())
         .wal_sync_policy(wal_policy)
+        .commit_policy(commit_policy)
         .build()
         .await?;
 
@@ -79,6 +82,7 @@ pub async fn create_index(
 ///
 /// * `data_dir`  - Root directory of an existing index.
 /// * `wal_policy` - WAL durability policy threaded into the engine builder.
+/// * `commit_policy` - Auto-commit policy threaded into the engine builder.
 ///
 /// # Returns
 ///
@@ -89,7 +93,11 @@ pub async fn create_index(
 /// Returns an error if no index exists at `data_dir` (i.e. `schema.toml` is
 /// missing), if the schema file cannot be read or parsed, or if the engine
 /// fails to initialise.
-pub async fn open_index(data_dir: &Path, wal_policy: WalSyncPolicy) -> anyhow::Result<Engine> {
+pub async fn open_index(
+    data_dir: &Path,
+    wal_policy: WalSyncPolicy,
+    commit_policy: CommitPolicy,
+) -> anyhow::Result<Engine> {
     let schema_path = data_dir.join(SCHEMA_FILE);
     if !schema_path.exists() {
         bail!(
@@ -107,6 +115,7 @@ pub async fn open_index(data_dir: &Path, wal_policy: WalSyncPolicy) -> anyhow::R
     let storage = StorageFactory::open(storage_config)?;
     let engine = Engine::builder(storage, schema)
         .wal_sync_policy(wal_policy)
+        .commit_policy(commit_policy)
         .build()
         .await?;
 

--- a/laurus-server/src/server.rs
+++ b/laurus-server/src/server.rs
@@ -55,12 +55,15 @@ pub async fn run(config: &Config) -> anyhow::Result<()> {
     tracing::info!("Laurus server starting");
     tracing::info!("Data directory: {}", config.index.data_dir.display());
 
-    // Resolve the WAL durability policy once; it applies to both the boot-time
-    // open below and any index created later via the CreateIndex RPC.
+    // Resolve the WAL durability and auto-commit policies once; they apply to
+    // both the boot-time open below and any index created later via the
+    // CreateIndex RPC.
     let wal_policy = config.index.wal.to_policy();
+    let commit_policy = config.index.commit.to_policy();
 
     // Open an existing index. If none exists, start without an index.
-    let engine = match context::open_index(&config.index.data_dir, wal_policy).await {
+    let engine = match context::open_index(&config.index.data_dir, wal_policy, commit_policy).await
+    {
         Ok(engine) => {
             tracing::info!("Opened existing index");
             Some(engine)
@@ -82,6 +85,7 @@ pub async fn run(config: &Config) -> anyhow::Result<()> {
         engine: engine.clone(),
         data_dir,
         wal_policy,
+        commit_policy,
     };
     let search_service = SearchService {
         engine: engine.clone(),

--- a/laurus-server/src/service/index.rs
+++ b/laurus-server/src/service/index.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
-use laurus::{Engine, WalSyncPolicy};
+use laurus::{CommitPolicy, Engine, WalSyncPolicy};
 
 use crate::context;
 use crate::convert::{error, schema as schema_convert};
@@ -29,6 +29,8 @@ pub struct IndexService {
     pub data_dir: PathBuf,
     /// WAL durability policy applied to indices created via this service.
     pub wal_policy: WalSyncPolicy,
+    /// Auto-commit policy applied to indices created via this service.
+    pub commit_policy: CommitPolicy,
 }
 
 #[tonic::async_trait]
@@ -50,9 +52,10 @@ impl IndexServiceTrait for IndexService {
             return Err(Status::already_exists("Index already exists"));
         }
 
-        let engine = context::create_index(&self.data_dir, &schema, self.wal_policy)
-            .await
-            .map_err(error::anyhow_to_status)?;
+        let engine =
+            context::create_index(&self.data_dir, &schema, self.wal_policy, self.commit_policy)
+                .await
+                .map_err(error::anyhow_to_status)?;
         *guard = Some(engine);
 
         tracing::info!("Index created at {}", self.data_dir.display());

--- a/laurus-wasm/src/commit.rs
+++ b/laurus-wasm/src/commit.rs
@@ -1,0 +1,78 @@
+//! WASM wrapper for the Laurus [`CommitPolicy`] value object (Issue #893).
+//!
+//! Exposes the auto-commit policy to JavaScript so that callers can opt into
+//! automatic commits when constructing an [`crate::index::WasmIndex`].
+
+use laurus::CommitPolicy;
+use wasm_bindgen::prelude::*;
+
+/// Auto-commit policy for an [`crate::index::WasmIndex`].
+///
+/// Controls when the engine automatically runs the commit ladder during
+/// ingestion:
+///
+/// - **Manual** (the default) — the caller drives every `commit()`.
+/// - **Every-docs** — the engine commits after every `n` applied documents,
+///   across the singular and batch ingest APIs (and every `n` documents within
+///   a single batch).
+///
+/// This is orthogonal to `WalSyncPolicy`.
+///
+/// ```javascript
+/// import { Index, Schema, CommitPolicy } from "laurus-wasm";
+///
+/// const schema = new Schema();
+/// schema.addTextField("title");
+///
+/// // Auto-commit after every 1000 applied documents.
+/// const index = await Index.create(schema, undefined, CommitPolicy.everyDocs(1000));
+///
+/// // Manual (the default if no policy is supplied).
+/// const manual = CommitPolicy.manual();
+/// ```
+///
+/// **wasm note:** unlike `WalSyncPolicy`'s `maxIntervalMs` timer, `everyDocs`
+/// needs no background thread — it is checked inline during ingestion — so it
+/// works fully under WebAssembly.
+#[wasm_bindgen(js_name = "CommitPolicy")]
+#[derive(Clone, Copy)]
+pub struct WasmCommitPolicy {
+    /// The wrapped core auto-commit policy passed to `EngineBuilder`.
+    pub(crate) inner: CommitPolicy,
+}
+
+#[wasm_bindgen(js_class = "CommitPolicy")]
+impl WasmCommitPolicy {
+    /// The manual policy: the engine commits only when `commit()` is called
+    /// explicitly. This is the default when no policy is supplied.
+    ///
+    /// # Returns
+    ///
+    /// A `CommitPolicy` wrapping [`CommitPolicy::Manual`].
+    #[wasm_bindgen(js_name = "manual")]
+    pub fn manual() -> WasmCommitPolicy {
+        WasmCommitPolicy {
+            inner: CommitPolicy::Manual,
+        }
+    }
+
+    /// The auto-commit-every-`n`-documents policy.
+    ///
+    /// `everyDocs(0)` disables auto-commit, which is equivalent to
+    /// [`WasmCommitPolicy::manual`].
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - Commit after this many applied documents. `0` disables
+    ///   auto-commit.
+    ///
+    /// # Returns
+    ///
+    /// A `CommitPolicy` wrapping [`CommitPolicy::EveryDocs`].
+    #[wasm_bindgen(js_name = "everyDocs")]
+    pub fn every_docs(n: u32) -> WasmCommitPolicy {
+        WasmCommitPolicy {
+            inner: CommitPolicy::EveryDocs(n as usize),
+        }
+    }
+}

--- a/laurus-wasm/src/index.rs
+++ b/laurus-wasm/src/index.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use crate::commit::WasmCommitPolicy;
 use crate::convert::{data_value_to_json, json_to_document};
 use crate::errors::laurus_err;
 use crate::query::{
@@ -173,6 +174,9 @@ impl WasmIndex {
     /// * `wal_sync_policy` - Optional WAL durability policy. Defaults to
     ///   per-record fsync when omitted. Pass `WalSyncPolicy.group()` to opt into
     ///   group-commit batching.
+    /// * `commit_policy` - Optional auto-commit policy. Defaults to manual
+    ///   (caller-driven commits) when omitted. Pass `CommitPolicy.everyDocs(n)`
+    ///   to auto-commit every `n` documents.
     ///
     /// # Returns
     ///
@@ -181,6 +185,7 @@ impl WasmIndex {
     pub async fn create(
         schema: WasmSchema,
         wal_sync_policy: Option<WasmWalSyncPolicy>,
+        commit_policy: Option<WasmCommitPolicy>,
     ) -> Result<WasmIndex, JsValue> {
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
         let js_embedders = schema.js_embedders;
@@ -203,6 +208,9 @@ impl WasmIndex {
         }
         if let Some(policy) = wal_sync_policy {
             builder = builder.wal_sync_policy(policy.inner);
+        }
+        if let Some(policy) = commit_policy {
+            builder = builder.commit_policy(policy.inner);
         }
 
         let engine = builder.build().await.map_err(laurus_err)?;
@@ -228,6 +236,9 @@ impl WasmIndex {
     /// * `wal_sync_policy` - Optional WAL durability policy. Defaults to
     ///   per-record fsync when omitted. Pass `WalSyncPolicy.group()` to opt into
     ///   group-commit batching.
+    /// * `commit_policy` - Optional auto-commit policy. Defaults to manual
+    ///   (caller-driven commits) when omitted. Pass `CommitPolicy.everyDocs(n)`
+    ///   to auto-commit every `n` documents.
     ///
     /// # Returns
     ///
@@ -237,6 +248,7 @@ impl WasmIndex {
         name: String,
         schema: WasmSchema,
         wal_sync_policy: Option<WasmWalSyncPolicy>,
+        commit_policy: Option<WasmCommitPolicy>,
     ) -> Result<WasmIndex, JsValue> {
         let opfs = OpfsPersistence::open(&name).await?;
         let storage = opfs.load().await?;
@@ -259,6 +271,9 @@ impl WasmIndex {
         }
         if let Some(policy) = wal_sync_policy {
             builder = builder.wal_sync_policy(policy.inner);
+        }
+        if let Some(policy) = commit_policy {
+            builder = builder.commit_policy(policy.inner);
         }
 
         let engine = builder.build().await.map_err(laurus_err)?;

--- a/laurus-wasm/src/lib.rs
+++ b/laurus-wasm/src/lib.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::enum_variant_names)]
 
 mod analysis;
+mod commit;
 mod convert;
 mod embedder;
 mod errors;


### PR DESCRIPTION
## Summary

Surfaces the engine-level auto-commit policy added in #890 (`CommitPolicy::{ Manual, EveryDocs(usize) }`) through the **five language bindings and the gRPC server**, mirroring each target's existing `WalSyncPolicy` exposure. This completes the #890 campaign: `CommitPolicy` is now available on the engine, the CLI, all five bindings, and the server.

Scope: `EveryDocs(usize)` only (a time-based `Interval` is #892); default = optional/none = `Manual`.

Refs #890
Closes #893

## What changed

Each target follows its `WalSyncPolicy` precedent 1:1. Universal rule: `CommitPolicy` is `#[non_exhaustive]`, so every downstream wrapper's `inspect`/`to_string`/`repr` match carries a `_ =>` arm; `every_docs(0)` is accepted everywhere and disables auto-commit (== `Manual`).

### Bindings

- **python** (`src/index.rs`, `src/lib.rs`): `PyCommitPolicy` with `manual()` / `every_docs(n)` static methods; `commit_policy=None` kwarg on `Index`.
- **nodejs** (`src/commit.rs`, `src/lib.rs`, `src/index.rs`): `JsCommitPolicy` napi class; `everyDocs(n: u32) as usize`; 4th `commitPolicy` arg on `Index.create`.
- **wasm** (`src/commit.rs`, `src/lib.rs`, `src/index.rs`): `WasmCommitPolicy`; `commitPolicy?` on `create`/`open`. `everyDocs` needs no background thread, so it works **fully on wasm** (unlike `WalSyncPolicy`'s `maxIntervalMs` timer).
- **ruby** (`src/commit_policy.rs`, `src/lib.rs`, `src/index.rs`): `RbCommitPolicy` with singleton `manual` / `every_docs(n)`; `commit_policy:` kwarg.
- **php** (`src/index.rs`, `src/lib.rs`): `PhpCommitPolicy` with static `manual()` / `everyDocs(n)`; 4th `__construct` arg. `everyDocs(n: i64)` is guarded with `n.max(0) as usize`.

### Server (`laurus-server`)

A `CommitConfig` / `CommitPolicyKind` / `to_policy()` block in `config.rs` (mirroring `WalConfig`), embedded in `IndexConfig` with `#[serde(default)]`, and threaded through `context.rs` (`create_index` / `open_index`), `server.rs`, and `service/index.rs` — so the policy applies to both the boot-opened index and `CreateIndex`-created ones.

```toml
[index.commit]
policy = "every_docs"   # "manual" (default) | "every_docs"
every_docs = 1000       # unset/0 disables auto-commit
```

## Tests

- **Per-binding smoke tests** assert wrapper construction + that `Index` accepts each policy (and the default), matching the depth of the existing WAL smoke tests: python `pytest` 3/3, nodejs `vitest` 3/3, ruby `rake test` 0 failures, php `phpunit` 2 tests/6 assertions. wasm is build+clippy only (no local JS runtime). A "put-without-commit then retrieve" check is included but is **not** treated as a strict auto-commit discriminator — the NRT active-segment scan (#640) makes uncommitted docs retrievable under `Manual` too; the strict behavior is already gated by the engine tests in #890.
- **Server**: three `config` tests (default = manual, `every_docs` threshold mapping, unset threshold == disabled), plus the full `laurus-server` suite (44+2 passed).

## Adversarial review

A focused 3-dimension review (default preservation on policy-omission / `#[non_exhaustive]` + integer-conversion soundness / server TOML mapping) returned **0 findings** — each dimension an all-clear after real review activity (git diff + per-file reads).

## Verification

fmt clean · clippy 1.95 + 1.97 (server + 5 bindings, wasm on `wasm32-unknown-unknown`, `-D warnings`) 0 · language smoke tests green · `laurus-server` 44+2 · markdownlint (EN + JA) 0. Docs EN/JA added for all five bindings' `api_reference` and the server `configuration` reference (12 pages).
