### PR TITLE
fix(vector/index): clamp IVF n_clusters to the available corpus instead of erroring (#905)

### DIFF
--- a/laurus/src/vector/index/ivf/writer.rs
+++ b/laurus/src/vector/index/ivf/writer.rs
@@ -47,6 +47,16 @@ pub struct IvfIndexWriter {
     is_finalized: bool,
     total_vectors_to_add: Option<usize>,
     next_vec_id: u64,
+    /// The cluster-count ceiling the caller configured (via
+    /// [`IvfIndexConfig::n_clusters`], [`Self::with_ivf_params`], or
+    /// [`Self::set_expected_vector_count`]) — never mutated by training.
+    /// `train_centroids` clamps the *effective* `index_config.n_clusters`
+    /// down to `min(configured_n_clusters, vectors.len())` for training and
+    /// serialization, but this field is what that clamp is always computed
+    /// from, so the effective count recovers (rather than staying
+    /// permanently shrunk) once the corpus grows past it again (Issue #889
+    /// PR-5).
+    configured_n_clusters: usize,
 }
 
 impl IvfIndexWriter {
@@ -62,6 +72,7 @@ impl IvfIndexWriter {
         writer_config: VectorIndexWriterConfig,
         path: impl Into<String>,
     ) -> Result<Self> {
+        let configured_n_clusters = index_config.n_clusters;
         Ok(Self {
             index_config,
             writer_config,
@@ -74,6 +85,7 @@ impl IvfIndexWriter {
             is_finalized: false,
             total_vectors_to_add: None,
             next_vec_id: 0,
+            configured_n_clusters,
         })
     }
 
@@ -95,6 +107,7 @@ impl IvfIndexWriter {
             return Self::load(index_config, writer_config, storage, &path);
         }
 
+        let configured_n_clusters = index_config.n_clusters;
         Ok(Self {
             index_config,
             writer_config,
@@ -106,6 +119,7 @@ impl IvfIndexWriter {
             is_finalized: false,
             total_vectors_to_add: None,
             next_vec_id: 0,
+            configured_n_clusters,
         })
     }
 
@@ -254,6 +268,7 @@ impl IvfIndexWriter {
         let max_id = vectors.iter().map(|(id, _, _)| *id).max().unwrap_or(0);
         let next_vec_id = if num_vectors > 0 { max_id + 1 } else { 0 };
 
+        let configured_n_clusters = index_config.n_clusters;
         Ok(Self {
             index_config,
             writer_config,
@@ -266,21 +281,29 @@ impl IvfIndexWriter {
             is_finalized: true,
             total_vectors_to_add: Some(num_vectors),
             next_vec_id,
+            configured_n_clusters,
         })
     }
 
     /// Set IVF-specific parameters.
     pub fn with_ivf_params(mut self, n_clusters: usize, n_probe: usize) -> Self {
         self.index_config.n_clusters = n_clusters;
+        self.configured_n_clusters = n_clusters;
         self.index_config.n_probe = n_probe;
         self
     }
 
     /// Set the expected total number of vectors (for progress tracking).
+    ///
+    /// Also updates the cluster-count ceiling ([`Self::with_ivf_params`]'s
+    /// `n_clusters`, or the configured default) to a size-appropriate
+    /// default, since the caller is stating a new expectation about the
+    /// eventual corpus size.
     pub fn set_expected_vector_count(&mut self, count: usize) {
         self.total_vectors_to_add = Some(count);
         // Adjust number of clusters based on dataset size
         self.index_config.n_clusters = Self::compute_default_clusters(count);
+        self.configured_n_clusters = self.index_config.n_clusters;
     }
 
     /// Compute default number of clusters based on dataset size.
@@ -343,18 +366,13 @@ impl IvfIndexWriter {
             ));
         }
 
-        if self.vectors.len() < self.index_config.n_clusters {
-            return Err(LaurusError::InvalidOperation(format!(
-                "Cannot create {} clusters from {} vectors",
-                self.index_config.n_clusters,
-                self.vectors.len() as u64
-            )));
-        }
-
-        println!(
-            "Training {} centroids using k-means...",
-            self.index_config.n_clusters
-        );
+        // Issue #889 PR-5: clamp to the available corpus instead of
+        // hard-erroring. `configured_n_clusters` is the ceiling the caller
+        // asked for and is never mutated by training, so the effective
+        // count recovers as the corpus grows across successive
+        // `add_vectors` calls rather than staying permanently shrunk once a
+        // small commit clamps it down.
+        self.index_config.n_clusters = self.configured_n_clusters.min(self.vectors.len()).max(1);
 
         // Initialize centroids with k-means++
         self.init_centroids_kmeans_plus_plus()?;
@@ -363,7 +381,7 @@ impl IvfIndexWriter {
         let max_iterations = 100;
         let convergence_threshold = 1e-6;
 
-        for iteration in 0..max_iterations {
+        for _iteration in 0..max_iterations {
             let old_centroids = self.centroids.clone();
 
             // Assign vectors to clusters
@@ -375,7 +393,6 @@ impl IvfIndexWriter {
             // Check for convergence
             let convergence = self.compute_convergence(&old_centroids);
             if convergence < convergence_threshold {
-                println!("K-means converged after {} iterations", iteration + 1);
                 break;
             }
         }
@@ -1022,11 +1039,9 @@ impl VectorIndexWriter for IvfIndexWriter {
         self.vectors = vectors;
         self.total_vectors_to_add = Some(self.vectors.len());
 
-        // Adjust cluster count if needed
-        if self.vectors.len() < self.index_config.n_clusters {
-            self.index_config.n_clusters = self.vectors.len().max(1);
-        }
-
+        // Cluster-count clamping now happens uniformly in `train_centroids`
+        // (Issue #889 PR-5), regardless of whether vectors arrived via
+        // `build` or `add_vectors`.
         self.check_memory_limit()?;
         Ok(())
     }
@@ -1279,23 +1294,14 @@ impl VectorIndexWriter for IvfIndexWriter {
             ));
         }
 
-        println!("Optimizing IVF index...");
-
         // Rebalance clusters if they're too uneven
         let total_vectors = self.vectors.len();
         let avg_vectors_per_cluster = total_vectors / self.index_config.n_clusters.max(1);
         let sparse_threshold = avg_vectors_per_cluster / 4;
         let dense_threshold = avg_vectors_per_cluster * 4;
 
-        let merged = self.merge_sparse_clusters(sparse_threshold.max(2))?;
-        if merged > 0 {
-            println!("Merged {} sparse clusters", merged);
-        }
-
-        let split = self.split_dense_clusters(dense_threshold)?;
-        if split > 0 {
-            println!("Split {} dense clusters", split);
-        }
+        self.merge_sparse_clusters(sparse_threshold.max(2))?;
+        self.split_dense_clusters(dense_threshold)?;
 
         // For now, just compact memory
         self.vectors.shrink_to_fit();

--- a/laurus/tests/vector_ivf_adaptive_clusters_test.rs
+++ b/laurus/tests/vector_ivf_adaptive_clusters_test.rs
@@ -1,0 +1,190 @@
+//! Regression tests for Issue #889 PR-5: `IvfIndexWriter` used to
+//! hard-error whenever the committed corpus was smaller than the
+//! configured `n_clusters` (default 100) — and `add_vectors()` (the path
+//! `VectorStore` actually calls in production) never clamped `n_clusters`
+//! down the way `build()` did, so a fresh IVF index committing fewer than
+//! ~100 documents failed outright on `main` before this fix.
+//!
+//! `train_centroids()` now clamps the *effective* cluster count to
+//! `min(configured_n_clusters, vector_count).max(1)` instead of erroring,
+//! and the configured ceiling itself is preserved (not silently
+//! overwritten), so the effective count recovers as the corpus grows.
+
+use std::sync::Arc;
+
+use laurus::storage::Storage;
+use laurus::storage::memory::MemoryStorage;
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::index::ivf::reader::IvfIndexReader;
+use laurus::vector::index::ivf::writer::IvfIndexWriter;
+use laurus::vector::reader::VectorIndexReader;
+use laurus::vector::{IvfIndexConfig, Vector, VectorIndexWriter, VectorIndexWriterConfig};
+
+const DIM: usize = 4;
+
+fn doc_vec(i: u64) -> Vector {
+    let t = i as f32 * 0.1;
+    Vector::new(vec![t.cos(), t.sin(), (t * 2.0).cos(), (t * 2.0).sin()])
+}
+
+/// Read back `ivf_params()` (n_clusters, n_probe) from the on-disk file.
+fn read_n_clusters(storage: Arc<dyn Storage>, name: &str) -> usize {
+    let reader = IvfIndexReader::load(storage, name, DistanceMetric::Cosine).unwrap();
+    reader.ivf_params().0
+}
+
+/// #889 PR-5: a fresh IVF index committing 50 documents via `add_vectors`
+/// (not `build`) — the path `VectorStore` actually uses — must succeed and
+/// every document must be searchable. This is the exact scenario that
+/// hard-errored on `main` before this fix (default `n_clusters` is 100,
+/// `add_vectors` never clamped it).
+#[test]
+fn add_vectors_below_default_n_clusters_commits_successfully() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::default());
+    let config = IvfIndexConfig {
+        dimension: DIM,
+        distance_metric: DistanceMetric::Cosine,
+        normalize_vectors: false,
+        ..IvfIndexConfig::default()
+    };
+    assert_eq!(
+        config.n_clusters, 100,
+        "test assumes the documented default"
+    );
+
+    let mut writer = IvfIndexWriter::with_storage(
+        config,
+        VectorIndexWriterConfig::default(),
+        "ivf_small",
+        storage.clone(),
+    )
+    .unwrap();
+    let vectors: Vec<_> = (0..50).map(|i| (i, "v".to_string(), doc_vec(i))).collect();
+    writer.add_vectors(vectors).unwrap();
+    writer.finalize().unwrap();
+    writer.write().unwrap();
+
+    let reader = IvfIndexReader::load(storage, "ivf_small", DistanceMetric::Cosine).unwrap();
+    let mut ids: Vec<u64> = reader
+        .vector_ids()
+        .unwrap()
+        .into_iter()
+        .map(|(d, _)| d)
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(ids, (0..50).collect::<Vec<_>>());
+}
+
+/// A single-vector commit must degrade all the way to K=1 (brute-force
+/// within that one "cluster") rather than erroring.
+#[test]
+fn single_vector_commit_degrades_to_one_cluster() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::default());
+    let config = IvfIndexConfig {
+        dimension: DIM,
+        distance_metric: DistanceMetric::Cosine,
+        normalize_vectors: false,
+        ..IvfIndexConfig::default()
+    };
+    let mut writer = IvfIndexWriter::with_storage(
+        config,
+        VectorIndexWriterConfig::default(),
+        "ivf_one",
+        storage.clone(),
+    )
+    .unwrap();
+    writer
+        .add_vectors(vec![(0, "v".to_string(), doc_vec(0))])
+        .unwrap();
+    writer.finalize().unwrap();
+    writer.write().unwrap();
+
+    assert_eq!(read_n_clusters(storage, "ivf_one"), 1);
+}
+
+/// A corpus larger than the configured `n_clusters` must still honor it as
+/// an upper bound — the adaptive clamp only kicks in below the ceiling.
+#[test]
+fn large_corpus_honors_configured_n_clusters_as_upper_bound() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::default());
+    let config = IvfIndexConfig {
+        dimension: DIM,
+        distance_metric: DistanceMetric::Cosine,
+        normalize_vectors: false,
+        n_clusters: 5,
+        ..IvfIndexConfig::default()
+    };
+    let mut writer = IvfIndexWriter::with_storage(
+        config,
+        VectorIndexWriterConfig::default(),
+        "ivf_large",
+        storage.clone(),
+    )
+    .unwrap();
+    let vectors: Vec<_> = (0..200).map(|i| (i, "v".to_string(), doc_vec(i))).collect();
+    writer.add_vectors(vectors).unwrap();
+    writer.finalize().unwrap();
+    writer.write().unwrap();
+
+    assert_eq!(
+        read_n_clusters(storage, "ivf_large"),
+        5,
+        "n_clusters must stay at the configured ceiling when the corpus exceeds it"
+    );
+}
+
+/// The configured ceiling is not permanently overwritten by an initial
+/// small commit: a later commit that grows the corpus back past the
+/// ceiling recovers the full cluster count instead of staying clamped.
+#[test]
+fn ceiling_recovers_after_corpus_grows_past_it() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::default());
+    let config = IvfIndexConfig {
+        dimension: DIM,
+        distance_metric: DistanceMetric::Cosine,
+        normalize_vectors: false,
+        n_clusters: 20,
+        ..IvfIndexConfig::default()
+    };
+
+    // First commit: only 5 vectors, well below the ceiling of 20.
+    {
+        let mut writer = IvfIndexWriter::with_storage(
+            config.clone(),
+            VectorIndexWriterConfig::default(),
+            "ivf_recover",
+            storage.clone(),
+        )
+        .unwrap();
+        let vectors: Vec<_> = (0..5).map(|i| (i, "v".to_string(), doc_vec(i))).collect();
+        writer.add_vectors(vectors).unwrap();
+        writer.finalize().unwrap();
+        writer.write().unwrap();
+    }
+    assert_eq!(
+        read_n_clusters(storage.clone(), "ivf_recover"),
+        5,
+        "clamped down to the small first commit's corpus size"
+    );
+
+    // Second commit (fresh writer, reloading the 5 committed docs): add 95
+    // more, bringing the corpus to 100 -- well past the ceiling of 20.
+    {
+        let mut writer = IvfIndexWriter::with_storage(
+            config,
+            VectorIndexWriterConfig::default(),
+            "ivf_recover",
+            storage.clone(),
+        )
+        .unwrap();
+        let vectors: Vec<_> = (5..100).map(|i| (i, "v".to_string(), doc_vec(i))).collect();
+        writer.add_vectors(vectors).unwrap();
+        writer.finalize().unwrap();
+        writer.write().unwrap();
+    }
+    assert_eq!(
+        read_n_clusters(storage, "ivf_recover"),
+        20,
+        "the ceiling must recover once the corpus grows past it again, not stay clamped at 5"
+    );
+}


