### PR TITLE
feat(vector/index): default Flat/IVF to segment-per-commit layout (#907)

### DIFF
--- a/docs/ja/src/concepts/indexing/vector_indexing.md
+++ b/docs/ja/src/concepts/indexing/vector_indexing.md
@@ -504,18 +504,19 @@ search の独立 budget）や 4 bit PQ variant でこの gap を埋める方向�
 | Flat | `.flat` | 生ベクトルとメタデータ |
 | IVF | `.ivf` | クラスタセントロイド、割り当て済みベクトル、メタデータ |
 
-Flat と IVF はコミットのたびに書き直される単一ファイルにデータを格納します。
-HNSW はデフォルトで **segment-per-commit** レイアウトを使用します（下記参照）。
-単一ファイルの monolithic レイアウトは、インデックスを直接利用する場合に
-`HnswIndexConfig { segmented: false, .. }` で引き続き選択できます。
+3つのインデックスタイプはすべてデフォルトで **segment-per-commit** レイアウトを
+使用します（下記参照）。単一ファイルの monolithic レイアウトは、インデックスを
+直接利用する場合に `{Flat,Hnsw,Ivf}IndexConfig { segmented: false, .. }` で
+引き続き選択できます。
 
-### segment-per-commit レイアウト（HNSW、デフォルト）
+### segment-per-commit レイアウト（3タイプ共通のデフォルト）
 
-[#634](https://github.com/mosuka/laurus/issues/634) 以降、HNSW の各コミットは
-**新規追加ベクトルのみ**を不変の `segment_NNNNNN.hnsw` ファイルとして seal し、
-原子的・チェックサム付きの `segments.json` manifest に登録します —
+[#634](https://github.com/mosuka/laurus/issues/634)（HNSW）および
+[#889](https://github.com/mosuka/laurus/issues/889)（Flat・IVF）以降、各コミットは
+**新規追加ベクトルのみ**を不変の `segment_NNNNNN.{hnsw,flat,ivf}` ファイルとして
+seal し、原子的・チェックサム付きの `segments.json` manifest に登録します —
 コミットあたりのコストは O(インデックス) から O(新規ドキュメント) に下がり、
-既存コーパスの再量子化も発生しません。
+既存セグメントの全面的な作り直しも発生しません。
 
 - **検索**は sealed セグメント群を（新しい世代から順に）fan-out し、
   同一ドキュメントの複製を newest-wins マスキングで重複排除します。
@@ -526,19 +527,49 @@ HNSW はデフォルトで **segment-per-commit** レイアウトを使用しま
 - **マージ**: 世代連続・サイズ類似の tiered マージポリシーがインジェストの
   進行に応じてセグメント列を集約し（各ベクトルの生涯書き直し回数は
   O(log N)）、`optimize()` は全セグメントを 1 つに force-merge します。
+  IVF のマージはセグメントごとの cluster ID を引き継ごうとしません
+  （セグメントをまたいだ意味を持たないため）— 重複排除済みの生存ベクトルを
+  平坦化し、union サイズに応じて適応的に再計算した cluster 数で centroid を
+  ゼロから再学習します。Flat には f32 rerank サイドカーによるフォールバックが
+  ないため、マージのたびに dequantize → scalar quantization パラメータの
+  再学習 → requantize が発生し、HNSW/IVF のほぼロスレスな再量子化経路とは
+  異なり、マージを重ねるごとにわずかな量子化ドリフトが蓄積します。
+- **セグメントごとの学習**: HNSW のグラフと IVF の centroid はいずれも
+  セグメントごとに独立して構築されます（IVF はスキーマの `n_clusters` を
+  上限としてセグメント自身のサイズに適応した cluster 数を学習します）。
+  検索はセグメントごとに fan-out して top-k をマージするため、
+  どちらのインデックスタイプもセグメント間の合意は不要です。
 - **削除**は論理削除です。インデックスレベルの bitmap（`{name}.delmap`）を
   すべてのセグメントリーダーが参照し、マージ時に物理回収されます。
-- **移行**はゼロコピーです。既存の monolithic `.hnsw` は初回オープン時に
-  そのまま最初のセグメントとして登録されます — manifest への 1 書き込みのみで、
-  データ移動はありません。
+- **移行**はゼロコピーです。既存の monolithic セグメントファイルは初回
+  オープン時にそのまま最初のセグメントとして登録されます — manifest への
+  1書き込みのみで、データ移動はありません。
 - **耐久性**: セグメントファイルと manifest は temp ファイル + fsync +
   原子的 rename で書かれ、manifest はカバー対象の状態がすべて durable に
   なった後にのみ公開される WAL checkpoint を保持します —
   [永続化](../../laurus/persistence.md)を参照。
 
-### コミット跨ぎの writer 保持（monolithic レイアウト）
+### コミット跨ぎの writer 保持（monolithic レイアウトのみ）
 
-monolithic レイアウトの HNSW では、ストアは writer を**コミットを跨いで**キャッシュし続けます（Issue #864）。コミット直後の writer のメモリ内状態は、たった今書き出したファイルと等価であるため、コミット後最初の upsert はストレージから `.hnsw` 全体をリロード（+ 全 dequantize）する代わりに、その場で writer を拡張します — コミットの多いインジェストでは、このリロードがサイクルあたり O(インデックスサイズ) のコストでした。ただし、writer の**裏で**インデックスが書き換えられる場合 — コミット中の auto-compaction 発火、または明示的な `optimize()` — はキャッシュを破棄します。どちらも fresh writer 経由でファイルを再構築して deletion bitmap をクリアするため、stale な保持 writer は回収済みベクトルを書き戻してしまうからです。また、コミットが途中で失敗した場合も writer とディスクの一致が不明になるため破棄します。副次効果として、保留変更のない保持 writer はインデックス書き出し自体をスキップするため、変更なしの `commit()` は `.hnsw` への書き込みコストがゼロになります。Flat と IVF は同じ不変条件の監査が済むまで、従来のコミット時破棄の挙動を維持します。
+writer の保持は **monolithic** レイアウト（`segmented: false`）にのみ
+適用されます。segmented な writer は常に空のバッファから始まるため、
+保持すべき状態がそもそも存在しません。monolithic レイアウトの HNSW では、
+ストアは writer を**コミットを跨いで**キャッシュし続けます（Issue #864）。
+コミット直後の writer のメモリ内状態は、たった今書き出したファイルと等価で
+あるため、コミット後最初の upsert はストレージから `.hnsw` 全体をリロード
+（+ 全 dequantize）する代わりに、その場で writer を拡張します —
+コミットの多いインジェストでは、このリロードがサイクルあたり O(インデックス
+サイズ) のコストでした。ただし、writer の**裏で**インデックスが書き換えられる
+場合 — コミット中の auto-compaction 発火、または明示的な `optimize()` —
+はキャッシュを破棄します。どちらも fresh writer 経由でファイルを再構築して
+deletion bitmap をクリアするため、stale な保持 writer は回収済みベクトルを
+書き戻してしまうからです。また、コミットが途中で失敗した場合も writer と
+ディスクの一致が不明になるため破棄します。副次効果として、保留変更のない
+保持 writer はインデックス書き出し自体をスキップするため、変更なしの
+`commit()` は `.hnsw` への書き込みコストがゼロになります。monolithic の
+Flat と IVF は従来のコミット時破棄の挙動を維持しており、同じ不変条件の
+監査はまだ済んでいません — 現在この経路に到達するには segmented デフォルトを
+明示的にオプトアウトする必要があります。
 
 ## コード例
 

--- a/docs/src/concepts/indexing/vector_indexing.md
+++ b/docs/src/concepts/indexing/vector_indexing.md
@@ -527,18 +527,20 @@ search budget) and / or a 4-bit PQ variant to close the gap.
 | Flat | `.flat` | Raw vectors and metadata |
 | IVF | `.ivf` | Cluster centroids, assigned vectors, and metadata |
 
-Flat and IVF store their data in a single file that is rewritten on every
-commit. HNSW uses the **segment-per-commit** layout by default (see below);
-the monolithic single-file layout remains available via
-`HnswIndexConfig { segmented: false, .. }` for direct index users.
+All three index types default to the **segment-per-commit** layout (see
+below); the monolithic single-file layout remains available via
+`{Flat,Hnsw,Ivf}IndexConfig { segmented: false, .. }` for direct index
+users.
 
-### Segment-per-commit layout (HNSW, default)
+### Segment-per-commit layout (default for all three index types)
 
-Since [#634](https://github.com/mosuka/laurus/issues/634), each HNSW commit
-seals only the **newly added vectors** as an immutable
-`segment_NNNNNN.hnsw` file and registers it in an atomic, checksummed
-`segments.json` manifest — the per-commit cost drops from O(index) to
-O(new documents), with no re-quantization of the existing corpus:
+Since [#634](https://github.com/mosuka/laurus/issues/634) (HNSW) and
+[#889](https://github.com/mosuka/laurus/issues/889) (Flat and IVF), each
+commit seals only the **newly added vectors** as an immutable
+`segment_NNNNNN.{hnsw,flat,ivf}` file and registers it in an atomic,
+checksummed `segments.json` manifest — the per-commit cost drops from
+O(index) to O(new documents), with no full-corpus rework for the existing
+segments:
 
 - **Search** fans out over the sealed segments (newest generation first)
   and deduplicates same-document copies with newest-wins masking, so a
@@ -549,34 +551,50 @@ O(new documents), with no re-quantization of the existing corpus:
 - **Merging**: a tiered, generation-contiguous merge policy collapses
   size-similar segment runs as ingest proceeds (each vector is rewritten
   O(log N) times over its lifetime), and `optimize()` force-merges
-  everything into one segment.
+  everything into one segment. IVF's merge does not try to reconcile
+  per-segment cluster ids (they carry no cross-segment meaning): it
+  flattens the deduplicated survivors and retrains centroids from scratch
+  over the merged union, with the cluster count re-derived adaptively for
+  the union's size. Flat has no f32 rerank sidecar to fall back on, so each
+  merge dequantizes, retrains scalar-quantization parameters, and
+  requantizes — a small amount of quantization drift accumulates across
+  merges, unlike HNSW's/IVF's lossless-ish requantization path.
+- **Per-segment training**: HNSW's graphs and IVF's centroids are both
+  built independently per segment — IVF adapts its cluster count to each
+  segment's own size (capped by the schema's `n_clusters`) rather than
+  training a fixed count regardless of how many vectors landed in that
+  commit. No cross-segment agreement is needed for either index type,
+  since search fans out per segment and merges top-k results.
 - **Deletions** are logical: an index-level bitmap (`{name}.delmap`) is
   consulted by every segment reader and physically reclaimed by merges.
-- **Migration** is zero-copy: an existing monolithic `.hnsw` is registered
-  verbatim as the first segment on first open — one manifest write, no
-  data movement.
+- **Migration** is zero-copy: an existing monolithic segment file is
+  registered verbatim as the first segment on first open — one manifest
+  write, no data movement.
 - **Durability**: segment files and the manifest are written via
   temp-file + fsync + atomic rename, and the manifest carries the WAL
   checkpoint published only after all covered state is durable — see
   [Persistence](../../laurus/persistence.md).
 
-### Writer retention across commits (monolithic layout)
+### Writer retention across commits (monolithic layout only)
 
-For the monolithic HNSW layout, the store keeps its writer cached **across
-commits** (Issue #864):
-after a commit the writer's in-memory state is equivalent to the file it just
-wrote, so the first upsert after a commit extends it in place instead of
-reloading (and dequantizing) the whole `.hnsw` from storage — under
-commit-heavy ingest that reload was O(index size) per cycle. The cache is
-dropped whenever the index is rewritten *behind* the writer — auto-compaction
-firing inside a commit, or an explicit `optimize()` — because both rebuild the
-file through a fresh writer and clear the deletion bitmap, and a stale
-retained writer would write the reclaimed vectors back — and whenever a
-commit fails partway, where the writer/disk agreement is unknown. As a bonus,
-a retained writer with no pending changes skips the index rewrite entirely,
-so a no-change `commit()` costs no `.hnsw` write at all. Flat and IVF keep
-the previous drop-on-commit behavior until they are audited for the same
-invariants.
+Retention only applies to the **monolithic** layout (`segmented: false`);
+a segmented writer always starts from an empty buffer, so there is nothing
+to retain. For the monolithic HNSW layout, the store keeps its writer
+cached **across commits** (Issue #864): after a commit the writer's
+in-memory state is equivalent to the file it just wrote, so the first
+upsert after a commit extends it in place instead of reloading (and
+dequantizing) the whole `.hnsw` from storage — under commit-heavy ingest
+that reload was O(index size) per cycle. The cache is dropped whenever the
+index is rewritten *behind* the writer — auto-compaction firing inside a
+commit, or an explicit `optimize()` — because both rebuild the file
+through a fresh writer and clear the deletion bitmap, and a stale retained
+writer would write the reclaimed vectors back — and whenever a commit
+fails partway, where the writer/disk agreement is unknown. As a bonus, a
+retained writer with no pending changes skips the index rewrite entirely,
+so a no-change `commit()` costs no `.hnsw` write at all. The monolithic
+Flat and IVF layouts keep the previous drop-on-commit behavior, unaudited
+for the same invariants — reaching for that code path today requires
+opting out of the segmented default explicitly.
 
 ## Code Example
 

--- a/laurus/src/vector/index/config.rs
+++ b/laurus/src/vector/index/config.rs
@@ -321,11 +321,14 @@ pub struct FlatIndexConfig {
 
     /// Whether this index uses the segment-per-commit layout (Issue #889).
     ///
-    /// Mirrors [`HnswIndexConfig::segmented`]. Defaults to `false` — unlike
-    /// HNSW (where the flag flipped to `true` in #882 after the design was
-    /// proven in production), Flat's segmented layout ships behind the flag
-    /// until it has had the same real-world exercise.
-    #[serde(default)]
+    /// Mirrors [`HnswIndexConfig::segmented`]. Defaults to `true` (Issue
+    /// #907, mirroring HNSW's own #882 flip): Flat's segmented layout
+    /// shipped behind this flag in #904 and, once proven, the default
+    /// flipped the same way HNSW's did. A config serialized before this
+    /// field existed still deserializes to `true` (`default_segmented`),
+    /// so persisted configs from before #904 pick up the new layout on
+    /// next open rather than silently staying monolithic.
+    #[serde(default = "default_segmented")]
     pub segmented: bool,
 
     /// Automatically compact (purge logically deleted vectors) on commit
@@ -399,7 +402,7 @@ impl Default for FlatIndexConfig {
             rerank_storage: None,
             merge_factor: 10,
             max_segments: 100,
-            segmented: false,
+            segmented: true,
             auto_compaction: false,
             compaction_threshold: default_compaction_threshold(),
             embedder: default_embedder(),
@@ -712,10 +715,11 @@ pub struct IvfIndexConfig {
 
     /// Whether this index uses the segment-per-commit layout (Issue #889).
     ///
-    /// Mirrors [`FlatIndexConfig::segmented`]. Defaults to `false` — IVF's
-    /// segmented layout ships behind the flag until it has had the same
-    /// real-world exercise HNSW's had since #882.
-    #[serde(default)]
+    /// Mirrors [`FlatIndexConfig::segmented`]. Defaults to `true` (Issue
+    /// #907, mirroring HNSW's own #882 flip): IVF's segmented layout
+    /// shipped behind this flag in #906 and, once proven, the default
+    /// flipped the same way HNSW's and Flat's did.
+    #[serde(default = "default_segmented")]
     pub segmented: bool,
 
     /// Automatically compact (purge logically deleted vectors) on commit
@@ -759,7 +763,7 @@ impl Default for IvfIndexConfig {
             rerank_storage: None,
             merge_factor: 10,
             max_segments: 100,
-            segmented: false,
+            segmented: true,
             auto_compaction: false,
             compaction_threshold: default_compaction_threshold(),
             embedder: default_embedder(),

--- a/laurus/src/vector/index/factory.rs
+++ b/laurus/src/vector/index/factory.rs
@@ -338,7 +338,14 @@ mod tests {
 
     #[test]
     fn test_vector_index_stats() {
-        let config = VectorIndexTypeConfig::default();
+        // Pinned to the monolithic layout (Issue #907 audit): `stats().last_modified`
+        // tracks a real timestamp only for the monolithic `IndexMetadata`; the
+        // segmented layout (the default since #907) hardcodes it to 0, since a
+        // multi-segment manifest has no single natural "last modified" moment.
+        let config = VectorIndexTypeConfig::Flat(FlatIndexConfig {
+            segmented: false,
+            ..Default::default()
+        });
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
 
         let index = VectorIndexFactory::create(storage, "test_index", config).unwrap();

--- a/laurus/src/vector/index/flat/segmented.rs
+++ b/laurus/src/vector/index/flat/segmented.rs
@@ -23,12 +23,12 @@
 //! This is a first-time implementation for Flat — the monolithic
 //! [`super::FlatIndex`] has no soft-delete/compaction wiring at all.
 //!
-//! [`FlatIndexConfig::segmented`] defaults to `false` (unlike HNSW's `true`
-//! since #882): Flat's segmented layout has not yet had the same
-//! production exercise, so it ships behind the flag until a follow-up
-//! flips the default (Issue #889 PR-7). A legacy monolithic index is
-//! migrated zero-copy on first open with the flag on (its `.flat` becomes
-//! segment 0 of the manifest, no data movement).
+//! [`FlatIndexConfig::segmented`] defaults to `true` (Issue #907, mirroring
+//! HNSW's own #882 flip): this is now the default Flat layout, with the
+//! monolithic single-file layout still available via `segmented: false`. A
+//! legacy monolithic index is migrated zero-copy on first open with the
+//! flag on (its `.flat` becomes segment 0 of the manifest, no data
+//! movement).
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/laurus/src/vector/index/ivf/segmented.rs
+++ b/laurus/src/vector/index/ivf/segmented.rs
@@ -33,12 +33,12 @@
 //! This is a first-time implementation for IVF — the monolithic
 //! [`super::IvfIndex`] has no soft-delete/compaction wiring at all.
 //!
-//! [`IvfIndexConfig::segmented`] defaults to `false` (unlike HNSW's `true`
-//! since #882): IVF's segmented layout has not yet had the same production
-//! exercise, so it ships behind the flag until a follow-up flips the
-//! default (Issue #889 PR-7). A legacy monolithic index is migrated
-//! zero-copy on first open with the flag on (its `.ivf` becomes segment 0
-//! of the manifest, no data movement).
+//! [`IvfIndexConfig::segmented`] defaults to `true` (Issue #907, mirroring
+//! HNSW's own #882 flip): this is now the default IVF layout, with the
+//! monolithic single-file layout still available via `segmented: false`. A
+//! legacy monolithic index is migrated zero-copy on first open with the
+//! flag on (its `.ivf` becomes segment 0 of the manifest, no data
+//! movement).
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/laurus/tests/vector_segmented_flat_test.rs
+++ b/laurus/tests/vector_segmented_flat_test.rs
@@ -593,10 +593,12 @@ fn append_only_segment_count_is_bounded_by_auto_merge() {
     }
 }
 
-/// serde behavior of the (still-off-by-default) flag — a config missing
-/// the field deserializes to `false`; an explicit `true` is preserved.
+/// serde behavior of the (now on-by-default, Issue #907) flag — a config
+/// missing the field deserializes to `true`; an explicit `false` is
+/// preserved.
 #[test]
-fn segmented_flag_serde_default_and_explicit_true() {
+fn segmented_flag_serde_default_and_explicit_false() {
+    // A pre-#907 config = today's config with the `segmented` key removed.
     let mut value: serde_json::Value = serde_json::to_value(FlatIndexConfig::default()).unwrap();
     value
         .as_object_mut()
@@ -605,20 +607,19 @@ fn segmented_flag_serde_default_and_explicit_true() {
         .expect("the flag must serialize");
     let config: FlatIndexConfig = serde_json::from_value(value).unwrap();
     assert!(
-        !config.segmented,
-        "a config serialized before the field existed must open monolithic \
-         (Flat's segmented default is false, unlike HNSW's)"
+        config.segmented,
+        "a config serialized before the field existed must open segmented (#907)"
     );
 
-    let explicit_true = serde_json::to_string(&FlatIndexConfig {
-        segmented: true,
+    let explicit_false = serde_json::to_string(&FlatIndexConfig {
+        segmented: false,
         ..FlatIndexConfig::default()
     })
     .unwrap();
-    let config: FlatIndexConfig = serde_json::from_str(&explicit_true).unwrap();
+    let config: FlatIndexConfig = serde_json::from_str(&explicit_false).unwrap();
     assert!(
-        config.segmented,
-        "an explicit `segmented: true` must be preserved"
+        !config.segmented,
+        "an explicit `segmented: false` must be preserved"
     );
 }
 

--- a/laurus/tests/vector_segmented_ivf_test.rs
+++ b/laurus/tests/vector_segmented_ivf_test.rs
@@ -582,9 +582,10 @@ fn append_only_segment_count_is_bounded_by_auto_merge() {
     }
 }
 
-/// serde behavior of the (off-by-default) flag.
+/// serde behavior of the (now on-by-default, Issue #907) flag.
 #[test]
-fn segmented_flag_serde_default_and_explicit_true() {
+fn segmented_flag_serde_default_and_explicit_false() {
+    // A pre-#907 config = today's config with the `segmented` key removed.
     let mut value: serde_json::Value = serde_json::to_value(IvfIndexConfig::default()).unwrap();
     value
         .as_object_mut()
@@ -593,19 +594,19 @@ fn segmented_flag_serde_default_and_explicit_true() {
         .expect("the flag must serialize");
     let config: IvfIndexConfig = serde_json::from_value(value).unwrap();
     assert!(
-        !config.segmented,
-        "a config serialized before the field existed must open monolithic"
+        config.segmented,
+        "a config serialized before the field existed must open segmented (#907)"
     );
 
-    let explicit_true = serde_json::to_string(&IvfIndexConfig {
-        segmented: true,
+    let explicit_false = serde_json::to_string(&IvfIndexConfig {
+        segmented: false,
         ..IvfIndexConfig::default()
     })
     .unwrap();
-    let config: IvfIndexConfig = serde_json::from_str(&explicit_true).unwrap();
+    let config: IvfIndexConfig = serde_json::from_str(&explicit_false).unwrap();
     assert!(
-        config.segmented,
-        "an explicit `segmented: true` must be preserved"
+        !config.segmented,
+        "an explicit `segmented: false` must be preserved"
     );
 }
 


### PR DESCRIPTION
## Summary

- Flips `FlatIndexConfig::segmented` and `IvfIndexConfig::segmented` to default `true`, mirroring HNSW's own #881/#882 two-step rollout in a single PR (justified since Flat/IVF share the same #889 infrastructure). Both fields now use `#[serde(default = "default_segmented")]` (reusing HNSW's existing function) instead of bare `#[serde(default)]`, so a config missing the field also deserializes to `true` — not just `Default::default()`.
- A workspace-wide audit (posted to #907 before implementation) found only 2 tests needed inverting (`segmented_flag_serde_default_and_explicit_true` → `_false` in both `vector_segmented_flat_test.rs`/`vector_segmented_ivf_test.rs`) and confirmed zero impact on bindings/CLI/server/MCP.
- Running the full suite caught one regression the audit missed: `factory.rs::test_vector_index_stats` implicitly relied on the monolithic-only `last_modified` timestamp behavior — pinned that test to `segmented: false` explicitly rather than let it silently start testing something else.
- Updated `docs/src`/`docs/ja`'s `vector_indexing.md` to describe segment-per-commit as the default for all three index types.

This completes the #889 campaign (PR-0 through PR-7).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` (stable 1.97.1 + pinned 1.97.0)
- [x] `cargo test -p laurus --lib` — 1248 passed
- [x] `cargo test -p laurus --doc` — 125 passed
- [x] `cargo test -p laurus --tests` — all binaries green
- [x] `cargo doc -p laurus --no-deps` — 73 warnings, matches `main` baseline
- [x] `markdownlint-cli2` (both `docs/src` and `docs/ja/src`) — zero errors
- [x] `mdbook build` (both English and Japanese books) — success

Part of #889
Closes #907