### PR TITLE
fix(engine): mutations concurrent with commit can lose their WAL records to truncate() (#876)

### DIFF
--- a/docs/ja/src/laurus/persistence.md
+++ b/docs/ja/src/laurus/persistence.md
@@ -231,7 +231,9 @@ let engine = Engine::builder(storage, schema)
    `sync()`。
 3. **`vector.commit()`** — vector セグメントを書き、`sync()`。
 4. **`commit_documents()`** — document store セグメントを書き、`sync()`。
-5. **`truncate()`** — WAL を空の fsync 済みファイルで置き換える。
+5. **`truncate_retaining_after(applied_before)`** — このコミットが対象とした WAL レコードを
+   破棄し、コミット開始時点で両ストアへの適用が完了していなかったレコードは**保持**する
+   （Issue #876）。
 
 この順序は次の 2 つの不変条件を保証します。
 
@@ -239,8 +241,16 @@ let engine = Engine::builder(storage, schema)
   以降でのみ永続化され、必ずステップ 1 のバリアの後に実行されるため、コミット済み index が
   まだ durable でない WAL レコードを参照することはありません。
 - **すべてのストアは WAL が truncate される前に完全に durable 化される。** ステップ 2〜4 は
-  ステップ 5 が WAL を空にする前にそれぞれ `sync()` するため、WAL はそれが記述したデータが
+  ステップ 5 が対象範囲を破棄する前にそれぞれ `sync()` するため、WAL はそれが記述したデータが
   安全に materialize された後にのみ破棄されます。
+
+`commit()` は並行する `put`/`add`/`delete` 呼び出しと直列化**されません**（`CommitPolicy::Interval`
+の背景タイマーも同じラダーを実行するため同様です）。ステップ 5 はこれを踏まえた設計になって
+います: ステップ 1 の実行前にエンジンの ingest high-water mark をスナップショットし、その
+スナップショットより後の WAL レコードはすべて保持します。これにより、commit と並行した
+mutation はこの commit の materialize には含まれなくても WAL レコードを保持し続け、次回の
+リカバリで replay されます。並行する mutation が無い通常ケースでは、スナップショットが WAL
+全体をカバーするため、ステップ 5 は従来どおり WAL を空にします。
 
 リカバリは次回の `build()` で WAL を replay し、各ストアの `last_wal_seq` 以下のレコードを
 スキップします。replay は**冪等（idempotent）**です。各レコードを元々記録された `doc_id`
@@ -259,7 +269,7 @@ let engine = Engine::builder(storage, schema)
 | ステップ 2 の後、3 の前 | WAL + lexical（`last_wal_seq = N`） | lexical は ≤ N をスキップ、vector は WAL から replay |
 | ステップ 3 の後、4 の前 | WAL + lexical + vector | 両ストアがスキップ、documents は WAL から復元 |
 | ステップ 4 の後、5 の前 | WAL + 全ストア | WAL は残存、両ストアがスキップ、重複なし |
-| ステップ 5 の後 | 全ストア、WAL は空 | replay 対象なし |
+| ステップ 5 の後 | 全ストア。並行 mutation が無ければ WAL は空 | replay 対象なし（並行 mutation があればそのレコードのみ） |
 
 コミット済み index が失われた WAL レコードを参照する interleaving は存在しないため、group
 commit は文書化された契約（`flush_wal()` や `commit()` でまだ durable 化されていない書き込みの

--- a/docs/src/laurus/persistence.md
+++ b/docs/src/laurus/persistence.md
@@ -225,7 +225,9 @@ The commit ladder is:
    `last_wal_seq`), then `sync()`.
 3. **`vector.commit()`** — write the vector segment, then `sync()`.
 4. **`commit_documents()`** — write the document store segment, then `sync()`.
