### PR TITLE
feat(vector/index): segment-per-commit SegmentedIvfIndex (#906)

### DIFF
--- a/laurus/src/vector/index/config.rs
+++ b/laurus/src/vector/index/config.rs
@@ -710,6 +710,29 @@ pub struct IvfIndexConfig {
     /// Maximum number of segments before merging.
     pub max_segments: u32,
 
+    /// Whether this index uses the segment-per-commit layout (Issue #889).
+    ///
+    /// Mirrors [`FlatIndexConfig::segmented`]. Defaults to `false` — IVF's
+    /// segmented layout ships behind the flag until it has had the same
+    /// real-world exercise HNSW's had since #882.
+    #[serde(default)]
+    pub segmented: bool,
+
+    /// Automatically compact (purge logically deleted vectors) on commit
+    /// when the deletion ratio crosses [`Self::compaction_threshold`]
+    /// (Issue #889, mirroring [`FlatIndexConfig::auto_compaction`]).
+    /// Defaults to `false`; the `VectorStore` populates it from
+    /// [`crate::maintenance::deletion::DeletionConfig::auto_compaction`].
+    #[serde(default)]
+    pub auto_compaction: bool,
+
+    /// Deletion ratio (deleted / total committed vectors, `0.0`–`1.0`) at or
+    /// above which [`Self::auto_compaction`] triggers a compaction on commit.
+    /// Ignored when `auto_compaction` is `false`. Mirrors
+    /// [`FlatIndexConfig::compaction_threshold`].
+    #[serde(default = "default_compaction_threshold")]
+    pub compaction_threshold: f64,
+
     /// Embedder for converting text/images to vectors.
     ///
     /// This embedder is used when documents contain text or image fields that need to be
@@ -736,6 +759,9 @@ impl Default for IvfIndexConfig {
             rerank_storage: None,
             merge_factor: 10,
             max_segments: 100,
+            segmented: false,
+            auto_compaction: false,
+            compaction_threshold: default_compaction_threshold(),
             embedder: default_embedder(),
         }
     }
@@ -756,6 +782,9 @@ impl std::fmt::Debug for IvfIndexConfig {
             .field("rerank_storage", &self.rerank_storage)
             .field("merge_factor", &self.merge_factor)
             .field("max_segments", &self.max_segments)
+            .field("segmented", &self.segmented)
+            .field("auto_compaction", &self.auto_compaction)
+            .field("compaction_threshold", &self.compaction_threshold)
             .field("embedder", &self.embedder.name())
             .finish()
     }

--- a/laurus/src/vector/index/factory.rs
+++ b/laurus/src/vector/index/factory.rs
@@ -86,8 +86,7 @@ impl VectorIndexFactory {
                 Self::dispatch_hnsw(storage, name, hnsw_config, false)
             }
             VectorIndexTypeConfig::IVF(ivf_config) => {
-                let index = IvfIndex::create(storage, name, ivf_config)?;
-                Ok(Box::new(index))
+                Self::dispatch_ivf(storage, name, ivf_config, false)
             }
         }
     }
@@ -176,6 +175,48 @@ impl VectorIndexFactory {
         Ok(Box::new(index))
     }
 
+    /// Dispatch an IVF config to the segmented or monolithic implementation
+    /// (Issue #889 PR-6, mirroring `dispatch_flat`/`dispatch_hnsw`).
+    ///
+    /// The `segmented` flag (defaulting `false` until #889 PR-7) routes to
+    /// [`SegmentedIvfIndex::open_or_create`], which handles create, open,
+    /// AND the zero-copy migration of a legacy monolithic index — so BOTH
+    /// factory arms must come through here: a legacy index always has a
+    /// `metadata.json` and therefore always takes the *open* arm, which is
+    /// exactly where the migration must fire.
+    ///
+    /// With the flag off, opening a directory that contains a segment
+    /// manifest is rejected: the monolithic index would silently serve only
+    /// the migrated segment-0 data and hide every later segment.
+    fn dispatch_ivf(
+        storage: Arc<dyn Storage>,
+        name: &str,
+        ivf_config: crate::vector::index::config::IvfIndexConfig,
+        open_only: bool,
+    ) -> Result<Box<dyn VectorIndex>> {
+        use crate::vector::index::ivf::segmented::SegmentedIvfIndex;
+
+        if ivf_config.segmented {
+            let index = SegmentedIvfIndex::open_or_create(storage, name, ivf_config)?;
+            return Ok(Box::new(index));
+        }
+        // Reverse guard: a segmented directory must not be opened
+        // monolithically — the single-file view would silently hide every
+        // segment sealed after the migration.
+        if storage.file_exists("segments.json") {
+            return Err(crate::error::LaurusError::invalid_config(format!(
+                "index '{name}' uses the segmented layout (segments.json exists) but \
+                 `segmented` is disabled; enable it to open this index"
+            )));
+        }
+        let index = if open_only {
+            IvfIndex::open(storage, name, ivf_config)?
+        } else {
+            IvfIndex::create(storage, name, ivf_config)?
+        };
+        Ok(Box::new(index))
+    }
+
     /// Open an existing index or create a new one if it doesn't exist.
     ///
     /// This is the recommended method for general use, as it handles both
@@ -249,8 +290,11 @@ impl VectorIndexFactory {
                 Self::dispatch_hnsw(storage, name, hnsw_config, true)
             }
             VectorIndexTypeConfig::IVF(ivf_config) => {
-                let index = IvfIndex::open(storage, name, ivf_config)?;
-                Ok(Box::new(index))
+                // Same dispatch as `create` (Issue #889 PR-6): the segmented
+                // path's `open_or_create` opens existing manifests and
+                // migrates legacy monolithic indexes; the flag-off path is
+                // reverse-guarded against segmented directories.
+                Self::dispatch_ivf(storage, name, ivf_config, true)
             }
         }
     }

--- a/laurus/src/vector/index/ivf.rs
+++ b/laurus/src/vector/index/ivf.rs
@@ -2,6 +2,8 @@
 
 pub mod reader;
 pub mod searcher;
+pub mod segment;
+pub mod segmented;
 #[cfg(test)]
 mod tests;
 pub mod writer;

--- a/laurus/src/vector/index/ivf/reader.rs
+++ b/laurus/src/vector/index/ivf/reader.rs
@@ -334,7 +334,13 @@ impl IvfIndexReader {
         &self.vectors
     }
 
