### PR TITLE
perf(vector/index): avoid merge-path clone and pre-size HNSW search heaps (#636, #680)

### DIFF
--- a/laurus/src/vector/index/flat/segment/merge_engine.rs
+++ b/laurus/src/vector/index/flat/segment/merge_engine.rs
@@ -72,8 +72,6 @@ impl MergeEngine {
         let start_time = crate::util::time::Timer::now();
 
         let segments_merged = segments.len() as u32;
-        #[allow(unused_assignments)]
-        let mut vectors_merged = 0;
         let mut deletions_removed = 0;
         let mut duplicates_removed = 0u64;
 
@@ -112,6 +110,8 @@ impl MergeEngine {
         }
 
         // 2. Write to new segment.
+        let vectors_merged = all_vectors.len() as u64;
+        let total_size = vectors_merged * 128; // Dummy estimate; measured from storage by `add_segment`.
         let mut writer = FlatIndexWriter::with_storage(
             self.index_config.clone(),
             self.writer_config.clone(),
@@ -119,12 +119,14 @@ impl MergeEngine {
             self.storage.clone(),
         )?;
 
-        writer.add_vectors(all_vectors.clone())?;
+        // Issue #636: move instead of clone -- `all_vectors` is not read
+        // again after this call, and merges are routine under
+        // segment-per-commit's tiered policy rather than rare full
+        // rewrites, so the clone's peak-memory doubling recurs on every
+        // merge instead of occasionally.
+        writer.add_vectors(all_vectors)?;
         writer.finalize()?;
         writer.write()?;
-
-        vectors_merged = all_vectors.len() as u64;
-        let total_size = vectors_merged * 128; // Dummy estimate; measured from storage by `add_segment`.
 
         let merge_time_ms = start_time.elapsed_ms();
 

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -765,8 +765,14 @@ impl HnswSearcher {
         }
 
         // 3. Search at layer 0 with ef_search
-        let mut candidates = BinaryHeap::new(); // Min-heap (nearest first)
-        let mut found = BinaryHeap::new(); // Max-heap (furthest first)
+        // Issue #680: pre-size both heaps instead of growing geometrically
+        // from empty on every query. `found` never holds more than
+        // `ef_search + 1` entries (pushed then immediately popped back down
+        // once it overflows, below); `candidates` has no hard cap, but stays
+        // in the same order of magnitude in practice, so the same estimate
+        // is used for both.
+        let mut candidates = BinaryHeap::with_capacity(ef_search * 2); // Min-heap (nearest first)
+        let mut found = BinaryHeap::with_capacity(ef_search * 2); // Max-heap (furthest first)
 
         // A node enters the result heap only if it satisfies the admission
         // predicate; the frontier (`candidates`) always expands through every

--- a/laurus/src/vector/index/hnsw/segment/merge_engine.rs
+++ b/laurus/src/vector/index/hnsw/segment/merge_engine.rs
@@ -70,12 +70,8 @@ impl MergeEngine {
 
         // Calculate statistics
         let segments_merged = segments.len() as u32;
-        #[allow(unused_assignments)]
-        let mut vectors_merged = 0;
         let mut deletions_removed = 0;
         let mut duplicates_removed = 0u64;
-        #[allow(unused_assignments)]
-        let mut total_size = segments.iter().map(|s| s.size_bytes).sum::<u64>();
 
         let mut all_vectors: Vec<(u64, String, Vector)> = Vec::new();
 
@@ -130,6 +126,8 @@ impl MergeEngine {
 
         // 2. Write to new segment
         // We use with_storage to ensure it writes to the correct location
+        let vectors_merged = all_vectors.len() as u64;
+        let total_size = vectors_merged * 128; // Dummy estimate; measured from storage by `add_segment`.
         let mut writer = HnswIndexWriter::with_storage(
             self.index_config.clone(),
             self.writer_config.clone(),
@@ -137,12 +135,14 @@ impl MergeEngine {
             self.storage.clone(),
         )?;
 
-        writer.add_vectors(all_vectors.clone())?;
+        // Issue #636: move instead of clone -- `all_vectors` is not read
+        // again after this call, and merges are routine under
+        // segment-per-commit's tiered policy rather than rare full
+        // rewrites, so the clone's peak-memory doubling recurs on every
+        // merge instead of occasionally.
+        writer.add_vectors(all_vectors)?;
         writer.finalize()?;
         writer.write()?;
-
-        vectors_merged = all_vectors.len() as u64;
-        total_size = vectors_merged * 128; // Dummy estimate
 
         let merge_time_ms = start_time.elapsed_ms();
 


### PR DESCRIPTION
## Summary

Picked up from a post-#889 re-triage of the Round-3 perf backlog (a dedicated agent audit of 27 open vector/index and vector/search issues rated these two the clearest GO — trivial, zero-risk, and both grew more relevant since #634/#889 made segment merges routine instead of rare).

- **#636**: `hnsw/segment/merge_engine.rs` and `flat/segment/merge_engine.rs` both cloned the deduplicated vector list before handing it to the new segment's writer, doubling peak memory on every merge. `ivf/segment/merge_engine.rs` (new in #889 PR-6) already moves it instead — a working precedent already shipped in this codebase. Moved the length capture before the writer construction and changed `.clone()` to a plain move in both files.
- **#680**: `hnsw/searcher.rs`'s graph-traversal search left both the candidate min-heap and the result max-heap unsized. `found` never exceeds `ef_search + 1`; `candidates` has no hard cap but stays in the same order of magnitude in practice. Pre-sized both to `ef_search * 2`, matching the issue's own suggested direction. Left the file's other `BinaryHeap::new()` sites alone (the cardinality-driven filter path is already bounded differently; the rest are unrelated NaN-ordering unit tests).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` (stable 1.97.1 + pinned 1.97.0)
- [x] `cargo test -p laurus --lib` — 1248 passed
- [x] `cargo test -p laurus --tests` — all binaries green, including `hnsw_reachability_test` and the ~213s `vector_recall_test`
- [x] `cargo doc -p laurus --no-deps` — 73 warnings, matches `main` baseline

Closes #636
Closes #680