-5. **`truncate()`** — replace the WAL with a fresh, empty, fsync'd file.
+5. **`truncate_retaining_after(applied_before)`** — discard every WAL record
+   this commit covered; **retain** any record whose mutation had not finished
+   applying to both stores when the commit started (Issue #876).
 
 This order guarantees two invariants:
 
@@ -233,8 +235,18 @@ This order guarantees two invariants:
   only persisted in step 2+, which always runs *after* the step-1 barrier, so a
   committed index can never reference a WAL record that is not yet durable.
 - **Every store is fully durable before the WAL is truncated.** Steps 2–4 each
-  `sync()` before step 5 empties the WAL, so the WAL is only discarded once the
-  data it described is safely materialized.
+  `sync()` before step 5 discards the covered portion of the WAL, so nothing is
+  discarded before the data it described is safely materialized.
+
+`commit()` is **not** serialized against concurrent `put`/`add`/`delete` calls
+(nor against `CommitPolicy::Interval`'s background timer, which runs this same
+ladder). Step 5 accounts for this: it snapshots the engine's ingest high-water
+mark *before* step 1 runs, and retains every WAL record past that snapshot
+instead of unconditionally emptying the file. A mutation racing the commit
+therefore keeps its WAL record — and is replayed on the next recovery — even
+though it was not included in this commit's materialization. When nothing
+races the commit (the common case), the snapshot covers the whole WAL and step
+5 empties the file exactly as before.
 
 Recovery replays the WAL on the next `build()`, skipping records at or below each
 store's `last_wal_seq`. Replay is **idempotent** — it re-applies each record
@@ -254,7 +266,7 @@ The table below shows the outcome of a crash at each step (identical for
 | After step 2, before step 3 | WAL + lexical (`last_wal_seq = N`) | Lexical skips ≤ N; vector replays from WAL |
 | After step 3, before step 4 | WAL + lexical + vector | Both stores skip; documents restored from WAL |
 | After step 4, before step 5 | WAL + all stores | WAL still present; both stores skip, no duplicates |
-| After step 5 | All stores, WAL empty | Nothing to replay |
+| After step 5 | All stores; WAL empty unless a mutation raced this commit | Nothing to replay (or just the racing mutation's record) |
 
 No interleaving lets a committed index reference a lost WAL record, so group
 commit introduces no new durability gap beyond its documented contract (a crash

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -185,7 +185,16 @@ async fn run_commit_ladder(
     vector: &VectorStore,
     log: &DocumentLog,
     docs_since_commit: &AtomicU64,
+    applied_seq: &AtomicU64,
 ) -> Result<()> {
+    // Snapshot the ingest high-water mark BEFORE any store materializes
+    // (Issue #876). `applied_seq` is advanced only after a document has landed
+    // in BOTH stores' NRT buffers, so every record at or below this snapshot is
+    // guaranteed to be materialized by the `lexical.commit()` below — the store
+    // commits hold the same writer lock those upserts take, so a document that
+    // finished before this point cannot be excluded from the commit. Anything
+    // appended (or applied) afterwards must survive the truncate.
+    let applied_before = applied_seq.load(Ordering::Acquire);
     // Hard durability barrier: force the WAL durable before any store
     // materializes its state, so the WAL is never less durable than the
     // committed lexical/vector indexes. A near-no-op under the per-record
@@ -196,8 +205,15 @@ async fn run_commit_ladder(
     lexical.commit()?;
     vector.commit().await?;
     log.commit_documents()?;
-    // After successful commit to all stores, truncate the log.
-    log.truncate()?;
+    // Truncate the log, but RETAIN every record this commit did not materialize
+    // (Issue #876). The ladder is not serialized against ingestion, so a
+    // mutation can append its WAL record while the commit runs — wiping the
+    // whole file would destroy that record while its data lives only in the
+    // fresh in-memory writer, losing an acknowledged write on the next crash.
+    // Retaining from the pre-commit snapshot is conservative: a record that was
+    // in fact materialized is merely replayed again on recovery, which is
+    // idempotent.
+    log.truncate_retaining_after(applied_before)?;
     // Reset the auto-commit counter so a manual commit and an `EveryDocs`
     // auto-commit keep the same cadence going forward (#890).
     docs_since_commit.store(0, Ordering::Release);
@@ -243,6 +259,7 @@ impl CommitTimer {
         vector: Arc<VectorStore>,
         log: Arc<DocumentLog>,
         docs_since_commit: Arc<AtomicU64>,
+        applied_seq: Arc<AtomicU64>,
         interval: Duration,
     ) -> Result<Self> {
         use std::sync::mpsc::RecvTimeoutError;
@@ -282,6 +299,7 @@ impl CommitTimer {
                             &vector,
                             &log,
                             &docs_since_commit,
+                            &applied_seq,
                         ))
                     }));
                     match outcome {
@@ -354,6 +372,16 @@ pub struct Engine {
     /// [`CommitTimer`] shares the same counter and resets it on each timed
     /// commit.
     docs_since_commit: Arc<AtomicU64>,
+    /// Highest WAL sequence number whose mutation has been applied to **both**
+    /// stores' NRT buffers (Issue #876).
+    ///
+    /// Advanced in [`Self::index_internal`] / the delete path only after both
+    /// stores accepted the mutation, so a commit can snapshot it up front and
+    /// know that everything at or below it will be materialized by that commit.
+    /// [`run_commit_ladder`] uses the snapshot as the WAL retain point, so a
+    /// record appended by a mutation racing the commit is preserved instead of
+    /// being wiped by the truncate. `Arc` so the [`CommitTimer`] shares it.
+    applied_seq: Arc<AtomicU64>,
     /// Background WAL flush timer for a [`WalSyncPolicy::Group`] configured with
     /// a `max_interval`. `None` when no interval is set. Held only to keep the
     /// timer thread alive for the engine's lifetime; dropping the engine stops
@@ -465,6 +493,14 @@ impl Engine {
                     if record.seq > vector_last_seq {
                         self.vector.set_last_wal_seq(record.seq);
                     }
+                    // Publish the high-water mark exactly as `index_internal`
+                    // does (Issue #876): by this point both stores are at or
+                    // above `record.seq`, whether just applied here or already
+                    // covered by an earlier partial commit. Without this, the
+                    // `self.commit()` below would snapshot `applied_seq` at its
+                    // stale build-time 0 and its own truncate would wrongly
+                    // retain every record it just durably committed.
+                    self.applied_seq.fetch_max(record.seq, Ordering::AcqRel);
                 }
                 LogEntry::Delete {
                     doc_id,
@@ -484,6 +520,8 @@ impl Engine {
                     if record.seq > vector_last_seq {
                         self.vector.set_last_wal_seq(record.seq);
                     }
+                    // See the matching comment in the `Upsert` arm above.
+                    self.applied_seq.fetch_max(record.seq, Ordering::AcqRel);
                 }
             }
         }
@@ -741,6 +779,11 @@ impl Engine {
         // This ensures failed index operations are retried on recovery.
         self.lexical.set_last_wal_seq(seq)?;
         self.vector.set_last_wal_seq(seq);
+        // Publish the ingest high-water mark only now that BOTH stores hold the
+        // mutation, so a concurrent commit can safely treat everything at or
+        // below it as materializable (Issue #876). `fetch_max` keeps it
+        // monotonic under concurrent writers.
+        self.applied_seq.fetch_max(seq, Ordering::AcqRel);
 
         // 7. Count the applied document toward the auto-commit threshold. The
         // trigger itself lives at the API boundary (see `maybe_auto_commit`),
@@ -985,6 +1028,9 @@ impl Engine {
             // This ensures failed deletes are retried on recovery.
             self.lexical.set_last_wal_seq(seq)?;
             self.vector.set_last_wal_seq(seq);
+            // Publish the high-water mark only once both stores hold the delete
+            // (Issue #876) — see `index_internal` for the rationale.
+            self.applied_seq.fetch_max(seq, Ordering::AcqRel);
         }
         Ok(())
     }
@@ -999,7 +1045,9 @@ impl Engine {
     ///    where the lexical `last_wal_seq` checkpoint is persisted.
     /// 3. `vector.commit()` — materialize + fsync the vector store.
     /// 4. `commit_documents()` — materialize + fsync the document store.
-    /// 5. `truncate()` — replace the WAL with an empty, fsync'd file.
+    /// 5. `truncate_retaining_after(applied_before)` — discard everything this
+    ///    commit covered; **retain** anything appended (or still being applied)
+    ///    concurrently (Issue #876).
     ///
     /// This order upholds two invariants. First, `last_wal_seq` is persisted
     /// only in step 2+, always *after* the step-1 barrier, so a committed index
@@ -1008,7 +1056,14 @@ impl Engine {
     /// so the WAL is discarded only once the data it described is durable. A
     /// crash between any two steps therefore leaves enough in the WAL for the
     /// idempotent replay in [`Self::recover`] to reconstruct a consistent state.
-    /// After a successful commit, the WAL is empty and all data is durable.
+    ///
+    /// This method itself is **not** serialized against concurrent
+    /// `put`/`add`/`delete` calls. After a successful commit with no concurrent
+    /// mutation, the WAL is empty and all data is durable, exactly as before
+    /// Issue #876. Under a mutation that raced this commit, the WAL is **not**
+    /// necessarily empty afterward: it retains that mutation's record so the
+    /// next crash can still recover it. `CommitPolicy::Interval`'s background
+    /// timer runs this same ladder, so the same caveat applies to auto-commits.
     ///
     /// # Errors
     ///
@@ -1020,6 +1075,7 @@ impl Engine {
             &self.vector,
             &self.log,
             &self.docs_since_commit,
+            &self.applied_seq,
         )
         .await
     }
@@ -2358,6 +2414,7 @@ impl EngineBuilder {
         let lexical = Arc::new(LexicalStore::new(lexical_storage, lexical_config)?);
         let vector = Arc::new(VectorStore::new(vector_storage, vector_config)?);
         let docs_since_commit = Arc::new(AtomicU64::new(0));
+        let applied_seq = Arc::new(AtomicU64::new(0));
 
         let log = Arc::new(DocumentLog::with_sync_policy(
             self.storage,
@@ -2388,6 +2445,7 @@ impl EngineBuilder {
                 Arc::clone(&vector),
                 Arc::clone(&log),
                 Arc::clone(&docs_since_commit),
+                Arc::clone(&applied_seq),
                 interval,
             )?),
             _ => None,
@@ -2402,6 +2460,7 @@ impl EngineBuilder {
             embedding_cache,
             commit_policy: self.commit_policy,
             docs_since_commit,
+            applied_seq,
             #[cfg(not(target_arch = "wasm32"))]
             _wal_flush_timer: wal_flush_timer,
             #[cfg(not(target_arch = "wasm32"))]
@@ -4067,5 +4126,118 @@ mod tests {
             1,
             "an Interval-committed doc must be searchable without an explicit commit"
         );
+    }
+
+    /// #876: a mutation whose WAL record was appended but not yet applied to
+    /// the stores when a commit starts must not lose that record to the WAL
+    /// truncate.
+    ///
+    /// `index_internal` appends the WAL record for a mutation *before* applying
+    /// it to the lexical/vector stores, so there is a real window — between the
+    /// append and the apply — where a concurrent commit could run. This test
+    /// makes that window deterministic instead of racing threads (which would
+    /// deadlock: every ladder step holds a lock the "racing" apply needs): it
+    /// appends "b"'s WAL record directly via `log.append`, exactly as
+    /// `index_internal` does, but — like a mutation caught mid-flight — does
+    /// NOT apply it to the stores before `commit()` runs. `commit()` must
+    /// snapshot `applied_seq` (covering only "a", already applied) BEFORE
+    /// materializing, so "b"'s un-applied record is retained by the truncate
+    /// and replayed on the next recovery.
+    #[tokio::test]
+    async fn wal_record_appended_but_not_yet_applied_survives_commit_truncate() {
+        let (engine, storage) = commit_policy_engine(CommitPolicy::Manual).await;
+
+        // "a" goes through the normal path: WAL-appended AND applied to both
+        // stores before `commit()` runs.
+        engine.put_document("a", title_doc("alpha")).await.unwrap();
+
+        // "b" simulates a mutation caught between its WAL append and its store
+        // apply: append the WAL record directly (mirrors `index_internal`'s
+        // step 2) without upserting it into `lexical`/`vector` (which would be
+        // steps 4-5) — `applied_seq` is therefore NOT advanced for it.
+        engine.log.append("b", title_doc("bravo")).unwrap();
+
+        // The commit ladder must snapshot `applied_seq` before materializing,
+        // so "b" — appended but never applied — is retained by the truncate
+        // rather than wiped with the rest of the (now-covered) WAL.
+        engine.commit().await.unwrap();
+        assert!(
+            wal_bytes(&storage) > 0,
+            "the WAL record for the not-yet-applied mutation must survive the \
+             commit's truncate (#876)"
+        );
+
+        // Recovery must replay it: reopen on the same storage.
+        drop(engine);
+        let reopened = Engine::new(storage.clone(), {
+            use crate::engine::schema::FieldOption;
+            use crate::lexical::core::field::TextOption;
+            Schema::builder()
+                .add_field("title", FieldOption::Text(TextOption::default()))
+                .build()
+        })
+        .await
+        .unwrap();
+
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+        let alpha = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:alpha"))
+            .limit(10)
+            .build();
+        assert_eq!(reopened.search(alpha).await.unwrap().len(), 1);
+
+        let bravo = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:bravo"))
+            .limit(10)
+            .build();
+        assert_eq!(
+            reopened.search(bravo).await.unwrap().len(),
+            1,
+            "the mutation caught mid-flight during commit must be recovered \
+             from its retained WAL record (#876)"
+        );
+    }
+
+    /// #876: `recover()`'s own internal `commit()` must actually empty the
+    /// WAL, not just replay the records into the stores.
+    ///
+    /// `recover()` mutates the stores directly rather than through
+    /// `index_internal`, so it must publish `applied_seq` itself; otherwise the
+    /// `commit()` it calls at the end snapshots the stale build-time `0`,
+    /// `truncate_retaining_after` takes the slow path unconditionally, and
+    /// re-retains every record it just durably committed — the WAL never
+    /// shrinks until an unrelated future mutation happens to raise
+    /// `applied_seq` past it.
+    #[tokio::test]
+    async fn recover_commit_empties_the_wal() {
+        let (engine, storage) = commit_policy_engine(CommitPolicy::Manual).await;
+        engine.put_document("a", title_doc("alpha")).await.unwrap();
+        // Crash: drop without an explicit commit, leaving "a" WAL-only.
+        drop(engine);
+        assert!(
+            wal_bytes(&storage) > 0,
+            "precondition: WAL has a pending record"
+        );
+
+        // Reopen: recover() replays "a" and commits internally.
+        let schema = {
+            use crate::engine::schema::FieldOption;
+            use crate::lexical::core::field::TextOption;
+            Schema::builder()
+                .add_field("title", FieldOption::Text(TextOption::default()))
+                .build()
+        };
+        let reopened = Engine::new(storage.clone(), schema).await.unwrap();
+        assert_eq!(
+            wal_bytes(&storage),
+            0,
+            "recovery's own commit must empty the WAL, matching the documented \
+             post-commit invariant (#876)"
+        );
+
+        // An immediately-following no-op commit must stay a no-op (fast path),
+        // not repeat a read-back/rewrite of the same stale tail forever.
+        reopened.commit().await.unwrap();
+        assert_eq!(wal_bytes(&storage), 0);
     }
 }

--- a/laurus/src/store/log.rs
+++ b/laurus/src/store/log.rs
@@ -899,27 +899,115 @@ impl DocumentLog {
     ///
     /// Called after a successful commit to discard processed entries.
     pub fn truncate(&self) -> Result<()> {
-        {
-            let mut writer_guard = self.wal_writer.lock();
-            // Flush + close the open handle before discarding it. The flush is
-            // guarded by `dirty`, so it's skipped when every record is already
-            // self-synced (the per-record default) but still runs once fsync is
-            // deferred — dropping the handle with unsynced bytes would lose them
-            // (#542 Phase 2/3).
-            if let Some(mut state) = writer_guard.take() {
-                if state.dirty {
-                    state.out.flush_and_sync()?;
-                }
-                state.out.close()?;
+        // Retain nothing: the caller asserts every record is covered by a
+        // durable checkpoint. `SeqNumber::MAX` leaves no record with a greater
+        // seq, so this is the historical whole-file truncate.
+        self.truncate_retaining_after(SeqNumber::MAX)
+    }
+
+    /// Truncate the WAL, **retaining every record whose seq is greater than
+    /// `retain_after_seq`** (Issue #876).
+    ///
+    /// [`Self::truncate`] wipes the whole file, which is only safe when every
+    /// record it discards is already covered by the stores' persisted
+    /// checkpoints. A mutation that lands *while* a commit is running is not:
+    /// the commit ladder is not serialized against ingestion, so a record can
+    /// be appended after the stores materialized their state but before the
+    /// truncate. Wiping it would lose an acknowledged write on the next crash —
+    /// its data lives only in the fresh in-memory writer. Passing the stores'
+    /// durable checkpoint keeps exactly those uncovered records, so recovery
+    /// replays them.
+    ///
+    /// # Arguments
+    ///
+    /// * `retain_after_seq` - The highest sequence number the caller has made
+    ///   durable. Records with `seq > retain_after_seq` are preserved; the rest
+    ///   are discarded.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing, reading back, recreating, or re-appending
+    /// to the WAL file fails.
+    pub fn truncate_retaining_after(&self, retain_after_seq: SeqNumber) -> Result<()> {
+        // Hold the writer lock across the whole operation so a concurrent
+        // append cannot interleave with the read-back and rewrite; it blocks
+        // and lands cleanly on the file this call produces.
+        let mut writer_guard = self.wal_writer.lock();
+        // Flush + close the open handle before reading/discarding it. The flush
+        // is guarded by `dirty`, so it's skipped when every record is already
+        // self-synced (the per-record default) but still runs once fsync is
+        // deferred — dropping the handle with unsynced bytes would lose them
+        // (#542 Phase 2/3).
+        if let Some(mut state) = writer_guard.take() {
+            if state.dirty {
+                state.out.flush_and_sync()?;
             }
+            state.out.close()?;
         }
 
-        let mut writer = self.wal_storage.create_output(&self.wal_path)?;
-        writer.flush_and_sync()?;
-        writer.close()?;
+        // Fast path: nothing was appended past the caller's checkpoint, so the
+        // whole file is covered and an in-place wipe is safe — every record it
+        // discards is already durably represented in the stores' committed
+        // segments, so there is nothing at risk in the moment the file is
+        // empty. This is the no-concurrency common case and is byte-identical
+        // to the historical `truncate()`.
+        if self.last_seq() <= retain_after_seq {
+            let mut writer = self.wal_storage.create_output(&self.wal_path)?;
+            writer.flush_and_sync()?;
+            writer.close()?;
+            self.wal_storage.sync()?;
+            return Ok(());
+        }
 
-        // Sync storage to ensure the truncated WAL file is visible.
-        // Critical on Windows where file metadata may be cached.
+        // Slow path: a mutation raced this commit. The writer is closed, so the
+        // file is complete. `read_all` only ever advances the id/seq counters
+        // (never regresses them), so replaying it here is safe.
+        let retained: Vec<LogRecord> = self
+            .read_all()?
+            .into_iter()
+            .filter(|record| record.seq > retain_after_seq)
+            .collect();
+
+        // Build the retained tail in a TEMP file and atomically rename it over
+        // the WAL, rather than truncating the live file in place and rewriting
+        // it afterwards. `retained` holds exactly the records that are NOT yet
+        // durably represented anywhere else (that is why this path exists at
+        // all) — an in-place wipe would make the WAL durably empty for the
+        // window before the rewrite completes, so a crash in that window would
+        // permanently lose them, reintroducing the very bug (#876) this method
+        // fixes. The rename is a single atomic filesystem operation: the WAL is
+        // never observably in a state that is missing a retained record.
+        let (tmp_name, tmp_out) = self.wal_storage.create_temp_output(&self.wal_path)?;
+        let mut tmp_state = Some(WalWriterState {
+            out: tmp_out,
+            format: WalFormat::V3,
+            dirty: false,
+            unsynced_records: 0,
+            unsynced_bytes: 0,
+            #[cfg(test)]
+            sync_count: 0,
+        });
+        if let Some(state) = tmp_state.as_mut() {
+            state.out.write_all(WAL_MAGIC)?;
+            state.out.write_all(&[WAL_VERSION])?;
+        }
+        // Defer the per-record fsync `write_record` would otherwise do under
+        // `WalSyncPolicy::PerRecord` (one syscall per retained record) and
+        // sync once after the whole tail is written instead.
+        {
+            let _deferral = self.defer_sync();
+            for record in &retained {
+                self.write_record(&mut tmp_state, record)?;
+            }
+        }
+        if let Some(state) = tmp_state.as_mut() {
+            state.out.flush_and_sync()?;
+            state.out.close()?;
+        }
+
+        self.wal_storage.rename_file(&tmp_name, &self.wal_path)?;
+        // Sync storage to ensure the renamed WAL file is visible. Critical on
+        // Windows where directory listings and file metadata may be cached.
         self.wal_storage.sync()?;
 
         Ok(())
@@ -1958,5 +2046,114 @@ mod tests {
         log.commit_documents().unwrap();
         let retrieved = log.get_document(1).unwrap();
         assert!(retrieved.is_some());
+    }
+
+    /// Append `external_id` and return the seq the WAL assigned it.
+    fn append_named(log: &DocumentLog, external_id: &str) -> SeqNumber {
+        log.append(external_id, small_doc()).unwrap().1
+    }
+
+    /// The `external_id`s still present in the WAL, in seq order.
+    fn surviving_ids(log: &DocumentLog) -> Vec<String> {
+        log.read_all()
+            .unwrap()
+            .into_iter()
+            .map(|r| match r.entry {
+                LogEntry::Upsert { external_id, .. } => external_id,
+                LogEntry::Delete { external_id, .. } => external_id,
+            })
+            .collect()
+    }
+
+    /// #876: `truncate_retaining_after` keeps only records with `seq` strictly
+    /// greater than the retain point — this is the primitive the commit ladder
+    /// relies on to preserve a mutation that raced the commit instead of losing
+    /// it to a whole-file truncate.
+    #[test]
+    fn truncate_retaining_after_keeps_only_later_records() {
+        let log = make_log();
+        append_named(&log, "a"); // seq 1
+        let retain_from = append_named(&log, "b"); // seq 2 — the commit's snapshot
+        append_named(&log, "c"); // seq 3 — raced the commit
+        append_named(&log, "d"); // seq 4 — also raced
+
+        log.truncate_retaining_after(retain_from).unwrap();
+
+        assert_eq!(
+            surviving_ids(&log),
+            vec!["c".to_string(), "d".to_string()],
+            "only records appended after the retain point must survive"
+        );
+    }
+
+    /// #876: when nothing was appended past the retain point, the result must
+    /// be indistinguishable from the historical whole-file truncate — the
+    /// no-concurrency common case must not pay for the read-back/rewrite path.
+    #[test]
+    fn truncate_retaining_after_is_a_full_truncate_when_nothing_raced() {
+        let log = make_log();
+        append_named(&log, "a");
+        let retain_from = append_named(&log, "b");
+
+        log.truncate_retaining_after(retain_from).unwrap();
+
+        assert!(
+            surviving_ids(&log).is_empty(),
+            "no record raced the retain point, so none should survive"
+        );
+        // The file itself is empty (the fast path recreates it, same as `truncate`).
+        assert_eq!(
+            log.wal_storage.file_size(&log.wal_path).unwrap(),
+            0,
+            "the fast path must leave a zero-byte file, matching `truncate()`"
+        );
+    }
+
+    /// #876: `truncate()` (used by every caller that has nothing to retain,
+    /// e.g. tests exercising the historical behavior) is unaffected — it is
+    /// `truncate_retaining_after(SeqNumber::MAX)`, so it always takes the fast
+    /// path and wipes everything.
+    #[test]
+    fn truncate_still_wipes_everything() {
+        let log = make_log();
+        append_named(&log, "a");
+        append_named(&log, "b");
+
+        log.truncate().unwrap();
+
+        assert!(surviving_ids(&log).is_empty());
+    }
+
+    /// #876: a delete record appended after the retain point must survive the
+    /// truncate exactly like an upsert — the retain filter is entry-agnostic.
+    #[test]
+    fn truncate_retaining_after_preserves_a_racing_delete() {
+        let log = make_log();
+        let retain_from = append_named(&log, "a");
+        log.append_delete(1, "b").unwrap();
+
+        log.truncate_retaining_after(retain_from).unwrap();
+
+        assert_eq!(surviving_ids(&log), vec!["b".to_string()]);
+    }
+
+    /// #876: after a partial truncate, the WAL is still a well-formed file that
+    /// further appends and a fresh `read_all` can build on — the rewritten tail
+    /// must stamp a valid header, not just raw frames.
+    #[test]
+    fn truncate_retaining_after_leaves_a_well_formed_wal_for_further_appends() {
+        let log = make_log();
+        let retain_from = append_named(&log, "a");
+        append_named(&log, "b");
+
+        log.truncate_retaining_after(retain_from).unwrap();
+        append_named(&log, "c");
+
+        assert_eq!(
+            surviving_ids(&log),
+            vec!["b".to_string(), "c".to_string()],
+            "a further append after the partial truncate must be readable \
+             alongside the retained tail"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`Engine::commit`'s ladder (`flush_wal -> lexical.commit -> vector.commit -> commit_documents -> truncate`) was never serialized against concurrent `put`/`add`/`delete` calls, and `DocumentLog::truncate()` unconditionally wiped the whole WAL file. A mutation whose WAL record was appended (or whose store-apply was still in flight) while a commit ran could have its record destroyed by the truncate while its data lived only in the fresh in-memory writer — losing an **acknowledged write** on the next crash. `CommitPolicy::Interval`'s background timer (#892) made this easier to hit, since an app only has to configure auto-commit rather than call `commit()` concurrently itself.

Refs #875, #542, #551
Closes #876

## Design

`Engine.applied_seq` (`Arc<AtomicU64>`) is published via `fetch_max` only *after* a mutation has landed in **both** stores' NRT buffers (`index_internal`, the delete path, and `recover()`'s replay loop). `run_commit_ladder` snapshots it before the ladder starts and passes it to the new `DocumentLog::truncate_retaining_after(seq)`: everything at or below the snapshot is guaranteed materialized by that commit — both stores hold the same writer lock across upsert + checkpoint + commit — so a fast path (nothing to retain) is byte-identical to the old whole-file truncate (the no-concurrency common case pays nothing extra), and a slow path preserves anything that raced the commit for replay on the next recovery.

An initial "retain to `min(lexical.last_wal_seq, vector.last_wal_seq)`" design broke in practice — `LexicalStore::last_wal_seq()` doesn't reflect the just-committed checkpoint the way assumed, collapsing the retain point to 0 — and was replaced with the `applied_seq` snapshot above.

## Adversarial review — 5 confirmed findings, all fixed

A post-implementation adversarial review (3 dimensions) found **5 confirmed defects**, including one **in this fix's own first pass**:

- **[critical, fixed]** `truncate_retaining_after`'s slow path was **not crash-atomic**: it read the retained tail into memory, truncated the live WAL file *in place* (fsync'd empty), then wrote the tail back. A crash in that window permanently loses exactly the records this fix exists to protect. Switched to the write-tmp-then-atomic-rename idiom already used elsewhere in the codebase (e.g. `document.rs`).
- **[high, fixed]** `recover()` mutates the stores directly and never published `applied_seq`, so its own internal `commit()` after a crash-recovery reopen would snapshot a stale `0` and wrongly re-retain every record it just durably committed — the WAL would never shrink until an unrelated future mutation advanced `applied_seq`. Fixed by publishing it in both the `Upsert` and `Delete` replay arms, mirroring `index_internal`.
- **[medium, fixed]** The `commit()` doc comment and `persistence.md` (EN+JA) still claimed the WAL is unconditionally empty after a successful commit. Updated to describe the retain-on-race behavior.
- **[low, fixed]** The retained-tail rewrite fsync'd once per record; resolved as a side effect of the atomicity fix (wrapped in `defer_sync()`).

## Tests

- **`laurus/src/store/log.rs`** — 5 deterministic unit gates on `truncate_retaining_after`: retains only later records; the fast path is byte-identical to the old `truncate()`; `truncate()` still wipes everything; a racing delete survives; the rewritten WAL stays well-formed for further appends.
- **`laurus/src/engine.rs`** — 2 integration gates:
  - `wal_record_appended_but_not_yet_applied_survives_commit_truncate` — the core race, made deterministic *without* real concurrency. Hooking storage to inject the race deadlocks (every ladder step holds a lock the racer needs), so this directly constructs the "WAL-appended but not yet store-applied" state the same way `index_internal` produces it.
  - `recover_commit_empties_the_wal` — the review-driven recovery fix.

All gates were proven RED (fail without the fix) and GREEN (pass with it) before finalizing.

## Verification

fmt clean · clippy 1.95 + 1.97 (`-D warnings`) 0 · lib 1259 passed (incl. 8 new gates) · integration 1461 passed · `laurus-server` 2 · `laurus-cli` 6 · `laurus-wasm` clippy clean · markdownlint (EN + JA) 0.
