### PR TITLE
feat(vector/index): shared PQ codebook file + train-free encode path

### DIFF
--- a/laurus/benches/pq_train_bench.rs
+++ b/laurus/benches/pq_train_bench.rs
@@ -1,4 +1,6 @@
-//! PQ codebook training benchmark (Issue #622).
+//! PQ codebook training benchmark (Issue #622), plus the Issue #631 A/B
+//! counterpart that reuses a pre-trained shared codebook instead of
+//! retraining.
 //!
 //! PQ is HNSW-only, and training runs inside the writer's `write()`
 //! (not `finalize()`): `quantize_segment_pq` → `pq_train_codebook`
@@ -9,6 +11,12 @@
 //! in-memory storage, so training dominates the measured op. This is
 //! the designated A/B gate metric for #622's PQ-side changes
 //! (parallel sub-vector training + SIMD L2 kernel).
+//!
+//! The "PQ Encode Shared Codebook" group mirrors "PQ Train" at the same
+//! corpus sizes but configures `HnswIndexConfig::pq_codebook_path` with a
+//! codebook trained once up front, so the measured `write()` calls skip
+//! k-means entirely (Issue #631) — the delta against "PQ Train" is the
+//! actual training cost eliminated by reuse.
 //!
 //! Setup is in-memory and deterministic via `common::DEFAULT_SEED`.
 
@@ -22,6 +30,7 @@ use laurus::vector::core::distance::DistanceMetric;
 use laurus::vector::core::quantization::QuantizationMethod;
 use laurus::vector::index::ManagedVectorIndex;
 use laurus::vector::index::config::{HnswIndexConfig, VectorIndexTypeConfig};
+use laurus::vector::index::pq_codebook::train_and_write_pq_codebook;
 
 /// Vector dimension (matches the other vector benches; M = 16 gives
 /// `sub_dim` = 8).
@@ -78,5 +87,59 @@ fn bench_pq_train(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_pq_train);
+/// Repeated `write()` on a finalized HNSW+PQ index configured with a
+/// shared codebook (Issue #631): the codebook is trained once, up front,
+/// outside the timed loop, and every measured `write()` call encodes
+/// against it via `VectorQuantizer::from_pq_codebook` instead of running
+/// `pq_train_codebook`.
+fn bench_pq_encode_shared_codebook(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PQ Encode Shared Codebook");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    for &count in &[2048usize, 8192] {
+        let storage = select_storage();
+        let vectors = generate_vectors(count, DIM);
+
+        // Train on the same corpus, normalized the same way `write()`
+        // will see it (Cosine below implies `normalize_vectors: true`,
+        // Issue #794's scale trap): `add_vectors`/`build` normalize in
+        // place before the writer's buffer is populated, so the shared
+        // codebook must be trained on normalized vectors too.
+        let training_sample: Vec<Vector> = vectors.iter().map(|(_, _, v)| v.clone()).collect();
+        let codebook_name = "field.pqcb".to_string();
+        train_and_write_pq_codebook(
+            storage.as_ref(),
+            &codebook_name,
+            DIM,
+            16,
+            true,
+            &training_sample,
+        )
+        .unwrap();
+
+        let config = HnswIndexConfig {
+            dimension: DIM,
+            m: 16,
+            ef_construction: 200,
+            distance_metric: DistanceMetric::Cosine,
+            quantization_method: QuantizationMethod::ProductQuantization {
+                subvector_count: 16,
+            },
+            pq_codebook_path: Some(codebook_name),
+            ..Default::default()
+        };
+        let mut index =
+            ManagedVectorIndex::new(VectorIndexTypeConfig::HNSW(config), storage, "bench").unwrap();
+        index.add_vectors(vectors).unwrap();
+        index.finalize().unwrap();
+
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| index.write().unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_pq_train, bench_pq_encode_shared_codebook);
 criterion_main!(benches);

--- a/laurus/src/vector/index.rs
+++ b/laurus/src/vector/index.rs
@@ -15,6 +15,7 @@ pub mod format;
 pub mod hnsw;
 pub mod io;
 pub mod ivf;
+pub mod pq_codebook;
 pub mod pq_fastscan_avx2;
 #[cfg(feature = "pq-fastscan")]
 pub mod pq_fastscan_io;
