### PR TITLE
feat(vector/index): segment-per-commit SegmentedFlatIndex (#904)

### DIFF
--- a/laurus/src/vector/index/config.rs
+++ b/laurus/src/vector/index/config.rs
@@ -319,6 +319,30 @@ pub struct FlatIndexConfig {
     /// will be triggered to consolidate them.
     pub max_segments: u32,
 
+    /// Whether this index uses the segment-per-commit layout (Issue #889).
+    ///
+    /// Mirrors [`HnswIndexConfig::segmented`]. Defaults to `false` — unlike
+    /// HNSW (where the flag flipped to `true` in #882 after the design was
+    /// proven in production), Flat's segmented layout ships behind the flag
+    /// until it has had the same real-world exercise.
+    #[serde(default)]
+    pub segmented: bool,
+
+    /// Automatically compact (purge logically deleted vectors) on commit
+    /// when the deletion ratio crosses [`Self::compaction_threshold`]
+    /// (Issue #889, mirroring [`HnswIndexConfig::auto_compaction`] / #782).
+    /// Defaults to `false`; the `VectorStore` populates it from
+    /// [`crate::maintenance::deletion::DeletionConfig::auto_compaction`].
+    #[serde(default)]
+    pub auto_compaction: bool,
+
+    /// Deletion ratio (deleted / total committed vectors, `0.0`–`1.0`) at or
+    /// above which [`Self::auto_compaction`] triggers a compaction on commit.
+    /// Ignored when `auto_compaction` is `false`. Mirrors
+    /// [`HnswIndexConfig::compaction_threshold`].
+    #[serde(default = "default_compaction_threshold")]
+    pub compaction_threshold: f64,
+
     /// Embedder for converting text/images to vectors.
     ///
     /// This embedder is used when documents contain text or image fields that need to be
@@ -375,6 +399,9 @@ impl Default for FlatIndexConfig {
             rerank_storage: None,
             merge_factor: 10,
             max_segments: 100,
+            segmented: false,
+            auto_compaction: false,
+            compaction_threshold: default_compaction_threshold(),
             embedder: default_embedder(),
         }
     }
@@ -393,6 +420,9 @@ impl std::fmt::Debug for FlatIndexConfig {
             .field("rerank_storage", &self.rerank_storage)
             .field("merge_factor", &self.merge_factor)
             .field("max_segments", &self.max_segments)
+            .field("segmented", &self.segmented)
+            .field("auto_compaction", &self.auto_compaction)
+            .field("compaction_threshold", &self.compaction_threshold)
             .field("embedder", &self.embedder.name())
             .finish()
     }

--- a/laurus/src/vector/index/factory.rs
+++ b/laurus/src/vector/index/factory.rs
@@ -80,8 +80,7 @@ impl VectorIndexFactory {
     ) -> Result<Box<dyn VectorIndex>> {
         match config {
             VectorIndexTypeConfig::Flat(flat_config) => {
-                let index = FlatIndex::create(storage, name, flat_config)?;
-                Ok(Box::new(index))
+                Self::dispatch_flat(storage, name, flat_config, false)
             }
             VectorIndexTypeConfig::HNSW(hnsw_config) => {
                 Self::dispatch_hnsw(storage, name, hnsw_config, false)
@@ -91,6 +90,48 @@ impl VectorIndexFactory {
                 Ok(Box::new(index))
             }
         }
+    }
+
+    /// Dispatch a Flat config to the segmented or monolithic implementation
+    /// (Issue #889 PR-4, mirroring `dispatch_hnsw`).
+    ///
+    /// The `segmented` flag (defaulting `false` until #889 PR-7) routes to
+    /// [`SegmentedFlatIndex::open_or_create`], which handles create, open,
+    /// AND the zero-copy migration of a legacy monolithic index — so BOTH
+    /// factory arms must come through here: a legacy index always has a
+    /// `metadata.json` and therefore always takes the *open* arm, which is
+    /// exactly where the migration must fire.
+    ///
+    /// With the flag off, opening a directory that contains a segment
+    /// manifest is rejected: the monolithic index would silently serve only
+    /// the migrated segment-0 data and hide every later segment.
+    fn dispatch_flat(
+        storage: Arc<dyn Storage>,
+        name: &str,
+        flat_config: crate::vector::index::config::FlatIndexConfig,
+        open_only: bool,
+    ) -> Result<Box<dyn VectorIndex>> {
+        use crate::vector::index::flat::segmented::SegmentedFlatIndex;
+
+        if flat_config.segmented {
+            let index = SegmentedFlatIndex::open_or_create(storage, name, flat_config)?;
+            return Ok(Box::new(index));
+        }
+        // Reverse guard: a segmented directory must not be opened
+        // monolithically — the single-file view would silently hide every
+        // segment sealed after the migration.
+        if storage.file_exists("segments.json") {
+            return Err(crate::error::LaurusError::invalid_config(format!(
+                "index '{name}' uses the segmented layout (segments.json exists) but \
+                 `segmented` is disabled; enable it to open this index"
+            )));
+        }
+        let index = if open_only {
+            FlatIndex::open(storage, name, flat_config)?
+        } else {
+            FlatIndex::create(storage, name, flat_config)?
+        };
+        Ok(Box::new(index))
     }
 
     /// Dispatch an HNSW config to the segmented or monolithic implementation
@@ -194,8 +235,11 @@ impl VectorIndexFactory {
     ) -> Result<Box<dyn VectorIndex>> {
         match config {
             VectorIndexTypeConfig::Flat(flat_config) => {
-                let index = FlatIndex::open(storage, name, flat_config)?;
-                Ok(Box::new(index))
+                // Same dispatch as `create` (Issue #889 PR-4): the segmented
+                // path's `open_or_create` opens existing manifests and
+                // migrates legacy monolithic indexes; the flag-off path is
+                // reverse-guarded against segmented directories.
+                Self::dispatch_flat(storage, name, flat_config, true)
             }
             VectorIndexTypeConfig::HNSW(hnsw_config) => {
                 // Same dispatch as `create` (#882): the segmented path's

--- a/laurus/src/vector/index/flat.rs
+++ b/laurus/src/vector/index/flat.rs
@@ -2,6 +2,8 @@
 
 pub mod reader;
 pub mod searcher;
+pub mod segment;
+pub mod segmented;
 pub mod writer;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -281,7 +281,13 @@ impl FlatVectorIndexReader {
         &self.vectors
     }
 
-    fn is_deleted(&self, doc_id: u64) -> bool {
+    /// Whether `doc_id` is logically deleted per the attached bitmap (if
+    /// any). `pub(crate)` so the searcher's per-storage-mode fast paths
+    /// (e.g. the quantized-pool scan in [`crate::vector::index::flat::searcher`],
+    /// which reads straight from the quantized pool and bypasses
+    /// [`VectorIndexReader::get_vector`]) can filter deleted docs without
+    /// going through that slower, allocation-heavy accessor.
+    pub(crate) fn is_deleted(&self, doc_id: u64) -> bool {
         if let Some(bitmap) = &self.deletion_bitmap {
             bitmap.is_deleted(doc_id)
         } else {

--- a/laurus/src/vector/index/flat/searcher.rs
+++ b/laurus/src/vector/index/flat/searcher.rs
@@ -100,6 +100,7 @@ impl VectorIndexSearcher for FlatVectorSearcher {
                     }
                     if let Some((prepared, pool, idx)) = &quant_ctx
                         && let Some(&pos) = idx.get(&doc_id)
+                        && !flat_reader.is_some_and(|r| r.is_deleted(doc_id))
                     {
                         let (int8, meta) = pool.record_at(pos);
                         let distance = distance_quantized(metric, prepared, int8, meta);

--- a/laurus/src/vector/index/flat/segment.rs
+++ b/laurus/src/vector/index/flat/segment.rs
@@ -1,0 +1,20 @@
+//! Flat-specific segment file layout and merge engine.
+//!
+//! The generic segment manifest/manager, merge policies, reader cache, and
+//! fan-out search layer shared across index types live in
+//! [`crate::vector::index::segment`] (Issue #889); this module keeps only
+//! what is Flat-specific: the merge engine (its I/O is Flat-typed) and this
+//! index type's on-disk file layout descriptor.
+
+use crate::vector::index::segment::manager::SegmentFileLayout;
+
+pub mod merge_engine;
+
+/// On-disk file-suffix layout for Flat segments: a primary `.flat` file, no
+/// sidecars (Flat has no rerank sidecar), staged through a `.flat.tmp` temp
+/// file.
+pub const LAYOUT: SegmentFileLayout = SegmentFileLayout {
+    primary: ".flat",
+    sidecars: &[],
+    tmp: ".flat.tmp",
+};

--- a/laurus/src/vector/index/flat/segment/merge_engine.rs
+++ b/laurus/src/vector/index/flat/segment/merge_engine.rs
@@ -1,0 +1,192 @@
+//! Merge engine for Flat vector index segments.
+//!
+//! This module handles the actual merging of segments. [`MergeConfig`],
+//! [`MergeStats`], and [`MergeResult`] are the shared, index-type-agnostic
+//! data shapes defined in [`crate::vector::index::segment::merge`]; this
+//! engine's own logic (below) is Flat-typed. Unlike HNSW, Flat has no f32
+//! rerank sidecar (Issue #795 does not apply) and no graph, so a merge is
+//! just: read every live vector from the source segments (newest
+//! generation first, deletion-filtered, deduplicated), then write the
+//! survivors into a new segment.
+
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::storage::Storage;
+use crate::vector::core::vector::Vector;
+
+use crate::vector::index::segment::manager::ManagedSegmentInfo;
+use crate::vector::index::segment::merge::{MergeConfig, MergeResult, MergeStats};
+
+use crate::maintenance::deletion::DeletionBitmap;
+use crate::vector::index::config::FlatIndexConfig;
+use crate::vector::index::flat::reader::FlatVectorIndexReader;
+use crate::vector::index::flat::writer::FlatIndexWriter;
+use crate::vector::reader::VectorIndexReader;
+use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
+
+/// Engine for merging Flat vector index segments.
+pub struct MergeEngine {
+    config: MergeConfig,
+    storage: Arc<dyn Storage>,
+    index_config: FlatIndexConfig,
+    writer_config: VectorIndexWriterConfig,
+    deletion_bitmap: Option<Arc<DeletionBitmap>>,
+}
+
+impl MergeEngine {
+    /// Create a new merge engine.
+    pub fn new(
+        config: MergeConfig,
+        storage: Arc<dyn Storage>,
+        index_config: FlatIndexConfig,
+        writer_config: VectorIndexWriterConfig,
+    ) -> Self {
+        Self {
+            config,
+            storage,
+            index_config,
+            writer_config,
+            deletion_bitmap: None,
+        }
+    }
+
+    /// Set deletion bitmap for filtering deleted vectors during merge.
+    pub fn set_deletion_bitmap(&mut self, bitmap: Arc<DeletionBitmap>) {
+        self.deletion_bitmap = Some(bitmap);
+    }
+
+    /// Merge multiple segments into a single segment.
+    ///
+    /// Reads every live vector from the source segments (deletion-filtered
+    /// via the configured bitmap), deduplicates cross-segment duplicates of
+    /// the same `(doc_id, field)` with **newest-generation wins** semantics
+    /// (Issue #880 — same-id upserts replayed from the WAL land in newer
+    /// segments and must shadow the stale copies), and writes the
+    /// survivors into a new segment.
+    pub fn merge_segments(
+        &self,
+        segments: Vec<ManagedSegmentInfo>,
+        new_segment_id: String,
+    ) -> Result<MergeResult> {
+        let start_time = crate::util::time::Timer::now();
+
+        let segments_merged = segments.len() as u32;
+        #[allow(unused_assignments)]
+        let mut vectors_merged = 0;
+        let mut deletions_removed = 0;
+        let mut duplicates_removed = 0u64;
+
+        let mut all_vectors: Vec<(u64, String, Vector)> = Vec::new();
+
+        // Newest generation FIRST, so the first occurrence of a
+        // `(doc_id, field)` key is the authoritative (newest) copy and every
+        // later one is a stale duplicate (Issue #880).
+        let mut sources = segments.clone();
+        sources.sort_by_key(|s| std::cmp::Reverse(s.generation));
+        let mut seen: std::collections::HashSet<(u64, String)> = std::collections::HashSet::new();
+
+        // 1. Read all live vectors from source segments (newest first).
+        for segment in &sources {
+            let reader = FlatVectorIndexReader::load(
+                self.storage.clone(),
+                &segment.segment_id,
+                self.index_config.distance_metric,
+            )?;
+
+            let mut iterator = reader.vector_iterator()?;
+            while let Some((doc_id, field, vector)) = iterator.next()? {
+                if let Some(bitmap) = &self.deletion_bitmap
+                    && bitmap.is_deleted(doc_id)
+                {
+                    deletions_removed += 1;
+                    continue;
+                }
+                if !seen.insert((doc_id, field.clone())) {
+                    // A newer segment already contributed this key.
+                    duplicates_removed += 1;
+                    continue;
+                }
+                all_vectors.push((doc_id, field, vector));
+            }
+        }
+
+        // 2. Write to new segment.
+        let mut writer = FlatIndexWriter::with_storage(
+            self.index_config.clone(),
+            self.writer_config.clone(),
+            &new_segment_id,
+            self.storage.clone(),
+        )?;
+
+        writer.add_vectors(all_vectors.clone())?;
+        writer.finalize()?;
+        writer.write()?;
+
+        vectors_merged = all_vectors.len() as u64;
+        let total_size = vectors_merged * 128; // Dummy estimate; measured from storage by `add_segment`.
+
+        let merge_time_ms = start_time.elapsed_ms();
+
+        let merged_segment = ManagedSegmentInfo {
+            segment_id: new_segment_id,
+            vector_count: vectors_merged,
+            vector_offset: 0,
+            // The merged output represents data no newer than its newest
+            // source, so it inherits max(source generations) — NOT max+1
+            // (Issue #880): with +1 a merge over non-adjacent sources would
+            // out-rank untouched newer segments, laundering a stale copy
+            // from an old source above a genuinely newer one under the
+            // newest-generation-wins dedup. Generations are unique (stamped
+            // max+1 at flush) and the sources are removed with the merge, so
+            // inheriting the maximum cannot collide with a live segment.
+            generation: segments.iter().map(|s| s.generation).max().unwrap_or(0),
+            has_deletions: false,
+            size_bytes: total_size,
+        };
+
+        let stats = MergeStats {
+            segments_merged,
+            vectors_merged,
+            deletions_removed,
+            duplicates_removed,
+            merge_time_ms,
+            merged_size_bytes: total_size,
+        };
+
+        Ok(MergeResult {
+            merged_segment,
+            stats,
+            merged_segment_ids: segments.iter().map(|s| s.segment_id.clone()).collect(),
+        })
+    }
+
+    /// Get storage reference.
+    pub fn storage(&self) -> &Arc<dyn Storage> {
+        &self.storage
+    }
+
+    /// Get configuration.
+    pub fn config(&self) -> &MergeConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_engine_basic() {
+        let config = MergeConfig::default();
+        let storage = Arc::new(crate::storage::memory::MemoryStorage::new(
+            crate::storage::memory::MemoryStorageConfig::default(),
+        ));
+        let index_config = FlatIndexConfig::default();
+        let writer_config = VectorIndexWriterConfig::default();
+
+        let engine = MergeEngine::new(config, storage, index_config, writer_config);
+
+        assert_eq!(engine.config.max_merge_segments, 10);
+    }
+}

--- a/laurus/src/vector/index/flat/segmented.rs
+++ b/laurus/src/vector/index/flat/segmented.rs
@@ -1,0 +1,805 @@
+//! Segment-per-commit Flat vector index (Issue #889 PR-4, mirroring HNSW's
+//! #634/#882 design — see [`crate::vector::index::hnsw::segmented`]).
+//!
+//! [`SegmentedFlatIndex`] implements [`VectorIndex`] over a set of immutable
+//! per-segment `.flat` files registered in an atomic, checksummed
+//! `segments.json` manifest, instead of the monolithic single-file layout
+//! of [`super::FlatIndex`]: each commit seals only the newly added vectors
+//! as a new segment, turning the per-commit cost from O(index) into
+//! O(new docs) — no full rewrite, no re-quantization of the existing
+//! corpus.
+//!
+//! Search fans out over the sealed segments newest-generation-first with
+//! containment-based newest-wins deduplication (mirroring HNSW's #880): a
+//! hit from an older segment is dropped when any newer segment contains the
+//! same `(doc_id, field)` — same-id upserts replayed from the WAL leave
+//! stale copies behind until a merge physically collapses them. Uncommitted
+//! adds are invisible until commit, matching the monolithic semantics.
+//!
+//! Deletions are logical: a shared index-level [`DeletionBitmap`] is marked
+//! by [`VectorIndex::soft_delete_document`], persisted to `{name}.delmap`
+//! by [`VectorIndex::persist_deletions`], filtered by every segment reader,
+//! and physically reclaimed by [`VectorIndex::optimize`] (a force-merge).
+//! This is a first-time implementation for Flat — the monolithic
+//! [`super::FlatIndex`] has no soft-delete/compaction wiring at all.
+//!
+//! [`FlatIndexConfig::segmented`] defaults to `false` (unlike HNSW's `true`
+//! since #882): Flat's segmented layout has not yet had the same
+//! production exercise, so it ships behind the flag until a follow-up
+//! flips the default (Issue #889 PR-7). A legacy monolithic index is
+//! migrated zero-copy on first open with the flag on (its `.flat` becomes
+//! segment 0 of the manifest, no data movement).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use parking_lot::RwLock;
+
+use crate::embedding::embedder::Embedder;
+use crate::error::{LaurusError, Result};
+use crate::maintenance::deletion::DeletionBitmap;
+use crate::storage::Storage;
+use crate::storage::structured::{StructReader, StructWriter};
+use crate::vector::core::vector::Vector;
+use crate::vector::index::config::FlatIndexConfig;
+use crate::vector::index::flat::reader::FlatVectorIndexReader;
+use crate::vector::index::flat::searcher::FlatVectorSearcher;
+use crate::vector::index::flat::segment::merge_engine::MergeEngine;
+use crate::vector::index::flat::writer::FlatIndexWriter;
+use crate::vector::index::segment::fanout::{SegmentFanoutSearcher, SegmentedReaderFacade};
+use crate::vector::index::segment::manager::{
+    ManagedSegmentInfo, MergeCandidate, SegmentManager, SegmentManagerConfig,
+};
+use crate::vector::index::segment::merge::MergeConfig;
+use crate::vector::index::segment::reader_cache::SegmentedReaderCache;
+use crate::vector::index::{VectorIndex, VectorIndexStats};
+use crate::vector::reader::VectorIndexReader;
+use crate::vector::search::searcher::VectorIndexSearcher;
+use crate::vector::store::embedding_writer::EmbeddingVectorIndexWriter;
+use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
+
+/// State shared between the index handle, its writers, and its searchers.
+#[derive(Debug)]
+struct SegmentedShared {
+    /// Index name — the prefix for the deletion bitmap file. Segment files
+    /// are named by the manager (`segment_NNNNNN.flat`).
+    name: String,
+
+    /// Storage backend.
+    storage: Arc<dyn Storage>,
+
+    /// Segment registry (atomic manifest).
+    manager: Arc<SegmentManager>,
+
+    /// Per-segment reader cache; invalidated on merge.
+    reader_cache: Arc<SegmentedReaderCache<FlatVectorIndexReader>>,
+
+    /// Index-level logical-deletion bitmap (doc-scoped). `None` means "not
+    /// yet loaded / no deletions"; lazily loaded from `{name}.delmap`.
+    deletion: RwLock<Option<Arc<DeletionBitmap>>>,
+
+    /// Bumped when the bitmap is CREATED (first soft delete). Readers cached
+    /// before that moment are not attached to it; the reader-building loop
+    /// re-checks this epoch after populating from the cache and rebuilds if
+    /// a create raced it — clearing the cache alone is not enough, because
+    /// a concurrent build could repopulate it with bitmap-less readers
+    /// after the clear.
+    bitmap_epoch: std::sync::atomic::AtomicU64,
+
+    /// Highest WAL sequence number applied to this index but NOT yet
+    /// published to the manifest. Published (and persisted) by
+    /// [`VectorIndex::persist_deletions`] at the end of the store's commit
+    /// ladder, once every covered mutation is durable.
+    pending_wal_seq: std::sync::atomic::AtomicU64,
+}
+
+impl SegmentedShared {
+    fn delmap_file_name(&self) -> String {
+        format!("{}.delmap", self.name)
+    }
+
+    /// Load (or lazily create) the shared deletion bitmap.
+    ///
+    /// Mirrors `SegmentedHnswIndex`'s bitmap handling. When a bitmap is
+    /// created for the first time, the reader cache is cleared so
+    /// subsequently loaded segment readers attach it (cached readers hold
+    /// the bitmap by `Arc`, so later marks on an *already attached* bitmap
+    /// are always visible).
+    fn load_or_get_bitmap(&self, create_if_missing: bool) -> Result<Option<Arc<DeletionBitmap>>> {
+        if let Some(bitmap) = self.deletion.read().as_ref() {
+            return Ok(Some(bitmap.clone()));
+        }
+
+        let mut guard = self.deletion.write();
+        if let Some(bitmap) = guard.as_ref() {
+            return Ok(Some(bitmap.clone()));
+        }
+
+        let file = self.delmap_file_name();
+        if self.storage.file_exists(&file) {
+            let input = self.storage.open_input(&file)?;
+            let mut reader = StructReader::new(input)?;
+            let bitmap = Arc::new(DeletionBitmap::read_from_storage(&mut reader)?);
+            *guard = Some(bitmap.clone());
+            return Ok(Some(bitmap));
+        }
+
+        if create_if_missing {
+            let bitmap = Arc::new(DeletionBitmap::new(self.name.clone(), 0, u64::MAX - 1));
+            *guard = Some(bitmap.clone());
+            self.reader_cache.clear();
+            self.bitmap_epoch.fetch_add(1, Ordering::Release);
+            return Ok(Some(bitmap));
+        }
+
+        Ok(None)
+    }
+
+    /// Sealed segment readers, newest generation first, with the deletion
+    /// bitmap attached.
+    fn sealed_readers_newest_first(
+        &self,
+        config: &FlatIndexConfig,
+    ) -> Result<Vec<Arc<FlatVectorIndexReader>>> {
+        let mut segments = self.manager.list_segments();
+        segments.sort_by_key(|s| std::cmp::Reverse(s.generation));
+
+        loop {
+            let epoch = self.bitmap_epoch.load(Ordering::Acquire);
+            let bitmap = self.load_or_get_bitmap(false)?;
+            let mut readers = Vec::with_capacity(segments.len());
+            for info in &segments {
+                let storage = self.storage.clone();
+                let metric = config.distance_metric;
+                let bitmap_for_loader = bitmap.clone();
+                let segment_id = info.segment_id.clone();
+                let reader = self.reader_cache.get_or_load(&segment_id, || {
+                    let mut r = FlatVectorIndexReader::load(storage, &segment_id, metric)?;
+                    if let Some(b) = bitmap_for_loader {
+                        r.set_deletion_bitmap(b);
+                    }
+                    Ok(r)
+                })?;
+                readers.push(reader);
+            }
+            // A bitmap create that raced this build may have been missed by
+            // readers loaded from our (pre-create) snapshot; the epoch bump
+            // detects it. Creation happens at most once per index lifetime,
+            // so the loop reruns at most once.
+            if self.bitmap_epoch.load(Ordering::Acquire) == epoch {
+                return Ok(readers);
+            }
+            self.reader_cache.clear();
+        }
+    }
+}
+
+/// Segment-per-commit Flat index (see the module docs).
+#[derive(Debug)]
+pub struct SegmentedFlatIndex {
+    shared: Arc<SegmentedShared>,
+    config: FlatIndexConfig,
+    closed: AtomicBool,
+}
+
+impl SegmentedFlatIndex {
+    /// Open an existing segmented index or create a new one.
+    ///
+    /// # Arguments
+    ///
+    /// * `storage` - Storage backend.
+    /// * `name` - Index name (bitmap file prefix; segment files are named
+    ///   by the segment manager).
+    /// * `config` - Flat configuration (with [`FlatIndexConfig::segmented`]
+    ///   set).
+    ///
+    /// A legacy monolithic index is migrated **zero-copy**: the existing
+    /// `{name}.flat` is registered verbatim as the first segment — its
+    /// segment id is the index name, which every reader treats as a plain
+    /// path prefix — with a single atomic manifest write and no data
+    /// movement. A crash before the manifest save leaves the legacy layout
+    /// intact, so the migration simply re-runs on the next open. The
+    /// pre-existing `{name}.delmap` keeps its meaning: it is the
+    /// index-level deletion bitmap in both layouts (and
+    /// `delete_segment_files` never touches `.delmap` files for exactly
+    /// this reason).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the manifest fails to load (corruption fails
+    /// loudly), when reading the legacy file's header during migration
+    /// fails, or when the legacy file's persisted dimension does not match
+    /// `config.dimension` (closing a dimension-validation gap that HNSW's
+    /// own segmented adapter still has).
+    pub fn open_or_create(
+        storage: Arc<dyn Storage>,
+        name: &str,
+        config: FlatIndexConfig,
+    ) -> Result<Self> {
+        // The generated-segment namespace is reserved: an index named like
+        // a generated id would collide with sealed segments (same file
+        // names, orphan-sweep patterns, and merge GC) — reject it loudly.
+        if let Some(ordinal) = name.strip_prefix("segment_")
+            && !ordinal.is_empty()
+            && ordinal.bytes().all(|b| b.is_ascii_digit())
+        {
+            return Err(LaurusError::invalid_config(format!(
+                "index name '{name}' collides with the reserved segment-id \
+                 namespace (segment_<digits>)"
+            )));
+        }
+
+        let legacy_file = format!("{name}.flat");
+        let migrate = storage.file_exists(&legacy_file) && !storage.file_exists("segments.json");
+
+        // The manager's orphan sweep only touches `segment_NNNNNN.*` names,
+        // so an unmigrated `{name}.flat` is never swept.
+        let manager = Arc::new(SegmentManager::new(
+            SegmentManagerConfig::default(),
+            storage.clone(),
+            crate::vector::index::flat::segment::LAYOUT,
+        )?);
+
+        if migrate {
+            // Read the committed vector count (u32 — Flat's header, unlike
+            // HNSW's u64) and dimension from the legacy file's leading
+            // fields (same header every reader loads).
+            let (vector_count, dimension) = {
+                use std::io::Read;
+                let mut input = storage.open_input(&legacy_file)?;
+                let mut count_buf = [0u8; 4];
+                input.read_exact(&mut count_buf)?;
+                let mut dim_buf = [0u8; 4];
+                input.read_exact(&mut dim_buf)?;
+                (
+                    u32::from_le_bytes(count_buf) as u64,
+                    u32::from_le_bytes(dim_buf) as usize,
+                )
+            };
+            if dimension != config.dimension {
+                return Err(LaurusError::index(format!(
+                    "Dimension mismatch during migration: stored {dimension}, config {}",
+                    config.dimension
+                )));
+            }
+            // `add_segment` stamps generation 1, measures the on-storage
+            // size, and saves the manifest atomically — the moment it
+            // returns, the index is segmented; before that, it is still a
+            // valid legacy index. A legacy delmap (same file in both
+            // layouts) means the segment carries deletions.
+            let mut info = ManagedSegmentInfo::new(name.to_string(), vector_count, 0, 0);
+            info.has_deletions = storage.file_exists(&format!("{name}.delmap"));
+            manager.add_segment(info)?;
+
+            // Drop the monolithic index's now-stale `metadata.json` so the
+            // factory's open/create routing can never again mistake this
+            // directory for a monolithic index (mirrors HNSW's #882
+            // review fix).
+            let _ = storage.delete_file("metadata.json");
+        }
+
+        Ok(Self {
+            shared: Arc::new(SegmentedShared {
+                name: name.to_string(),
+                storage,
+                manager,
+                reader_cache: Arc::new(SegmentedReaderCache::new()),
+                deletion: RwLock::new(None),
+                bitmap_epoch: std::sync::atomic::AtomicU64::new(0),
+                pending_wal_seq: std::sync::atomic::AtomicU64::new(0),
+            }),
+            config,
+            closed: AtomicBool::new(false),
+        })
+    }
+
+    fn check_closed(&self) -> Result<()> {
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(LaurusError::InvalidOperation("Index is closed".to_string()));
+        }
+        Ok(())
+    }
+
+    /// Merge one policy-selected window of segments.
+    ///
+    /// Uses the generation-contiguous, size-similar `TieredMergePolicy`
+    /// through the deletion-filtering, duplicate-collapsing merge engine;
+    /// source readers are invalidated afterwards. Returns whether a merge
+    /// actually ran.
+    fn merge_once(&self) -> Result<bool> {
+        use crate::vector::index::segment::merge_policy::TieredMergePolicy;
+
+        let Some(candidate) = self.shared.manager.check_merge(&TieredMergePolicy::new()) else {
+            return Ok(false);
+        };
+
+        let mut engine = MergeEngine::new(
+            MergeConfig::default(),
+            self.shared.storage.clone(),
+            self.config.clone(),
+            VectorIndexWriterConfig::default(),
+        );
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(false)? {
+            engine.set_deletion_bitmap(bitmap);
+        }
+
+        let new_segment_id = self.shared.manager.generate_segment_id();
+        let result = engine.merge_segments(candidate.segments.clone(), new_segment_id)?;
+
+        let source_ids: Vec<String> = candidate
+            .segments
+            .iter()
+            .map(|s| s.segment_id.clone())
+            .collect();
+        self.shared
+            .manager
+            .apply_merge(candidate, result.merged_segment)?;
+        for id in &source_ids {
+            self.shared.reader_cache.invalidate(id);
+        }
+        Ok(true)
+    }
+
+    /// Drop the deletion state after a compaction physically reclaimed the
+    /// deleted documents.
+    fn clear_deletions(&self) -> Result<()> {
+        *self.shared.deletion.write() = None;
+        let file = self.shared.delmap_file_name();
+        let _ = self.shared.storage.delete_file(&file);
+        Ok(())
+    }
+}
+
+impl VectorIndex for SegmentedFlatIndex {
+    fn reader(&self) -> Result<Arc<dyn VectorIndexReader>> {
+        self.check_closed()?;
+        let readers = self.shared.sealed_readers_newest_first(&self.config)?;
+        let readers: Vec<Arc<dyn VectorIndexReader>> = readers
+            .into_iter()
+            .map(|r| r as Arc<dyn VectorIndexReader>)
+            .collect();
+        let bitmap = self.shared.load_or_get_bitmap(false)?;
+        Ok(Arc::new(SegmentedReaderFacade::new(
+            readers,
+            bitmap,
+            self.config.dimension,
+            self.config.distance_metric,
+        )))
+    }
+
+    fn writer(&self) -> Result<Box<dyn VectorIndexWriter>> {
+        self.check_closed()?;
+
+        // A fresh, EMPTY active-segment writer per call: constructing it does
+        // not touch the existing segments — the whole point of the layout.
+        let segment_id = self.shared.manager.generate_segment_id();
+        let inner = FlatIndexWriter::with_storage(
+            self.config.clone(),
+            VectorIndexWriterConfig::default(),
+            &segment_id,
+            self.shared.storage.clone(),
+        )?;
+        let writer = SegmentedFlatWriter {
+            shared: self.shared.clone(),
+            segment_id,
+            inner,
+            sealed_len: None,
+        };
+        let embedder = self.embedder();
+        Ok(Box::new(EmbeddingVectorIndexWriter::new(
+            Box::new(writer),
+            embedder,
+        )))
+    }
+
+    fn storage(&self) -> &Arc<dyn Storage> {
+        &self.shared.storage
+    }
+
+    fn close(&self) -> Result<()> {
+        self.closed.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::SeqCst)
+    }
+
+    fn stats(&self) -> Result<VectorIndexStats> {
+        self.check_closed()?;
+        // `total` sums per-segment row counts: stale same-id upsert copies
+        // awaiting a merge are counted once per segment, so this (and the
+        // auto-compaction ratio derived from it) slightly over-counts until
+        // the next merge. Exact distinct-key counting would cost O(total
+        // ids) per call; the approximation is intentional (mirrors HNSW).
+        let total = self.shared.manager.total_vectors();
+        let deleted = match self.shared.load_or_get_bitmap(false)? {
+            Some(bitmap) => bitmap.deleted_count.load(Ordering::Relaxed),
+            None => 0,
+        };
+        let stats = self.shared.manager.stats();
+        Ok(VectorIndexStats {
+            vector_count: total.saturating_sub(deleted),
+            dimension: self.config.dimension,
+            total_size: stats.total_size,
+            deleted_count: deleted,
+            last_modified: 0,
+        })
+    }
+
+    fn retain_writer_after_commit(&self) -> bool {
+        // Retention exists only to avoid a monolithic writer's O(index)
+        // reload after commit. A segmented writer starts EMPTY — there is
+        // nothing to reload — so the store can drop it and construct a
+        // fresh one per commit cycle; each commit then seals exactly one
+        // new segment.
+        false
+    }
+
+    fn optimize(&self) -> Result<()> {
+        self.check_closed()?;
+
+        let segments = self.shared.manager.list_segments();
+        if segments.is_empty() {
+            return Ok(());
+        }
+        // Force-merge everything into one segment; the merge engine filters
+        // through the deletion bitmap (physical reclamation) and collapses
+        // same-key duplicates newest-generation-first.
+        let mut engine = MergeEngine::new(
+            MergeConfig::default(),
+            self.shared.storage.clone(),
+            self.config.clone(),
+            VectorIndexWriterConfig::default(),
+        );
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(false)? {
+            engine.set_deletion_bitmap(bitmap);
+        }
+
+        let new_segment_id = self.shared.manager.generate_segment_id();
+        let result = engine.merge_segments(segments.clone(), new_segment_id)?;
+
+        let candidate = MergeCandidate {
+            total_vectors: segments.iter().map(|s| s.vector_count).sum(),
+            total_size: segments.iter().map(|s| s.size_bytes).sum(),
+            segments,
+        };
+        let source_ids: Vec<String> = candidate
+            .segments
+            .iter()
+            .map(|s| s.segment_id.clone())
+            .collect();
+        self.shared
+            .manager
+            .apply_merge(candidate, result.merged_segment)?;
+        for id in &source_ids {
+            self.shared.reader_cache.invalidate(id);
+        }
+
+        // Every logically deleted doc was physically dropped by the merge.
+        self.clear_deletions()?;
+        Ok(())
+    }
+
+    // `refresh` keeps its trait default (no-op), like the monolithic index:
+    // sealed segment files are immutable, segment-set changes are picked up
+    // from the shared manager on every `searcher()`/`reader()` call, and
+    // merges invalidate their source readers explicitly. Clearing the reader
+    // cache here would force an O(all segments) reload on every commit —
+    // defeating the O(delta) design this index exists for.
+
+    fn searcher(&self) -> Result<Box<dyn VectorIndexSearcher>> {
+        self.check_closed()?;
+        let readers = self.shared.sealed_readers_newest_first(&self.config)?;
+        let readers: Vec<Arc<dyn VectorIndexReader>> = readers
+            .into_iter()
+            .map(|r| r as Arc<dyn VectorIndexReader>)
+            .collect();
+        let bitmap = self.shared.load_or_get_bitmap(false)?;
+        Ok(Box::new(SegmentFanoutSearcher::new(
+            readers,
+            bitmap,
+            move |reader| {
+                Ok(Box::new(FlatVectorSearcher::new(reader)?) as Box<dyn VectorIndexSearcher>)
+            },
+        )))
+    }
+
+    fn embedder(&self) -> Arc<dyn Embedder> {
+        Arc::clone(&self.config.embedder)
+    }
+
+    fn last_wal_seq(&self) -> u64 {
+        // The PUBLISHED checkpoint: the value loaded from (or last saved
+        // to) the manifest — never the pending one, which may not be
+        // durable yet. Recovery skips WAL records at or below this seq, so
+        // it must only ever reflect state that is already on storage.
+        self.shared.manager.last_wal_seq()
+    }
+
+    fn set_last_wal_seq(&self, seq: u64) -> Result<()> {
+        // Recorded as PENDING only. It is published into the manifest at
+        // the end of `persist_deletions` — the last vector step of the
+        // store's commit ladder — at which point the sealed segment files
+        // AND the deletion bitmap for every record up to `seq` are
+        // durable, and the engine has not yet truncated the WAL (a
+        // checkpoint must never outrun the durability of the state it
+        // covers).
+        self.shared
+            .pending_wal_seq
+            .fetch_max(seq, Ordering::Release);
+        Ok(())
+    }
+
+    fn supports_soft_delete(&self) -> bool {
+        true
+    }
+
+    fn soft_delete_document(&self, doc_id: u64) -> Result<()> {
+        self.check_closed()?;
+        let bitmap = self
+            .shared
+            .load_or_get_bitmap(true)?
+            .ok_or_else(|| LaurusError::internal("deletion bitmap unexpectedly missing"))?;
+        let newly_deleted = bitmap.delete_document(doc_id)?;
+        if newly_deleted && !self.shared.manager.list_segments().is_empty() {
+            // Conservative-all flagging: segment infos carry no doc-id
+            // range, and the flag only feeds merge-policy prioritization.
+            self.shared.manager.mark_all_has_deletions()?;
+        }
+        Ok(())
+    }
+
+    fn persist_deletions(&self) -> Result<()> {
+        let guard = self.shared.deletion.read();
+        if let Some(bitmap) = guard.as_ref() {
+            let file = self.shared.delmap_file_name();
+            if bitmap.deleted_count.load(Ordering::Relaxed) > 0 {
+                // Temp-then-rename for crash safety; the payload is CRC-32
+                // protected by `StructWriter`.
+                let tmp = format!("{file}.tmp");
+                let output = self.shared.storage.create_output(&tmp)?;
+                let mut writer = StructWriter::new(output);
+                bitmap.write_to_storage(&mut writer)?;
+                writer.close()?;
+                self.shared.storage.rename_file(&tmp, &file)?;
+            } else if self.shared.storage.file_exists(&file) {
+                // Undelete-to-zero: the upsert dance's re-add can clear
+                // every mark, and a previously persisted delmap would then
+                // be STALE — on reopen it would mask the committed upsert
+                // in every segment. "Nothing deleted" must persist as "no
+                // delmap file", not "keep whatever file exists".
+                self.shared.storage.delete_file(&file)?;
+            }
+        }
+        drop(guard);
+
+        // Publish the WAL checkpoint. This is the last vector step of the
+        // store's commit ladder: the sealed segment files (fsynced +
+        // manifest-registered by `writer.commit()`) and the deletion
+        // bitmap (written above) are durable for every record up to the
+        // pending seq, and `Engine::commit` truncates the WAL only after
+        // all stores finish — so a crash on either side of this save is
+        // safe: before it, recovery replays idempotently from the old
+        // checkpoint; after it, everything skipped is already on storage.
+        let pending = self.shared.pending_wal_seq.load(Ordering::Acquire);
+        if pending > self.shared.manager.last_wal_seq() {
+            self.shared.manager.set_last_wal_seq(pending);
+            self.shared.manager.save_state()?;
+        }
+        Ok(())
+    }
+
+    fn maybe_auto_compact(&self) -> Result<bool> {
+        // Tiered auto-merge: the policy itself is the trigger — it returns
+        // a candidate when a generation-contiguous, size-similar window
+        // fills up (steady-state: every `merge_factor` commits the newest
+        // tier collapses upward, giving each vector O(log N) rewrites over
+        // its lifetime) or when the hard segment-count bound is exceeded.
+        // Runs regardless of `auto_compaction`, which gates deletion
+        // *reclamation*, not the structural segment bound.
+        if self.merge_once()? {
+            return Ok(true);
+        }
+
+        if !self.config.auto_compaction {
+            return Ok(false);
+        }
+        let deleted = match self.shared.load_or_get_bitmap(false)? {
+            Some(bitmap) => bitmap.deleted_count.load(Ordering::Relaxed),
+            None => 0,
+        };
+        if deleted == 0 {
+            return Ok(false);
+        }
+        let total = self.shared.manager.total_vectors();
+        if total == 0 {
+            return Ok(false);
+        }
+        let ratio = deleted as f64 / total as f64;
+        if ratio >= self.config.compaction_threshold {
+            self.optimize()?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+}
+
+/// Active-segment writer for [`SegmentedFlatIndex`].
+///
+/// Buffers new vectors in an ordinary [`FlatIndexWriter`] whose path is a
+/// fresh `segment_NNNNNN`; [`VectorIndexWriter::commit`] seals it as a new
+/// immutable segment file and registers it in the manifest exactly once. A
+/// sealed writer is DONE: committing again with new changes is rejected —
+/// re-writing a registered segment would carry its original generation
+/// while newer segments may have sealed in between, inverting the
+/// newest-wins ordering. The store never does this
+/// (`retain_writer_after_commit` is false); direct API users get a loud
+/// error instead of silent metadata corruption.
+#[derive(Debug)]
+struct SegmentedFlatWriter {
+    shared: Arc<SegmentedShared>,
+    segment_id: String,
+    inner: FlatIndexWriter,
+    /// Buffer length at the moment this writer's segment was sealed and
+    /// registered; `None` until then. Used to make the post-commit
+    /// `close()` a no-op (the inner buffer is retained after commit, so a
+    /// plain "buffer non-empty" check would re-enter `commit`).
+    sealed_len: Option<usize>,
+}
+
+impl VectorIndexWriter for SegmentedFlatWriter {
+    fn next_vector_id(&self) -> u64 {
+        self.inner.next_vector_id()
+    }
+
+    fn build(&mut self, vectors: Vec<(u64, String, Vector)>) -> Result<()> {
+        self.add_vectors(vectors)
+    }
+
+    fn add_vectors(&mut self, vectors: Vec<(u64, String, Vector)>) -> Result<()> {
+        // Same-id upsert completion: the delete-first step marked the ids
+        // so sealed copies stop matching; clear the marks so the NEW
+        // copies are not shadowed by their own delete once this segment
+        // seals. Revived stale copies are masked by newest-wins containment
+        // at search and collapsed at merge.
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(false)? {
+            for (doc_id, _, _) in &vectors {
+                let _ = bitmap.undelete_document(*doc_id)?;
+            }
+        }
+        self.inner.add_vectors(vectors)
+    }
+
+    fn finalize(&mut self) -> Result<()> {
+        self.inner.finalize()
+    }
+
+    fn progress(&self) -> f32 {
+        self.inner.progress()
+    }
+
+    fn estimated_memory_usage(&self) -> usize {
+        self.inner.estimated_memory_usage()
+    }
+
+    fn vectors(&self) -> &[(u64, String, Vector)] {
+        self.inner.vectors()
+    }
+
+    fn write(&self) -> Result<()> {
+        if self.inner.vectors().is_empty() {
+            // Nothing buffered — sealing would create an empty segment file
+            // per commit. Deletion persistence is handled by
+            // `persist_deletions` on the index.
+            return Ok(());
+        }
+        // Writes `{segment_id}.flat`; manifest registration happens in
+        // `commit()` (`&mut self`), which is the store's entry point.
+        self.inner.write()
+    }
+
+    fn has_storage(&self) -> bool {
+        self.inner.has_storage()
+    }
+
+    fn delete_document(&mut self, doc_id: u64) -> Result<()> {
+        // Upsert delete-first: remove any buffered copy AND mark the
+        // shared bitmap so copies in sealed segments stop matching. A pure
+        // delete stays marked; a following `add_vectors` with the same id
+        // clears the mark.
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(true)? {
+            let newly_deleted = bitmap.delete_document(doc_id)?;
+            if newly_deleted && !self.shared.manager.list_segments().is_empty() {
+                self.shared.manager.mark_all_has_deletions()?;
+            }
+        }
+        let _ = self.inner.delete_document(doc_id);
+        Ok(())
+    }
+
+    fn has_pending_changes(&self) -> bool {
+        match self.sealed_len {
+            // Sealed: pending only if the buffer changed since the seal.
+            Some(sealed) => self.inner.vectors().len() != sealed,
+            None => !self.inner.vectors().is_empty(),
+        }
+    }
+
+    fn commit(&mut self) -> Result<()> {
+        if self.inner.vectors().is_empty() {
+            return Ok(());
+        }
+        if let Some(sealed) = self.sealed_len {
+            if self.inner.vectors().len() == sealed {
+                // Post-commit close(): the segment is already sealed and the
+                // buffer is unchanged — nothing to do.
+                return Ok(());
+            }
+            // See the struct docs: re-sealing a registered segment would
+            // invert the newest-wins generation ordering.
+            return Err(LaurusError::InvalidOperation(format!(
+                "segment '{}' is already sealed; obtain a fresh writer for further changes",
+                self.segment_id
+            )));
+        }
+        self.inner.finalize()?;
+        self.inner.write()?;
+        let vector_count = self.inner.vectors().len() as u64;
+        // generation 0 → the manager stamps max+1; size_bytes 0 → measured
+        // from storage by `add_segment`.
+        let info = ManagedSegmentInfo::new(self.segment_id.clone(), vector_count, 0, 0);
+        self.shared.manager.add_segment(info)?;
+        self.sealed_len = Some(self.inner.vectors().len());
+        self.shared.reader_cache.invalidate(&self.segment_id);
+        Ok(())
+    }
+
+    fn rollback(&mut self) -> Result<()> {
+        // Rolled-back mutations are discarded, so the pending WAL
+        // checkpoint must not keep covering their sequence numbers: roll
+        // it back to the published value; their WAL records then stay
+        // replayable.
+        self.shared
+            .pending_wal_seq
+            .store(self.shared.manager.last_wal_seq(), Ordering::Release);
+        self.inner.rollback()
+    }
+
+    fn pending_docs(&self) -> u64 {
+        self.inner.pending_docs()
+    }
+
+    fn close(&mut self) -> Result<()> {
+        if self.has_pending_changes() {
+            self.commit()?;
+        }
+        self.inner.close()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    fn build_reader(&self) -> Result<Arc<dyn VectorIndexReader>> {
+        self.inner.build_reader()
+    }
+}
+
+impl Drop for SegmentedFlatWriter {
+    fn drop(&mut self) {
+        // Backstop: dropping a writer whose buffered mutations were never
+        // sealed discards the only in-process copy, while the pending WAL
+        // checkpoint may already cover their sequence numbers — publishing
+        // it later would hide the loss from recovery. Roll the pending
+        // value back to the published checkpoint so those records stay
+        // replayable. The store never drops a dirty writer (its
+        // commit/optimize/add_field paths retain it on failure), so this
+        // fires only on direct API use.
+        if self.has_pending_changes() {
+            self.shared
+                .pending_wal_seq
+                .store(self.shared.manager.last_wal_seq(), Ordering::Release);
+        }
+    }
+}

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -136,6 +136,11 @@ impl VectorStore {
                         // distances.
                         normalize_vectors: opt.distance
                             == crate::vector::core::distance::DistanceMetric::Cosine,
+                        // Wire the deletion config's compaction policy into
+                        // the index so commit can auto-compact under the
+                        // segmented layout (Issue #889, mirroring HNSW/#782).
+                        auto_compaction: config.deletion_config.auto_compaction,
+                        compaction_threshold: config.deletion_config.compaction_threshold,
                         embedder: config.embedder.clone(),
                         ..Default::default()
                     }),

--- a/laurus/tests/common/mod.rs
+++ b/laurus/tests/common/mod.rs
@@ -1,0 +1,120 @@
+//! Shared test helpers for integration tests (Issue #889 PR-4).
+//!
+//! `tests/common/mod.rs` (not `tests/common.rs`) is the standard Cargo idiom
+//! for code shared between integration test binaries without being picked
+//! up as its own test target.
+
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use laurus::storage::{Storage, StorageInput, StorageOutput};
+
+/// Storage decorator counting every byte written through `create_output`
+/// (including rewrites — file sizes alone cannot see them).
+///
+/// Originated in the #634 HNSW segment-per-commit campaign
+/// (`vector_segmented_index_test.rs`); moved here in #889 PR-4 so Flat's
+/// (and IVF's, in PR-6) segmented gates can reuse it instead of copying it
+/// a third time.
+#[derive(Debug)]
+pub struct ByteCountingStorage {
+    inner: Arc<dyn Storage>,
+    pub written: Arc<AtomicU64>,
+}
+
+impl ByteCountingStorage {
+    pub fn new(inner: Arc<dyn Storage>) -> Self {
+        Self {
+            inner,
+            written: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CountingOutput {
+    inner: Box<dyn StorageOutput>,
+    written: Arc<AtomicU64>,
+}
+
+impl Write for CountingOutput {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.written.fetch_add(n as u64, Ordering::Relaxed);
+        Ok(n)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl std::io::Seek for CountingOutput {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
+impl StorageOutput for CountingOutput {
+    fn flush_and_sync(&mut self) -> laurus::Result<()> {
+        self.inner.flush_and_sync()
+    }
+    fn position(&self) -> laurus::Result<u64> {
+        self.inner.position()
+    }
+    fn close(&mut self) -> laurus::Result<()> {
+        self.inner.close()
+    }
+}
+
+impl Storage for ByteCountingStorage {
+    fn open_input(&self, name: &str) -> laurus::Result<Box<dyn StorageInput>> {
+        self.inner.open_input(name)
+    }
+    fn create_output(&self, name: &str) -> laurus::Result<Box<dyn StorageOutput>> {
+        Ok(Box::new(CountingOutput {
+            inner: self.inner.create_output(name)?,
+            written: self.written.clone(),
+        }))
+    }
+    fn create_output_append(&self, name: &str) -> laurus::Result<Box<dyn StorageOutput>> {
+        Ok(Box::new(CountingOutput {
+            inner: self.inner.create_output_append(name)?,
+            written: self.written.clone(),
+        }))
+    }
+    fn delete_file(&self, name: &str) -> laurus::Result<()> {
+        self.inner.delete_file(name)
+    }
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+    fn list_files(&self) -> laurus::Result<Vec<String>> {
+        self.inner.list_files()
+    }
+    fn file_size(&self, name: &str) -> laurus::Result<u64> {
+        self.inner.file_size(name)
+    }
+    fn rename_file(&self, from: &str, to: &str) -> laurus::Result<()> {
+        self.inner.rename_file(from, to)
+    }
+    fn metadata(&self, name: &str) -> laurus::Result<laurus::storage::FileMetadata> {
+        self.inner.metadata(name)
+    }
+    fn create_temp_output(&self, prefix: &str) -> laurus::Result<(String, Box<dyn StorageOutput>)> {
+        let (name, output) = self.inner.create_temp_output(prefix)?;
+        Ok((
+            name,
+            Box::new(CountingOutput {
+                inner: output,
+                written: self.written.clone(),
+            }),
+        ))
+    }
+    fn sync(&self) -> laurus::Result<()> {
+        self.inner.sync()
+    }
+    fn close(&mut self) -> laurus::Result<()> {
+        Ok(())
+    }
+}

--- a/laurus/tests/vector_segmented_flat_test.rs
+++ b/laurus/tests/vector_segmented_flat_test.rs
@@ -1,11 +1,12 @@
-//! Gates for the segment-per-commit HNSW index (#634 PR-3 / #881).
+//! Gates for the segment-per-commit Flat index (Issue #889 PR-4, mirroring
+//! `vector_segmented_index_test.rs`'s HNSW gates).
 //!
 //! The deterministic core gate: committing 1 new document on an N-document
 //! base writes O(delta) bytes — a new small segment file plus the manifest —
 //! never a rewrite of the existing segments. Plus: config-OFF invariance
-//! (the monolithic layout stays byte-identical), legacy-index rejection
-//! (zero-copy migration is #882), multi-segment recall parity, and
-//! upsert/delete semantics across commits.
+//! (the monolithic layout stays byte-identical), legacy-index rejection,
+//! zero-copy migration, multi-segment recall parity, and the first-time
+//! soft-delete/compaction lifecycle for Flat.
 
 mod common;
 
@@ -14,9 +15,9 @@ use std::sync::Arc;
 use laurus::storage::Storage;
 use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
 use laurus::vector::index::VectorIndex;
-use laurus::vector::index::config::HnswIndexConfig;
-use laurus::vector::index::hnsw::HnswIndex;
-use laurus::vector::index::hnsw::segmented::SegmentedHnswIndex;
+use laurus::vector::index::config::FlatIndexConfig;
+use laurus::vector::index::flat::FlatIndex;
+use laurus::vector::index::flat::segmented::SegmentedFlatIndex;
 use laurus::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryParams};
 use laurus::vector::{DistanceMetric, Vector};
 
@@ -30,11 +31,9 @@ fn doc_vec(i: u64) -> Vector {
     Vector::new(v)
 }
 
-fn config(segmented: bool) -> HnswIndexConfig {
-    HnswIndexConfig {
+fn config(segmented: bool) -> FlatIndexConfig {
+    FlatIndexConfig {
         dimension: 16,
-        m: 16,
-        ef_construction: 100,
         normalize_vectors: false,
         distance_metric: DistanceMetric::Cosine,
         segmented,
@@ -66,12 +65,12 @@ fn query(id: u64, top_k: usize) -> VectorIndexQuery {
     }
 }
 
-/// #881 core gate: a 1-doc commit on a 1000-doc base writes a new segment
-/// that is a tiny fraction of the base segment, and never rewrites the base.
+/// Core gate: a 1-doc commit on a 1000-doc base writes a new segment that is
+/// a tiny fraction of the base segment, and never rewrites the base.
 #[test]
 fn one_doc_commit_writes_o_delta_bytes() {
     let storage = storage();
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -79,11 +78,11 @@ fn one_doc_commit_writes_o_delta_bytes() {
     .unwrap();
 
     commit_batch(&index, 0..1000);
-    let base_file = "segment_000000.hnsw";
+    let base_file = "segment_000000.flat";
     let base_size = storage.file_size(base_file).unwrap();
 
     commit_batch(&index, 1000..1001);
-    let delta_file = "segment_000001.hnsw";
+    let delta_file = "segment_000001.flat";
     let delta_size = storage.file_size(delta_file).unwrap();
 
     assert!(
@@ -93,29 +92,28 @@ fn one_doc_commit_writes_o_delta_bytes() {
     assert_eq!(
         storage.file_size(base_file).unwrap(),
         base_size,
-        "the base segment must never be rewritten by a later commit (#634)"
+        "the base segment must never be rewritten by a later commit"
     );
 
-    // Exactly the two sealed segments exist — no other .hnsw files.
-    let hnsw_files: Vec<String> = storage
+    let flat_files: Vec<String> = storage
         .list_files()
         .unwrap()
         .into_iter()
-        .filter(|f| f.ends_with(".hnsw"))
+        .filter(|f| f.ends_with(".flat"))
         .collect();
     assert_eq!(
-        hnsw_files.len(),
+        flat_files.len(),
         2,
-        "exactly one new segment per non-empty commit, got {hnsw_files:?}"
+        "exactly one new segment per non-empty commit, got {flat_files:?}"
     );
 }
 
-/// #881: with `segmented: false` (the default) the factory path stays
-/// monolithic — no manifest, single `.hnsw` file.
+/// With `segmented: false` (the default for Flat) the factory path stays
+/// monolithic — no manifest, single `.flat` file.
 #[test]
 fn config_off_keeps_monolithic_layout() {
     let storage = storage();
-    let index = HnswIndex::create(
+    let index = FlatIndex::create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(false),
@@ -127,18 +125,18 @@ fn config_off_keeps_monolithic_layout() {
         !storage.file_exists("segments.json"),
         "config OFF must not create a segment manifest"
     );
-    assert!(storage.file_exists("vector_index.hnsw"));
+    assert!(storage.file_exists("vector_index.flat"));
 }
 
-/// #882: a legacy monolithic index is migrated ZERO-COPY on first segmented
-/// open — the existing `.hnsw` becomes segment 0 verbatim (no data
-/// movement), search results are identical, and later commits append new
-/// segments without ever touching the legacy file.
+/// A legacy monolithic index is migrated ZERO-COPY on first segmented open
+/// — the existing `.flat` becomes segment 0 verbatim (no data movement),
+/// search results are identical, and later commits append new segments
+/// without ever touching the legacy file.
 #[test]
 fn legacy_monolithic_index_migrates_zero_copy() {
     let storage = storage();
     {
-        let index = HnswIndex::create(
+        let index = FlatIndex::create(
             storage.clone() as Arc<dyn Storage>,
             "vector_index",
             config(false),
@@ -146,32 +144,28 @@ fn legacy_monolithic_index_migrates_zero_copy() {
         .unwrap();
         commit_batch(&index, 0..100);
     }
-    let legacy_size = storage.file_size("vector_index.hnsw").unwrap();
+    let legacy_size = storage.file_size("vector_index.flat").unwrap();
 
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(true),
     )
     .unwrap();
 
-    // Migration wrote only the manifest; the legacy file is untouched.
     assert!(storage.file_exists("segments.json"), "manifest created");
     assert_eq!(
-        storage.file_size("vector_index.hnsw").unwrap(),
+        storage.file_size("vector_index.flat").unwrap(),
         legacy_size,
-        "zero-copy: the legacy file must not be rewritten (#882)"
+        "zero-copy: the legacy file must not be rewritten"
     );
 
-    // The migrated data is searchable...
     let searcher = index.searcher().unwrap();
     let results = searcher.search(&query(42, 1)).unwrap();
     assert_eq!(results.results[0].doc_id, 42);
 
-    // ...and a later commit appends a NEW segment, still leaving the legacy
-    // file untouched.
     commit_batch(&index, 100..101);
-    assert_eq!(storage.file_size("vector_index.hnsw").unwrap(), legacy_size);
+    assert_eq!(storage.file_size("vector_index.flat").unwrap(), legacy_size);
     let searcher = index.searcher().unwrap();
     assert_eq!(
         searcher.search(&query(100, 1)).unwrap().results[0].doc_id,
@@ -182,10 +176,10 @@ fn legacy_monolithic_index_migrates_zero_copy() {
         42
     );
 
-    // Re-open: the migration must not re-run (idempotent — the manifest
-    // already exists) and everything stays searchable.
+    // Re-open: the migration must not re-run (idempotent) and everything
+    // stays searchable.
     drop(index);
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -202,13 +196,13 @@ fn legacy_monolithic_index_migrates_zero_copy() {
     );
 }
 
-/// #882: the WAL checkpoint is published only by `persist_deletions` (the
-/// end of the store's commit ladder) — never by intermediate manifest saves
-/// — so recovery can only skip records whose effects are already durable.
+/// The WAL checkpoint is published only by `persist_deletions` (the end of
+/// the store's commit ladder) — never by intermediate manifest saves — so
+/// recovery can only skip records whose effects are already durable.
 #[test]
 fn wal_checkpoint_publishes_only_after_persist_deletions() {
     let storage = storage();
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -219,33 +213,31 @@ fn wal_checkpoint_publishes_only_after_persist_deletions() {
     assert_eq!(
         index.last_wal_seq(),
         0,
-        "a pending seq must not be visible before persist_deletions (#882)"
+        "a pending seq must not be visible before persist_deletions"
     );
 
-    // Sealing a segment saves the manifest, but must NOT publish the
-    // pending checkpoint (the deletion bitmap for seq<=7 may not be
-    // durable yet).
     commit_batch(&index, 0..5);
     assert_eq!(
         index.last_wal_seq(),
         0,
-        "sealing must not publish the pending checkpoint (#882)"
+        "sealing must not publish the pending checkpoint"
     );
 
-    // persist_deletions publishes and persists it.
     index.persist_deletions().unwrap();
     assert_eq!(index.last_wal_seq(), 7);
 }
 
-/// #881: self-recall@10 of a 5-segment index matches a monolithic build of
-/// the same corpus within tolerance (#872-style gate).
+/// Self-recall@10 of a multi-segment index matches a monolithic build of the
+/// same corpus. Flat is exact brute-force search, so both should be at (or
+/// very near) 1.0 — this pins that the newest-wins containment masking
+/// across segments does not accidentally drop or duplicate live docs.
 #[test]
 fn multi_segment_self_recall_matches_monolithic() {
     let n = 2000u64;
     let per_commit = 400u64;
 
     let seg_storage = storage();
-    let seg_index = SegmentedHnswIndex::open_or_create(
+    let seg_index = SegmentedFlatIndex::open_or_create(
         seg_storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -258,7 +250,7 @@ fn multi_segment_self_recall_matches_monolithic() {
     }
 
     let mono_storage = storage();
-    let mono_index = HnswIndex::create(
+    let mono_index = FlatIndex::create(
         mono_storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(false),
@@ -280,21 +272,22 @@ fn multi_segment_self_recall_matches_monolithic() {
 
     let mono = recall(&mono_index);
     let seg = recall(&seg_index);
-    assert!(mono > 0.9, "monolithic self-recall sanity, got {mono:.4}");
+    assert!(mono > 0.99, "monolithic exact-search sanity, got {mono:.4}");
     assert!(
-        seg >= mono - 0.05,
+        seg >= mono - 0.01,
         "multi-segment self-recall ({seg:.4}) must match the monolithic build \
-         ({mono:.4}) within tolerance (#881)"
+         ({mono:.4}) within tolerance"
     );
 }
 
-/// #881: a same-id upsert across commits resolves to the newest copy exactly
-/// once, and a soft delete of a sealed doc is search-invisible and physically
-/// reclaimed by optimize().
+/// A same-id upsert across commits resolves to the newest copy exactly
+/// once, and a soft delete of a sealed doc is search-invisible and
+/// physically reclaimed by optimize() — the first-time soft-delete/
+/// compaction implementation for Flat.
 #[test]
 fn upsert_and_soft_delete_across_commits() {
     let storage = storage();
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -314,19 +307,20 @@ fn upsert_and_soft_delete_across_commits() {
         writer.commit().unwrap();
     }
 
-    // The doc resolves via its NEW embedding...
     let searcher = index.searcher().unwrap();
     let results = searcher.search(&query(9000, 1)).unwrap();
     assert_eq!(results.results[0].doc_id, 1, "newest copy must win");
-    // ...and its stale OLD copy must not outrank the true neighbours of the
-    // old embedding.
     let results = searcher.search(&query(1, 1)).unwrap();
     assert_ne!(
         results.results[0].doc_id, 1,
-        "the stale copy in the older segment must be masked (#880/#881)"
+        "the stale copy in the older segment must be masked"
     );
 
-    // Soft delete a sealed doc: search-invisible immediately.
+    // Soft delete a doc living in an already-SEALED segment: search-
+    // invisible immediately. This is the regression this PR exists to
+    // close — the monolithic Flat writer's hard-delete only ever worked
+    // because its buffer WAS the whole corpus; under segment-per-commit a
+    // hard delete against an empty new-segment buffer would silently no-op.
     index.soft_delete_document(10).unwrap();
     index.persist_deletions().unwrap();
     let searcher = index.searcher().unwrap();
@@ -339,14 +333,14 @@ fn upsert_and_soft_delete_across_commits() {
     // Optimize: one merged segment, deletion physically reclaimed, bitmap
     // cleared.
     index.optimize().unwrap();
-    let hnsw_files: Vec<String> = storage
+    let flat_files: Vec<String> = storage
         .list_files()
         .unwrap()
         .into_iter()
-        .filter(|f| f.ends_with(".hnsw"))
+        .filter(|f| f.ends_with(".flat"))
         .collect();
     assert_eq!(
-        hnsw_files.len(),
+        flat_files.len(),
         1,
         "optimize must force-merge to one segment"
     );
@@ -364,19 +358,17 @@ fn upsert_and_soft_delete_across_commits() {
     );
 
     let stats = index.stats().unwrap();
-    // ids 1..=49 (49 docs; the upsert replaces doc 1 in place) minus the
-    // physically reclaimed doc 10.
     assert_eq!(stats.vector_count, 48);
 }
 
-/// #881 review (HIGH): the upsert dance can undelete every mark; a previously
-/// persisted delmap must then be REMOVED — a stale file would mask the
-/// committed upsert in every segment after reopen.
+/// The upsert dance can undelete every mark; a previously persisted delmap
+/// must then be REMOVED — a stale file would mask the committed upsert in
+/// every segment after reopen.
 #[test]
 fn undelete_to_zero_removes_stale_delmap_and_survives_reopen() {
     let storage = storage();
     {
-        let index = SegmentedHnswIndex::open_or_create(
+        let index = SegmentedFlatIndex::open_or_create(
             storage.clone() as Arc<dyn Storage>,
             "vector_index",
             config(true),
@@ -384,12 +376,10 @@ fn undelete_to_zero_removes_stale_delmap_and_survives_reopen() {
         .unwrap();
         commit_batch(&index, 1..10);
 
-        // Soft-delete doc 3 and persist: the delmap file exists.
         index.soft_delete_document(3).unwrap();
         index.persist_deletions().unwrap();
         assert!(storage.file_exists("vector_index.delmap"));
 
-        // Same-id upsert of doc 3: the re-add clears the only mark.
         let mut writer = index.writer().unwrap();
         writer.delete_document(3).unwrap();
         writer
@@ -399,13 +389,11 @@ fn undelete_to_zero_removes_stale_delmap_and_survives_reopen() {
         index.persist_deletions().unwrap();
         assert!(
             !storage.file_exists("vector_index.delmap"),
-            "undelete-to-zero must remove the stale delmap (#881)"
+            "undelete-to-zero must remove the stale delmap"
         );
     }
 
-    // Reopen: the committed upsert must be visible (a stale delmap would
-    // have masked doc 3 in every segment).
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -415,17 +403,17 @@ fn undelete_to_zero_removes_stale_delmap_and_survives_reopen() {
     let results = searcher.search(&query(9000, 1)).unwrap();
     assert_eq!(
         results.results[0].doc_id, 3,
-        "the committed upsert must survive a reopen (#881)"
+        "the committed upsert must survive a reopen"
     );
 }
 
-/// #881 review (HIGH): a sealed writer must reject further commits (loud
-/// error instead of silently resetting the segment's generation), while a
-/// post-commit close() stays a clean no-op.
+/// A sealed writer must reject further commits (loud error instead of
+/// silently resetting the segment's generation), while a post-commit
+/// close() stays a clean no-op.
 #[test]
 fn sealed_writer_rejects_second_commit_and_close_is_noop() {
     let storage = storage();
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -438,11 +426,9 @@ fn sealed_writer_rejects_second_commit_and_close_is_noop() {
         .unwrap();
     writer.commit().unwrap();
 
-    // Post-commit close: no pending changes, no error, no metadata churn.
     assert!(!writer.has_pending_changes());
     writer.close().unwrap();
 
-    // A sealed writer with NEW changes must refuse to commit again.
     let mut writer = index.writer().unwrap();
     writer
         .add_vectors(vec![(2, "v".to_string(), doc_vec(2))])
@@ -454,15 +440,15 @@ fn sealed_writer_rejects_second_commit_and_close_is_noop() {
     let err = writer.commit();
     assert!(
         err.is_err(),
-        "a sealed writer must reject a second commit with new changes (#881)"
+        "a sealed writer must reject a second commit with new changes"
     );
 }
 
-/// #881 review: count() excludes soft-deleted docs.
+/// count() excludes soft-deleted docs.
 #[test]
 fn count_excludes_soft_deleted_docs() {
     let storage = storage();
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -473,15 +459,12 @@ fn count_excludes_soft_deleted_docs() {
 
     let searcher = index.searcher().unwrap();
     let count = searcher.count(query(0, 1)).unwrap();
-    assert_eq!(count, 9, "count must exclude soft-deleted docs (#881)");
+    assert_eq!(count, 9, "count must exclude soft-deleted docs");
 }
 
-/// #882 (CRITICAL review find): the migration must fire through the
-/// PRODUCTION factory path. A legacy index always has a `metadata.json`, so
-/// it always takes the factory's OPEN arm — which previously had no
-/// segmented dispatch, leaving every existing deployment monolithic forever
-/// and (worse) flipping an already-migrated directory back to a monolithic
-/// view that silently hid post-migration segments.
+/// The migration must fire through the PRODUCTION factory path. A legacy
+/// index always has a `metadata.json`, so it always takes the factory's
+/// OPEN arm — which must be exactly where the migration fires.
 #[test]
 fn factory_open_path_migrates_legacy_index_and_stays_segmented() {
     use laurus::vector::index::config::VectorIndexTypeConfig;
@@ -489,7 +472,7 @@ fn factory_open_path_migrates_legacy_index_and_stays_segmented() {
 
     let storage = storage();
     {
-        let index = HnswIndex::create(
+        let index = FlatIndex::create(
             storage.clone() as Arc<dyn Storage>,
             "vector_index",
             config(false),
@@ -503,27 +486,25 @@ fn factory_open_path_migrates_legacy_index_and_stays_segmented() {
     let index = VectorIndexFactory::open_or_create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
-        VectorIndexTypeConfig::HNSW(config(true)),
+        VectorIndexTypeConfig::Flat(config(true)),
     )
     .unwrap();
     assert!(
         storage.file_exists("segments.json"),
-        "the factory OPEN arm must migrate a legacy index (#882)"
+        "the factory OPEN arm must migrate a legacy index"
     );
     assert!(
         !storage.file_exists("metadata.json"),
         "the stale monolithic metadata.json must be removed so factory \
-         routing can never regress to the monolithic view (#882)"
+         routing can never regress to the monolithic view"
     );
 
-    // Commit through the migrated index, then reopen through the factory
-    // again: the segmented view must persist and serve ALL data.
     commit_batch(index.as_ref(), 50..51);
     drop(index);
     let index = VectorIndexFactory::open_or_create(
         storage as Arc<dyn Storage>,
         "vector_index",
-        VectorIndexTypeConfig::HNSW(config(true)),
+        VectorIndexTypeConfig::Flat(config(true)),
     )
     .unwrap();
     let searcher = index.searcher().unwrap();
@@ -537,9 +518,8 @@ fn factory_open_path_migrates_legacy_index_and_stays_segmented() {
     );
 }
 
-/// #882: opening a segmented directory with `segmented: false` must be
-/// rejected loudly — the monolithic view would silently hide every sealed
-/// segment.
+/// Opening a segmented directory with `segmented: false` must be rejected
+/// loudly — the monolithic view would silently hide every sealed segment.
 #[test]
 fn factory_rejects_segmented_directory_with_flag_off() {
     use laurus::vector::index::config::VectorIndexTypeConfig;
@@ -547,7 +527,7 @@ fn factory_rejects_segmented_directory_with_flag_off() {
 
     let storage = storage();
     {
-        let index = SegmentedHnswIndex::open_or_create(
+        let index = SegmentedFlatIndex::open_or_create(
             storage.clone() as Arc<dyn Storage>,
             "vector_index",
             config(true),
@@ -559,28 +539,27 @@ fn factory_rejects_segmented_directory_with_flag_off() {
     let result = VectorIndexFactory::open_or_create(
         storage as Arc<dyn Storage>,
         "vector_index",
-        VectorIndexTypeConfig::HNSW(config(false)),
+        VectorIndexTypeConfig::Flat(config(false)),
     );
     assert!(
         result.is_err(),
-        "a segmented directory must not open monolithically (#882)"
+        "a segmented directory must not open monolithically"
     );
 }
 
-/// #882: pure-append workloads must not grow the segment count unboundedly
-/// — `maybe_auto_compact` merges a policy window once the manager's
-/// threshold is exceeded (tiered policy lands with #883).
+/// Pure-append workloads must not grow the segment count unboundedly —
+/// `maybe_auto_compact` merges a policy window once the manager's
+/// threshold is exceeded.
 #[test]
 fn append_only_segment_count_is_bounded_by_auto_merge() {
     let storage = storage();
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(true),
     )
     .unwrap();
 
-    // 101 one-doc commits exceed the default max_segments (100).
     for i in 0..101u64 {
         commit_batch(&index, i..i + 1);
     }
@@ -588,7 +567,7 @@ fn append_only_segment_count_is_bounded_by_auto_merge() {
         .list_files()
         .unwrap()
         .iter()
-        .filter(|f| f.ends_with(".hnsw"))
+        .filter(|f| f.ends_with(".flat"))
         .count();
     assert!(before > 100, "precondition: {before} segments");
 
@@ -598,14 +577,13 @@ fn append_only_segment_count_is_bounded_by_auto_merge() {
         .list_files()
         .unwrap()
         .iter()
-        .filter(|f| f.ends_with(".hnsw"))
+        .filter(|f| f.ends_with(".flat"))
         .count();
     assert!(
         after < before,
         "the merge must reduce the segment count ({before} -> {after})"
     );
 
-    // Every doc is still searchable through the merged layout.
     let searcher = index.searcher().unwrap();
     for id in [0u64, 50, 100] {
         assert_eq!(
@@ -615,42 +593,42 @@ fn append_only_segment_count_is_bounded_by_auto_merge() {
     }
 }
 
-/// #882: serde behavior of the flipped default — a config missing the field
-/// deserializes to `true`; an explicit `false` is preserved.
+/// serde behavior of the (still-off-by-default) flag — a config missing
+/// the field deserializes to `false`; an explicit `true` is preserved.
 #[test]
-fn segmented_flag_serde_default_and_explicit_false() {
-    // A pre-#882 config = today's config with the `segmented` key removed.
-    let mut value: serde_json::Value = serde_json::to_value(HnswIndexConfig::default()).unwrap();
+fn segmented_flag_serde_default_and_explicit_true() {
+    let mut value: serde_json::Value = serde_json::to_value(FlatIndexConfig::default()).unwrap();
     value
         .as_object_mut()
         .unwrap()
         .remove("segmented")
         .expect("the flag must serialize");
-    let config: HnswIndexConfig = serde_json::from_value(value).unwrap();
-    assert!(
-        config.segmented,
-        "a config serialized before the field existed must open segmented (#882)"
-    );
-
-    let explicit_false = serde_json::to_string(&HnswIndexConfig {
-        segmented: false,
-        ..HnswIndexConfig::default()
-    })
-    .unwrap();
-    let config: HnswIndexConfig = serde_json::from_str(&explicit_false).unwrap();
+    let config: FlatIndexConfig = serde_json::from_value(value).unwrap();
     assert!(
         !config.segmented,
-        "an explicit `segmented: false` must be preserved (#882)"
+        "a config serialized before the field existed must open monolithic \
+         (Flat's segmented default is false, unlike HNSW's)"
+    );
+
+    let explicit_true = serde_json::to_string(&FlatIndexConfig {
+        segmented: true,
+        ..FlatIndexConfig::default()
+    })
+    .unwrap();
+    let config: FlatIndexConfig = serde_json::from_str(&explicit_true).unwrap();
+    assert!(
+        config.segmented,
+        "an explicit `segmented: true` must be preserved"
     );
 }
 
-/// #883: under sustained ingest with the store-ladder cadence (compact after
+/// Under sustained ingest with the store-ladder cadence (compact after
 /// every commit), the tiered policy keeps the segment count logarithmically
 /// bounded instead of one-segment-per-commit.
 #[test]
 fn sustained_ingest_keeps_segment_count_tiered() {
     let storage = storage();
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -659,7 +637,6 @@ fn sustained_ingest_keeps_segment_count_tiered() {
 
     for i in 0..100u64 {
         commit_batch(&index, i * 5..(i + 1) * 5);
-        // The store's commit ladder calls maybe_auto_compact every commit.
         index.maybe_auto_compact().unwrap();
     }
 
@@ -667,17 +644,14 @@ fn sustained_ingest_keeps_segment_count_tiered() {
         .list_files()
         .unwrap()
         .iter()
-        .filter(|f| f.ends_with(".hnsw"))
+        .filter(|f| f.ends_with(".flat"))
         .count();
     assert!(
         segments <= 30,
         "tiered merging must keep the segment count bounded under \
-         sustained ingest, got {segments} after 100 commits (#883)"
+         sustained ingest, got {segments} after 100 commits"
     );
 
-    // Every doc remains searchable through the merged layout (top-5, since
-    // the corpus is a tight curve where adjacent ids are near-duplicates
-    // and approximate top-1 can legitimately flip between neighbours).
     let searcher = index.searcher().unwrap();
     for id in [0u64, 250, 499] {
         let results = searcher.search(&query(id, 5)).unwrap();
@@ -688,17 +662,15 @@ fn sustained_ingest_keeps_segment_count_tiered() {
     }
 }
 
-/// #883: adaptive refill — a live doc ranked *below a deep band of stale
-/// upsert copies inside the same segment* must still surface. This is a
-/// red/green gate for the whole refill feature: the stale band (30 copies) is
-/// deeper than the first pass's 2x over-fetch AND deeper than any fixed
-/// multiplier (the earlier one-shot 8x refill missed it), so the query
-/// returns the wrong far doc unless the budget expands geometrically until
-/// the live hit is reached.
+/// Adaptive refill — a live doc ranked *below a deep band of stale upsert
+/// copies inside the same segment* must still surface. Flat's per-segment
+/// search is exact brute force, so this pins that the SHARED (#889 PR-2)
+/// containment-masking + expanding-refill layer is wired correctly for
+/// Flat, not just HNSW.
 #[test]
 fn adaptive_refill_recovers_live_doc_behind_stale_band() {
     let storage = storage();
-    let index = SegmentedHnswIndex::open_or_create(
+    let index = SegmentedFlatIndex::open_or_create(
         storage.clone() as Arc<dyn Storage>,
         "vector_index",
         config(true),
@@ -708,9 +680,7 @@ fn adaptive_refill_recovers_live_doc_behind_stale_band() {
     // Segment A (older): the stale band (docs 1..=30, tightly clustered
     // around doc_vec(0)) AND the LIVE doc 100 (doc_vec(31), just past the
     // band) are committed together, so doc 100 sits at rank 31 *within the
-    // same segment* — behind all 30 copies. This is the construction the
-    // refill must handle; committing doc 100 separately would let it surface
-    // unmasked from its own segment and never exercise the refill.
+    // same segment* — behind all 30 copies.
     {
         let mut writer = index.writer().unwrap();
         let mut batch: Vec<_> = (1..=30u64)
@@ -735,22 +705,58 @@ fn adaptive_refill_recovers_live_doc_behind_stale_band() {
         writer.commit().unwrap();
     }
 
-    // Query at the old cluster centre with top_k=1: the 30 hits ranked above
-    // doc 100 in segment A are all masked stale copies. A fixed 2x (or 8x)
-    // over-fetch never reaches rank 31; only the expanding refill does.
     let searcher = index.searcher().unwrap();
     let results = searcher.search(&query(0, 1)).unwrap();
     assert_eq!(
         results.results.first().map(|r| r.doc_id),
         Some(100),
         "the live doc behind the deep stale band must surface via the \
-         expanding adaptive refill (#883), got {:?}",
+         expanding adaptive refill, got {:?}",
         results.results
     );
 }
 
-/// #883: the campaign's headline number as a permanent deterministic gate —
-/// the auto-commit ingest scenario writes an order of magnitude fewer
+/// Flat-specific pin: unlike HNSW (which has an f32 rerank sidecar,
+/// Issue #795), Flat's segment merge dequantizes int8 -> re-trains
+/// per-segment `ScalarQuantParams` -> re-quantizes, so every merge bakes in
+/// one additional generation of quantization error. Recall must still hold
+/// after a forced merge — this is the pin for that accepted trade-off.
+#[test]
+fn recall_holds_after_forced_merge() {
+    let n = 500u64;
+    let storage = storage();
+    let index = SegmentedFlatIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    let mut lo = 0u64;
+    while lo < n {
+        commit_batch(&index, lo..(lo + 50).min(n));
+        lo += 50;
+    }
+    index.optimize().unwrap();
+
+    let searcher = index.searcher().unwrap();
+    let mut hits = 0u64;
+    for id in 0..n {
+        let results = searcher.search(&query(id, 10)).unwrap();
+        if results.results.iter().any(|r| r.doc_id == id) {
+            hits += 1;
+        }
+    }
+    let recall = hits as f32 / n as f32;
+    assert!(
+        recall > 0.99,
+        "self-recall must hold after a forced merge despite requantization \
+         drift, got {recall:.4}"
+    );
+}
+
+/// The campaign's headline number as a permanent deterministic gate — the
+/// auto-commit ingest scenario writes an order of magnitude fewer
 /// cumulative bytes under the segmented layout than under the monolithic
 /// one (each monolithic commit rewrites and re-quantizes the whole index).
 #[test]
@@ -764,7 +770,7 @@ fn auto_commit_cumulative_bytes_are_bounded() {
         let written = counting.written.clone();
         let index: Box<dyn VectorIndex> = if segmented {
             Box::new(
-                SegmentedHnswIndex::open_or_create(
+                SegmentedFlatIndex::open_or_create(
                     counting.clone() as Arc<dyn Storage>,
                     "vector_index",
                     config(true),
@@ -773,7 +779,7 @@ fn auto_commit_cumulative_bytes_are_bounded() {
             )
         } else {
             Box::new(
-                HnswIndex::create(
+                FlatIndex::create(
                     counting.clone() as Arc<dyn Storage>,
                     "vector_index",
                     config(false),
@@ -799,6 +805,6 @@ fn auto_commit_cumulative_bytes_are_bounded() {
     assert!(
         segmented * 5 < monolithic,
         "the segmented layout must write at least 5x fewer cumulative bytes \
-         under auto-commit ingest, got monolithic={monolithic} vs segmented={segmented} (#883)"
+         under auto-commit ingest, got monolithic={monolithic} vs segmented={segmented}"
     );
 }


### PR DESCRIPTION
## Summary

- Adds `SegmentedFlatIndex` (`flat/segmented.rs`), extending the segment-per-commit layout (#634/#882 design) to Flat on the shared infrastructure from #889 PR-1/PR-2/PR-3: atomic `segments.json` manifest, newest-wins containment masking with expanding refill at search, tiered auto-merge, zero-copy migration of a legacy `.flat` file into segment 0.
- First-time soft-delete/compaction implementation for Flat (`supports_soft_delete`/`soft_delete_document`/`persist_deletions`/`maybe_auto_compact`), landed together with the layout since the writer's buffer under segment-per-commit only holds the new segment's own vectors — shipping layout alone would make deleting a document in an already-sealed segment a silent no-op.
- `FlatIndexConfig` gains `segmented` (defaults `false`, unlike HNSW's `true`), `auto_compaction`, `compaction_threshold`. `factory.rs` gains `dispatch_flat()`.
- Fixes a real pre-existing bug found while writing the soft-delete tests: `flat/searcher.rs`'s field-filtered search path had an int8-quantized-pool fast path that bypassed the deletion check entirely (dormant until now because the monolithic `FlatIndex` never wired soft-delete).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` (stable 1.97.1 + pinned 1.97.0)
- [x] `cargo test -p laurus --lib` — 1246 passed
- [x] `cargo test -p laurus --tests` — all binaries green, including new `vector_segmented_flat_test.rs` (17 tests)
- [x] `cargo doc -p laurus --no-deps` — 73 warnings, matches `main` baseline
- [x] RED/GREEN: the deletion-bypass bug was observed failing before the fix and green immediately after

Part of #889
Closes #904