### PR TITLE
refactor(vector/index): extract shared segment infrastructure into vector/index/segment/ (#901)

### DIFF
--- a/laurus/benches/nrt_active_search_bench.rs
+++ b/laurus/benches/nrt_active_search_bench.rs
@@ -22,7 +22,8 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use common::{DEFAULT_SEED, SAMPLE_SIZE_FAST, lcg_vec_unit};
 use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
 use laurus::vector::index::field::{FieldSearchInput, VectorFieldReader, VectorFieldWriter};
-use laurus::vector::index::hnsw::segment::manager::{SegmentManager, SegmentManagerConfig};
+use laurus::vector::index::hnsw;
+use laurus::vector::index::segment::manager::{SegmentManager, SegmentManagerConfig};
 use laurus::vector::index::segmented_field::SegmentedVectorField;
 use laurus::vector::store::request::QueryVector;
 use laurus::vector::{
@@ -46,8 +47,12 @@ const DIM: usize = 128;
 fn active_field_with(count: usize) -> SegmentedVectorField {
     let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
     let manager = Arc::new(
-        SegmentManager::new(SegmentManagerConfig::default(), storage.clone())
-            .expect("segment manager"),
+        SegmentManager::new(
+            SegmentManagerConfig::default(),
+            storage.clone(),
+            hnsw::segment::LAYOUT,
+        )
+        .expect("segment manager"),
     );
     let field_config = VectorFieldConfig {
         vector: Some(FieldOption::Hnsw(HnswOption {

--- a/laurus/src/vector/index.rs
+++ b/laurus/src/vector/index.rs
@@ -27,6 +27,7 @@ pub mod quantized_segment;
 pub mod quantized_storage;
 pub mod rerank_sidecar;
 pub mod rerank_storage;
+pub mod segment;
 pub mod segmented_field;
 pub mod storage;
 pub mod wal;

--- a/laurus/src/vector/index/hnsw/segment.rs
+++ b/laurus/src/vector/index/hnsw/segment.rs
@@ -1,35 +1,19 @@
-//! Segment management for HNSW vector indexes.
+//! HNSW-specific segment file layout and merge engine.
 //!
-//! This module handles segment operations for HNSW indexes:
-//! - Segment manager for coordinating segments
-//! - Merge engine for combining segments
-//! - Merge policy for determining when to merge
+//! The generic segment manifest/manager, merge policies, and reader cache
+//! shared across index types live in [`crate::vector::index::segment`]
+//! (Issue #889); this module keeps only what is HNSW-specific: the merge
+//! engine (its I/O is HNSW-graph-typed) and this index type's on-disk file
+//! layout descriptor.
 
-use serde::{Deserialize, Serialize};
+use crate::vector::index::segment::manager::SegmentFileLayout;
 
-/// Information about a segment in the HNSW vector index.
-///
-/// This structure contains metadata about an individual segment,
-/// including vector counts, offsets, and deletion status.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SegmentInfo {
-    /// Segment identifier.
-    pub segment_id: String,
-
-    /// Number of vectors in this segment.
-    pub vector_count: u64,
-
-    /// Vector offset for this segment.
-    pub vector_offset: u64,
-
-    /// Generation number of this segment.
-    pub generation: u64,
-
-    /// Whether this segment has deletions.
-    pub has_deletions: bool,
-}
-
-pub mod manager;
 pub mod merge_engine;
-pub mod merge_policy;
-pub mod reader_cache;
+
+/// On-disk file-suffix layout for HNSW segments: a primary `.hnsw` file plus
+/// its `.hnsw.f32` rerank sidecar, staged through a `.hnsw.tmp` temp file.
+pub const LAYOUT: SegmentFileLayout = SegmentFileLayout {
+    primary: ".hnsw",
+    sidecars: &[".hnsw.f32"],
+    tmp: ".hnsw.tmp",
+};

--- a/laurus/src/vector/index/hnsw/segment/merge_engine.rs
+++ b/laurus/src/vector/index/hnsw/segment/merge_engine.rs
@@ -1,15 +1,18 @@
 //! Merge engine for vector index segments.
 //!
-//! This module handles the actual merging of segments.
+//! This module handles the actual merging of segments. [`MergeConfig`],
+//! [`MergeStats`], and [`MergeResult`] are the shared, index-type-agnostic
+//! data shapes defined in [`crate::vector::index::segment::merge`]; this
+//! engine's own logic (below) is HNSW-graph-typed.
 
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::error::Result;
 use crate::storage::Storage;
 use crate::vector::core::vector::Vector;
 
-use super::manager::ManagedSegmentInfo;
+use crate::vector::index::segment::manager::ManagedSegmentInfo;
+use crate::vector::index::segment::merge::{MergeConfig, MergeResult, MergeStats};
 
 use crate::maintenance::deletion::DeletionBitmap;
 use crate::vector::index::config::HnswIndexConfig;
@@ -17,99 +20,6 @@ use crate::vector::index::hnsw::reader::HnswIndexReader;
 use crate::vector::index::hnsw::writer::HnswIndexWriter;
 use crate::vector::reader::VectorIndexReader;
 use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
-
-/// Configuration for merge operations.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MergeConfig {
-    /// Maximum number of segments to merge at once.
-    pub max_merge_segments: u32,
-
-    /// Target segment size after merge (in vectors).
-    pub target_segment_size: u64,
-
-    /// Whether to use parallel merging.
-    pub parallel_merge: bool,
-
-    /// Number of threads to use for parallel merging.
-    pub num_threads: usize,
-}
-
-impl Default for MergeConfig {
-    fn default() -> Self {
-        Self {
-            max_merge_segments: 10,
-            target_segment_size: 1000000,
-            parallel_merge: true,
-            num_threads: 4,
-        }
-    }
-}
-
-/// Statistics about a merge operation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MergeStats {
-    /// Number of segments merged.
-    pub segments_merged: u32,
-
-    /// Number of vectors in merged segment.
-    pub vectors_merged: u64,
-
-    /// Number of deleted vectors removed.
-    pub deletions_removed: u64,
-
-    /// Number of stale cross-segment duplicates removed — copies of a
-    /// `(doc_id, field)` key shadowed by a newer segment's copy
-    /// (Issue #880). Defaults to 0 when deserializing older stats.
-    #[serde(default)]
-    pub duplicates_removed: u64,
-
-    /// Time taken for merge (in milliseconds).
-    pub merge_time_ms: u64,
-
-    /// Size of merged segment (in bytes).
-    pub merged_size_bytes: u64,
-}
-
-impl MergeStats {
-    /// Create new merge stats.
-    pub fn new() -> Self {
-        Self {
-            segments_merged: 0,
-            vectors_merged: 0,
-            deletions_removed: 0,
-            duplicates_removed: 0,
-            merge_time_ms: 0,
-            merged_size_bytes: 0,
-        }
-    }
-
-    /// Calculate compression ratio.
-    pub fn compression_ratio(&self) -> f64 {
-        if self.vectors_merged == 0 {
-            return 1.0;
-        }
-        1.0 - (self.deletions_removed as f64 / self.vectors_merged as f64)
-    }
-}
-
-impl Default for MergeStats {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Result of a merge operation.
-#[derive(Debug, Clone)]
-pub struct MergeResult {
-    /// Information about the new merged segment.
-    pub merged_segment: ManagedSegmentInfo,
-
-    /// Statistics about the merge.
-    pub stats: MergeStats,
-
-    /// IDs of segments that were merged.
-    pub merged_segment_ids: Vec<String>,
-}
 
 /// Engine for merging vector index segments.
 pub struct MergeEngine {

--- a/laurus/src/vector/index/hnsw/segmented.rs
+++ b/laurus/src/vector/index/hnsw/segmented.rs
@@ -43,12 +43,13 @@ use crate::vector::core::vector::Vector;
 use crate::vector::index::config::HnswIndexConfig;
 use crate::vector::index::hnsw::reader::HnswIndexReader;
 use crate::vector::index::hnsw::searcher::HnswSearcher;
-use crate::vector::index::hnsw::segment::manager::{
+use crate::vector::index::hnsw::segment::merge_engine::MergeEngine;
+use crate::vector::index::hnsw::writer::HnswIndexWriter;
+use crate::vector::index::segment::manager::{
     ManagedSegmentInfo, MergeCandidate, SegmentManager, SegmentManagerConfig,
 };
-use crate::vector::index::hnsw::segment::merge_engine::{MergeConfig, MergeEngine};
-use crate::vector::index::hnsw::segment::reader_cache::SegmentedReaderCache;
-use crate::vector::index::hnsw::writer::HnswIndexWriter;
+use crate::vector::index::segment::merge::MergeConfig;
+use crate::vector::index::segment::reader_cache::SegmentedReaderCache;
 use crate::vector::index::{VectorIndex, VectorIndexStats};
 use crate::vector::reader::{
     ValidationReport, VectorIndexMetadata, VectorIndexReader, VectorIterator, VectorStats,
@@ -73,7 +74,7 @@ struct SegmentedShared {
     manager: Arc<SegmentManager>,
 
     /// Per-segment reader cache (#660); invalidated on merge.
-    reader_cache: Arc<SegmentedReaderCache>,
+    reader_cache: Arc<SegmentedReaderCache<HnswIndexReader>>,
 
     /// Index-level logical-deletion bitmap (doc-scoped). `None` means "not
     /// yet loaded / no deletions"; lazily loaded from `{name}.delmap`.
@@ -239,6 +240,7 @@ impl SegmentedHnswIndex {
         let manager = Arc::new(SegmentManager::new(
             SegmentManagerConfig::default(),
             storage.clone(),
+            crate::vector::index::hnsw::segment::LAYOUT,
         )?);
 
         if migrate {
@@ -306,7 +308,7 @@ impl SegmentedHnswIndex {
     /// engine; source readers are invalidated afterwards. Returns whether a
     /// merge actually ran.
     fn merge_once(&self) -> Result<bool> {
-        use crate::vector::index::hnsw::segment::merge_policy::TieredMergePolicy;
+        use crate::vector::index::segment::merge_policy::TieredMergePolicy;
 
         let Some(candidate) = self.shared.manager.check_merge(&TieredMergePolicy::new()) else {
             return Ok(false);

--- a/laurus/src/vector/index/segment.rs
+++ b/laurus/src/vector/index/segment.rs
@@ -1,0 +1,14 @@
+//! Shared segment-per-commit infrastructure for vector indexes (Issue #889).
+//!
+//! Extracted from the HNSW segment-per-commit implementation (Issue #634):
+//! the segment manifest/manager, merge policies, and the per-segment reader
+//! cache are index-type-agnostic and are shared here across HNSW, Flat, and
+//! IVF instead of being duplicated per index type. Each index type keeps its
+//! own merge engine (the actual segment-reader/segment-writer I/O is
+//! type-specific) and supplies a [`manager::SegmentFileLayout`] describing
+//! its on-disk file suffixes.
+
+pub mod manager;
+pub mod merge;
+pub mod merge_policy;
+pub mod reader_cache;

--- a/laurus/src/vector/index/segment/manager.rs
+++ b/laurus/src/vector/index/segment/manager.rs
@@ -6,10 +6,14 @@
 //! The segment registry is persisted in a `segments.json` manifest. Since
 //! #634 (PR-1 / #879) the manifest is **versioned, checksummed, and written
 //! atomically** (temp file + CRC-32 trailer + fsync + rename — the same
-//! #784/#786 standard the `.hnsw` segment files follow), so it can serve as
+//! #784/#786 standard the segment data files follow), so it can serve as
 //! the commit pivot for the segment-per-commit pipeline: a crash mid-save
 //! leaves the previous manifest intact, and a corrupted manifest fails the
 //! open loudly instead of silently starting empty.
+//!
+//! Originally HNSW-only, this manager is shared across index types since
+//! Issue #889 via [`SegmentFileLayout`] — the only piece of its behavior
+//! that varies by on-disk file suffix.
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -31,6 +35,44 @@ const MANIFEST_TMP_FILE: &str = "segments.json.tmp";
 
 /// Current manifest format version (see [`SegmentManifest`]).
 const MANIFEST_VERSION: u32 = 1;
+
+/// Filename suffixes a segment's on-disk files use, parameterizing
+/// [`SegmentManager`] across index types that share this manifest/merge
+/// machinery but write different file extensions (Issue #889).
+#[derive(Debug, Clone, Copy)]
+pub struct SegmentFileLayout {
+    /// Primary segment data file suffix, e.g. `.hnsw`.
+    pub primary: &'static str,
+
+    /// Sidecar file suffixes beyond the primary, e.g. `.hnsw.f32` for
+    /// HNSW's f32 rerank sidecar. Counted by [`SegmentManager::add_segment`]
+    /// size measurement and removed by
+    /// [`SegmentManager::delete_segment_files`] alongside the primary file.
+    pub sidecars: &'static [&'static str],
+
+    /// Suffix for a segment's own atomic-write temp-staging file, e.g.
+    /// `.hnsw.tmp`. Recognized (and swept if orphaned) by the segment
+    /// manager's internal orphan sweep on open.
+    pub tmp: &'static str,
+}
+
+impl SegmentFileLayout {
+    /// All suffixes this layout recognizes for a segment's own files, plus
+    /// the layout-independent `.delmap` suffix, ordered **longest first**.
+    ///
+    /// A shorter suffix that is itself the tail of a longer one (e.g.
+    /// `.hnsw` is the tail of `.hnsw.tmp`) must be tried last, or the longer
+    /// file gets mis-stemmed (`foo.hnsw.tmp` stripped of `.hnsw` leaves
+    /// `foo` + a dangling `.tmp`, not the segment id `foo`).
+    fn ordered_suffixes(&self) -> Vec<&'static str> {
+        let mut suffixes: Vec<&'static str> = self.sidecars.to_vec();
+        suffixes.push(self.primary);
+        suffixes.push(self.tmp);
+        suffixes.push(".delmap");
+        suffixes.sort_by_key(|s| std::cmp::Reverse(s.len()));
+        suffixes
+    }
+}
 
 /// Versioned payload of the `segments.json` manifest (#634 PR-1 / #879).
 ///
@@ -144,45 +186,6 @@ pub struct MergeCandidate {
     pub total_size: u64,
 }
 
-/// Strategy for selecting segments to merge.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MergeStrategy {
-    /// Merge smallest segments first.
-    Smallest,
-
-    /// Merge segments with most deletions first.
-    MostDeletions,
-
-    /// Merge adjacent segments.
-    Adjacent,
-}
-
-/// Urgency level for merge operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum MergeUrgency {
-    /// No urgent need to merge.
-    Low,
-
-    /// Should merge soon.
-    Medium,
-
-    /// Should merge immediately.
-    High,
-}
-
-/// Plan for merging segments.
-#[derive(Debug, Clone)]
-pub struct MergePlan {
-    /// Merge candidates.
-    pub candidates: Vec<MergeCandidate>,
-
-    /// Strategy used.
-    pub strategy: MergeStrategy,
-
-    /// Urgency level.
-    pub urgency: MergeUrgency,
-}
-
 /// Statistics about segment manager.
 #[derive(Debug, Clone)]
 pub struct SegmentManagerStats {
@@ -206,6 +209,7 @@ pub struct SegmentManagerStats {
 #[derive(Debug)]
 pub struct SegmentManager {
     config: SegmentManagerConfig,
+    layout: SegmentFileLayout,
     storage: Arc<dyn Storage>,
     segments: Arc<RwLock<Vec<ManagedSegmentInfo>>>,
     next_segment_id: Arc<RwLock<u64>>,
@@ -218,7 +222,7 @@ impl SegmentManager {
     /// Create a new segment manager with the given configuration.
     ///
     /// Loads the `segments.json` manifest when present and sweeps orphaned
-    /// segment files (a torn flush can leave a `segment_*.hnsw` on storage
+    /// segment files (a torn flush can leave a `segment_*` file on storage
     /// that never made it into the manifest — its documents are covered by
     /// WAL replay, so the file is garbage).
     ///
@@ -228,9 +232,14 @@ impl SegmentManager {
     /// CRC check — a corrupted registry must fail the open loudly rather
     /// than silently starting empty (which would orphan, and then sweep,
     /// every live segment).
-    pub fn new(config: SegmentManagerConfig, storage: Arc<dyn Storage>) -> Result<Self> {
+    pub fn new(
+        config: SegmentManagerConfig,
+        storage: Arc<dyn Storage>,
+        layout: SegmentFileLayout,
+    ) -> Result<Self> {
         let manager = Self {
             config,
+            layout,
             storage,
             segments: Arc::new(RwLock::new(Vec::new())),
             next_segment_id: Arc::new(RwLock::new(0)),
@@ -390,28 +399,25 @@ impl SegmentManager {
 
     /// Best-effort sweep of files that belong to no registered segment.
     ///
-    /// Only touches names this manager itself generates
-    /// (`segment_NNNNNN.hnsw` plus its `.hnsw.f32` / `.delmap` sidecars and
-    /// `.hnsw.tmp` staging files) and the manifest temp file, so foreign
-    /// files — e.g. a monolithic `vector_index.hnsw` in the same directory —
-    /// are never affected. Runs only after a successful manifest load.
+    /// Only touches names this manager itself generates (`segment_NNNNNN`
+    /// plus its [`SegmentFileLayout`] suffixes) and the manifest temp file,
+    /// so foreign files — e.g. a monolithic `vector_index.hnsw` in the same
+    /// directory — are never affected. Runs only after a successful
+    /// manifest load.
     fn cleanup_orphans(&self) {
         let Ok(files) = self.storage.list_files() else {
             return;
         };
         let segments = self.segments.read();
+        let suffixes = self.layout.ordered_suffixes();
         for file in files {
             if file == MANIFEST_TMP_FILE {
                 let _ = self.storage.delete_file(&file);
                 continue;
             }
-            // Strip a known suffix; skip files that are not segment-shaped.
-            let Some(stem) = file
-                .strip_suffix(".hnsw.tmp")
-                .or_else(|| file.strip_suffix(".hnsw.f32"))
-                .or_else(|| file.strip_suffix(".delmap"))
-                .or_else(|| file.strip_suffix(".hnsw"))
-            else {
+            // Strip a known suffix (longest first); skip files that are not
+            // segment-shaped.
+            let Some(stem) = suffixes.iter().find_map(|suffix| file.strip_suffix(suffix)) else {
                 continue;
             };
             let Some(ordinal) = stem.strip_prefix("segment_") else {
@@ -449,20 +455,18 @@ impl SegmentManager {
         self.save_state_locked(&segments)
     }
 
-    /// Sum the on-storage sizes of a segment's file and rerank sidecar.
+    /// Sum the on-storage sizes of a segment's primary file and sidecars.
     ///
     /// `.delmap` is deliberately excluded (#882): per-segment deletion
     /// bitmaps do not exist — the bitmap is index-level — and for a
     /// legacy-migrated segment (whose id equals the index name) including
     /// it would misattribute the index bitmap's size to the segment.
     fn measure_segment_size(&self, segment_id: &str) -> u64 {
-        [
-            format!("{segment_id}.hnsw"),
-            format!("{segment_id}.hnsw.f32"),
-        ]
-        .iter()
-        .filter_map(|name| self.storage.file_size(name).ok())
-        .sum()
+        std::iter::once(self.layout.primary)
+            .chain(self.layout.sidecars.iter().copied())
+            .map(|suffix| format!("{segment_id}{suffix}"))
+            .filter_map(|name| self.storage.file_size(&name).ok())
+            .sum()
     }
 
     /// Remove a segment.
@@ -477,8 +481,8 @@ impl SegmentManager {
     }
 
     /// Delete physical files associated with a segment, including its
-    /// rerank sidecar (`.hnsw.f32`) — leaving it behind orphans storage
-    /// after every merge (#879).
+    /// sidecars — leaving them behind orphans storage after every merge
+    /// (#879).
     ///
     /// Deliberately does NOT touch `{segment_id}.delmap` (#882): the
     /// segmented index keeps ONE index-level deletion bitmap named
@@ -488,8 +492,11 @@ impl SegmentManager {
     /// merge consumes that segment.
     pub fn delete_segment_files(&self, segment_id: &str) -> Result<()> {
         // Best effort deletion - ignore if a file doesn't exist
-        let _ = self.storage.delete_file(&format!("{segment_id}.hnsw"));
-        let _ = self.storage.delete_file(&format!("{segment_id}.hnsw.f32"));
+        for suffix in
+            std::iter::once(self.layout.primary).chain(self.layout.sidecars.iter().copied())
+        {
+            let _ = self.storage.delete_file(&format!("{segment_id}{suffix}"));
+        }
         Ok(())
     }
 
@@ -624,55 +631,6 @@ impl SegmentManager {
         segments.len() as u32 > self.config.max_segments
     }
 
-    /// Create a merge plan.
-    pub fn create_merge_plan(&self, strategy: MergeStrategy) -> Option<MergePlan> {
-        let segments = self.segments.read();
-
-        if segments.len() <= 1 {
-            return None;
-        }
-
-        let mut segment_list: Vec<_> = segments.iter().cloned().collect();
-
-        // Sort based on strategy
-        match strategy {
-            MergeStrategy::Smallest => {
-                segment_list.sort_by_key(|s| s.vector_count);
-            }
-            MergeStrategy::MostDeletions => {
-                segment_list.sort_by_key(|s| std::cmp::Reverse(s.has_deletions));
-            }
-            MergeStrategy::Adjacent => {
-                segment_list.sort_by_key(|s| s.vector_offset);
-            }
-        }
-
-        // Select segments to merge
-        let merge_count = self.config.merge_factor.min(segment_list.len() as u32) as usize;
-        let to_merge = &segment_list[..merge_count];
-
-        let candidate = MergeCandidate {
-            segments: to_merge.to_vec(),
-            total_vectors: to_merge.iter().map(|s| s.vector_count).sum(),
-            total_size: to_merge.iter().map(|s| s.size_bytes).sum(),
-        };
-
-        // Determine urgency
-        let urgency = if segments.len() as u32 > self.config.max_segments * 2 {
-            MergeUrgency::High
-        } else if segments.len() as u32 > self.config.max_segments {
-            MergeUrgency::Medium
-        } else {
-            MergeUrgency::Low
-        };
-
-        Some(MergePlan {
-            candidates: vec![candidate],
-            strategy,
-            urgency,
-        })
-    }
-
     /// Get statistics.
     pub fn stats(&self) -> SegmentManagerStats {
         let segments = self.segments.read();
@@ -700,7 +658,16 @@ impl SegmentManager {
 mod tests {
     use super::*;
     use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
-    use crate::vector::index::hnsw::segment::merge_policy::SimpleMergePolicy;
+    use crate::vector::index::segment::merge_policy::SimpleMergePolicy;
+
+    /// The layout exercised by every test below except the
+    /// layout-parameterization test itself: mirrors HNSW's real on-disk
+    /// suffixes, matching these tests' `.hnsw`-shaped fixture names.
+    const TEST_LAYOUT: SegmentFileLayout = SegmentFileLayout {
+        primary: ".hnsw",
+        sidecars: &[".hnsw.f32"],
+        tmp: ".hnsw.tmp",
+    };
 
     fn create_info(id: &str, count: u64) -> ManagedSegmentInfo {
         ManagedSegmentInfo {
@@ -717,7 +684,7 @@ mod tests {
     fn test_segment_manager_basic() {
         let config = SegmentManagerConfig::default();
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
-        let manager = SegmentManager::new(config, storage).unwrap();
+        let manager = SegmentManager::new(config, storage, TEST_LAYOUT).unwrap();
 
         let segment_id = manager.generate_segment_id();
         assert_eq!(segment_id, "segment_000000");
@@ -736,7 +703,8 @@ mod tests {
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
 
         {
-            let manager = SegmentManager::new(config.clone(), storage.clone()).unwrap();
+            let manager =
+                SegmentManager::new(config.clone(), storage.clone(), TEST_LAYOUT).unwrap();
             let info = ManagedSegmentInfo::new("segment_000000".to_string(), 1000, 0, 0);
             manager.add_segment(info).unwrap();
             // Saves automatically
@@ -744,7 +712,7 @@ mod tests {
 
         // Reload
         {
-            let manager = SegmentManager::new(config, storage.clone()).unwrap();
+            let manager = SegmentManager::new(config, storage.clone(), TEST_LAYOUT).unwrap();
             let segments = manager.list_segments();
             assert_eq!(segments.len(), 1);
             assert_eq!(segments[0].segment_id, "segment_000000");
@@ -759,7 +727,8 @@ mod tests {
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
 
         {
-            let manager = SegmentManager::new(config.clone(), storage.clone()).unwrap();
+            let manager =
+                SegmentManager::new(config.clone(), storage.clone(), TEST_LAYOUT).unwrap();
             let id0 = manager.generate_segment_id();
             let id1 = manager.generate_segment_id();
             manager
@@ -776,7 +745,7 @@ mod tests {
         }
 
         {
-            let manager = SegmentManager::new(config, storage).unwrap();
+            let manager = SegmentManager::new(config, storage, TEST_LAYOUT).unwrap();
             let segments = manager.list_segments();
             assert_eq!(segments.len(), 1);
             assert_eq!(segments[0].segment_id, "segment_000000");
@@ -804,7 +773,7 @@ mod tests {
             out.close().unwrap();
         }
 
-        let manager = SegmentManager::new(config.clone(), storage.clone()).unwrap();
+        let manager = SegmentManager::new(config.clone(), storage.clone(), TEST_LAYOUT).unwrap();
         assert_eq!(manager.list_segments().len(), 1);
         assert_eq!(
             manager.generate_segment_id(),
@@ -814,7 +783,7 @@ mod tests {
 
         // A save upgrades the file; a reload parses the versioned format.
         manager.save_state().unwrap();
-        let manager = SegmentManager::new(config, storage).unwrap();
+        let manager = SegmentManager::new(config, storage, TEST_LAYOUT).unwrap();
         assert_eq!(manager.list_segments().len(), 1);
         assert_eq!(manager.list_segments()[0].segment_id, "segment_000007");
     }
@@ -827,7 +796,8 @@ mod tests {
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
 
         {
-            let manager = SegmentManager::new(config.clone(), storage.clone()).unwrap();
+            let manager =
+                SegmentManager::new(config.clone(), storage.clone(), TEST_LAYOUT).unwrap();
             manager
                 .add_segment(create_info("segment_000000", 100))
                 .unwrap();
@@ -848,7 +818,7 @@ mod tests {
         }
 
         assert!(
-            SegmentManager::new(config, storage).is_err(),
+            SegmentManager::new(config, storage, TEST_LAYOUT).is_err(),
             "a corrupted manifest must fail the open, not silently start empty"
         );
     }
@@ -873,7 +843,7 @@ mod tests {
             out.close().unwrap();
         }
 
-        let manager = SegmentManager::new(config, storage).unwrap();
+        let manager = SegmentManager::new(config, storage, TEST_LAYOUT).unwrap();
         let segments = manager.list_segments();
         assert_eq!(segments[0].generation, 1, "stamped in list order");
         assert_eq!(segments[1].generation, 2, "monotone with position");
@@ -900,7 +870,7 @@ mod tests {
             out.close().unwrap();
         }
 
-        let manager = SegmentManager::new(config, storage).unwrap();
+        let manager = SegmentManager::new(config, storage, TEST_LAYOUT).unwrap();
         let segments = manager.list_segments();
         let gen_of = |id: &str| {
             segments
@@ -927,7 +897,8 @@ mod tests {
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
 
         {
-            let manager = SegmentManager::new(config.clone(), storage.clone()).unwrap();
+            let manager =
+                SegmentManager::new(config.clone(), storage.clone(), TEST_LAYOUT).unwrap();
             manager
                 .add_segment(create_info("segment_000000", 100))
                 .unwrap();
@@ -948,7 +919,7 @@ mod tests {
             out.close().unwrap();
         }
 
-        let err = SegmentManager::new(config, storage).unwrap_err();
+        let err = SegmentManager::new(config, storage, TEST_LAYOUT).unwrap_err();
         assert!(
             err.to_string().contains("checksum mismatch"),
             "the CRC verify must reject a trailer-only corruption, got: {err}"
@@ -963,7 +934,8 @@ mod tests {
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
 
         {
-            let manager = SegmentManager::new(config.clone(), storage.clone()).unwrap();
+            let manager =
+                SegmentManager::new(config.clone(), storage.clone(), TEST_LAYOUT).unwrap();
             manager
                 .add_segment(create_info("segment_000000", 100))
                 .unwrap();
@@ -975,7 +947,7 @@ mod tests {
             out.close().unwrap();
         }
 
-        let manager = SegmentManager::new(config, storage.clone()).unwrap();
+        let manager = SegmentManager::new(config, storage.clone(), TEST_LAYOUT).unwrap();
         assert_eq!(
             manager.list_segments().len(),
             1,
@@ -1002,7 +974,8 @@ mod tests {
         };
 
         {
-            let manager = SegmentManager::new(config.clone(), storage.clone()).unwrap();
+            let manager =
+                SegmentManager::new(config.clone(), storage.clone(), TEST_LAYOUT).unwrap();
             manager
                 .add_segment(create_info("segment_000000", 100))
                 .unwrap();
@@ -1019,7 +992,7 @@ mod tests {
         write("vector_index.hnsw");
         write("not_a_segment.hnsw");
 
-        let _manager = SegmentManager::new(config, storage.clone()).unwrap();
+        let _manager = SegmentManager::new(config, storage.clone(), TEST_LAYOUT).unwrap();
         assert!(storage.file_exists("segment_000000.hnsw"));
         assert!(storage.file_exists("segment_000000.hnsw.f32"));
         assert!(!storage.file_exists("segment_000042.hnsw"), "orphan swept");
@@ -1030,16 +1003,63 @@ mod tests {
         assert!(storage.file_exists("not_a_segment.hnsw"), "foreign spared");
     }
 
-    /// #879/#882: deleting a segment's files removes the rerank sidecar
-    /// along with the index file — but never a `.delmap`: the deletion
-    /// bitmap is index-level, and a legacy-migrated segment shares the
-    /// index's name (#882), so touching it would destroy live deletion
-    /// state.
+    /// #889: a distinct layout (Flat-shaped: no sidecars, a different
+    /// primary/tmp suffix) sweeps its own orphans and spares foreign/HNSW
+    /// files — proving the layout parameterization, not just the HNSW
+    /// default, actually drives the sweep.
+    #[test]
+    fn test_cleanup_orphans_respects_a_different_layout() {
+        const FLAT_LAYOUT: SegmentFileLayout = SegmentFileLayout {
+            primary: ".flat",
+            sidecars: &[],
+            tmp: ".flat.tmp",
+        };
+        let config = SegmentManagerConfig::default();
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+        let write = |name: &str| {
+            let mut out = storage.create_output(name).unwrap();
+            std::io::Write::write_all(&mut out, b"x").unwrap();
+            out.close().unwrap();
+        };
+
+        {
+            let manager =
+                SegmentManager::new(config.clone(), storage.clone(), FLAT_LAYOUT).unwrap();
+            manager
+                .add_segment(create_info("segment_000000", 100))
+                .unwrap();
+        }
+        // Registered segment's file: must survive.
+        write("segment_000000.flat");
+        // An orphaned Flat segment (a torn flush): must be swept.
+        write("segment_000042.flat");
+        write("segment_000042.flat.tmp");
+        // Foreign / other-index-type files: must never be touched, even
+        // though they share the `segment_NNNNNN` numbering shape.
+        write("segment_000099.hnsw");
+        write("vector_index.flat");
+
+        let _manager = SegmentManager::new(config, storage.clone(), FLAT_LAYOUT).unwrap();
+        assert!(storage.file_exists("segment_000000.flat"));
+        assert!(!storage.file_exists("segment_000042.flat"), "orphan swept");
+        assert!(!storage.file_exists("segment_000042.flat.tmp"));
+        assert!(
+            storage.file_exists("segment_000099.hnsw"),
+            "a different index type's segment file must never be swept by this layout"
+        );
+        assert!(storage.file_exists("vector_index.flat"), "foreign spared");
+    }
+
+    /// #879/#882: deleting a segment's files removes its sidecars along
+    /// with the primary file — but never a `.delmap`: the deletion bitmap
+    /// is index-level, and a legacy-migrated segment shares the index's
+    /// name (#882), so touching it would destroy live deletion state.
     #[test]
     fn test_delete_segment_files_includes_sidecars() {
         let config = SegmentManagerConfig::default();
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
-        let manager = SegmentManager::new(config, storage.clone()).unwrap();
+        let manager = SegmentManager::new(config, storage.clone(), TEST_LAYOUT).unwrap();
 
         for name in [
             "segment_000001.hnsw",
@@ -1070,7 +1090,7 @@ mod tests {
     fn test_add_segment_fills_metadata() {
         let config = SegmentManagerConfig::default();
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
-        let manager = SegmentManager::new(config, storage.clone()).unwrap();
+        let manager = SegmentManager::new(config, storage.clone(), TEST_LAYOUT).unwrap();
 
         {
             let mut out = storage.create_output("segment_000000.hnsw").unwrap();
@@ -1114,7 +1134,7 @@ mod tests {
         };
 
         // We use a temporary config for the manager
-        let manager = SegmentManager::new(config, storage).unwrap();
+        let manager = SegmentManager::new(config, storage, TEST_LAYOUT).unwrap();
 
         // 1. Add segments (not enough for merge)
         manager.add_segment(create_info("1", 100)).unwrap();

--- a/laurus/src/vector/index/segment/merge.rs
+++ b/laurus/src/vector/index/segment/merge.rs
@@ -1,0 +1,104 @@
+//! Shared merge-operation data types for vector index segments.
+//!
+//! [`MergeConfig`], [`MergeStats`], and [`MergeResult`] are index-type-
+//! agnostic; each index type's own merge engine (e.g.
+//! `hnsw::segment::merge_engine::MergeEngine`) performs the actual
+//! type-specific segment-reader/segment-writer I/O and returns these shared
+//! shapes.
+
+use serde::{Deserialize, Serialize};
+
+use crate::vector::index::segment::manager::ManagedSegmentInfo;
+
+/// Configuration for merge operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeConfig {
+    /// Maximum number of segments to merge at once.
+    pub max_merge_segments: u32,
+
+    /// Target segment size after merge (in vectors).
+    pub target_segment_size: u64,
+
+    /// Whether to use parallel merging.
+    pub parallel_merge: bool,
+
+    /// Number of threads to use for parallel merging.
+    pub num_threads: usize,
+}
+
+impl Default for MergeConfig {
+    fn default() -> Self {
+        Self {
+            max_merge_segments: 10,
+            target_segment_size: 1000000,
+            parallel_merge: true,
+            num_threads: 4,
+        }
+    }
+}
+
+/// Statistics about a merge operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeStats {
+    /// Number of segments merged.
+    pub segments_merged: u32,
+
+    /// Number of vectors in merged segment.
+    pub vectors_merged: u64,
+
+    /// Number of deleted vectors removed.
+    pub deletions_removed: u64,
+
+    /// Number of stale cross-segment duplicates removed — copies of a
+    /// `(doc_id, field)` key shadowed by a newer segment's copy
+    /// (Issue #880). Defaults to 0 when deserializing older stats.
+    #[serde(default)]
+    pub duplicates_removed: u64,
+
+    /// Time taken for merge (in milliseconds).
+    pub merge_time_ms: u64,
+
+    /// Size of merged segment (in bytes).
+    pub merged_size_bytes: u64,
+}
+
+impl MergeStats {
+    /// Create new merge stats.
+    pub fn new() -> Self {
+        Self {
+            segments_merged: 0,
+            vectors_merged: 0,
+            deletions_removed: 0,
+            duplicates_removed: 0,
+            merge_time_ms: 0,
+            merged_size_bytes: 0,
+        }
+    }
+
+    /// Calculate compression ratio.
+    pub fn compression_ratio(&self) -> f64 {
+        if self.vectors_merged == 0 {
+            return 1.0;
+        }
+        1.0 - (self.deletions_removed as f64 / self.vectors_merged as f64)
+    }
+}
+
+impl Default for MergeStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Result of a merge operation.
+#[derive(Debug, Clone)]
+pub struct MergeResult {
+    /// Information about the new merged segment.
+    pub merged_segment: ManagedSegmentInfo,
+
+    /// Statistics about the merge.
+    pub stats: MergeStats,
+
+    /// IDs of segments that were merged.
+    pub merged_segment_ids: Vec<String>,
+}

--- a/laurus/src/vector/index/segment/merge_policy.rs
+++ b/laurus/src/vector/index/segment/merge_policy.rs
@@ -4,7 +4,7 @@
 
 use std::fmt::Debug;
 
-use crate::vector::index::hnsw::segment::manager::{ManagedSegmentInfo, SegmentManagerConfig};
+use crate::vector::index::segment::manager::{ManagedSegmentInfo, SegmentManagerConfig};
 
 /// Trait for merge policies.
 pub trait MergePolicy: Debug + Send + Sync {
@@ -185,7 +185,7 @@ impl MergePolicy for ForceMergePolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vector::index::hnsw::segment::manager::ManagedSegmentInfo;
+    use crate::vector::index::segment::manager::ManagedSegmentInfo;
 
     fn create_info(id: &str, count: u64) -> ManagedSegmentInfo {
         ManagedSegmentInfo {

--- a/laurus/src/vector/index/segment/reader_cache.rs
+++ b/laurus/src/vector/index/segment/reader_cache.rs
@@ -1,18 +1,19 @@
-//! Per-segment [`HnswIndexReader`] cache for
-//! [`SegmentedVectorField`](crate::vector::index::segmented_field::SegmentedVectorField).
+//! Per-segment reader cache shared across segment-per-commit vector index
+//! types (Issue #889; originated in HNSW's segment-per-commit design,
+//! Issue #634).
 //!
-//! Before this cache existed, each `search_managed_segments` call reloaded
-//! every managed segment from disk via `HnswIndexReader::load`, re-parsing
-//! the segment header, rebuilding the int8 quantized pool, the prefetch
-//! index, and the per-field doc-id lookup. For a multi-segment index the
-//! per-query I/O often dominated the actual graph traversal cost.
+//! Before this cache existed, every search against a segmented index
+//! reloaded every managed segment from disk on each call, re-parsing the
+//! segment header and rebuilding its in-memory search state. For a
+//! multi-segment index the per-query I/O often dominated the actual search
+//! cost.
 //!
-//! This cache holds an [`Arc<HnswIndexReader>`] per `segment_id` so that the
-//! second and subsequent searches against the same segment hit memory only.
-//! Entries are invalidated by
-//! [`SegmentedVectorField::perform_merge_with_policy`](crate::vector::index::segmented_field::SegmentedVectorField::perform_merge_with_policy)
-//! immediately after the underlying segment manager removes a source
-//! segment as part of a merge.
+//! This cache holds an `Arc<R>` per `segment_id` (`R` is the index type's
+//! concrete reader — `HnswIndexReader`, `FlatVectorIndexReader`,
+//! `IvfIndexReader`) so that the second and subsequent searches against the
+//! same segment hit memory only. Entries are invalidated by the owning
+//! index's merge path immediately after the segment manager removes a
+//! source segment as part of a merge.
 //!
 //! Issue [#660](https://github.com/mosuka/laurus/issues/660). Reuses the
 //! storage-level per-segment input cache landed in
@@ -26,21 +27,30 @@ use ahash::AHashMap;
 use parking_lot::RwLock;
 
 use crate::error::Result;
-use crate::vector::index::hnsw::reader::HnswIndexReader;
 
-/// Caches `Arc<HnswIndexReader>` per `segment_id`.
+/// Caches `Arc<R>` per `segment_id`.
 ///
-/// The cache is intentionally minimal: it stores every requested reader
-/// for the lifetime of the owning
-/// [`SegmentedVectorField`](crate::vector::index::segmented_field::SegmentedVectorField)
-/// (i.e. no LRU eviction or memory budget). A future change can swap the
-/// inner map for an LRU-backed implementation without touching call sites.
-#[derive(Debug, Default)]
-pub struct SegmentedReaderCache {
-    inner: RwLock<AHashMap<String, Arc<HnswIndexReader>>>,
+/// The cache is intentionally minimal: it stores every requested reader for
+/// the lifetime of the owning index (i.e. no LRU eviction or memory
+/// budget). A future change can swap the inner map for an LRU-backed
+/// implementation without touching call sites.
+#[derive(Debug)]
+pub struct SegmentedReaderCache<R> {
+    inner: RwLock<AHashMap<String, Arc<R>>>,
 }
 
-impl SegmentedReaderCache {
+impl<R> Default for SegmentedReaderCache<R> {
+    // Not derived: `#[derive(Default)]` on a generic struct adds an `R:
+    // Default` bound, but `R` here is only ever stored behind an `Arc` and
+    // never itself defaulted.
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(AHashMap::default()),
+        }
+    }
+}
+
+impl<R> SegmentedReaderCache<R> {
     /// Create an empty cache.
     pub fn new() -> Self {
         Self::default()
@@ -56,15 +66,15 @@ impl SegmentedReaderCache {
     ///
     /// * `segment_id` - The segment identifier to look up.
     /// * `loader` - Invoked only on a cache miss; returns the freshly-built
-    ///   [`HnswIndexReader`].
+    ///   reader.
     ///
     /// # Returns
     ///
     /// `Ok(Arc::clone(&reader))` if the reader is found or successfully
     /// loaded. Propagates `loader`'s error otherwise.
-    pub fn get_or_load<F>(&self, segment_id: &str, loader: F) -> Result<Arc<HnswIndexReader>>
+    pub fn get_or_load<F>(&self, segment_id: &str, loader: F) -> Result<Arc<R>>
     where
-        F: FnOnce() -> Result<HnswIndexReader>,
+        F: FnOnce() -> Result<R>,
     {
         if let Some(reader) = self.inner.read().get(segment_id) {
             return Ok(Arc::clone(reader));
@@ -125,19 +135,18 @@ mod tests {
     use crate::error::LaurusError;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// Build a dummy `HnswIndexReader` from a `SimpleVectorReader`-style
-    /// shortcut would be ideal, but the cache only stores `Arc<HnswIndexReader>`
-    /// and our tests don't need the reader to be functional — they only
-    /// need to assert that the loader is invoked the right number of times
-    /// for a given access pattern.
+    /// The cache only stores `Arc<R>` and these tests don't need the reader
+    /// to be functional — they only need to assert that the loader is
+    /// invoked the right number of times for a given access pattern.
     ///
     /// Instead, return an `Err` from the loader and assert the call count.
     /// `get_or_load` propagates the error without inserting anything, so we
-    /// can use call counters to distinguish hits from misses.
+    /// can use call counters to distinguish hits from misses. `()` stands in
+    /// for a concrete reader type here.
 
     #[test]
     fn get_or_load_invokes_loader_on_miss_only() {
-        let cache = SegmentedReaderCache::new();
+        let cache: SegmentedReaderCache<()> = SegmentedReaderCache::new();
         let calls = AtomicUsize::new(0);
 
         // First call: loader is invoked, returns Err so nothing is cached.
@@ -160,7 +169,7 @@ mod tests {
 
     #[test]
     fn invalidate_is_noop_for_unknown_segment() {
-        let cache = SegmentedReaderCache::new();
+        let cache: SegmentedReaderCache<()> = SegmentedReaderCache::new();
         cache.invalidate("never-cached");
         assert_eq!(cache.len(), 0);
         assert!(cache.is_empty());
@@ -168,7 +177,7 @@ mod tests {
 
     #[test]
     fn clear_empties_the_cache() {
-        let cache = SegmentedReaderCache::new();
+        let cache: SegmentedReaderCache<()> = SegmentedReaderCache::new();
         assert!(cache.is_empty());
         cache.clear();
         assert!(cache.is_empty());
@@ -176,9 +185,31 @@ mod tests {
 
     #[test]
     fn contains_reports_membership() {
-        let cache = SegmentedReaderCache::new();
+        let cache: SegmentedReaderCache<()> = SegmentedReaderCache::new();
         assert!(!cache.contains("seg-a"));
         // No way to insert via the public API without a real reader; that
         // case is covered by the integration test in `segmented_field`.
+    }
+
+    #[test]
+    fn get_or_load_caches_successful_loads() {
+        let cache: SegmentedReaderCache<u32> = SegmentedReaderCache::new();
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(42)
+        };
+
+        let r1 = cache.get_or_load("seg-a", load).unwrap();
+        assert_eq!(*r1, 42);
+        assert_eq!(cache.len(), 1);
+
+        let r2 = cache.get_or_load("seg-a", load).unwrap();
+        assert_eq!(*r2, 42);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "second call must hit the cache, not reinvoke the loader"
+        );
     }
 }

--- a/laurus/src/vector/index/segmented_field.rs
+++ b/laurus/src/vector/index/segmented_field.rs
@@ -17,10 +17,11 @@ use crate::vector::index::field::{
 };
 use crate::vector::index::hnsw::reader::HnswIndexReader;
 use crate::vector::index::hnsw::searcher::HnswSearcher;
-use crate::vector::index::hnsw::segment::manager::{ManagedSegmentInfo, SegmentManager};
-use crate::vector::index::hnsw::segment::merge_engine::{MergeConfig, MergeEngine};
-use crate::vector::index::hnsw::segment::reader_cache::SegmentedReaderCache;
+use crate::vector::index::hnsw::segment::merge_engine::MergeEngine;
 use crate::vector::index::hnsw::writer::HnswIndexWriter;
+use crate::vector::index::segment::manager::{ManagedSegmentInfo, SegmentManager};
+use crate::vector::index::segment::merge::MergeConfig;
+use crate::vector::index::segment::reader_cache::SegmentedReaderCache;
 use crate::vector::search::searcher::{
     VectorIndexQuery, VectorIndexQueryParams, VectorIndexSearcher,
 };
@@ -69,7 +70,7 @@ pub struct SegmentedVectorField {
     /// Invalidated by [`Self::perform_merge_with_policy`] when source
     /// segments are removed as part of a merge. Issue
     /// [#660](https://github.com/mosuka/laurus/issues/660).
-    pub reader_cache: Arc<SegmentedReaderCache>,
+    pub reader_cache: Arc<SegmentedReaderCache<HnswIndexReader>>,
 }
 
 impl SegmentedVectorField {
@@ -153,14 +154,14 @@ impl SegmentedVectorField {
 
     /// Trigger a background merge of segments using various policies.
     pub fn perform_merge(&self) -> Result<()> {
-        let policy = crate::vector::index::hnsw::segment::merge_policy::SimpleMergePolicy::new();
+        let policy = crate::vector::index::segment::merge_policy::SimpleMergePolicy::new();
         self.perform_merge_with_policy(&policy)
     }
 
     /// Trigger a merge with a specific policy.
     pub fn perform_merge_with_policy(
         &self,
-        policy: &dyn crate::vector::index::hnsw::segment::merge_policy::MergePolicy,
+        policy: &dyn crate::vector::index::segment::merge_policy::MergePolicy,
     ) -> Result<()> {
         if let Some(mut candidate) = self.segment_manager.check_merge(policy) {
             // Close generation gaps in the candidate (Issue #880): the merged
@@ -397,7 +398,7 @@ impl VectorFieldWriter for SegmentedVectorField {
     }
 
     async fn optimize(&self) -> Result<()> {
-        let policy = crate::vector::index::hnsw::segment::merge_policy::ForceMergePolicy::new();
+        let policy = crate::vector::index::segment::merge_policy::ForceMergePolicy::new();
         self.perform_merge_with_policy(&policy)
     }
 }
@@ -709,7 +710,7 @@ mod tests {
     use super::*;
     use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
     use crate::vector::core::field::HnswOption;
-    use crate::vector::index::hnsw::segment::manager::SegmentManagerConfig;
+    use crate::vector::index::segment::manager::SegmentManagerConfig;
     use crate::vector::store::request::QueryVector;
 
     fn field_with_bitmap() -> (
@@ -726,6 +727,7 @@ mod tests {
                     ..Default::default()
                 },
                 storage.clone(),
+                crate::vector::index::hnsw::segment::LAYOUT,
             )
             .unwrap(),
         );

--- a/laurus/tests/vector_merge_test.rs
+++ b/laurus/tests/vector_merge_test.rs
@@ -6,8 +6,9 @@ use laurus::vector::Vector;
 use laurus::vector::VectorFieldConfig;
 use laurus::vector::core::rerank::RerankStorageKind;
 use laurus::vector::index::field::{FieldSearchInput, VectorFieldReader, VectorFieldWriter};
+use laurus::vector::index::hnsw;
 use laurus::vector::index::hnsw::reader::HnswIndexReader;
-use laurus::vector::index::hnsw::segment::manager::{SegmentManager, SegmentManagerConfig};
+use laurus::vector::index::segment::manager::{SegmentManager, SegmentManagerConfig};
 use laurus::vector::index::segmented_field::SegmentedVectorField;
 use laurus::vector::store::request::QueryVector;
 use laurus::vector::{FieldOption, HnswOption};
@@ -25,7 +26,11 @@ async fn test_segmented_field_manual_merge() -> Result<(), Box<dyn std::error::E
         ..Default::default()
     };
 
-    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+    let manager = Arc::new(SegmentManager::new(
+        manager_config,
+        storage.clone(),
+        hnsw::segment::LAYOUT,
+    )?);
 
     // 2. Setup Field
     let field_config = VectorFieldConfig {
@@ -113,7 +118,11 @@ async fn segmented_field_reader_cache_reuses_and_invalidates()
         min_vectors_per_segment: 1,
         ..Default::default()
     };
-    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+    let manager = Arc::new(SegmentManager::new(
+        manager_config,
+        storage.clone(),
+        hnsw::segment::LAYOUT,
+    )?);
 
     let field_config = VectorFieldConfig {
         vector: Some(FieldOption::Hnsw(HnswOption {
@@ -253,7 +262,11 @@ async fn segmented_flush_and_merge_emit_rerank_sidecar() -> Result<(), Box<dyn s
         min_vectors_per_segment: 1,
         ..Default::default()
     };
-    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+    let manager = Arc::new(SegmentManager::new(
+        manager_config,
+        storage.clone(),
+        hnsw::segment::LAYOUT,
+    )?);
 
     let field_config = VectorFieldConfig {
         vector: Some(FieldOption::Hnsw(HnswOption {
@@ -364,7 +377,11 @@ async fn segmented_merge_keeps_vectors_unnormalized_for_euclidean()
         min_vectors_per_segment: 1,
         ..Default::default()
     };
-    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+    let manager = Arc::new(SegmentManager::new(
+        manager_config,
+        storage.clone(),
+        hnsw::segment::LAYOUT,
+    )?);
 
     let field_config = VectorFieldConfig {
         vector: Some(FieldOption::Hnsw(HnswOption {
@@ -469,7 +486,11 @@ async fn segmented_merge_preserves_rerank_sidecar_f32_losslessly()
         min_vectors_per_segment: 1,
         ..Default::default()
     };
-    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+    let manager = Arc::new(SegmentManager::new(
+        manager_config,
+        storage.clone(),
+        hnsw::segment::LAYOUT,
+    )?);
 
     let field_config = VectorFieldConfig {
         vector: Some(FieldOption::Hnsw(HnswOption {
@@ -585,6 +606,7 @@ fn cosine_field(
             ..Default::default()
         },
         storage.clone(),
+        hnsw::segment::LAYOUT,
     )?);
     let field_config = VectorFieldConfig {
         vector: Some(FieldOption::Hnsw(HnswOption {

--- a/laurus/tests/vector_segmented_correctness_test.rs
+++ b/laurus/tests/vector_segmented_correctness_test.rs
@@ -20,8 +20,9 @@ use laurus::vector::core::quantization::QuantizationMethod;
 use laurus::vector::index::VectorIndex;
 use laurus::vector::index::config::HnswIndexConfig;
 use laurus::vector::index::field::{FieldSearchInput, VectorFieldReader, VectorFieldWriter};
+use laurus::vector::index::hnsw;
 use laurus::vector::index::hnsw::HnswIndex;
-use laurus::vector::index::hnsw::segment::manager::{SegmentManager, SegmentManagerConfig};
+use laurus::vector::index::segment::manager::{SegmentManager, SegmentManagerConfig};
 use laurus::vector::index::segmented_field::SegmentedVectorField;
 use laurus::vector::index::storage::VectorStorage;
 use laurus::vector::store::request::QueryVector;
@@ -55,7 +56,11 @@ fn segmented_field(
         min_vectors_per_segment: 1,
         ..Default::default()
     };
-    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+    let manager = Arc::new(SegmentManager::new(
+        manager_config,
+        storage.clone(),
+        hnsw::segment::LAYOUT,
+    )?);
     let field =
         SegmentedVectorField::create("embedding", field_config(4), manager.clone(), storage, None)?;
     Ok((field, manager))
@@ -229,7 +234,11 @@ async fn partial_merge_preserves_newest_wins_ordering() -> Result<(), Box<dyn st
         min_vectors_per_segment: 1,
         ..Default::default()
     };
-    let manager = Arc::new(SegmentManager::new(manager_config, storage.clone())?);
+    let manager = Arc::new(SegmentManager::new(
+        manager_config,
+        storage.clone(),
+        hnsw::segment::LAYOUT,
+    )?);
     let field =
         SegmentedVectorField::create("embedding", field_config(4), manager.clone(), storage, None)?;
 


### PR DESCRIPTION
## Summary

- Extracted HNSW's `#634` segment-per-commit machinery's genuinely index-type-agnostic pieces into a shared `vector/index/segment/` module: `SegmentManager` (parameterized by a new `SegmentFileLayout { primary, sidecars, tmp }` third constructor argument, replacing three hardcoded `.hnsw`/`.hnsw.f32` suffix call sites), `merge_policy.rs` (moved verbatim, already 100% generic), a genericized `SegmentedReaderCache<R>`, and `MergeConfig`/`MergeStats`/`MergeResult` (moved into a new `segment/merge.rs`; `MergeEngine` itself stays HNSW-typed since its I/O is graph-specific).
- HNSW switches directly to the shared module (not a re-export, to avoid a duplicate-type ambiguity for future code).
- `cleanup_orphans` now sorts its recognized suffixes longest-first before `strip_suffix`, so a `.hnsw.tmp` file isn't mis-stemmed by matching the shorter `.hnsw` suffix first — this matters more once other index types' suffixes join the mix.
- Dropped code confirmed dead even within HNSW's own `segmented.rs` during the move rather than relocating it: `create_merge_plan`/`MergePlan`/`MergeStrategy`/`vector_offset` (only `check_merge` is ever called), and an unused `SegmentInfo` struct in `hnsw/segment.rs`'s old shim (unrelated to `ManagedSegmentInfo`, zero references anywhere).
- `segmented_field.rs`, `tests/vector_merge_test.rs`, and `benches/nrt_active_search_bench.rs` share these types (confirmed via investigation before touching anything) and needed mechanical import-path updates plus the new layout argument — no logic changes.

This is PR-1 of the #889 campaign (extending segment-per-commit to Flat/IVF): this shared infrastructure is what Flat's and IVF's own segmented implementations (later PRs) will build on, instead of copy-pasting a third time.

## Test plan

- [x] `cargo build -p laurus` clean
- [x] `cargo test -p laurus --lib`: 1245 passed (2 new tests: a layout-parameterization proof for `cleanup_orphans`, and a cache-hit-path test the old concrete-typed cache couldn't unit-test)
- [x] `cargo test -p laurus --tests`: full suite green. `vector_segmented_index_test.rs` (16/16) and `vector_segmented_correctness_test.rs` (5/5) pass with **only import-path edits** — the zero-behavior-change gate. `vector_merge_test.rs` (8/8) confirms `segmented_field.rs`'s logic is unaffected
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` clean on both stable (1.97.1) and pinned 1.97.0 toolchains
- [x] `cargo doc -p laurus --no-deps`: warning count matches the `main` baseline exactly (one new intra-doc-link warning was caught and fixed along the way)

Part of #889.
Closes #901