@@ -258,11 +259,19 @@ impl ManagedVectorIndex {
     /// * `storage` - Storage backend (MemoryStorage, FileStorage, etc.)
     /// * `path` - Base path/name for the index files
     pub fn new(
-        config: VectorIndexTypeConfig,
+        mut config: VectorIndexTypeConfig,
         storage: Arc<dyn Storage>,
         path: impl Into<String>,
     ) -> Result<Self> {
         let path = path.into();
+        // Resolve a configured shared PQ codebook (Issue #631) before
+        // constructing the writer -- mirrors `factory.rs`'s
+        // `dispatch_hnsw` resolution point for the `VectorIndexFactory`
+        // path; this constructor is the other (bench/direct-use) path
+        // into an HNSW writer.
+        if let VectorIndexTypeConfig::HNSW(hnsw_config) = &mut config {
+            hnsw_config.resolve_pq_codebook(storage.as_ref())?;
+        }
         // Create builder based on config type
         let builder: Box<dyn VectorIndexWriter> = match &config {
             VectorIndexTypeConfig::Flat(flat_config) => {

--- a/laurus/src/vector/index/config.rs
+++ b/laurus/src/vector/index/config.rs
@@ -534,6 +534,31 @@ pub struct HnswIndexConfig {
     #[serde(default = "default_compaction_threshold")]
     pub compaction_threshold: f64,
 
+    /// Storage-relative file name of a pre-trained, shared PQ codebook
+    /// (Issue #631), e.g. `"embedding.pqcb"`.
+    ///
+    /// `None` (the default) keeps today's behavior: every segment's
+    /// `write()` trains its own PQ codebook from scratch. When set,
+    /// [`Self::resolve_pq_codebook`] loads the file once at index-open
+    /// time into [`Self::pq_codebook`]; `write()` then encodes against
+    /// that codebook instead of training, which is the actual point of
+    /// this field (PQ training is a multi-second cost that otherwise
+    /// recurs at every segment flush and every merge tier). Ignored
+    /// (not yet resolvable) until `hnsw/writer.rs` reads it in Issue
+    /// #631 PR-1.
+    #[serde(default)]
+    pub pq_codebook_path: Option<String>,
+
+    /// The resolved shared PQ codebook, loaded from
+    /// [`Self::pq_codebook_path`] by [`Self::resolve_pq_codebook`].
+    ///
+    /// Not serialized (mirrors [`Self::embedder`]): this is runtime
+    /// state resolved once per index instance, not part of the
+    /// persisted schema. Retraining the codebook file on disk does not
+    /// affect an already-open index; reopen to pick up the change.
+    #[serde(skip)]
+    pub pq_codebook: Option<Arc<crate::vector::index::pq_codebook::SharedPqCodebook>>,
+
     /// Embedder for converting text/images to vectors.
     ///
     /// This embedder is used when documents contain text or image fields that need to be
@@ -573,6 +598,8 @@ impl Default for HnswIndexConfig {
             max_segments: 100,
             auto_compaction: false,
             compaction_threshold: default_compaction_threshold(),
+            pq_codebook_path: None,
+            pq_codebook: None,
             embedder: default_embedder(),
         }
     }
@@ -596,6 +623,11 @@ impl std::fmt::Debug for HnswIndexConfig {
             .field("max_segments", &self.max_segments)
             .field("auto_compaction", &self.auto_compaction)
             .field("compaction_threshold", &self.compaction_threshold)
+            .field("pq_codebook_path", &self.pq_codebook_path)
+            .field(
+                "pq_codebook",
+                &self.pq_codebook.as_ref().map(|cb| cb.params),
+            )
             .field("embedder", &self.embedder.name())
             .finish()
     }
@@ -657,6 +689,44 @@ impl HnswIndexConfig {
             normalize_vectors: opt.distance == DistanceMetric::Cosine,
             ..Self::default()
         }
+    }
+
+    /// Resolve [`Self::pq_codebook_path`] into [`Self::pq_codebook`], if set.
+    ///
+    /// A no-op when `pq_codebook_path` is `None`. When set but the file
+    /// does not exist yet — the schema names a codebook that has not
+    /// been trained — this is *also* a no-op (lenient at open):
+    /// `hnsw/writer.rs`'s `write()` is what hard-errors instead, only
+    /// once a commit actually needs to encode against the missing
+    /// codebook. Erroring here would make `create`/`open` fail for a
+    /// schema whose codebook has not been trained yet, an unbreakable
+    /// ordering deadlock against a `train` step that itself needs an
+    /// open index (Issue #631).
+    ///
+    /// # Arguments
+    ///
+    /// * `storage` - The vector index's storage namespace to load the
+    ///   codebook file from (the same namespace `write()` will later
+    ///   read segment files from).
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`crate::vector::index::pq_codebook::read_pq_codebook`]'s
+    /// error when the file exists but is corrupted or declares a
+    /// geometry `write()` cannot use — both fail loudly rather than
+    /// silently falling back to per-segment training, since an
+    /// invisible regression to the multi-second training cost would
+    /// defeat the point of this feature.
+    pub fn resolve_pq_codebook(&mut self, storage: &dyn crate::storage::Storage) -> Result<()> {
+        let Some(path) = &self.pq_codebook_path else {
+            return Ok(());
+        };
+        if !storage.file_exists(path) {
+            return Ok(());
+        }
+        let codebook = crate::vector::index::pq_codebook::read_pq_codebook(storage, path)?;
+        self.pq_codebook = Some(Arc::new(codebook));
+        Ok(())
     }
 }
 

--- a/laurus/src/vector/index/factory.rs
+++ b/laurus/src/vector/index/factory.rs
@@ -149,10 +149,17 @@ impl VectorIndexFactory {
     fn dispatch_hnsw(
         storage: Arc<dyn Storage>,
         name: &str,
-        hnsw_config: crate::vector::index::config::HnswIndexConfig,
+        mut hnsw_config: crate::vector::index::config::HnswIndexConfig,
         open_only: bool,
     ) -> Result<Box<dyn VectorIndex>> {
         use crate::vector::index::hnsw::segmented::SegmentedHnswIndex;
+
+        // Resolve a configured shared PQ codebook (Issue #631) once here,
+        // the single choke point both the segmented and monolithic HNSW
+        // paths go through — every writer built from this config (and,
+        // for the segmented path, the merge engine, which clones this same
+        // config) picks up the resolved `Arc` for free.
+        hnsw_config.resolve_pq_codebook(storage.as_ref())?;
 
         if hnsw_config.segmented {
             let index = SegmentedHnswIndex::open_or_create(storage, name, hnsw_config)?;

--- a/laurus/src/vector/index/hnsw/tests.rs
+++ b/laurus/src/vector/index/hnsw/tests.rs
@@ -597,6 +597,144 @@ fn test_hnsw_pq_search_returns_corpus_neighbour() -> Result<()> {
     Ok(())
 }
 
+/// Issue #631: a segment below `PQ_MIN_TRAIN_VECTORS` (256) normally
+/// degrades to Scalar8Bit (nothing to train k-means on) -- but when a
+/// shared codebook is configured there is nothing to train either way,
+/// so the degradation rationale no longer applies and the segment
+/// should stay Product Quantization, encoding directly against the
+/// shared codebook.
+#[test]
+fn shared_pq_codebook_keeps_small_segment_on_pq() -> Result<()> {
+    use crate::vector::core::quantization::QuantizationMethod;
+    use crate::vector::index::pq_codebook::train_and_write_pq_codebook;
+    use crate::vector::index::storage::VectorStorage;
+
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+
+    // Train the shared codebook on a representative sample well above the
+    // min-train threshold, entirely separate from the tiny corpus the
+    // segment itself will hold.
+    let mut state: u64 = 0xABCD_EF01_2345_6789;
+    let training_sample: Vec<Vector> = (0..300)
+        .map(|_| {
+            let data: Vec<f32> = (0..4)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                })
+                .collect();
+            Vector::new(data)
+        })
+        .collect();
+    train_and_write_pq_codebook(
+        storage.as_ref(),
+        "shared.pqcb",
+        4,
+        2,
+        false,
+        &training_sample,
+    )?;
+
+    let mut config = HnswIndexConfig {
+        dimension: 4,
+        m: 8,
+        ef_construction: 50,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantization { subvector_count: 2 },
+        pq_codebook_path: Some("shared.pqcb".to_string()),
+        ..Default::default()
+    };
+    config.resolve_pq_codebook(storage.as_ref())?;
+    assert!(
+        config.pq_codebook.is_some(),
+        "the shared codebook must resolve from the file just written"
+    );
+
+    let index = HnswIndex::create(storage.clone(), "small_segment", config)?;
+    let mut writer = index.writer()?;
+    // Only 10 vectors -- far below PQ_MIN_TRAIN_VECTORS (256).
+    let vectors: Vec<_> = (0..10u64)
+        .map(|i| {
+            (
+                i + 1,
+                "embedding".to_string(),
+                Vector::new(vec![i as f32, i as f32, i as f32 * 2.0, i as f32 * 2.0]),
+            )
+        })
+        .collect();
+    writer.build(vectors)?;
+    writer.finalize()?;
+    writer.commit()?;
+
+    let reader = index.reader()?;
+    let hnsw_reader = reader
+        .as_any()
+        .downcast_ref::<HnswIndexReader>()
+        .expect("HnswIndex::reader() always returns an HnswIndexReader");
+    assert!(
+        matches!(hnsw_reader.vectors(), VectorStorage::OwnedPq(_)),
+        "a 10-vector segment with a shared codebook configured must stay \
+         Product Quantization, not degrade to Scalar8Bit"
+    );
+    Ok(())
+}
+
+/// Issue #631: a `pq_codebook_path` naming a file that has not been
+/// trained yet must not block opening the index (the schema may be
+/// created before `laurus train pq-codebook` runs) -- but `write()`
+/// must fail loudly, with the exact command to fix it, rather than
+/// silently falling back to per-segment training (which would defeat
+/// the point of configuring a shared codebook at all).
+#[test]
+fn missing_shared_pq_codebook_is_lenient_at_open_but_errors_at_write() -> Result<()> {
+    use crate::vector::core::quantization::QuantizationMethod;
+
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+    let mut config = HnswIndexConfig {
+        dimension: 4,
+        m: 8,
+        ef_construction: 50,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantization { subvector_count: 2 },
+        pq_codebook_path: Some("not-yet-trained.pqcb".to_string()),
+        ..Default::default()
+    };
+    // Lenient at open: no file exists yet, but resolution must not error.
+    config.resolve_pq_codebook(storage.as_ref())?;
+    assert!(config.pq_codebook.is_none());
+
+    let index = HnswIndex::create(storage.clone(), "no_codebook_yet", config)?;
+    let mut writer = index.writer()?;
+    let vectors: Vec<_> = (0..300u64)
+        .map(|i| {
+            (
+                i + 1,
+                "embedding".to_string(),
+                Vector::new(vec![i as f32, i as f32, i as f32 * 2.0, i as f32 * 2.0]),
+            )
+        })
+        .collect();
+    writer.build(vectors)?;
+    writer.finalize()?;
+
+    // A path is configured but never resolved to an actual codebook --
+    // `write()` must fail loudly (naming the configured path and the fix)
+    // rather than silently falling back to training a fresh codebook,
+    // which would defeat the point of configuring a shared codebook.
+    let err = writer.write().expect_err(
+        "write() must reject a configured-but-unresolved pq_codebook_path instead of \
+         silently training a fresh codebook",
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("not-yet-trained.pqcb"),
+        "error must name the configured path, got: {message}"
+    );
+    Ok(())
+}
+
 /// Regression / parity test for Issue #644: HNSW `ef_search` must honour
 /// the per-query override and the schema-level default, instead of being
 /// permanently capped at the historical `50` constant.

--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -1750,12 +1750,19 @@ impl VectorIndexWriter for HnswIndexWriter {
         // a merged (large) segment picks PQ back up automatically. Empty
         // segments keep the configured method's header for uniform
         // dispatch.
+        //
+        // This guard does not apply when a shared PQ codebook (Issue #631)
+        // is configured: nothing is trained in that case, so the
+        // degenerate-codebook rationale above does not hold, and small
+        // segment-per-commit flushes can stay PQ instead of degrading to
+        // Scalar8Bit.
+        let has_shared_pq_codebook = self.index_config.pq_codebook.is_some();
         let effective_quantization = {
             use crate::vector::core::quantization::QuantizationMethod as Qm;
             let n = f32_vectors.len();
             match self.index_config.quantization_method {
                 Qm::ProductQuantization { subvector_count }
-                    if n > 0 && n < PQ_MIN_TRAIN_VECTORS =>
+                    if n > 0 && n < PQ_MIN_TRAIN_VECTORS && !has_shared_pq_codebook =>
                 {
                     // The fallback must not skip config validation: an
                     // invalid PQ geometry (subvector_count not dividing the
@@ -1832,11 +1839,36 @@ impl VectorIndexWriter for HnswIndexWriter {
                         .with_field_dict(field_dict.clone())
                         .write_to(&mut output)?;
                 } else {
+                    // Issue #631: a configured-but-unresolved shared
+                    // codebook (the path was set, but no file existed
+                    // there when the index was opened) must fail loudly
+                    // here rather than silently falling through to
+                    // per-segment training below -- an invisible
+                    // regression to the multi-second training cost would
+                    // defeat the entire point of configuring a shared
+                    // codebook. This is the ONLY place in the writer that
+                    // can catch it: `resolve_pq_codebook` (index-open
+                    // time) is deliberately lenient about a not-yet-
+                    // trained codebook, since erroring there would make
+                    // `create`/`open` fail for a schema whose codebook
+                    // simply hasn't been trained yet.
+                    if self.index_config.pq_codebook_path.is_some()
+                        && self.index_config.pq_codebook.is_none()
+                    {
+                        return Err(LaurusError::InvalidOperation(format!(
+                            "HNSW field configures pq_codebook_path = {:?} but no codebook \
+                             has been trained there yet; train one first (e.g. `laurus train \
+                             pq-codebook`) before committing, or clear pq_codebook_path to use \
+                             per-segment training",
+                            self.index_config.pq_codebook_path.as_deref().unwrap_or_default()
+                        )));
+                    }
                     let (params, codebook, codes) =
                         crate::vector::index::pq_io::quantize_segment_pq(
                             &f32_vectors,
                             self.index_config.dimension,
                             subvector_count,
+                            self.index_config.pq_codebook.as_deref(),
                         )?;
                     VectorSegmentHeader::product_quantization(params, codebook)
                         .with_version(VERSION_FIELD_DICT)

--- a/laurus/src/vector/index/pq_codebook.rs
+++ b/laurus/src/vector/index/pq_codebook.rs
@@ -1,0 +1,383 @@
+//! Standalone shared PQ codebook file (Issue #631, part of the #631
+//! campaign).
+//!
+//! A codebook trained once (via [`train_and_write_pq_codebook`],
+//! typically driven by `Engine::train_pq_codebook`/the
+//! `laurus train pq-codebook` CLI command in a later PR) and reused by
+//! every segment's `write()` instead of retraining k-means from
+//! scratch on every commit and every merge — HNSW's `write()`
+//! currently does that unconditionally, measured at multiple seconds
+//! per call and recurring at every tier of the segment-per-commit
+//! merge hierarchy.
+//!
+//! # File format
+//!
+//! Reuses [`VectorSegmentHeader::product_quantization`]'s existing
+//! serialization verbatim (so the params/codebook bytes are laid out
+//! exactly as they would be inline in a `.hnsw` segment header, with
+//! no vector records and the default field dictionary), followed by a
+//! CRC-32 footer — the same shape as
+//! [`crate::vector::index::rerank_sidecar`]'s file, just carrying a PQ
+//! header instead of a rerank payload.
+
+use std::io::{Read, Write};
+
+use crate::error::{LaurusError, Result};
+use crate::storage::Storage;
+use crate::storage::checksum::{CrcReader, CrcWriter};
+use crate::vector::core::quantization::{PqParams, pq_train_codebook};
+use crate::vector::core::vector::Vector;
+use crate::vector::index::format::{QuantHeader, VectorSegmentHeader};
+
+/// Magic value for the codebook file's trailing footer ("PQCB" ASCII),
+/// distinguishing it from other footer-bearing formats in this crate
+/// (HNSW's own segment footer, the rerank sidecar's footer).
+const PQ_CODEBOOK_FOOTER_MAGIC: u32 = 0x5051_4342;
+
+/// Footer size in bytes: magic (`u32`) + CRC-32 (`u32`).
+const FOOTER_SIZE: usize = 8;
+
+/// Byte length of the fixed PQ header prefix this module reads before
+/// trusting any length it declares: the 16-byte [`VectorSegmentHeader`]
+/// fixed header plus the 8-byte `m`/`k`/`sub_dim`/padding block.
+const PQ_HEADER_PREFIX_SIZE: usize = 24;
+
+/// A trained PQ codebook loaded from (or about to be persisted to) a
+/// standalone file, shared across many segments instead of being
+/// retrained inline by every `write()` call.
+#[derive(Debug, Clone)]
+pub struct SharedPqCodebook {
+    /// PQ geometry (`m`, `k`, `sub_dim`) this codebook was trained for.
+    pub params: PqParams,
+    /// Row-major codebook, `params.codebook_len()` entries.
+    pub codebook: Vec<f32>,
+}
+
+impl SharedPqCodebook {
+    /// Confirm this codebook can be used to encode `dimension`-d
+    /// vectors split into `subvector_count` sub-vectors.
+    ///
+    /// # Arguments
+    ///
+    /// * `dimension` - The caller's configured vector dimension.
+    /// * `subvector_count` - The caller's configured PQ `m`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LaurusError::InvalidOperation`] if the codebook's
+    /// geometry does not match the caller's expectations, or if its
+    /// stored length is inconsistent with its own params (defensive;
+    /// [`read_pq_codebook`] already guarantees this on the load path).
+    pub fn validate_for(&self, dimension: usize, subvector_count: usize) -> Result<()> {
+        if self.params.original_dim() != dimension {
+            return Err(LaurusError::InvalidOperation(format!(
+                "shared PQ codebook dimension {} does not match the configured \
+                 dimension {dimension}",
+                self.params.original_dim()
+            )));
+        }
+        if self.params.m as usize != subvector_count {
+            return Err(LaurusError::InvalidOperation(format!(
+                "shared PQ codebook subvector_count {} does not match the configured \
+                 subvector_count {subvector_count}",
+                self.params.m
+            )));
+        }
+        if self.codebook.len() != self.params.codebook_len() {
+            return Err(LaurusError::InvalidOperation(format!(
+                "shared PQ codebook has {} entries, expected {} for params {:?}",
+                self.codebook.len(),
+                self.params.codebook_len(),
+                self.params
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Default storage-relative file name for a field's shared codebook
+/// (e.g. `"embedding.pqcb"`).
+pub fn default_codebook_name(field: &str) -> String {
+    format!("{field}.pqcb")
+}
+
+/// Persist `params`/`codebook` to `name` in `storage`, via a
+/// temp-file + fsync + atomic rename (mirroring the `.hnsw` segment
+/// write pattern, Issue #784) so a crash mid-write cannot leave a torn
+/// file behind.
+///
+/// # Errors
+///
+/// Any I/O error from `storage`.
+pub fn write_pq_codebook(
+    storage: &dyn Storage,
+    name: &str,
+    params: PqParams,
+    codebook: &[f32],
+) -> Result<()> {
+    let tmp_name = format!("{name}.tmp");
+    let mut output = CrcWriter::new(storage.create_output(&tmp_name)?);
+    VectorSegmentHeader::product_quantization(params, codebook.to_vec()).write_to(&mut output)?;
+    let content_crc = output.checksum();
+    let mut inner = output.into_inner();
+    inner.write_all(&PQ_CODEBOOK_FOOTER_MAGIC.to_le_bytes())?;
+    inner.write_all(&content_crc.to_le_bytes())?;
+    inner.close()?;
+    storage.rename_file(&tmp_name, name)?;
+    Ok(())
+}
+
+/// Load a codebook previously written by [`write_pq_codebook`],
+/// verifying its CRC-32 footer.
+///
+/// # Allocation safety
+///
+/// The full header parse (which allocates the `codebook: Vec<f32>`
+/// buffer internally) trusts its own `m`/`k`/`sub_dim` fields, which
+/// are not yet integrity-checked at that point — mirroring the
+/// `rerank_sidecar` module's Issue #791 guard, this function first
+/// reads only the small fixed prefix, computes the codebook's declared
+/// byte size from it, and rejects the file as corrupted *before*
+/// calling into the real parse if that declared size cannot fit in the
+/// file's actual on-disk length.
+///
+/// # Errors
+///
+/// * [`LaurusError::Index`] if the file is truncated, the footer magic
+///   is wrong, the checksum does not match, or the header declares a
+///   codebook larger than the file can hold.
+/// * Any I/O error from `storage`.
+pub fn read_pq_codebook(storage: &dyn Storage, name: &str) -> Result<SharedPqCodebook> {
+    let file_size = storage.file_size(name)?;
+
+    let declared = {
+        let mut input = storage.open_input(name)?;
+        let mut prefix = [0u8; PQ_HEADER_PREFIX_SIZE];
+        input.read_exact(&mut prefix)?;
+        let m = u16::from_le_bytes([prefix[16], prefix[17]]);
+        let k = u16::from_le_bytes([prefix[18], prefix[19]]);
+        let sub_dim = u16::from_le_bytes([prefix[20], prefix[21]]);
+        PqParams::new(m, k, sub_dim).map_err(|e| {
+            LaurusError::index(format!(
+                "shared PQ codebook '{name}' has invalid params: {e}"
+            ))
+        })?
+    };
+    let min_total = (PQ_HEADER_PREFIX_SIZE as u64)
+        .checked_add(declared.codebook_byte_size() as u64)
+        .and_then(|n| n.checked_add(FOOTER_SIZE as u64))
+        .ok_or_else(|| {
+            LaurusError::index(format!(
+                "shared PQ codebook '{name}' declared size overflows u64: file is corrupted"
+            ))
+        })?;
+    if min_total > file_size {
+        return Err(LaurusError::index(format!(
+            "shared PQ codebook '{name}' declares a {}-byte codebook but the file is \
+             only {file_size} bytes: file is corrupted",
+            declared.codebook_byte_size()
+        )));
+    }
+
+    // Bounded: re-parse for real now that `file_size` has confirmed the
+    // declared codebook fits.
+    let mut crc_reader = CrcReader::new(storage.open_input(name)?);
+    let header = VectorSegmentHeader::read_from(&mut crc_reader)
+        .map_err(|e| LaurusError::index(format!("shared PQ codebook '{name}': {e}")))?;
+    let (params, codebook) = match header.quant {
+        QuantHeader::ProductQuantization { params, codebook } => (params, codebook),
+        other => {
+            return Err(LaurusError::index(format!(
+                "shared PQ codebook '{name}' has an unexpected quantization kind: {other:?}"
+            )));
+        }
+    };
+
+    let computed = crc_reader.checksum();
+    let inner = crc_reader.get_mut();
+    let mut footer = [0u8; FOOTER_SIZE];
+    inner.read_exact(&mut footer)?;
+    let magic = u32::from_le_bytes([footer[0], footer[1], footer[2], footer[3]]);
+    if magic != PQ_CODEBOOK_FOOTER_MAGIC {
+        return Err(LaurusError::index(format!(
+            "shared PQ codebook '{name}' footer magic mismatch: file is corrupted"
+        )));
+    }
+    let stored_crc = u32::from_le_bytes([footer[4], footer[5], footer[6], footer[7]]);
+    if stored_crc != computed {
+        return Err(LaurusError::index(format!(
+            "shared PQ codebook '{name}' checksum mismatch: file is corrupted"
+        )));
+    }
+
+    Ok(SharedPqCodebook { params, codebook })
+}
+
+/// Train a PQ codebook on `vectors` (a representative sample) and
+/// persist it to `name` in `storage`.
+///
+/// # Arguments
+///
+/// * `storage` - The vector index's storage namespace to persist into.
+/// * `name` - Storage-relative file name (see [`default_codebook_name`]).
+/// * `dimension` - Original vector dimension.
+/// * `subvector_count` - PQ `m` (must divide `dimension`).
+/// * `normalize` - Must match the field's `HnswIndexConfig::normalize_vectors`
+///   (i.e. `true` for Cosine distance). Training on a different scale
+///   than the segments that will later encode against this codebook
+///   produces centroids on the wrong scale, silently degrading recall
+///   — the same trap as Issue #794.
+/// * `vectors` - The training sample.
+///
+/// # Errors
+///
+/// * [`LaurusError::InvalidOperation`] if `vectors` is empty, has
+///   mixed dimensions, or `subvector_count` does not divide `dimension`.
+/// * Any error from [`write_pq_codebook`].
+pub fn train_and_write_pq_codebook(
+    storage: &dyn Storage,
+    name: &str,
+    dimension: usize,
+    subvector_count: usize,
+    normalize: bool,
+    vectors: &[Vector],
+) -> Result<SharedPqCodebook> {
+    let params = PqParams::from_dim_and_m(dimension, subvector_count)?;
+
+    let normalized;
+    let training_set: &[Vector] = if normalize {
+        let mut owned = vectors.to_vec();
+        for v in &mut owned {
+            v.normalize();
+        }
+        normalized = owned;
+        &normalized
+    } else {
+        vectors
+    };
+
+    let codebook = pq_train_codebook(dimension, params, training_set)?;
+    write_pq_codebook(storage, name, params, &codebook)?;
+    Ok(SharedPqCodebook { params, codebook })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+    fn storage() -> MemoryStorage {
+        MemoryStorage::new(MemoryStorageConfig::default())
+    }
+
+    fn sample_vectors(count: usize, dim: usize) -> Vec<Vector> {
+        let mut state: u64 = 0x1234_5678_9ABC_DEF0;
+        (0..count)
+            .map(|_| {
+                let data: Vec<f32> = (0..dim)
+                    .map(|_| {
+                        state = state
+                            .wrapping_mul(6_364_136_223_846_793_005)
+                            .wrapping_add(1_442_695_040_888_963_407);
+                        ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                    })
+                    .collect();
+                Vector::new(data)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn write_read_roundtrip_preserves_params_and_codebook() {
+        let storage = storage();
+        let vectors = sample_vectors(300, 32);
+        let trained =
+            train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, false, &vectors).unwrap();
+
+        let loaded = read_pq_codebook(&storage, "field.pqcb").unwrap();
+        assert_eq!(loaded.params, trained.params);
+        assert_eq!(loaded.codebook, trained.codebook);
+    }
+
+    #[test]
+    fn corrupted_payload_byte_fails_checksum() {
+        let storage = storage();
+        let vectors = sample_vectors(300, 32);
+        train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, false, &vectors).unwrap();
+
+        // Flip one byte inside the codebook payload (after the 24-byte
+        // prefix) and confirm the CRC catches it.
+        let mut input = storage.open_input("field.pqcb").unwrap();
+        let mut bytes = Vec::new();
+        input.read_to_end(&mut bytes).unwrap();
+        bytes[30] ^= 0xFF;
+        let mut output = storage.create_output("field.pqcb").unwrap();
+        output.write_all(&bytes).unwrap();
+        output.close().unwrap();
+
+        let err = read_pq_codebook(&storage, "field.pqcb").unwrap_err();
+        assert!(
+            matches!(&err, LaurusError::Index(msg) if msg.contains("checksum")),
+            "expected a checksum-mismatch Index error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn truncated_file_is_rejected_before_allocating() {
+        let storage = storage();
+        let vectors = sample_vectors(300, 32);
+        train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, false, &vectors).unwrap();
+
+        // Truncate to just past the fixed prefix -- the declared
+        // codebook (m=4, k=256, sub_dim=8 -> 8192 floats = 32768 bytes)
+        // cannot possibly fit, so this must fail on the size check, not
+        // attempt a matching allocation.
+        let mut input = storage.open_input("field.pqcb").unwrap();
+        let mut bytes = Vec::new();
+        input.read_to_end(&mut bytes).unwrap();
+        bytes.truncate(PQ_HEADER_PREFIX_SIZE + 4);
+        let mut output = storage.create_output("field.pqcb").unwrap();
+        output.write_all(&bytes).unwrap();
+        output.close().unwrap();
+
+        let err = read_pq_codebook(&storage, "field.pqcb").unwrap_err();
+        assert!(
+            matches!(&err, LaurusError::Index(msg) if msg.contains("corrupted")),
+            "expected a size-mismatch Index error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_for_rejects_dimension_and_subvector_mismatch() {
+        let storage = storage();
+        let vectors = sample_vectors(300, 32);
+        let cb =
+            train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, false, &vectors).unwrap();
+
+        assert!(cb.validate_for(32, 4).is_ok());
+        assert!(
+            cb.validate_for(64, 4).is_err(),
+            "dimension mismatch must be rejected"
+        );
+        assert!(
+            cb.validate_for(32, 8).is_err(),
+            "subvector_count mismatch must be rejected"
+        );
+    }
+
+    #[test]
+    fn train_and_write_normalizes_training_sample_when_requested() {
+        let storage = storage();
+        let vectors = sample_vectors(300, 32);
+
+        let cb_raw =
+            train_and_write_pq_codebook(&storage, "raw.pqcb", 32, 4, false, &vectors).unwrap();
+        let cb_normalized =
+            train_and_write_pq_codebook(&storage, "norm.pqcb", 32, 4, true, &vectors).unwrap();
+
+        // Same input, different `normalize` flag: the trained codebooks
+        // must differ (proves normalization actually ran, rather than
+        // being silently ignored).
+        assert_ne!(cb_raw.codebook, cb_normalized.codebook);
+    }
+}

--- a/laurus/src/vector/index/pq_io.rs
+++ b/laurus/src/vector/index/pq_io.rs
@@ -22,6 +22,7 @@ use std::io::{Read, Write};
 use crate::error::Result;
 use crate::vector::core::quantization::{PqParams, QuantizationMethod, VectorQuantizer, pq_decode};
 use crate::vector::core::vector::Vector;
+use crate::vector::index::pq_codebook::SharedPqCodebook;
 
 /// Bytes consumed by the per-vector codes (everything after the
 /// field_name string ends). Equal to `m`.
@@ -35,31 +36,56 @@ pub(super) const fn pq_record_payload_size(m: u16) -> usize {
     m as usize
 }
 
-/// Train a PQ codebook on the given vectors and encode each one.
+/// Encode `vectors` against a PQ codebook, either training a fresh one
+/// or reusing a pre-trained [`SharedPqCodebook`] (Issue #631).
 ///
 /// Returns `(params, codebook, codes)` where `codes` is one
 /// `Vec<u8>` of length `params.m` per input vector, in the same order
 /// as the input slice. The caller pairs each entry back with its
 /// `(doc_id, field_name)` triple before writing.
 ///
+/// # Arguments
+///
+/// * `vectors` - The vectors to encode.
+/// * `dim` - Original vector dimension.
+/// * `subvector_count` - PQ `m` (must divide `dim`).
+/// * `shared` - When `Some`, skip training entirely and encode against
+///   this pre-trained codebook via [`VectorQuantizer::from_pq_codebook`]
+///   (Issue #631 — training a fresh codebook on every segment/merge
+///   costs multiple seconds and recurs at every tier of the
+///   segment-per-commit merge hierarchy). When `None`, train a fresh
+///   codebook on `vectors` as before.
+///
 /// # Errors
 ///
-/// Forwards any error from [`VectorQuantizer::train`] /
-/// [`VectorQuantizer::quantize`] (e.g. empty input, dimension
-/// mismatch, non-finite values, `dim % m != 0`).
+/// * Forwards [`SharedPqCodebook::validate_for`]'s error if `shared`'s
+///   geometry does not match `dim`/`subvector_count`.
+/// * Otherwise forwards any error from [`VectorQuantizer::train`] /
+///   [`VectorQuantizer::quantize`] (e.g. empty input, dimension
+///   mismatch, non-finite values, `dim % m != 0`).
 pub(super) fn quantize_segment_pq(
     vectors: &[Vector],
     dim: usize,
     subvector_count: usize,
+    shared: Option<&SharedPqCodebook>,
 ) -> Result<(PqParams, Vec<f32>, Vec<Vec<u8>>)> {
-    let mut quantizer = VectorQuantizer::new(
-        QuantizationMethod::ProductQuantization { subvector_count },
-        dim,
-    );
-    quantizer.train(vectors)?;
+    let quantizer = match shared {
+        Some(cb) => {
+            cb.validate_for(dim, subvector_count)?;
+            VectorQuantizer::from_pq_codebook(dim, cb.params, cb.codebook.clone())?
+        }
+        None => {
+            let mut quantizer = VectorQuantizer::new(
+                QuantizationMethod::ProductQuantization { subvector_count },
+                dim,
+            );
+            quantizer.train(vectors)?;
+            quantizer
+        }
+    };
     let (params, codebook_slice) = quantizer
         .pq_state()
-        .expect("PQ quantizer trained successfully implies pq_state is set");
+        .expect("PQ quantizer is trained or built from an existing codebook, so pq_state is set");
     let params = *params;
     let codebook: Vec<f32> = codebook_slice.to_vec();
     let codes: Vec<Vec<u8>> = vectors
@@ -109,7 +135,7 @@ mod tests {
             vec_of(&[-10.0, -10.0, -20.0, -20.0]),
             vec_of(&[10.1, 10.1, 20.1, 20.1]),
         ];
-        let (params, codebook, codes) = quantize_segment_pq(&vectors, 4, 2).unwrap();
+        let (params, codebook, codes) = quantize_segment_pq(&vectors, 4, 2, None).unwrap();
         assert_eq!(params.m, 2);
         assert_eq!(params.k, 256);
         assert_eq!(params.sub_dim, 2);
@@ -126,7 +152,7 @@ mod tests {
             vec_of(&[10.0, 10.0, 20.0, 20.0]),
             vec_of(&[-10.0, -10.0, -20.0, -20.0]),
         ];
-        let (params, codebook, codes) = quantize_segment_pq(&vectors, 4, 2).unwrap();
+        let (params, codebook, codes) = quantize_segment_pq(&vectors, 4, 2, None).unwrap();
 
         let mut buf = Vec::new();
         for c in &codes {
@@ -152,5 +178,42 @@ mod tests {
     fn payload_size_equals_m() {
         assert_eq!(pq_record_payload_size(0), 0);
         assert_eq!(pq_record_payload_size(16), 16);
+    }
+
+    /// Issue #631: encoding against a pre-trained [`SharedPqCodebook`]
+    /// must produce byte-identical output to training a fresh codebook
+    /// on the exact same corpus -- the strongest cheap correctness
+    /// check available, since `pq_train_codebook` is deterministic
+    /// (seeded k-means).
+    #[test]
+    fn shared_codebook_produces_byte_identical_codes_to_fresh_training() {
+        let mut state: u64 = 0x1234_5678_9ABC_DEF0;
+        let vectors: Vec<Vector> = (0..300)
+            .map(|_| {
+                let data: Vec<f32> = (0..32)
+                    .map(|_| {
+                        state = state
+                            .wrapping_mul(6_364_136_223_846_793_005)
+                            .wrapping_add(1_442_695_040_888_963_407);
+                        ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                    })
+                    .collect();
+                Vector::new(data)
+            })
+            .collect();
+
+        let (trained_params, trained_codebook, trained_codes) =
+            quantize_segment_pq(&vectors, 32, 4, None).unwrap();
+
+        let shared = crate::vector::index::pq_codebook::SharedPqCodebook {
+            params: trained_params,
+            codebook: trained_codebook.clone(),
+        };
+        let (shared_params, shared_codebook, shared_codes) =
+            quantize_segment_pq(&vectors, 32, 4, Some(&shared)).unwrap();
+
+        assert_eq!(shared_params, trained_params);
+        assert_eq!(shared_codebook, trained_codebook);
+        assert_eq!(shared_codes, trained_codes);
     }
 }

--- a/laurus/tests/pq_shared_codebook_test.rs
+++ b/laurus/tests/pq_shared_codebook_test.rs
@@ -1,0 +1,249 @@
+//! End-to-end tests for the Issue #631 shared PQ codebook feature.
+//!
+//! Complements the internal determinism check in
+//! `pq_io::tests::shared_codebook_produces_byte_identical_codes_to_fresh_training`
+//! by exercising the real `HnswIndex` / `SegmentedHnswIndex` write and search
+//! stack instead of calling `quantize_segment_pq` directly:
+//!
+//! 1. A shared-codebook index must return the exact same search results as
+//!    one that trains PQ fresh on the identical corpus.
+//! 2. A shared codebook must survive a segment-per-commit force-merge
+//!    unchanged -- the merge engine re-quantizes every surviving vector
+//!    through the same `write()` path, so this is the one path that could
+//!    accidentally retrain against the (non-representative) merged subset
+//!    instead of reusing the shared codebook.
+
+use std::sync::Arc;
+
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::core::quantization::QuantizationMethod;
+use laurus::vector::index::VectorIndex;
+use laurus::vector::index::config::HnswIndexConfig;
+use laurus::vector::index::hnsw::HnswIndex;
+use laurus::vector::index::hnsw::reader::HnswIndexReader;
+use laurus::vector::index::hnsw::segmented::SegmentedHnswIndex;
+use laurus::vector::index::pq_codebook::{default_codebook_name, train_and_write_pq_codebook};
+use laurus::vector::index::storage::VectorStorage;
+use laurus::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryParams};
+use laurus::vector::{DistanceMetric, Vector};
+
+const DIM: usize = 32;
+const M: usize = 4;
+
+/// Deterministic pseudo-random corpus of `count` vectors of dimension
+/// [`DIM`], ids starting at `id_offset` -- distinct `seed`/`id_offset` pairs
+/// give non-overlapping, reproducible corpora.
+fn make_corpus(count: usize, seed: u64, id_offset: u64) -> Vec<(u64, String, Vector)> {
+    let mut state = seed;
+    (0..count)
+        .map(|i| {
+            let data: Vec<f32> = (0..DIM)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                })
+                .collect();
+            (id_offset + i as u64, "v".to_string(), Vector::new(data))
+        })
+        .collect()
+}
+
+fn storage() -> Arc<MemoryStorage> {
+    Arc::new(MemoryStorage::new(MemoryStorageConfig::default()))
+}
+
+fn base_config() -> HnswIndexConfig {
+    HnswIndexConfig {
+        dimension: DIM,
+        m: 16,
+        ef_construction: 100,
+        normalize_vectors: false,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantization { subvector_count: M },
+        ..Default::default()
+    }
+}
+
+fn query(v: &Vector, top_k: usize) -> VectorIndexQuery {
+    VectorIndexQuery {
+        query: v.clone(),
+        params: VectorIndexQueryParams {
+            top_k,
+            ..Default::default()
+        },
+        field_name: Some("v".to_string()),
+        filter: None,
+    }
+}
+
+fn owned_pq_pool(
+    reader: &dyn laurus::vector::reader::VectorIndexReader,
+) -> Arc<laurus::vector::index::pq_storage::PqVectorPool> {
+    let hnsw_reader = reader
+        .as_any()
+        .downcast_ref::<HnswIndexReader>()
+        .expect("HnswIndexReader");
+    match hnsw_reader.vectors() {
+        VectorStorage::OwnedPq(pool) => pool.clone(),
+        other => panic!("expected OwnedPq, got {other:?}"),
+    }
+}
+
+/// A shared-codebook index must return byte-for-byte the same search
+/// results as one that trains PQ fresh on the exact same corpus -- the
+/// end-to-end counterpart of `pq_io`'s internal byte-identical-codes check.
+#[test]
+fn shared_codebook_search_results_match_fresh_training() {
+    let docs = make_corpus(400, 0x1234_5678_9ABC_DEF0, 0);
+
+    // Baseline: fresh per-segment training (today's existing behaviour).
+    let trained_storage = storage();
+    let trained_index =
+        HnswIndex::create(trained_storage.clone(), "trained", base_config()).unwrap();
+    {
+        let mut writer = trained_index.writer().unwrap();
+        writer.add_vectors(docs.clone()).unwrap();
+        writer.commit().unwrap();
+    }
+
+    // Shared-codebook variant: train once up front, point the config at it.
+    let shared_storage = storage();
+    let codebook_name = default_codebook_name("v");
+    let training_sample: Vec<Vector> = docs.iter().map(|(_, _, v)| v.clone()).collect();
+    train_and_write_pq_codebook(
+        shared_storage.as_ref() as &dyn Storage,
+        &codebook_name,
+        DIM,
+        M,
+        false,
+        &training_sample,
+    )
+    .unwrap();
+
+    let mut shared_config = base_config();
+    shared_config.pq_codebook_path = Some(codebook_name);
+    shared_config
+        .resolve_pq_codebook(shared_storage.as_ref() as &dyn Storage)
+        .unwrap();
+    assert!(
+        shared_config.pq_codebook.is_some(),
+        "codebook must resolve before the index is created"
+    );
+    let shared_index = HnswIndex::create(shared_storage.clone(), "shared", shared_config).unwrap();
+    {
+        let mut writer = shared_index.writer().unwrap();
+        writer.add_vectors(docs.clone()).unwrap();
+        writer.commit().unwrap();
+    }
+
+    // Same codebook, byte for byte.
+    let trained_pool = owned_pq_pool(trained_index.reader().unwrap().as_ref());
+    let shared_pool = owned_pq_pool(shared_index.reader().unwrap().as_ref());
+    assert_eq!(shared_pool.params, trained_pool.params);
+    assert_eq!(shared_pool.codebook, trained_pool.codebook);
+
+    // Same search results for several distinct queries.
+    let trained_searcher = trained_index.searcher().unwrap();
+    let shared_searcher = shared_index.searcher().unwrap();
+    for (doc_id, _, vector) in docs.iter().step_by(37) {
+        let trained_hits = trained_searcher.search(&query(vector, 5)).unwrap();
+        let shared_hits = shared_searcher.search(&query(vector, 5)).unwrap();
+        let trained_ids: Vec<u64> = trained_hits.results.iter().map(|r| r.doc_id).collect();
+        let shared_ids: Vec<u64> = shared_hits.results.iter().map(|r| r.doc_id).collect();
+        assert_eq!(
+            trained_ids, shared_ids,
+            "doc {doc_id}: shared-codebook search must match fresh-trained search"
+        );
+    }
+}
+
+/// A shared codebook must survive a segment-per-commit force-merge
+/// unchanged, proving the merge engine's re-quantization pass reuses it
+/// instead of silently retraining against the merged subset.
+#[test]
+fn shared_codebook_survives_a_forced_merge() {
+    let storage = storage();
+
+    // Train on a corpus DISTINCT from what gets indexed below, so an
+    // accidental retrain against the indexed/merged data would produce
+    // visibly different centroids -- making the failure mode unmistakable.
+    let training_sample: Vec<Vector> = make_corpus(400, 0x0F0F_0F0F_0F0F_0F0F, 100_000)
+        .into_iter()
+        .map(|(_, _, v)| v)
+        .collect();
+    let codebook_name = default_codebook_name("v");
+    let trained = train_and_write_pq_codebook(
+        storage.as_ref() as &dyn Storage,
+        &codebook_name,
+        DIM,
+        M,
+        false,
+        &training_sample,
+    )
+    .unwrap();
+
+    let mut config = base_config();
+    config.segmented = true;
+    config.pq_codebook_path = Some(codebook_name);
+    config
+        .resolve_pq_codebook(storage.as_ref() as &dyn Storage)
+        .unwrap();
+
+    let index =
+        SegmentedHnswIndex::open_or_create(storage.clone() as Arc<dyn Storage>, "vi", config)
+            .unwrap();
+
+    // 3 small commits, each well under PQ_MIN_TRAIN_VECTORS (256) -- exactly
+    // the point: a shared codebook keeps even tiny per-commit segments on
+    // PQ instead of falling back to Scalar8Bit.
+    for batch in 0..3u64 {
+        let docs = make_corpus(20, 0xA5A5_0000 + batch, batch * 20);
+        let mut writer = index.writer().unwrap();
+        writer.add_vectors(docs).unwrap();
+        writer.commit().unwrap();
+    }
+
+    index.optimize().unwrap();
+
+    let hnsw_files: Vec<String> = storage
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .filter(|f| f.ends_with(".hnsw"))
+        .collect();
+    assert_eq!(
+        hnsw_files.len(),
+        1,
+        "optimize must force-merge every commit's segment into one"
+    );
+    let segment_id = hnsw_files[0].trim_end_matches(".hnsw").to_string();
+
+    let merged_reader = HnswIndexReader::load(
+        storage.clone() as Arc<dyn Storage>,
+        &segment_id,
+        DistanceMetric::Euclidean,
+    )
+    .unwrap();
+    let merged_pool = match merged_reader.vectors() {
+        VectorStorage::OwnedPq(pool) => pool.clone(),
+        other => panic!("expected the merged segment to stay on PQ, got {other:?}"),
+    };
+    assert_eq!(
+        merged_pool.params, trained.params,
+        "the merged segment's PQ params must match the shared codebook, not a retrain"
+    );
+    assert_eq!(
+        merged_pool.codebook, trained.codebook,
+        "the merged segment's codebook must be byte-identical to the shared codebook"
+    );
+    assert_eq!(merged_pool.vector_count, 60);
+
+    // The merged segment is still searchable and returns sane neighbours.
+    let searcher = index.searcher().unwrap();
+    let (doc_id, _, vector) = &make_corpus(20, 0xA5A5_0001, 20)[0];
+    let hits = searcher.search(&query(vector, 1)).unwrap();
+    assert_eq!(hits.results[0].doc_id, *doc_id);
+}


### PR DESCRIPTION
## Summary

- HNSW's `write()` unconditionally retrains a fresh PQ codebook (k-means) on every flush and every segment-per-commit merge, costing multiple seconds per call and recurring at every tier of the merge hierarchy (#634/#889).
- Adds a standalone shared codebook file (`pq_codebook.rs`) trained once via `train_and_write_pq_codebook` and reused by every `write()` through `VectorQuantizer::from_pq_codebook` instead of retraining.
- `HnswIndexConfig` gains `pq_codebook_path` (schema-visible) and a resolved `pq_codebook` `Arc`, looked up once at index-open time in `dispatch_hnsw`/`ManagedVectorIndex::new` and inherited by the merge engine via its cloned config.
- A configured-but-never-trained codebook path fails `write()` explicitly instead of silently falling back to per-segment training (a gap found and self-corrected mid-implementation — see Issue #917 comment for detail).
- Filed #921 for a pre-existing, unrelated allocation-bound gap in `VectorSegmentHeader::read_from`'s PQ branch, found while designing this feature's own allocation guard.

This is PR-1 (library core) of the #631 4-PR campaign (mirrors #634/#889's shape). PR-2 (schema/CLI/server), PR-3 (bindings), and PR-4 (optional follow-ups) track as #918/#919/#920.

Closes #917
Refs #631

## Test plan

- [x] `cargo test -p laurus --lib`: 1256 passed, 0 failed
- [x] `cargo test -p laurus --tests`: full integration suite green, including 2 new tests in `pq_shared_codebook_test.rs` (search-result parity between fresh-trained and shared-codebook indexes; codebook survives a segment-per-commit force-merge byte-identical)
- [x] `cargo fmt --check`: clean
- [x] `cargo clippy -p laurus --all-targets -- -D warnings` on stable (1.97.1) and the pinned 1.97.0 CI toolchain: clean
- [x] `cargo doc -p laurus --no-deps`: 73 warnings, matching the existing baseline
- [x] `cargo bench -p laurus --bench pq_train_bench` A/B (same run): PQ Train vs PQ Encode Shared Codebook — 449.98ms → 40.83ms at 2,048 vectors (~91% reduction), 1.8130s → 151.37ms at 8,192 vectors (~92% reduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)