-    fn is_deleted(&self, doc_id: u64) -> bool {
+    /// Whether `doc_id` is logically deleted per the attached bitmap (if
+    /// any). `pub(crate)` so the searcher's quantized-pool fast path
+    /// (`crate::vector::index::ivf::searcher`, which reads straight from
+    /// the pool and bypasses [`VectorIndexReader::get_vector`]) can filter
+    /// deleted docs without going through that slower accessor (Issue
+    /// #889 PR-6, mirroring the same fix in the Flat reader/searcher).
+    pub(crate) fn is_deleted(&self, doc_id: u64) -> bool {
         if let Some(bitmap) = &self.deletion_bitmap {
             bitmap.is_deleted(doc_id)
         } else {

--- a/laurus/src/vector/index/ivf/searcher.rs
+++ b/laurus/src/vector/index/ivf/searcher.rs
@@ -266,6 +266,7 @@ impl VectorIndexSearcher for IvfSearcher {
                 }
                 if let (Some(pool), Some(prepared)) = (&quant_pool, &prepared_quantized)
                     && let Some((int8, meta)) = pool.get_record(*doc_id, field_name)
+                    && !ivf_reader.is_some_and(|r| r.is_deleted(*doc_id))
                 {
                     let distance = crate::vector::core::distance_quantized::distance_quantized(
                         metric, prepared, int8, meta,

--- a/laurus/src/vector/index/ivf/segment.rs
+++ b/laurus/src/vector/index/ivf/segment.rs
@@ -1,0 +1,21 @@
+//! IVF-specific segment file layout and merge engine.
+//!
+//! The generic segment manifest/manager, merge policies, reader cache, and
+//! fan-out search layer shared across index types live in
+//! [`crate::vector::index::segment`] (Issue #889); this module keeps only
+//! what is IVF-specific: the merge engine (its I/O is IVF-typed, and it
+//! re-clusters the merged union rather than just concatenating) and this
+//! index type's on-disk file layout descriptor.
+
+use crate::vector::index::segment::manager::SegmentFileLayout;
+
+pub mod merge_engine;
+
+/// On-disk file-suffix layout for IVF segments: a primary `.ivf` file, no
+/// sidecars (IVF has no rerank sidecar), staged through a `.ivf.tmp` temp
+/// file.
+pub const LAYOUT: SegmentFileLayout = SegmentFileLayout {
+    primary: ".ivf",
+    sidecars: &[],
+    tmp: ".ivf.tmp",
+};

--- a/laurus/src/vector/index/ivf/segment/merge_engine.rs
+++ b/laurus/src/vector/index/ivf/segment/merge_engine.rs
@@ -1,0 +1,210 @@
+//! Merge engine for IVF vector index segments.
+//!
+//! This module handles the actual merging of segments. [`MergeConfig`],
+//! [`MergeStats`], and [`MergeResult`] are the shared, index-type-agnostic
+//! data shapes defined in [`crate::vector::index::segment::merge`]; this
+//! engine's own logic (below) is IVF-typed.
+//!
+//! Unlike Flat/HNSW, an IVF segment's inverted-list structure is meaningless
+//! across a merge — cluster ids are assigned independently per segment (each
+//! trains its own centroids from adaptive K over its own buffer, Issue #889),
+//! so there is no way to reconcile cluster `i` in one source with cluster `i`
+//! in another. A merge therefore discards every source's inverted lists
+//! entirely, reduces to a flat, deduplicated, deletion-filtered
+//! `(doc_id, field, Vector)` list (same as Flat's merge), and re-clusters
+//! that union from scratch through the ordinary
+//! [`IvfIndexWriter`]/`add_vectors`/`finalize` pipeline. No special
+//! "expected count" setter is needed: `finalize` -> `train_centroids`
+//! already recomputes the effective cluster count as
+//! `configured_n_clusters.min(vectors.len()).max(1)` (Issue #889 PR-5) from
+//! whatever `index_config.n_clusters` the writer was constructed with, so
+//! constructing it with the same schema-level config the segmented index
+//! already uses is sufficient to re-derive the adaptive K for the merged
+//! union's size — including the zero-vectors case (Issue #889 PR-6), which
+//! trains zero clusters instead of erroring.
+
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::storage::Storage;
+use crate::vector::core::vector::Vector;
+
+use crate::vector::index::segment::manager::ManagedSegmentInfo;
+use crate::vector::index::segment::merge::{MergeConfig, MergeResult, MergeStats};
+
+use crate::maintenance::deletion::DeletionBitmap;
+use crate::vector::index::config::IvfIndexConfig;
+use crate::vector::index::ivf::reader::IvfIndexReader;
+use crate::vector::index::ivf::writer::IvfIndexWriter;
+use crate::vector::reader::VectorIndexReader;
+use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
+
+/// Engine for merging IVF vector index segments.
+pub struct MergeEngine {
+    config: MergeConfig,
+    storage: Arc<dyn Storage>,
+    index_config: IvfIndexConfig,
+    writer_config: VectorIndexWriterConfig,
+    deletion_bitmap: Option<Arc<DeletionBitmap>>,
+}
+
+impl MergeEngine {
+    /// Create a new merge engine.
+    pub fn new(
+        config: MergeConfig,
+        storage: Arc<dyn Storage>,
+        index_config: IvfIndexConfig,
+        writer_config: VectorIndexWriterConfig,
+    ) -> Self {
+        Self {
+            config,
+            storage,
+            index_config,
+            writer_config,
+            deletion_bitmap: None,
+        }
+    }
+
+    /// Set deletion bitmap for filtering deleted vectors during merge.
+    pub fn set_deletion_bitmap(&mut self, bitmap: Arc<DeletionBitmap>) {
+        self.deletion_bitmap = Some(bitmap);
+    }
+
+    /// Merge multiple segments into a single, freshly-reclustered segment.
+    ///
+    /// Reads every live vector from the source segments (deletion-filtered
+    /// via the configured bitmap), deduplicates cross-segment duplicates of
+    /// the same `(doc_id, field)` with **newest-generation wins** semantics
+    /// (same reasoning as Issue #880 for Flat/HNSW), then trains a fresh set
+    /// of centroids over the deduplicated union and rebuilds the inverted
+    /// lists from scratch — the per-segment cluster ids being merged carry
+    /// no cross-segment meaning, so there is nothing to reconcile.
+    pub fn merge_segments(
+        &self,
+        segments: Vec<ManagedSegmentInfo>,
+        new_segment_id: String,
+    ) -> Result<MergeResult> {
+        let start_time = crate::util::time::Timer::now();
+
+        let segments_merged = segments.len() as u32;
+        let mut deletions_removed = 0;
+        let mut duplicates_removed = 0u64;
+
+        let mut all_vectors: Vec<(u64, String, Vector)> = Vec::new();
+
+        // Newest generation FIRST, so the first occurrence of a
+        // `(doc_id, field)` key is the authoritative (newest) copy and every
+        // later one is a stale duplicate (Issue #880).
+        let mut sources = segments.clone();
+        sources.sort_by_key(|s| std::cmp::Reverse(s.generation));
+        let mut seen: std::collections::HashSet<(u64, String)> = std::collections::HashSet::new();
+
+        // 1. Read all live vectors from source segments (newest first),
+        //    discarding their inverted-list/cluster structure entirely.
+        for segment in &sources {
+            let reader = IvfIndexReader::load(
+                self.storage.clone(),
+                &segment.segment_id,
+                self.index_config.distance_metric,
+            )?;
+
+            let mut iterator = reader.vector_iterator()?;
+            while let Some((doc_id, field, vector)) = iterator.next()? {
+                if let Some(bitmap) = &self.deletion_bitmap
+                    && bitmap.is_deleted(doc_id)
+                {
+                    deletions_removed += 1;
+                    continue;
+                }
+                if !seen.insert((doc_id, field.clone())) {
+                    // A newer segment already contributed this key.
+                    duplicates_removed += 1;
+                    continue;
+                }
+                all_vectors.push((doc_id, field, vector));
+            }
+        }
+
+        // 2. Re-cluster the deduplicated union from scratch and write it as
+        //    a new segment. `finalize` -> `train_centroids` derives the
+        //    adaptive cluster count from `all_vectors.len()` (see the
+        //    module docs); the empty case (Issue #889 PR-6) trains zero
+        //    clusters instead of erroring.
+        let vectors_merged = all_vectors.len() as u64;
+        let mut writer = IvfIndexWriter::with_storage(
+            self.index_config.clone(),
+            self.writer_config.clone(),
+            &new_segment_id,
+            self.storage.clone(),
+        )?;
+        writer.add_vectors(all_vectors)?;
+        writer.finalize()?;
+        writer.write()?;
+
+        let total_size = vectors_merged * 128; // Dummy estimate; measured from storage by `add_segment`.
+
+        let merge_time_ms = start_time.elapsed_ms();
+
+        let merged_segment = ManagedSegmentInfo {
+            segment_id: new_segment_id,
+            vector_count: vectors_merged,
+            vector_offset: 0,
+            // The merged output represents data no newer than its newest
+            // source, so it inherits max(source generations) — NOT max+1
+            // (same reasoning as Issue #880 for Flat/HNSW): with +1 a merge
+            // over non-adjacent sources would out-rank untouched newer
+            // segments, laundering a stale copy from an old source above a
+            // genuinely newer one under the newest-generation-wins dedup.
+            // Generations are unique (stamped max+1 at flush) and the
+            // sources are removed with the merge, so inheriting the maximum
+            // cannot collide with a live segment.
+            generation: segments.iter().map(|s| s.generation).max().unwrap_or(0),
+            has_deletions: false,
+            size_bytes: total_size,
+        };
+
+        let stats = MergeStats {
+            segments_merged,
+            vectors_merged,
+            deletions_removed,
+            duplicates_removed,
+            merge_time_ms,
+            merged_size_bytes: total_size,
+        };
+
+        Ok(MergeResult {
+            merged_segment,
+            stats,
+            merged_segment_ids: segments.iter().map(|s| s.segment_id.clone()).collect(),
+        })
+    }
+
+    /// Get storage reference.
+    pub fn storage(&self) -> &Arc<dyn Storage> {
+        &self.storage
+    }
+
+    /// Get configuration.
+    pub fn config(&self) -> &MergeConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_engine_basic() {
+        let config = MergeConfig::default();
+        let storage = Arc::new(crate::storage::memory::MemoryStorage::new(
+            crate::storage::memory::MemoryStorageConfig::default(),
+        ));
+        let index_config = IvfIndexConfig::default();
+        let writer_config = VectorIndexWriterConfig::default();
+
+        let engine = MergeEngine::new(config, storage, index_config, writer_config);
+
+        assert_eq!(engine.config.max_merge_segments, 10);
+    }
+}

--- a/laurus/src/vector/index/ivf/segmented.rs
+++ b/laurus/src/vector/index/ivf/segmented.rs
@@ -1,0 +1,819 @@
+//! Segment-per-commit IVF vector index (Issue #889 PR-6, mirroring HNSW's
+//! #634/#882 design and Flat's PR-4 — see
+//! [`crate::vector::index::hnsw::segmented`] and
+//! [`crate::vector::index::flat::segmented`]).
+//!
+//! [`SegmentedIvfIndex`] implements [`VectorIndex`] over a set of immutable
+//! per-segment `.ivf` files registered in an atomic, checksummed
+//! `segments.json` manifest, instead of the monolithic single-file layout
+//! of [`super::IvfIndex`]: each commit trains centroids and seals only the
+//! newly added vectors as a new segment, turning the per-commit cost from a
+//! full corpus-wide re-training into training over just the new documents.
+//!
+//! Each segment trains its own centroids independently with an adaptive
+//! cluster count (Issue #889 PR-5's `configured_n_clusters` ceiling) — no
+//! cross-segment cluster-id agreement is needed, since search fans out per
+//! segment (via the shared [`crate::vector::index::segment::fanout`] layer)
+//! and merges top-k results, exactly how HNSW's per-segment graphs need no
+//! cross-segment agreement either. A merge does not attempt to reconcile
+//! source cluster ids: it flattens the deduplicated survivors and retrains
+//! from scratch (see [`crate::vector::index::ivf::segment::merge_engine`]).
+//!
+//! Search fans out over the sealed segments newest-generation-first with
+//! containment-based newest-wins deduplication (mirroring #880): a hit from
+//! an older segment is dropped when any newer segment contains the same
+//! `(doc_id, field)` — same-id upserts replayed from the WAL leave stale
+//! copies behind until a merge physically collapses them. Uncommitted adds
+//! are invisible until commit, matching the monolithic semantics.
+//!
+//! Deletions are logical: a shared index-level `DeletionBitmap` is marked
+//! by [`VectorIndex::soft_delete_document`], persisted to `{name}.delmap`
+//! by [`VectorIndex::persist_deletions`], filtered by every segment reader,
+//! and physically reclaimed by [`VectorIndex::optimize`] (a force-merge).
+//! This is a first-time implementation for IVF — the monolithic
+//! [`super::IvfIndex`] has no soft-delete/compaction wiring at all.
+//!
+//! [`IvfIndexConfig::segmented`] defaults to `false` (unlike HNSW's `true`
+//! since #882): IVF's segmented layout has not yet had the same production
+//! exercise, so it ships behind the flag until a follow-up flips the
+//! default (Issue #889 PR-7). A legacy monolithic index is migrated
+//! zero-copy on first open with the flag on (its `.ivf` becomes segment 0
+//! of the manifest, no data movement).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use parking_lot::RwLock;
+
+use crate::embedding::embedder::Embedder;
+use crate::error::{LaurusError, Result};
+use crate::maintenance::deletion::DeletionBitmap;
+use crate::storage::Storage;
+use crate::storage::structured::{StructReader, StructWriter};
+use crate::vector::core::vector::Vector;
+use crate::vector::index::config::IvfIndexConfig;
+use crate::vector::index::ivf::reader::IvfIndexReader;
+use crate::vector::index::ivf::searcher::IvfSearcher;
+use crate::vector::index::ivf::segment::merge_engine::MergeEngine;
+use crate::vector::index::ivf::writer::IvfIndexWriter;
+use crate::vector::index::segment::fanout::{SegmentFanoutSearcher, SegmentedReaderFacade};
+use crate::vector::index::segment::manager::{
+    ManagedSegmentInfo, MergeCandidate, SegmentManager, SegmentManagerConfig,
+};
+use crate::vector::index::segment::merge::MergeConfig;
+use crate::vector::index::segment::reader_cache::SegmentedReaderCache;
+use crate::vector::index::{VectorIndex, VectorIndexStats};
+use crate::vector::reader::VectorIndexReader;
+use crate::vector::search::searcher::VectorIndexSearcher;
+use crate::vector::store::embedding_writer::EmbeddingVectorIndexWriter;
+use crate::vector::writer::{VectorIndexWriter, VectorIndexWriterConfig};
+
+/// State shared between the index handle, its writers, and its searchers.
+#[derive(Debug)]
+struct SegmentedShared {
+    /// Index name — the prefix for the deletion bitmap file. Segment files
+    /// are named by the manager (`segment_NNNNNN.ivf`).
+    name: String,
+
+    /// Storage backend.
+    storage: Arc<dyn Storage>,
+
+    /// Segment registry (atomic manifest).
+    manager: Arc<SegmentManager>,
+
+    /// Per-segment reader cache; invalidated on merge.
+    reader_cache: Arc<SegmentedReaderCache<IvfIndexReader>>,
+
+    /// Index-level logical-deletion bitmap (doc-scoped). `None` means "not
+    /// yet loaded / no deletions"; lazily loaded from `{name}.delmap`.
+    deletion: RwLock<Option<Arc<DeletionBitmap>>>,
+
+    /// Bumped when the bitmap is CREATED (first soft delete). Readers cached
+    /// before that moment are not attached to it; the reader-building loop
+    /// re-checks this epoch after populating from the cache and rebuilds if
+    /// a create raced it — clearing the cache alone is not enough, because
+    /// a concurrent build could repopulate it with bitmap-less readers
+    /// after the clear.
+    bitmap_epoch: std::sync::atomic::AtomicU64,
+
+    /// Highest WAL sequence number applied to this index but NOT yet
+    /// published to the manifest. Published (and persisted) by
+    /// [`VectorIndex::persist_deletions`] at the end of the store's commit
+    /// ladder, once every covered mutation is durable.
+    pending_wal_seq: std::sync::atomic::AtomicU64,
+}
+
+impl SegmentedShared {
+    fn delmap_file_name(&self) -> String {
+        format!("{}.delmap", self.name)
+    }
+
+    /// Load (or lazily create) the shared deletion bitmap.
+    ///
+    /// Mirrors `SegmentedFlatIndex`'s bitmap handling. When a bitmap is
+    /// created for the first time, the reader cache is cleared so
+    /// subsequently loaded segment readers attach it (cached readers hold
+    /// the bitmap by `Arc`, so later marks on an *already attached* bitmap
+    /// are always visible).
+    fn load_or_get_bitmap(&self, create_if_missing: bool) -> Result<Option<Arc<DeletionBitmap>>> {
+        if let Some(bitmap) = self.deletion.read().as_ref() {
+            return Ok(Some(bitmap.clone()));
+        }
+
+        let mut guard = self.deletion.write();
+        if let Some(bitmap) = guard.as_ref() {
+            return Ok(Some(bitmap.clone()));
+        }
+
+        let file = self.delmap_file_name();
+        if self.storage.file_exists(&file) {
+            let input = self.storage.open_input(&file)?;
+            let mut reader = StructReader::new(input)?;
+            let bitmap = Arc::new(DeletionBitmap::read_from_storage(&mut reader)?);
+            *guard = Some(bitmap.clone());
+            return Ok(Some(bitmap));
+        }
+
+        if create_if_missing {
+            let bitmap = Arc::new(DeletionBitmap::new(self.name.clone(), 0, u64::MAX - 1));
+            *guard = Some(bitmap.clone());
+            self.reader_cache.clear();
+            self.bitmap_epoch.fetch_add(1, Ordering::Release);
+            return Ok(Some(bitmap));
+        }
+
+        Ok(None)
+    }
+
+    /// Sealed segment readers, newest generation first, with the deletion
+    /// bitmap attached.
+    fn sealed_readers_newest_first(
+        &self,
+        config: &IvfIndexConfig,
+    ) -> Result<Vec<Arc<IvfIndexReader>>> {
+        let mut segments = self.manager.list_segments();
+        segments.sort_by_key(|s| std::cmp::Reverse(s.generation));
+
+        loop {
+            let epoch = self.bitmap_epoch.load(Ordering::Acquire);
+            let bitmap = self.load_or_get_bitmap(false)?;
+            let mut readers = Vec::with_capacity(segments.len());
+            for info in &segments {
+                let storage = self.storage.clone();
+                let metric = config.distance_metric;
+                let bitmap_for_loader = bitmap.clone();
+                let segment_id = info.segment_id.clone();
+                let reader = self.reader_cache.get_or_load(&segment_id, || {
+                    let mut r = IvfIndexReader::load(storage, &segment_id, metric)?;
+                    if let Some(b) = bitmap_for_loader {
+                        r.set_deletion_bitmap(b);
+                    }
+                    Ok(r)
+                })?;
+                readers.push(reader);
+            }
+            // A bitmap create that raced this build may have been missed by
+            // readers loaded from our (pre-create) snapshot; the epoch bump
+            // detects it. Creation happens at most once per index lifetime,
+            // so the loop reruns at most once.
+            if self.bitmap_epoch.load(Ordering::Acquire) == epoch {
+                return Ok(readers);
+            }
+            self.reader_cache.clear();
+        }
+    }
+}
+
+/// Segment-per-commit IVF index (see the module docs).
+#[derive(Debug)]
+pub struct SegmentedIvfIndex {
+    shared: Arc<SegmentedShared>,
+    config: IvfIndexConfig,
+    closed: AtomicBool,
+}
+
+impl SegmentedIvfIndex {
+    /// Open an existing segmented index or create a new one.
+    ///
+    /// # Arguments
+    ///
+    /// * `storage` - Storage backend.
+    /// * `name` - Index name (bitmap file prefix; segment files are named
+    ///   by the segment manager).
+    /// * `config` - IVF configuration (with [`IvfIndexConfig::segmented`]
+    ///   set).
+    ///
+    /// A legacy monolithic index is migrated **zero-copy**: the existing
+    /// `{name}.ivf` is registered verbatim as the first segment — its
+    /// segment id is the index name, which every reader treats as a plain
+    /// path prefix — with a single atomic manifest write and no data
+    /// movement. A crash before the manifest save leaves the legacy layout
+    /// intact, so the migration simply re-runs on the next open. The
+    /// pre-existing `{name}.delmap` keeps its meaning: it is the
+    /// index-level deletion bitmap in both layouts (and
+    /// `delete_segment_files` never touches `.delmap` files for exactly
+    /// this reason).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the manifest fails to load (corruption fails
+    /// loudly), when reading the legacy file's header during migration
+    /// fails, or when the legacy file's persisted dimension does not match
+    /// `config.dimension`.
+    pub fn open_or_create(
+        storage: Arc<dyn Storage>,
+        name: &str,
+        config: IvfIndexConfig,
+    ) -> Result<Self> {
+        // The generated-segment namespace is reserved: an index named like
+        // a generated id would collide with sealed segments (same file
+        // names, orphan-sweep patterns, and merge GC) — reject it loudly.
+        if let Some(ordinal) = name.strip_prefix("segment_")
+            && !ordinal.is_empty()
+            && ordinal.bytes().all(|b| b.is_ascii_digit())
+        {
+            return Err(LaurusError::invalid_config(format!(
+                "index name '{name}' collides with the reserved segment-id \
+                 namespace (segment_<digits>)"
+            )));
+        }
+
+        let legacy_file = format!("{name}.ivf");
+        let migrate = storage.file_exists(&legacy_file) && !storage.file_exists("segments.json");
+
+        // The manager's orphan sweep only touches `segment_NNNNNN.*` names,
+        // so an unmigrated `{name}.ivf` is never swept.
+        let manager = Arc::new(SegmentManager::new(
+            SegmentManagerConfig::default(),
+            storage.clone(),
+            crate::vector::index::ivf::segment::LAYOUT,
+        )?);
+
+        if migrate {
+            // Read the committed vector count and dimension from the
+            // legacy file's leading two u32 fields (same header every
+            // reader loads; `n_clusters`/`n_probe` follow but migration
+            // needs neither).
+            let (vector_count, dimension) = {
+                use std::io::Read;
+                let mut input = storage.open_input(&legacy_file)?;
+                let mut count_buf = [0u8; 4];
+                input.read_exact(&mut count_buf)?;
+                let mut dim_buf = [0u8; 4];
+                input.read_exact(&mut dim_buf)?;
+                (
+                    u32::from_le_bytes(count_buf) as u64,
+                    u32::from_le_bytes(dim_buf) as usize,
+                )
+            };
+            if dimension != config.dimension {
+                return Err(LaurusError::index(format!(
+                    "Dimension mismatch during migration: stored {dimension}, config {}",
+                    config.dimension
+                )));
+            }
+            // `add_segment` stamps generation 1, measures the on-storage
+            // size, and saves the manifest atomically — the moment it
+            // returns, the index is segmented; before that, it is still a
+            // valid legacy index. A legacy delmap (same file in both
+            // layouts) means the segment carries deletions.
+            let mut info = ManagedSegmentInfo::new(name.to_string(), vector_count, 0, 0);
+            info.has_deletions = storage.file_exists(&format!("{name}.delmap"));
+            manager.add_segment(info)?;
+
+            // Drop the monolithic index's now-stale `metadata.json` so the
+            // factory's open/create routing can never again mistake this
+            // directory for a monolithic index (mirrors HNSW's #882
+            // review fix).
+            let _ = storage.delete_file("metadata.json");
+        }
+
+        Ok(Self {
+            shared: Arc::new(SegmentedShared {
+                name: name.to_string(),
+                storage,
+                manager,
+                reader_cache: Arc::new(SegmentedReaderCache::new()),
+                deletion: RwLock::new(None),
+                bitmap_epoch: std::sync::atomic::AtomicU64::new(0),
+                pending_wal_seq: std::sync::atomic::AtomicU64::new(0),
+            }),
+            config,
+            closed: AtomicBool::new(false),
+        })
+    }
+
+    fn check_closed(&self) -> Result<()> {
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(LaurusError::InvalidOperation("Index is closed".to_string()));
+        }
+        Ok(())
+    }
+
+    /// Merge one policy-selected window of segments.
+    ///
+    /// Uses the generation-contiguous, size-similar `TieredMergePolicy`
+    /// through the deletion-filtering, re-clustering merge engine; source
+    /// readers are invalidated afterwards. Returns whether a merge actually
+    /// ran.
+    fn merge_once(&self) -> Result<bool> {
+        use crate::vector::index::segment::merge_policy::TieredMergePolicy;
+
+        let Some(candidate) = self.shared.manager.check_merge(&TieredMergePolicy::new()) else {
+            return Ok(false);
+        };
+
+        let mut engine = MergeEngine::new(
+            MergeConfig::default(),
+            self.shared.storage.clone(),
+            self.config.clone(),
+            VectorIndexWriterConfig::default(),
+        );
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(false)? {
+            engine.set_deletion_bitmap(bitmap);
+        }
+
+        let new_segment_id = self.shared.manager.generate_segment_id();
+        let result = engine.merge_segments(candidate.segments.clone(), new_segment_id)?;
+
+        let source_ids: Vec<String> = candidate
+            .segments
+            .iter()
+            .map(|s| s.segment_id.clone())
+            .collect();
+        self.shared
+            .manager
+            .apply_merge(candidate, result.merged_segment)?;
+        for id in &source_ids {
+            self.shared.reader_cache.invalidate(id);
+        }
+        Ok(true)
+    }
+
+    /// Drop the deletion state after a compaction physically reclaimed the
+    /// deleted documents.
+    fn clear_deletions(&self) -> Result<()> {
+        *self.shared.deletion.write() = None;
+        let file = self.shared.delmap_file_name();
+        let _ = self.shared.storage.delete_file(&file);
+        Ok(())
+    }
+}
+
+impl VectorIndex for SegmentedIvfIndex {
+    fn reader(&self) -> Result<Arc<dyn VectorIndexReader>> {
+        self.check_closed()?;
+        let readers = self.shared.sealed_readers_newest_first(&self.config)?;
+        let readers: Vec<Arc<dyn VectorIndexReader>> = readers
+            .into_iter()
+            .map(|r| r as Arc<dyn VectorIndexReader>)
+            .collect();
+        let bitmap = self.shared.load_or_get_bitmap(false)?;
+        Ok(Arc::new(SegmentedReaderFacade::new(
+            readers,
+            bitmap,
+            self.config.dimension,
+            self.config.distance_metric,
+        )))
+    }
+
+    fn writer(&self) -> Result<Box<dyn VectorIndexWriter>> {
+        self.check_closed()?;
+
+        // A fresh, EMPTY active-segment writer per call: constructing it does
+        // not touch the existing segments — the whole point of the layout.
+        let segment_id = self.shared.manager.generate_segment_id();
+        let inner = IvfIndexWriter::with_storage(
+            self.config.clone(),
+            VectorIndexWriterConfig::default(),
+            &segment_id,
+            self.shared.storage.clone(),
+        )?;
+        let writer = SegmentedIvfWriter {
+            shared: self.shared.clone(),
+            segment_id,
+            inner,
+            sealed_len: None,
+        };
+        let embedder = self.embedder();
+        Ok(Box::new(EmbeddingVectorIndexWriter::new(
+            Box::new(writer),
+            embedder,
+        )))
+    }
+
+    fn storage(&self) -> &Arc<dyn Storage> {
+        &self.shared.storage
+    }
+
+    fn close(&self) -> Result<()> {
+        self.closed.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::SeqCst)
+    }
+
+    fn stats(&self) -> Result<VectorIndexStats> {
+        self.check_closed()?;
+        // `total` sums per-segment row counts: stale same-id upsert copies
+        // awaiting a merge are counted once per segment, so this (and the
+        // auto-compaction ratio derived from it) slightly over-counts until
+        // the next merge. Exact distinct-key counting would cost O(total
+        // ids) per call; the approximation is intentional (mirrors HNSW).
+        let total = self.shared.manager.total_vectors();
+        let deleted = match self.shared.load_or_get_bitmap(false)? {
+            Some(bitmap) => bitmap.deleted_count.load(Ordering::Relaxed),
+            None => 0,
+        };
+        let stats = self.shared.manager.stats();
+        Ok(VectorIndexStats {
+            vector_count: total.saturating_sub(deleted),
+            dimension: self.config.dimension,
+            total_size: stats.total_size,
+            deleted_count: deleted,
+            last_modified: 0,
+        })
+    }
+
+    fn retain_writer_after_commit(&self) -> bool {
+        // Retention exists only to avoid a monolithic writer's full
+        // corpus-wide re-training after commit. A segmented writer starts
+        // EMPTY — there is nothing to retrain — so the store can drop it
+        // and construct a fresh one per commit cycle; each commit then
+        // seals exactly one new segment.
+        false
+    }
+
+    fn optimize(&self) -> Result<()> {
+        self.check_closed()?;
+
+        let segments = self.shared.manager.list_segments();
+        if segments.is_empty() {
+            return Ok(());
+        }
+        // Force-merge everything into one segment; the merge engine filters
+        // through the deletion bitmap (physical reclamation), collapses
+        // same-key duplicates newest-generation-first, and re-clusters the
+        // survivors from scratch.
+        let mut engine = MergeEngine::new(
+            MergeConfig::default(),
+            self.shared.storage.clone(),
+            self.config.clone(),
+            VectorIndexWriterConfig::default(),
+        );
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(false)? {
+            engine.set_deletion_bitmap(bitmap);
+        }
+
+        let new_segment_id = self.shared.manager.generate_segment_id();
+        let result = engine.merge_segments(segments.clone(), new_segment_id)?;
+
+        let candidate = MergeCandidate {
+            total_vectors: segments.iter().map(|s| s.vector_count).sum(),
+            total_size: segments.iter().map(|s| s.size_bytes).sum(),
+            segments,
+        };
+        let source_ids: Vec<String> = candidate
+            .segments
+            .iter()
+            .map(|s| s.segment_id.clone())
+            .collect();
+        self.shared
+            .manager
+            .apply_merge(candidate, result.merged_segment)?;
+        for id in &source_ids {
+            self.shared.reader_cache.invalidate(id);
+        }
+
+        // Every logically deleted doc was physically dropped by the merge.
+        self.clear_deletions()?;
+        Ok(())
+    }
+
+    // `refresh` keeps its trait default (no-op), like the monolithic index:
+    // sealed segment files are immutable, segment-set changes are picked up
+    // from the shared manager on every `searcher()`/`reader()` call, and
+    // merges invalidate their source readers explicitly.
+
+    fn searcher(&self) -> Result<Box<dyn VectorIndexSearcher>> {
+        self.check_closed()?;
+        let readers = self.shared.sealed_readers_newest_first(&self.config)?;
+        let readers: Vec<Arc<dyn VectorIndexReader>> = readers
+            .into_iter()
+            .map(|r| r as Arc<dyn VectorIndexReader>)
+            .collect();
+        let bitmap = self.shared.load_or_get_bitmap(false)?;
+        let n_probe = self.config.n_probe;
+        Ok(Box::new(SegmentFanoutSearcher::new(
+            readers,
+            bitmap,
+            move |reader| {
+                Ok(Box::new(IvfSearcher::with_n_probe(reader, n_probe)?)
+                    as Box<dyn VectorIndexSearcher>)
+            },
+        )))
+    }
+
+    fn embedder(&self) -> Arc<dyn Embedder> {
+        Arc::clone(&self.config.embedder)
+    }
+
+    fn last_wal_seq(&self) -> u64 {
+        // The PUBLISHED checkpoint: the value loaded from (or last saved
+        // to) the manifest — never the pending one, which may not be
+        // durable yet. Recovery skips WAL records at or below this seq, so
+        // it must only ever reflect state that is already on storage.
+        self.shared.manager.last_wal_seq()
+    }
+
+    fn set_last_wal_seq(&self, seq: u64) -> Result<()> {
+        // Recorded as PENDING only. It is published into the manifest at
+        // the end of `persist_deletions` — the last vector step of the
+        // store's commit ladder — at which point the sealed segment files
+        // AND the deletion bitmap for every record up to `seq` are
+        // durable, and the engine has not yet truncated the WAL (a
+        // checkpoint must never outrun the durability of the state it
+        // covers).
+        self.shared
+            .pending_wal_seq
+            .fetch_max(seq, Ordering::Release);
+        Ok(())
+    }
+
+    fn supports_soft_delete(&self) -> bool {
+        true
+    }
+
+    fn soft_delete_document(&self, doc_id: u64) -> Result<()> {
+        self.check_closed()?;
+        let bitmap = self
+            .shared
+            .load_or_get_bitmap(true)?
+            .ok_or_else(|| LaurusError::internal("deletion bitmap unexpectedly missing"))?;
+        let newly_deleted = bitmap.delete_document(doc_id)?;
+        if newly_deleted && !self.shared.manager.list_segments().is_empty() {
+            // Conservative-all flagging: segment infos carry no doc-id
+            // range, and the flag only feeds merge-policy prioritization.
+            self.shared.manager.mark_all_has_deletions()?;
+        }
+        Ok(())
+    }
+
+    fn persist_deletions(&self) -> Result<()> {
+        let guard = self.shared.deletion.read();
+        if let Some(bitmap) = guard.as_ref() {
+            let file = self.shared.delmap_file_name();
+            if bitmap.deleted_count.load(Ordering::Relaxed) > 0 {
+                // Temp-then-rename for crash safety; the payload is CRC-32
+                // protected by `StructWriter`.
+                let tmp = format!("{file}.tmp");
+                let output = self.shared.storage.create_output(&tmp)?;
+                let mut writer = StructWriter::new(output);
+                bitmap.write_to_storage(&mut writer)?;
+                writer.close()?;
+                self.shared.storage.rename_file(&tmp, &file)?;
+            } else if self.shared.storage.file_exists(&file) {
+                // Undelete-to-zero: the upsert dance's re-add can clear
+                // every mark, and a previously persisted delmap would then
+                // be STALE — on reopen it would mask the committed upsert
+                // in every segment. "Nothing deleted" must persist as "no
+                // delmap file", not "keep whatever file exists".
+                self.shared.storage.delete_file(&file)?;
+            }
+        }
+        drop(guard);
+
+        // Publish the WAL checkpoint. This is the last vector step of the
+        // store's commit ladder: the sealed segment files (fsynced +
+        // manifest-registered by `writer.commit()`) and the deletion
+        // bitmap (written above) are durable for every record up to the
+        // pending seq, and `Engine::commit` truncates the WAL only after
+        // all stores finish — so a crash on either side of this save is
+        // safe: before it, recovery replays idempotently from the old
+        // checkpoint; after it, everything skipped is already on storage.
+        let pending = self.shared.pending_wal_seq.load(Ordering::Acquire);
+        if pending > self.shared.manager.last_wal_seq() {
+            self.shared.manager.set_last_wal_seq(pending);
+            self.shared.manager.save_state()?;
+        }
+        Ok(())
+    }
+
+    fn maybe_auto_compact(&self) -> Result<bool> {
+        // Tiered auto-merge: the policy itself is the trigger — it returns
+        // a candidate when a generation-contiguous, size-similar window
+        // fills up (steady-state: every `merge_factor` commits the newest
+        // tier collapses upward, giving each vector O(log N) rewrites over
+        // its lifetime) or when the hard segment-count bound is exceeded.
+        // Runs regardless of `auto_compaction`, which gates deletion
+        // *reclamation*, not the structural segment bound.
+        if self.merge_once()? {
+            return Ok(true);
+        }
+
+        if !self.config.auto_compaction {
+            return Ok(false);
+        }
+        let deleted = match self.shared.load_or_get_bitmap(false)? {
+            Some(bitmap) => bitmap.deleted_count.load(Ordering::Relaxed),
+            None => 0,
+        };
+        if deleted == 0 {
+            return Ok(false);
+        }
+        let total = self.shared.manager.total_vectors();
+        if total == 0 {
+            return Ok(false);
+        }
+        let ratio = deleted as f64 / total as f64;
+        if ratio >= self.config.compaction_threshold {
+            self.optimize()?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+}
+
+/// Active-segment writer for [`SegmentedIvfIndex`].
+///
+/// Buffers new vectors in an ordinary [`IvfIndexWriter`] whose path is a
+/// fresh `segment_NNNNNN`; [`VectorIndexWriter::commit`] seals it as a new
+/// immutable segment file (training centroids from just this segment's own
+/// buffer) and registers it in the manifest exactly once. A sealed writer is
+/// DONE: committing again with new changes is rejected — re-writing a
+/// registered segment would carry its original generation while newer
+/// segments may have sealed in between, inverting the newest-wins ordering.
+/// The store never does this (`retain_writer_after_commit` is false);
+/// direct API users get a loud error instead of silent metadata corruption.
+#[derive(Debug)]
+struct SegmentedIvfWriter {
+    shared: Arc<SegmentedShared>,
+    segment_id: String,
+    inner: IvfIndexWriter,
+    /// Buffer length at the moment this writer's segment was sealed and
+    /// registered; `None` until then. Used to make the post-commit
+    /// `close()` a no-op (the inner buffer is retained after commit, so a
+    /// plain "buffer non-empty" check would re-enter `commit`).
+    sealed_len: Option<usize>,
+}
+
+impl VectorIndexWriter for SegmentedIvfWriter {
+    fn next_vector_id(&self) -> u64 {
+        self.inner.next_vector_id()
+    }
+
+    fn build(&mut self, vectors: Vec<(u64, String, Vector)>) -> Result<()> {
+        self.add_vectors(vectors)
+    }
+
+    fn add_vectors(&mut self, vectors: Vec<(u64, String, Vector)>) -> Result<()> {
+        // Same-id upsert completion: the delete-first step marked the ids
+        // so sealed copies stop matching; clear the marks so the NEW
+        // copies are not shadowed by their own delete once this segment
+        // seals. Revived stale copies are masked by newest-wins containment
+        // at search and collapsed at merge.
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(false)? {
+            for (doc_id, _, _) in &vectors {
+                let _ = bitmap.undelete_document(*doc_id)?;
+            }
+        }
+        self.inner.add_vectors(vectors)
+    }
+
+    fn finalize(&mut self) -> Result<()> {
+        self.inner.finalize()
+    }
+
+    fn progress(&self) -> f32 {
+        self.inner.progress()
+    }
+
+    fn estimated_memory_usage(&self) -> usize {
+        self.inner.estimated_memory_usage()
+    }
+
+    fn vectors(&self) -> &[(u64, String, Vector)] {
+        self.inner.vectors()
+    }
+
+    fn write(&self) -> Result<()> {
+        if self.inner.vectors().is_empty() {
+            // Nothing buffered — sealing would create an empty segment file
+            // per commit. Deletion persistence is handled by
+            // `persist_deletions` on the index.
+            return Ok(());
+        }
+        // Writes `{segment_id}.ivf`; manifest registration happens in
+        // `commit()` (`&mut self`), which is the store's entry point.
+        self.inner.write()
+    }
+
+    fn has_storage(&self) -> bool {
+        self.inner.has_storage()
+    }
+
+    fn delete_document(&mut self, doc_id: u64) -> Result<()> {
+        // Upsert delete-first: remove any buffered copy AND mark the
+        // shared bitmap so copies in sealed segments stop matching. A pure
+        // delete stays marked; a following `add_vectors` with the same id
+        // clears the mark.
+        if let Some(bitmap) = self.shared.load_or_get_bitmap(true)? {
+            let newly_deleted = bitmap.delete_document(doc_id)?;
+            if newly_deleted && !self.shared.manager.list_segments().is_empty() {
+                self.shared.manager.mark_all_has_deletions()?;
+            }
+        }
+        let _ = self.inner.delete_document(doc_id);
+        Ok(())
+    }
+
+    fn has_pending_changes(&self) -> bool {
+        match self.sealed_len {
+            // Sealed: pending only if the buffer changed since the seal.
+            Some(sealed) => self.inner.vectors().len() != sealed,
+            // `IvfIndexWriter` doesn't override `has_pending_changes` (the
+            // trait default is an unconditional `true`), so checking it
+            // here would make this branch meaningless.
+            None => !self.inner.vectors().is_empty(),
+        }
+    }
+
+    fn commit(&mut self) -> Result<()> {
+        if self.inner.vectors().is_empty() {
+            return Ok(());
+        }
+        if let Some(sealed) = self.sealed_len {
+            if self.inner.vectors().len() == sealed {
+                // Post-commit close(): the segment is already sealed and the
+                // buffer is unchanged — nothing to do.
+                return Ok(());
+            }
+            // See the struct docs: re-sealing a registered segment would
+            // invert the newest-wins generation ordering.
+            return Err(LaurusError::InvalidOperation(format!(
+                "segment '{}' is already sealed; obtain a fresh writer for further changes",
+                self.segment_id
+            )));
+        }
+        self.inner.finalize()?;
+        self.inner.write()?;
+        let vector_count = self.inner.vectors().len() as u64;
+        // generation 0 → the manager stamps max+1; size_bytes 0 → measured
+        // from storage by `add_segment`.
+        let info = ManagedSegmentInfo::new(self.segment_id.clone(), vector_count, 0, 0);
+        self.shared.manager.add_segment(info)?;
+        self.sealed_len = Some(self.inner.vectors().len());
+        self.shared.reader_cache.invalidate(&self.segment_id);
+        Ok(())
+    }
+
+    fn rollback(&mut self) -> Result<()> {
+        // Rolled-back mutations are discarded, so the pending WAL
+        // checkpoint must not keep covering their sequence numbers: roll
+        // it back to the published value; their WAL records then stay
+        // replayable.
+        self.shared
+            .pending_wal_seq
+            .store(self.shared.manager.last_wal_seq(), Ordering::Release);
+        self.inner.rollback()
+    }
+
+    fn pending_docs(&self) -> u64 {
+        self.inner.pending_docs()
+    }
+
+    fn close(&mut self) -> Result<()> {
+        if self.has_pending_changes() {
+            self.commit()?;
+        }
+        self.inner.close()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    fn build_reader(&self) -> Result<Arc<dyn VectorIndexReader>> {
+        self.inner.build_reader()
+    }
+}
+
+impl Drop for SegmentedIvfWriter {
+    fn drop(&mut self) {
+        // Backstop: dropping a writer whose buffered mutations were never
+        // sealed discards the only in-process copy, while the pending WAL
+        // checkpoint may already cover their sequence numbers — publishing
+        // it later would hide the loss from recovery. Roll the pending
+        // value back to the published checkpoint so those records stay
+        // replayable. The store never drops a dirty writer (its
+        // commit/optimize/add_field paths retain it on failure), so this
+        // fires only on direct API use.
+        if self.has_pending_changes() {
+            self.shared
+                .pending_wal_seq
+                .store(self.shared.manager.last_wal_seq(), Ordering::Release);
+        }
+    }
+}

--- a/laurus/src/vector/index/ivf/writer.rs
+++ b/laurus/src/vector/index/ivf/writer.rs
@@ -361,9 +361,16 @@ impl IvfIndexWriter {
     /// Train centroids using k-means clustering.
     fn train_centroids(&mut self) -> Result<()> {
         if self.vectors.is_empty() {
-            return Err(LaurusError::InvalidOperation(
-                "Cannot train centroids on empty vector set".to_string(),
-            ));
+            // Issue #889 PR-6: a segmented force-merge can legitimately
+            // reduce a merge window to zero surviving vectors (every
+            // document in it was logically deleted). Represent that as
+            // zero clusters rather than erroring — `build_inverted_lists`,
+            // `write`, and every reader/searcher already handle
+            // `n_clusters == 0` gracefully (their loops just run zero
+            // times), so there is nothing downstream left to special-case.
+            self.index_config.n_clusters = 0;
+            self.centroids.clear();
+            return Ok(());
         }
 
         // Issue #889 PR-5: clamp to the available corpus instead of
@@ -1071,13 +1078,9 @@ impl VectorIndexWriter for IvfIndexWriter {
             return Ok(());
         }
 
-        if self.vectors.is_empty() {
-            return Err(LaurusError::InvalidOperation(
-                "Cannot finalize empty index".to_string(),
-            ));
-        }
-
-        // Train centroids using k-means
+        // `train_centroids` handles the empty-vectors case itself (Issue
+        // #889 PR-6: zero clusters, not an error) — no separate guard
+        // needed here.
         self.train_centroids()?;
 
         // Build inverted lists
@@ -1405,5 +1408,25 @@ mod tests {
             assignments_a, assignments_b,
             "cluster assignments must be identical across runs"
         );
+    }
+
+    /// Issue #889 PR-6: finalizing a writer with zero buffered vectors must
+    /// succeed with zero clusters instead of erroring — the segmented
+    /// force-merge path can legitimately reduce a merge window to zero
+    /// surviving vectors when every document in it was deleted.
+    #[test]
+    fn finalize_on_empty_vectors_succeeds_with_zero_clusters() {
+        let config = IvfIndexConfig {
+            dimension: 4,
+            n_clusters: 8,
+            n_probe: 1,
+            ..Default::default()
+        };
+        let mut writer =
+            IvfIndexWriter::new(config, VectorIndexWriterConfig::default(), "empty_merge").unwrap();
+
+        writer.finalize().unwrap();
+        assert_eq!(writer.centroids().len(), 0);
+        assert_eq!(writer.ivf_params().0, 0, "n_clusters must be reset to 0");
     }
 }

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -165,6 +165,11 @@ impl VectorStore {
                         // Cosine metric (Issue #794).
                         normalize_vectors: opt.distance
                             == crate::vector::core::distance::DistanceMetric::Cosine,
+                        // Wire the deletion config's compaction policy into
+                        // the index so commit can auto-compact under the
+                        // segmented layout (Issue #889, mirroring Flat/HNSW).
+                        auto_compaction: config.deletion_config.auto_compaction,
+                        compaction_threshold: config.deletion_config.compaction_threshold,
                         embedder: config.embedder.clone(),
                         ..Default::default()
                     }),

--- a/laurus/tests/vector_segmented_ivf_test.rs
+++ b/laurus/tests/vector_segmented_ivf_test.rs
@@ -1,0 +1,897 @@
+//! Gates for the segment-per-commit IVF index (Issue #889 PR-6, mirroring
+//! `vector_segmented_index_test.rs` (HNSW) and `vector_segmented_flat_test.rs`
+//! (Flat)).
+//!
+//! Two IVF-specific fixture choices, learned while stabilizing this suite:
+//!
+//! - `doc_vec` uses a well-mixed LCG (like `ivf/writer.rs`'s own
+//!   `lcg_vectors` test helper) rather than a smoothly-varying curve. A
+//!   slowly-varying curve (e.g. `cos(i * 0.001)`) packs neighboring ids too
+//!   closely together once int8-quantized (Scalar8Bit is IVF's default),
+//!   producing spurious similarity ties that make exact top-1 self-lookup
+//!   flaky — the LCG spreads ids pseudo-randomly across all 16 dimensions,
+//!   which is robust against that.
+//! - `config()` sets a large `n_probe` so per-segment search is effectively
+//!   exhaustive over that segment's own clusters. IVF search only examines
+//!   the `n_probe` nearest clusters — unlike Flat's brute-force scan, an
+//!   over-restrictive `n_probe` can starve the multi-segment fan-out's
+//!   masking/expanding-refill (Issue #883): if a query's nearest cluster in
+//!   an older segment is entirely shadowed by a newer segment, expanding
+//!   `top_k` within that SAME one probed cluster surfaces nothing new,
+//!   since the fan-out layer's refill loop does not also grow `n_probe`.
+//!   Structural/functional gates below want that confound removed; the
+//!   dedicated `recall_improves_after_merge_for_small_k_segments` test
+//!   deliberately overrides `n_probe` back down to exercise genuine
+//!   approximate search.
+
+mod common;
+
+use std::sync::Arc;
+
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::index::VectorIndex;
+use laurus::vector::index::config::IvfIndexConfig;
+use laurus::vector::index::ivf::IvfIndex;
+use laurus::vector::index::ivf::segmented::SegmentedIvfIndex;
+use laurus::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryParams};
+use laurus::vector::{DistanceMetric, Vector};
+
+fn doc_vec(i: u64) -> Vector {
+    let mut state: u64 = 0x9E3779B97F4A7C15u64.wrapping_add(i.wrapping_mul(0xBF58_476D_1CE4_E5B9));
+    let data: Vec<f32> = (0..16)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+        })
+        .collect();
+    Vector::new(data)
+}
+
+fn config(segmented: bool) -> IvfIndexConfig {
+    IvfIndexConfig {
+        dimension: 16,
+        normalize_vectors: false,
+        distance_metric: DistanceMetric::Cosine,
+        // Effectively exhaustive per-segment search (clamped internally to
+        // the segment's own cluster count) — see the module docs.
+        n_probe: 10_000,
+        segmented,
+        ..Default::default()
+    }
+}
+
+fn storage() -> Arc<MemoryStorage> {
+    Arc::new(MemoryStorage::new(MemoryStorageConfig::default()))
+}
+
+/// Add `ids` to a fresh writer and commit (one sealed segment).
+fn commit_batch(index: &dyn VectorIndex, ids: std::ops::Range<u64>) {
+    let mut writer = index.writer().unwrap();
+    let vectors: Vec<_> = ids.map(|i| (i, "v".to_string(), doc_vec(i))).collect();
+    writer.add_vectors(vectors).unwrap();
+    writer.commit().unwrap();
+}
+
+fn query(id: u64, top_k: usize) -> VectorIndexQuery {
+    VectorIndexQuery {
+        query: doc_vec(id),
+        params: VectorIndexQueryParams {
+            top_k,
+            ..Default::default()
+        },
+        field_name: Some("v".to_string()),
+        filter: None,
+    }
+}
+
+fn ivf_segment_files(storage: &MemoryStorage) -> Vec<String> {
+    storage
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .filter(|f| f.ends_with(".ivf"))
+        .collect()
+}
+
+/// Core gate: a 1-doc commit on a 1000-doc base writes a new segment that is
+/// a tiny fraction of the base segment, and never rewrites the base.
+#[test]
+fn one_doc_commit_writes_o_delta_bytes() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    commit_batch(&index, 0..1000);
+    let base_file = "segment_000000.ivf";
+    let base_size = storage.file_size(base_file).unwrap();
+
+    commit_batch(&index, 1000..1001);
+    let delta_file = "segment_000001.ivf";
+    let delta_size = storage.file_size(delta_file).unwrap();
+
+    assert!(
+        delta_size * 10 < base_size,
+        "a 1-doc commit must write O(delta) bytes, got delta={delta_size} vs base={base_size}"
+    );
+    assert_eq!(
+        storage.file_size(base_file).unwrap(),
+        base_size,
+        "the base segment must never be rewritten by a later commit"
+    );
+    assert_eq!(
+        ivf_segment_files(&storage).len(),
+        2,
+        "exactly one new segment per non-empty commit"
+    );
+}
+
+/// With `segmented: false` (the default for IVF) the factory path stays
+/// monolithic — no manifest, single `.ivf` file.
+#[test]
+fn config_off_keeps_monolithic_layout() {
+    let storage = storage();
+    let index = IvfIndex::create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(false),
+    )
+    .unwrap();
+
+    commit_batch(&index, 0..100);
+    assert!(
+        !storage.file_exists("segments.json"),
+        "config OFF must not create a segment manifest"
+    );
+    assert!(storage.file_exists("vector_index.ivf"));
+}
+
+/// A legacy monolithic index is migrated ZERO-COPY on first segmented open
+/// — the existing `.ivf` becomes segment 0 verbatim, search results are
+/// identical, and later commits append new segments without ever touching
+/// the legacy file.
+#[test]
+fn legacy_monolithic_index_migrates_zero_copy() {
+    let storage = storage();
+    {
+        let index = IvfIndex::create(
+            storage.clone() as Arc<dyn Storage>,
+            "vector_index",
+            config(false),
+        )
+        .unwrap();
+        commit_batch(&index, 0..100);
+    }
+    let legacy_size = storage.file_size("vector_index.ivf").unwrap();
+
+    let index = SegmentedIvfIndex::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    assert!(storage.file_exists("segments.json"), "manifest created");
+    assert_eq!(
+        storage.file_size("vector_index.ivf").unwrap(),
+        legacy_size,
+        "zero-copy: the legacy file must not be rewritten"
+    );
+
+    let searcher = index.searcher().unwrap();
+    let results = searcher.search(&query(42, 1)).unwrap();
+    assert_eq!(results.results[0].doc_id, 42);
+
+    commit_batch(&index, 100..101);
+    assert_eq!(storage.file_size("vector_index.ivf").unwrap(), legacy_size);
+    let searcher = index.searcher().unwrap();
+    assert_eq!(
+        searcher.search(&query(100, 1)).unwrap().results[0].doc_id,
+        100
+    );
+    assert_eq!(
+        searcher.search(&query(42, 1)).unwrap().results[0].doc_id,
+        42
+    );
+
+    drop(index);
+    let index = SegmentedIvfIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+    let searcher = index.searcher().unwrap();
+    assert_eq!(
+        searcher.search(&query(42, 1)).unwrap().results[0].doc_id,
+        42
+    );
+    assert_eq!(
+        searcher.search(&query(100, 1)).unwrap().results[0].doc_id,
+        100
+    );
+}
+
+/// The WAL checkpoint is published only by `persist_deletions` (the end of
+/// the store's commit ladder) — never by intermediate manifest saves.
+#[test]
+fn wal_checkpoint_publishes_only_after_persist_deletions() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    index.set_last_wal_seq(7).unwrap();
+    assert_eq!(
+        index.last_wal_seq(),
+        0,
+        "a pending seq must not be visible before persist_deletions"
+    );
+
+    commit_batch(&index, 0..5);
+    assert_eq!(
+        index.last_wal_seq(),
+        0,
+        "sealing must not publish the pending checkpoint"
+    );
+
+    index.persist_deletions().unwrap();
+    assert_eq!(index.last_wal_seq(), 7);
+}
+
+/// Self-recall of a multi-segment index matches a monolithic build of the
+/// same corpus. IVF self-lookup is always exact (see the module docs), so
+/// this pins that the newest-wins containment masking across segments does
+/// not accidentally drop or duplicate live docs.
+#[test]
+fn multi_segment_self_recall_matches_monolithic() {
+    let n = 1000u64;
+    let per_commit = 200u64;
+
+    let seg_storage = storage();
+    let seg_index = SegmentedIvfIndex::open_or_create(
+        seg_storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+    let mut lo = 0u64;
+    while lo < n {
+        commit_batch(&seg_index, lo..(lo + per_commit).min(n));
+        lo += per_commit;
+    }
+
+    let mono_storage = storage();
+    let mono_index = IvfIndex::create(
+        mono_storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(false),
+    )
+    .unwrap();
+    commit_batch(&mono_index, 0..n);
+
+    let recall = |index: &dyn VectorIndex| -> f32 {
+        let searcher = index.searcher().unwrap();
+        let mut hits = 0u64;
+        for id in 0..n {
+            let results = searcher.search(&query(id, 1)).unwrap();
+            if results.results.iter().any(|r| r.doc_id == id) {
+                hits += 1;
+            }
+        }
+        hits as f32 / n as f32
+    };
+
+    assert_eq!(recall(&mono_index), 1.0, "monolithic self-recall sanity");
+    assert_eq!(
+        recall(&seg_index),
+        1.0,
+        "multi-segment self-recall must match the monolithic build"
+    );
+}
+
+/// A same-id upsert across commits resolves to the newest copy exactly
+/// once, and a soft delete of a sealed doc is search-invisible and
+/// physically reclaimed by optimize() — the first-time soft-delete/
+/// compaction implementation for IVF.
+#[test]
+fn upsert_and_soft_delete_across_commits() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    commit_batch(&index, 1..50);
+
+    {
+        let mut writer = index.writer().unwrap();
+        writer.delete_document(1).unwrap();
+        writer
+            .add_vectors(vec![(1, "v".to_string(), doc_vec(9000))])
+            .unwrap();
+        writer.commit().unwrap();
+    }
+
+    let searcher = index.searcher().unwrap();
+    let results = searcher.search(&query(9000, 1)).unwrap();
+    assert_eq!(results.results[0].doc_id, 1, "newest copy must win");
+    let results = searcher.search(&query(1, 1)).unwrap();
+    assert_ne!(
+        results.results[0].doc_id, 1,
+        "the stale copy in the older segment must be masked"
+    );
+
+    // Soft delete a doc living in an already-SEALED segment (also exercises
+    // the quantized-pool fast-path `is_deleted` fix — Scalar8Bit is IVF's
+    // default quantization method, so `IvfSearcher`'s hot path is active).
+    index.soft_delete_document(10).unwrap();
+    index.persist_deletions().unwrap();
+    let searcher = index.searcher().unwrap();
+    let results = searcher.search(&query(10, 5)).unwrap();
+    assert!(
+        results.results.iter().all(|r| r.doc_id != 10),
+        "a soft-deleted sealed doc must be search-invisible"
+    );
+
+    index.optimize().unwrap();
+    assert_eq!(
+        ivf_segment_files(&storage).len(),
+        1,
+        "optimize must force-merge to one segment"
+    );
+    assert!(
+        !storage.file_exists("vector_index.delmap"),
+        "optimize must clear the persisted deletion bitmap"
+    );
+    let searcher = index.searcher().unwrap();
+    let results = searcher.search(&query(10, 5)).unwrap();
+    assert!(results.results.iter().all(|r| r.doc_id != 10));
+    let results = searcher.search(&query(9000, 1)).unwrap();
+    assert_eq!(
+        results.results[0].doc_id, 1,
+        "upserted copy survives the merge"
+    );
+
+    let stats = index.stats().unwrap();
+    assert_eq!(stats.vector_count, 48);
+}
+
+/// The upsert dance can undelete every mark; a previously persisted delmap
+/// must then be REMOVED.
+#[test]
+fn undelete_to_zero_removes_stale_delmap_and_survives_reopen() {
+    let storage = storage();
+    {
+        let index = SegmentedIvfIndex::open_or_create(
+            storage.clone() as Arc<dyn Storage>,
+            "vector_index",
+            config(true),
+        )
+        .unwrap();
+        commit_batch(&index, 1..10);
+
+        index.soft_delete_document(3).unwrap();
+        index.persist_deletions().unwrap();
+        assert!(storage.file_exists("vector_index.delmap"));
+
+        let mut writer = index.writer().unwrap();
+        writer.delete_document(3).unwrap();
+        writer
+            .add_vectors(vec![(3, "v".to_string(), doc_vec(9000))])
+            .unwrap();
+        writer.commit().unwrap();
+        index.persist_deletions().unwrap();
+        assert!(
+            !storage.file_exists("vector_index.delmap"),
+            "undelete-to-zero must remove the stale delmap"
+        );
+    }
+
+    let index = SegmentedIvfIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+    let searcher = index.searcher().unwrap();
+    let results = searcher.search(&query(9000, 1)).unwrap();
+    assert_eq!(
+        results.results[0].doc_id, 3,
+        "the committed upsert must survive a reopen"
+    );
+}
+
+/// A sealed writer must reject further commits, while a post-commit
+/// close() stays a clean no-op.
+#[test]
+fn sealed_writer_rejects_second_commit_and_close_is_noop() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    let mut writer = index.writer().unwrap();
+    writer
+        .add_vectors(vec![(1, "v".to_string(), doc_vec(1))])
+        .unwrap();
+    writer.commit().unwrap();
+
+    assert!(!writer.has_pending_changes());
+    writer.close().unwrap();
+
+    let mut writer = index.writer().unwrap();
+    writer
+        .add_vectors(vec![(2, "v".to_string(), doc_vec(2))])
+        .unwrap();
+    writer.commit().unwrap();
+    writer
+        .add_vectors(vec![(3, "v".to_string(), doc_vec(3))])
+        .unwrap();
+    let err = writer.commit();
+    assert!(
+        err.is_err(),
+        "a sealed writer must reject a second commit with new changes"
+    );
+}
+
+/// count() excludes soft-deleted docs.
+#[test]
+fn count_excludes_soft_deleted_docs() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+    commit_batch(&index, 0..10);
+    index.soft_delete_document(4).unwrap();
+
+    let searcher = index.searcher().unwrap();
+    let count = searcher.count(query(0, 1)).unwrap();
+    assert_eq!(count, 9, "count must exclude soft-deleted docs");
+}
+
+/// The migration must fire through the PRODUCTION factory path.
+#[test]
+fn factory_open_path_migrates_legacy_index_and_stays_segmented() {
+    use laurus::vector::index::config::VectorIndexTypeConfig;
+    use laurus::vector::index::factory::VectorIndexFactory;
+
+    let storage = storage();
+    {
+        let index = IvfIndex::create(
+            storage.clone() as Arc<dyn Storage>,
+            "vector_index",
+            config(false),
+        )
+        .unwrap();
+        commit_batch(&index, 0..50);
+    }
+    assert!(storage.file_exists("metadata.json"), "legacy precondition");
+
+    let index = VectorIndexFactory::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        VectorIndexTypeConfig::IVF(config(true)),
+    )
+    .unwrap();
+    assert!(
+        storage.file_exists("segments.json"),
+        "the factory OPEN arm must migrate a legacy index"
+    );
+    assert!(
+        !storage.file_exists("metadata.json"),
+        "the stale monolithic metadata.json must be removed"
+    );
+
+    commit_batch(index.as_ref(), 50..51);
+    drop(index);
+    let index = VectorIndexFactory::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        VectorIndexTypeConfig::IVF(config(true)),
+    )
+    .unwrap();
+    let searcher = index.searcher().unwrap();
+    assert_eq!(
+        searcher.search(&query(42, 1)).unwrap().results[0].doc_id,
+        42
+    );
+    assert_eq!(
+        searcher.search(&query(50, 1)).unwrap().results[0].doc_id,
+        50
+    );
+}
+
+/// Opening a segmented directory with `segmented: false` must be rejected
+/// loudly.
+#[test]
+fn factory_rejects_segmented_directory_with_flag_off() {
+    use laurus::vector::index::config::VectorIndexTypeConfig;
+    use laurus::vector::index::factory::VectorIndexFactory;
+
+    let storage = storage();
+    {
+        let index = SegmentedIvfIndex::open_or_create(
+            storage.clone() as Arc<dyn Storage>,
+            "vector_index",
+            config(true),
+        )
+        .unwrap();
+        commit_batch(&index, 0..10);
+    }
+
+    let result = VectorIndexFactory::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        VectorIndexTypeConfig::IVF(config(false)),
+    );
+    assert!(
+        result.is_err(),
+        "a segmented directory must not open monolithically"
+    );
+}
+
+/// Pure-append workloads must not grow the segment count unboundedly.
+#[test]
+fn append_only_segment_count_is_bounded_by_auto_merge() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    for i in 0..101u64 {
+        commit_batch(&index, i..i + 1);
+    }
+    let before = ivf_segment_files(&storage).len();
+    assert!(before > 100, "precondition: {before} segments");
+
+    let compacted = index.maybe_auto_compact().unwrap();
+    assert!(compacted, "the segment-count bound must trigger a merge");
+    let after = ivf_segment_files(&storage).len();
+    assert!(
+        after < before,
+        "the merge must reduce the segment count ({before} -> {after})"
+    );
+
+    let searcher = index.searcher().unwrap();
+    for id in [0u64, 50, 100] {
+        assert_eq!(
+            searcher.search(&query(id, 1)).unwrap().results[0].doc_id,
+            id
+        );
+    }
+}
+
+/// serde behavior of the (off-by-default) flag.
+#[test]
+fn segmented_flag_serde_default_and_explicit_true() {
+    let mut value: serde_json::Value = serde_json::to_value(IvfIndexConfig::default()).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .remove("segmented")
+        .expect("the flag must serialize");
+    let config: IvfIndexConfig = serde_json::from_value(value).unwrap();
+    assert!(
+        !config.segmented,
+        "a config serialized before the field existed must open monolithic"
+    );
+
+    let explicit_true = serde_json::to_string(&IvfIndexConfig {
+        segmented: true,
+        ..IvfIndexConfig::default()
+    })
+    .unwrap();
+    let config: IvfIndexConfig = serde_json::from_str(&explicit_true).unwrap();
+    assert!(
+        config.segmented,
+        "an explicit `segmented: true` must be preserved"
+    );
+}
+
+/// Under sustained ingest with the store-ladder cadence, the tiered policy
+/// keeps the segment count logarithmically bounded.
+#[test]
+fn sustained_ingest_keeps_segment_count_tiered() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage.clone() as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    for i in 0..100u64 {
+        commit_batch(&index, i * 5..(i + 1) * 5);
+        index.maybe_auto_compact().unwrap();
+    }
+
+    let segments = ivf_segment_files(&storage).len();
+    assert!(
+        segments <= 30,
+        "tiered merging must keep the segment count bounded, got {segments} after 100 commits"
+    );
+
+    let searcher = index.searcher().unwrap();
+    for id in [0u64, 250, 499] {
+        let results = searcher.search(&query(id, 5)).unwrap();
+        assert!(
+            results.results.iter().any(|r| r.doc_id == id),
+            "doc {id} must stay searchable after tiered merging"
+        );
+    }
+}
+
+/// The campaign's headline number as a permanent deterministic gate.
+#[test]
+fn auto_commit_cumulative_bytes_are_bounded() {
+    use common::ByteCountingStorage;
+
+    let run = |segmented: bool| -> u64 {
+        let counting = Arc::new(ByteCountingStorage::new(Arc::new(MemoryStorage::new(
+            MemoryStorageConfig::default(),
+        ))));
+        let written = counting.written.clone();
+        let index: Box<dyn VectorIndex> = if segmented {
+            Box::new(
+                SegmentedIvfIndex::open_or_create(
+                    counting.clone() as Arc<dyn Storage>,
+                    "vector_index",
+                    config(true),
+                )
+                .unwrap(),
+            )
+        } else {
+            Box::new(
+                IvfIndex::create(
+                    counting.clone() as Arc<dyn Storage>,
+                    "vector_index",
+                    config(false),
+                )
+                .unwrap(),
+            )
+        };
+        for i in 0..40u64 {
+            commit_batch(index.as_ref(), i * 50..(i + 1) * 50);
+            index.maybe_auto_compact().unwrap();
+        }
+        written.load(std::sync::atomic::Ordering::Relaxed)
+    };
+
+    let monolithic = run(false);
+    let segmented = run(true);
+    eprintln!(
+        "auto-commit cumulative bytes: monolithic={monolithic} segmented={segmented} \
+         ratio={:.1}x",
+        monolithic as f64 / segmented as f64
+    );
+    assert!(
+        segmented * 3 < monolithic,
+        "the segmented layout must write materially fewer cumulative bytes under \
+         auto-commit ingest, got monolithic={monolithic} vs segmented={segmented}"
+    );
+}
+
+/// A commit sealing fewer than `n_clusters` new vectors must succeed
+/// end-to-end via the adaptive-K clamp (Issue #889 PR-5), through the
+/// segmented writer specifically.
+#[test]
+fn sub_n_clusters_commit_succeeds_via_adaptive_k() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        config(true), // n_clusters defaults to 100
+    )
+    .unwrap();
+
+    // Only 5 vectors, far below the default 100-cluster ceiling.
+    commit_batch(&index, 0..5);
+
+    let searcher = index.searcher().unwrap();
+    for id in 0..5u64 {
+        assert_eq!(
+            searcher.search(&query(id, 1)).unwrap().results[0].doc_id,
+            id
+        );
+    }
+}
+
+/// Merge-time re-clustering: commit several small segments (whose own
+/// adaptive-K was clamped to their own tiny size), force-merge, and confirm
+/// every document is retrievable and the merged segment's cluster count
+/// matches the adaptive value for the UNION's size — not the sum, or any
+/// individual source's, cluster count.
+#[test]
+fn merge_time_reclustering_matches_union_adaptive_k() {
+    use laurus::vector::index::ivf::reader::IvfIndexReader;
+
+    let storage = storage();
+    let cfg = IvfIndexConfig {
+        n_clusters: 100,
+        ..config(true)
+    };
+    let index =
+        SegmentedIvfIndex::open_or_create(storage.clone() as Arc<dyn Storage>, "vector_index", cfg)
+            .unwrap();
+
+    // 5 segments of 10 docs each: each segment's own adaptive K is
+    // min(100, 10) = 10 (over-clustered relative to itself).
+    for i in 0..5u64 {
+        commit_batch(&index, i * 10..(i + 1) * 10);
+    }
+    assert_eq!(ivf_segment_files(&storage).len(), 5);
+
+    index.optimize().unwrap();
+    let remaining = ivf_segment_files(&storage);
+    assert_eq!(remaining.len(), 1, "force-merge collapses to one segment");
+    let segment_id = remaining[0].trim_end_matches(".ivf").to_string();
+
+    let reader = IvfIndexReader::load(
+        storage.clone() as Arc<dyn Storage>,
+        &segment_id,
+        DistanceMetric::Cosine,
+    )
+    .unwrap();
+    let (n_clusters, _) = reader.ivf_params();
+    assert_eq!(
+        n_clusters, 50,
+        "the merged segment must retrain adaptive K over the UNION size (50), \
+         not sum or inherit any source's own cluster count, got {n_clusters}"
+    );
+
+    let searcher = index.searcher().unwrap();
+    for id in 0..50u64 {
+        assert_eq!(
+            searcher.search(&query(id, 1)).unwrap().results[0].doc_id,
+            id,
+            "doc {id} must be retrievable after the merge"
+        );
+    }
+}
+
+/// A merge window whose every vector is logically deleted must reduce to a
+/// valid zero-vector, zero-cluster segment instead of erroring (gates the
+/// `IvfIndexWriter::finalize`/`train_centroids` fix — Issue #889 PR-6).
+#[test]
+fn full_deletion_then_merge_produces_valid_empty_segment() {
+    let storage = storage();
+    let index = SegmentedIvfIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vector_index",
+        config(true),
+    )
+    .unwrap();
+
+    commit_batch(&index, 0..20);
+    for id in 0..20u64 {
+        index.soft_delete_document(id).unwrap();
+    }
+    index.persist_deletions().unwrap();
+
+    // Force-merge a window where every source vector is deleted: must not
+    // error, and must leave a valid (empty) index behind.
+    index.optimize().unwrap();
+    let stats = index.stats().unwrap();
+    assert_eq!(stats.vector_count, 0);
+
+    // The index must still accept new commits after collapsing to empty.
+    commit_batch(&index, 100..105);
+    let searcher = index.searcher().unwrap();
+    let results = searcher.search(&query(100, 1)).unwrap();
+    assert_eq!(results.results[0].doc_id, 100);
+}
+
+/// Small, independently-over-clustered segments have worse *approximate*
+/// (non-self-lookup) recall than the same corpus re-clustered as a whole:
+/// with `n_clusters` >= each tiny commit's size, k-means degenerates to
+/// (near-)one-cluster-per-point, splitting near-identical pairs into
+/// different clusters; `n_probe = 1` then misses a pair's partner. Merging
+/// re-trains over the full union with the SAME `n_clusters` ceiling, which
+/// is now much coarser relative to corpus size, so k-means groups
+/// near-identical pairs together again. Asserted as an aggregate rate
+/// (not per-pair) to stay robust to individual seeded-k-means boundary
+/// cases.
+#[test]
+fn recall_improves_after_merge_for_small_k_segments() {
+    let storage = storage();
+    let cfg = IvfIndexConfig {
+        n_clusters: 10,
+        n_probe: 1,
+        ..config(true)
+    };
+    let index = SegmentedIvfIndex::open_or_create(storage as Arc<dyn Storage>, "vector_index", cfg)
+        .unwrap();
+
+    // 40 pair-groups, well separated from each other (an LCG-mixed 16-dim
+    // anchor per group — a fixed-dimension modulo scheme would alias
+    // distinct groups onto the same anchor); each pair member is a tiny
+    // epsilon perturbation of its group's anchor. 5 complete pairs (10
+    // vectors) per commit, so each tiny segment's own adaptive K = 10 = its
+    // own vector count (the degenerate all-singleton regime).
+    let pair_vec = |group: u64, member: u64| -> Vector {
+        let mut state: u64 =
+            0x9E3779B97F4A7C15u64.wrapping_add(group.wrapping_mul(0xBF58_476D_1CE4_E5B9));
+        let mut v: Vec<f32> = (0..16)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                ((state >> 33) as f32 / u32::MAX as f32) * 2000.0 - 1000.0
+            })
+            .collect();
+        v[0] += member as f32 * 0.01; // tiny epsilon distinguishing the pair
+        Vector::new(v)
+    };
+
+    let groups_per_commit = 5u64;
+    let total_groups = 40u64;
+    let mut group = 0u64;
+    while group < total_groups {
+        let mut writer = index.writer().unwrap();
+        let mut batch = Vec::new();
+        for g in group..(group + groups_per_commit).min(total_groups) {
+            batch.push((g * 2, "v".to_string(), pair_vec(g, 0)));
+            batch.push((g * 2 + 1, "v".to_string(), pair_vec(g, 1)));
+        }
+        writer.add_vectors(batch).unwrap();
+        writer.commit().unwrap();
+        group += groups_per_commit;
+    }
+
+    let pair_found_rate = |index: &dyn VectorIndex| -> f32 {
+        let searcher = index.searcher().unwrap();
+        let mut both_found = 0u64;
+        for g in 0..total_groups {
+            let q = VectorIndexQuery {
+                query: pair_vec(g, 0),
+                params: VectorIndexQueryParams {
+                    top_k: 2,
+                    ..Default::default()
+                },
+                field_name: Some("v".to_string()),
+                filter: None,
+            };
+            let results = searcher.search(&q).unwrap();
+            let ids: std::collections::HashSet<u64> =
+                results.results.iter().map(|r| r.doc_id).collect();
+            if ids.contains(&(g * 2)) && ids.contains(&(g * 2 + 1)) {
+                both_found += 1;
+            }
+        }
+        both_found as f32 / total_groups as f32
+    };
+
+    let before = pair_found_rate(&index);
+    index.optimize().unwrap();
+    let after = pair_found_rate(&index);
+
+    assert!(
+        after > before,
+        "merging must improve small-K segments' pair-recall, got before={before:.2} after={after:.2}"
+    );
+    assert!(
+        after >= 0.9,
+        "post-merge pair-recall should be high once re-clustered over the full union, got {after:.2}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `SegmentedIvfIndex` (`ivf/segmented.rs`), extending the segment-per-commit layout to IVF on the shared infrastructure from #889 PR-1/PR-2/PR-3/PR-5, mirroring #904's Flat implementation. Each segment trains its own centroids independently with adaptive K (PR-5's `configured_n_clusters` ceiling) — no cross-segment cluster-id agreement needed, since search fans out per segment and merges top-k.
- Merge does not reconcile source cluster ids (they carry no cross-segment meaning): `ivf/segment/merge_engine.rs` flattens the deduplicated, deletion-filtered survivors and retrains from scratch, reusing the ordinary `add_vectors`/`finalize` pipeline — no dedicated setter needed for adaptive-K re-derivation over the merged union.
- First-time soft-delete/compaction implementation for IVF, landed together with the layout for the same reason as Flat/#904.
- Two fixes found during investigation (posted to #906 before implementation) and landed alongside: `IvfIndexWriter::finalize()` no longer hard-errors on an empty vector set (needed for a fully-deleted merge window); the same quantized-fast-path deletion-bypass bug fixed in Flat's searcher during #904 also existed in `IvfSearcher::search()` — fixed proactively this time.
- `IvfIndexConfig` gains `segmented` (defaults `false`), `auto_compaction`, `compaction_threshold`. `factory.rs` gains `dispatch_ivf()`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` (stable 1.97.1 + pinned 1.97.0)
- [x] `cargo test -p laurus --lib` — 1248 passed
- [x] `cargo test -p laurus --tests` — all binaries green, including new `vector_segmented_ivf_test.rs` (19 tests: 16 ported gates + sub-`n_clusters` adaptive-K, merge-time re-clustering, full-deletion zero-vector merge, and a statistical recall-improves-after-merge test)
- [x] `cargo doc -p laurus --no-deps` — 73 warnings, matches `main` baseline
- [x] RED/GREEN: the `finalize()` empty-vector fix has a dedicated unit test verified against the reverted guard

Part of #889
Closes #906