### PR DESCRIPTION
## Summary

- `IvfIndexWriter::train_centroids()` hard-errored whenever the vector count was below `n_clusters` (default 100). `build()` pre-clamped `n_clusters` down to the corpus size before training, but `add_vectors()` — the only path `VectorStore` actually calls in production — did not, so a fresh IVF index committing fewer than ~100 documents failed outright on `main` today, independent of the #889 segmentation work.
- The originally-sketched fix (clamping via `compute_default_clusters`'s existing `sqrt(n)` heuristic) doesn't actually work: that helper has a hardcoded minimum of 10, which still exceeds the vector count for corpora under 10. Instead, added a new `configured_n_clusters` field, set once at construction from `index_config.n_clusters` and never mutated by training. `train_centroids()` now computes the effective K fresh on every call as `configured_n_clusters.min(vectors.len()).max(1)` — applied uniformly for both `build()` and `add_vectors()` paths, removing `build()`'s now-redundant clamp-and-mutate block. Because the ceiling is tracked separately from the working `n_clusters`, the effective cluster count recovers once the corpus grows back past an earlier small-commit clamp, instead of staying permanently shrunk.
- Also removed stray `println!` calls in `train_centroids`/`optimize` that would otherwise spam stdout once IVF segments seal far more frequently under #889 PR-6.

This is PR-5 of the #889 campaign — independently valuable (fixes a live bug) and a prerequisite for PR-6 (`SegmentedIvfIndex`), which needs small-segment commits to succeed routinely under the per-segment independent adaptive-K centroid design.

## Test plan

- [x] `cargo build -p laurus` clean
- [x] New `vector_ivf_adaptive_clusters_test.rs` (4 tests)
- [x] **RED/GREEN proof**: stashed just the `writer.rs` fix and confirmed 3 of the 4 new tests fail against unmodified `main` with the exact `"Cannot create N clusters from M vectors"` error, reproducing the live bug; restored the fix and re-verified all 4 green
- [x] `cargo test -p laurus --lib`: 1245 passed, 0 failed (11 IVF-specific tests, no regressions)
- [x] `cargo test -p laurus --tests`: full suite green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` clean on both stable (1.97.1) and pinned 1.97.0 toolchains
- [x] `cargo doc -p laurus --no-deps`: warning count matches the `main` baseline exactly

Part of #889.
Closes #905