### PR TITLE
feat(bindings): expose pq_codebook_path across 5 language bindings (#631 PR-3)

### DIFF
--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -202,7 +202,7 @@ class Schema {
 | `addGeoField(name, stored?, indexed?)` | 地理座標フィールド。 |
 | `addGeo3dField(name, stored?, indexed?)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `addDatetimeField(name, stored?, indexed?)` | UTC 日時フィールド。 |
-| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?)` | HNSW ベクトルフィールド。 |
+| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)` | HNSW ベクトルフィールド。 |
 | `addFlatField(name, dimension, distance?, embedder?)` | Flat（全探索）ベクトルフィールド。 |
 | `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)` | IVF ベクトルフィールド。 |
 | `addEmbedder(name, config)` | 名前付き Embedder を登録。 |
@@ -216,6 +216,7 @@ class Schema {
 
 - `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvectorCount`（`dimension` を割り切れる値）が必須です。
 - `rerankStorage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
+- `pqCodebookPath` — 共有 PQ codebook のストレージ相対ファイル名（Issue #631）。`laurus train pq-codebook` CLI コマンドで一度だけ学習します。`quantizer: "product_quantization"` との組み合わせでのみ意味を持ち、以後の commit は segment ごとの k-means 再学習の代わりに学習済み codebook で encode します。省略すると segment ごとの学習を維持します。
 
 #### Dynamic field policy（動的フィールドポリシー）
 

--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -169,7 +169,7 @@ new \Laurus\Schema()
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | 地理座標フィールド（緯度/経度）。 |
 | `addGeo3dField(string $name, bool $stored = true, bool $indexed = true): void` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `addDatetimeField(string $name, bool $stored = true, bool $indexed = true): void` | UTC 日時フィールド。 |
-| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null): void` | HNSW 近似最近傍ベクトルフィールド。 |
+| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null): void` | HNSW 近似最近傍ベクトルフィールド。 |
 | `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null): void` | Flat（総当たり）ベクトルフィールド。 |
 | `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null): void` | IVF 近似最近傍ベクトルフィールド。 |
 
@@ -177,6 +177,7 @@ new \Laurus\Schema()
 
 - `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvectorCount`（`dimension` を割り切れる値）が必須です。
 - `rerankStorage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
+- `pqCodebookPath` — 共有 PQ codebook のストレージ相対ファイル名（Issue #631）。`laurus train pq-codebook` CLI コマンドで一度だけ学習します。`$quantizer = "product_quantization"` との組み合わせでのみ意味を持ち、以後の commit は segment ごとの k-means 再学習の代わりに学習済み codebook で encode します。省略すると segment ごとの学習を維持します。
 
 ### その他のメソッド
 

--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -198,7 +198,7 @@ class Schema:
 | `add_geo_field(name, *, stored=True, indexed=True)` | 地理座標フィールド（緯度/経度）。 |
 | `add_geo3d_field(name, *, stored=True, indexed=True)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `add_datetime_field(name, *, stored=True, indexed=True)` | UTC 日時フィールド。 |
-| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None)` | HNSW 近似最近傍ベクトルフィールド。 |
+| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None)` | HNSW 近似最近傍ベクトルフィールド。 |
 | `add_flat_field(name, dimension, *, distance="cosine", embedder=None)` | Flat（総当たり）ベクトルフィールド。 |
 | `add_ivf_field(name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None)` | IVF 近似最近傍ベクトルフィールド。 |
 
@@ -206,6 +206,7 @@ class Schema:
 
 - `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvector_count`（`dimension` を割り切れる値）が必須です。
 - `rerank_storage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
+- `pq_codebook_path` — 共有 PQ codebook のストレージ相対ファイル名（Issue #631）。`laurus train pq-codebook` CLI コマンドで一度だけ学習します。`quantizer="product_quantization"` との組み合わせでのみ意味を持ち、以後の commit は segment ごとの k-means 再学習の代わりに学習済み codebook で encode します。省略すると segment ごとの学習を維持します。
 
 ### その他のメソッド
 

--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -161,7 +161,7 @@ Laurus::Schema.new
 | `add_geo_field(name, stored: true, indexed: true)` | 地理座標フィールド（緯度/経度）。 |
 | `add_geo3d_field(name, stored: true, indexed: true)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `add_datetime_field(name, stored: true, indexed: true)` | UTC 日時フィールド。 |
-| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil)` | HNSW 近似最近傍ベクトルフィールド。 |
+| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil, pq_codebook_path: nil)` | HNSW 近似最近傍ベクトルフィールド。 |
 | `add_flat_field(name, dimension, distance: "cosine", embedder: nil)` | Flat（総当たり）ベクトルフィールド。 |
 | `add_ivf_field(name, dimension, distance: "cosine", n_clusters: 100, n_probe: 1, embedder: nil)` | IVF 近似最近傍ベクトルフィールド。 |
 
@@ -169,6 +169,7 @@ Laurus::Schema.new
 
 - `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvector_count`（`dimension` を割り切れる値）が必須です。
 - `rerank_storage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
+- `pq_codebook_path` — 共有 PQ codebook のストレージ相対ファイル名（Issue #631）。`laurus train pq-codebook` CLI コマンドで一度だけ学習します。`quantizer: "product_quantization"` との組み合わせでのみ意味を持ち、以後の commit は segment ごとの k-means 再学習の代わりに学習済み codebook で encode します。省略すると segment ごとの学習を維持します。
 
 ### その他のメソッド
 

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -385,7 +385,7 @@ WASM バインディングは `Geo3dDistanceQuery` / `Geo3dBoundingBoxQuery` /
 
 バイナリデータフィールドを追加します。
 
-#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?)`
+#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)`
 
 HNSW ベクトルインデックスフィールドを追加します。
 
@@ -395,6 +395,7 @@ HNSW ベクトルインデックスフィールドを追加します。
 - `quantizer`: `"scalar_8bit"`（デフォルト）または `"product_quantization"`（`subvectorCount` が必須）
 - `subvectorCount`: PQ サブベクトル数。`dimension` を割り切れる値を指定します
 - `rerankStorage`: 省略（デフォルト）するか、`"f32"` を指定して完全精度のリランクサイドカーを保存します
+- `pqCodebookPath`: 省略（デフォルト）するか、segment 間で再利用する共有 PQ codebook のストレージ相対ファイル名（Issue #631）を指定します（segment ごとの学習の代替）
 
 #### `addFlatField(name, dimension, distance?, embedder?)`
 
@@ -411,6 +412,7 @@ IVF ベクトルインデックスフィールドを追加します。
 
 - `quantizer` — `"scalar_8bit"`（デフォルト、4 倍圧縮）または高圧縮率の `"product_quantization"`。Product quantization では `subvectorCount`（`dimension` を割り切れる値）が必須です。
 - `rerankStorage` — `"f32"` を指定すると完全精度の `*.hnsw.f32` サイドカーを書き出し、厳密な Stage-2 リランクを有効化します。省略すると int8 のみのセグメントを維持します。
+- `pqCodebookPath` — 共有 PQ codebook のストレージ相対ファイル名（Issue #631）。`laurus train pq-codebook` CLI コマンドで一度だけ学習します。`quantizer: "product_quantization"` との組み合わせでのみ意味を持ち、以後の commit は segment ごとの k-means 再学習の代わりに学習済み codebook で encode します。省略すると segment ごとの学習を維持します。
 
 #### `addAnalyzer(name, analyzer)`
 

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -200,7 +200,7 @@ class Schema {
 | `addGeoField(name, stored?, indexed?)` | Geographic coordinate field. |
 | `addGeo3dField(name, stored?, indexed?)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `addDatetimeField(name, stored?, indexed?)` | UTC datetime field. |
-| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?)` | HNSW vector field. |
+| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)` | HNSW vector field. |
 | `addFlatField(name, dimension, distance?, embedder?)` | Flat (brute-force) vector field. |
 | `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)` | IVF vector field. |
 | `addEmbedder(name, config)` | Register a named embedder. |
@@ -214,6 +214,7 @@ class Schema {
 
 - `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvectorCount` (must divide `dimension`).
 - `rerankStorage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
+- `pqCodebookPath` — storage-relative file name of a shared PQ codebook (Issue #631), trained once via the `laurus train pq-codebook` CLI command. Only meaningful with `quantizer: "product_quantization"`; commits then encode against the pre-trained codebook instead of re-training k-means per segment. Omit to keep per-segment training.
 
 #### Dynamic field policy
 

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -167,7 +167,7 @@ new \Laurus\Schema()
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | Geographic coordinate field (lat/lon). |
 | `addGeo3dField(string $name, bool $stored = true, bool $indexed = true): void` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `addDatetimeField(string $name, bool $stored = true, bool $indexed = true): void` | UTC datetime field. |
-| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null): void` | HNSW approximate nearest-neighbor vector field. |
+| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null): void` | HNSW approximate nearest-neighbor vector field. |
 | `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null): void` | Flat (brute-force) vector field. |
 | `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null): void` | IVF approximate nearest-neighbor vector field. |
 
@@ -175,6 +175,7 @@ new \Laurus\Schema()
 
 - `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvectorCount` (must divide `dimension`).
 - `rerankStorage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
+- `pqCodebookPath` — storage-relative file name of a shared PQ codebook (Issue #631), trained once via the `laurus train pq-codebook` CLI command. Only meaningful with `$quantizer = "product_quantization"`; commits then encode against the pre-trained codebook instead of re-training k-means per segment. Omit to keep per-segment training.
 
 ### Other methods
 

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -195,7 +195,7 @@ class Schema:
 | `add_geo_field(name, *, stored=True, indexed=True)` | Geographic coordinate field (lat/lon). |
 | `add_geo3d_field(name, *, stored=True, indexed=True)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `add_datetime_field(name, *, stored=True, indexed=True)` | UTC datetime field. |
-| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None)` | HNSW approximate nearest-neighbor vector field. |
+| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None)` | HNSW approximate nearest-neighbor vector field. |
 | `add_flat_field(name, dimension, *, distance="cosine", embedder=None)` | Flat (brute-force) vector field. |
 | `add_ivf_field(name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None)` | IVF approximate nearest-neighbor vector field. |
 
@@ -203,6 +203,7 @@ class Schema:
 
 - `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvector_count` (must divide `dimension`).
 - `rerank_storage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
+- `pq_codebook_path` — storage-relative file name of a shared PQ codebook (Issue #631), trained once via the `laurus train pq-codebook` CLI command. Only meaningful with `quantizer="product_quantization"`; commits then encode against the pre-trained codebook instead of re-training k-means per segment. Omit to keep per-segment training.
 
 ### Other methods
 

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -159,7 +159,7 @@ Laurus::Schema.new
 | `add_geo_field(name, stored: true, indexed: true)` | Geographic coordinate field (lat/lon). |
 | `add_geo3d_field(name, stored: true, indexed: true)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `add_datetime_field(name, stored: true, indexed: true)` | UTC datetime field. |
-| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil)` | HNSW approximate nearest-neighbor vector field. |
+| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil, pq_codebook_path: nil)` | HNSW approximate nearest-neighbor vector field. |
 | `add_flat_field(name, dimension, distance: "cosine", embedder: nil)` | Flat (brute-force) vector field. |
 | `add_ivf_field(name, dimension, distance: "cosine", n_clusters: 100, n_probe: 1, embedder: nil)` | IVF approximate nearest-neighbor vector field. |
 
@@ -167,6 +167,7 @@ Laurus::Schema.new
 
 - `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvector_count` (must divide `dimension`).
 - `rerank_storage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
+- `pq_codebook_path` — storage-relative file name of a shared PQ codebook (Issue #631), trained once via the `laurus train pq-codebook` CLI command. Only meaningful with `quantizer: "product_quantization"`; commits then encode against the pre-trained codebook instead of re-training k-means per segment. Omit to keep per-segment training.
 
 ### Other methods
 

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -384,7 +384,7 @@ above.
 
 Add a binary data field.
 
-#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?)`
+#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)`
 
 Add an HNSW vector index field.
 
@@ -397,6 +397,9 @@ Add an HNSW vector index field.
 - `subvectorCount`: number of PQ sub-vectors; must divide `dimension`
 - `rerankStorage`: omit (default) or `"f32"` to store a full-precision
   rerank sidecar
+- `pqCodebookPath`: omit (default) or the storage-relative file name of
+  a shared PQ codebook (Issue #631) to reuse across segments instead of
+  per-segment training
 
 #### `addFlatField(name, dimension, distance?, embedder?)`
 
@@ -413,6 +416,7 @@ Add an IVF vector index field.
 
 - `quantizer` — `"scalar_8bit"` (default, 4× compression) or `"product_quantization"` for higher compression. Product quantization requires `subvectorCount` (must divide `dimension`).
 - `rerankStorage` — set to `"f32"` to write a full-precision `*.hnsw.f32` sidecar enabling exact Stage-2 rerank; omit to keep the int8-only segment.
+- `pqCodebookPath` — storage-relative file name of a shared PQ codebook (Issue #631), trained once via the `laurus train pq-codebook` CLI command. Only meaningful with `quantizer: "product_quantization"`; commits then encode against the pre-trained codebook instead of re-training k-means per segment. Omit to keep per-segment training.
 
 #### `addAnalyzer(name, analyzer)`
 

--- a/laurus-nodejs/src/schema.rs
+++ b/laurus-nodejs/src/schema.rs
@@ -321,6 +321,12 @@ impl JsSchema {
     /// * `rerankStorage` - Stage-2 rerank sidecar — omitted (default) keeps
     ///   the int8-only segment, "f32" stores full-precision vectors in a
     ///   `*.hnsw.f32` sidecar for exact rerank distances.
+    /// * `pqCodebookPath` - Storage-relative file name of a shared PQ
+    ///   codebook (Issue #631), trained once via the
+    ///   `laurus train pq-codebook` CLI command. Only meaningful when
+    ///   `quantizer` is "product_quantization"; commits then encode against
+    ///   the pre-trained codebook instead of re-training k-means per
+    ///   segment. Omitted (default) keeps per-segment training.
     #[napi]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
@@ -335,6 +341,7 @@ impl JsSchema {
         quantizer: Option<String>,
         subvector_count: Option<u32>,
         rerank_storage: Option<String>,
+        pq_codebook_path: Option<String>,
     ) -> Result<()> {
         let opt = HnswOption {
             dimension: dimension as usize,
@@ -345,6 +352,7 @@ impl JsSchema {
             quantizer: parse_quantizer(quantizer.as_deref(), subvector_count.map(|v| v as usize))?,
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
+            pq_codebook_path,
             ..Default::default()
         };
         self.inner.fields.insert(name, FieldOption::Hnsw(opt));

--- a/laurus-php/src/schema.rs
+++ b/laurus-php/src/schema.rs
@@ -287,6 +287,12 @@ impl PhpSchema {
     /// * `rerank_storage` - Stage-2 rerank sidecar — omitted (default) keeps
     ///   the int8-only segment, "f32" stores full-precision vectors in a
     ///   `*.hnsw.f32` sidecar for exact rerank distances.
+    /// * `pq_codebook_path` - Storage-relative file name of a shared PQ
+    ///   codebook (Issue #631), trained once via the
+    ///   `laurus train pq-codebook` CLI command. Only meaningful when
+    ///   `quantizer` is "product_quantization"; commits then encode against
+    ///   the pre-trained codebook instead of re-training k-means per
+    ///   segment. Omitted (default) keeps per-segment training.
     #[php(defaults(m = 16, ef_construction = 200))]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
@@ -301,6 +307,7 @@ impl PhpSchema {
         quantizer: Option<String>,
         subvector_count: Option<i64>,
         rerank_storage: Option<String>,
+        pq_codebook_path: Option<String>,
     ) -> PhpResult<()> {
         let dist_str = distance.unwrap_or_else(|| "cosine".to_string());
         let opt = HnswOption {
@@ -312,6 +319,7 @@ impl PhpSchema {
             quantizer: parse_quantizer(quantizer.as_deref(), subvector_count.map(|v| v as usize))?,
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
+            pq_codebook_path,
             ..Default::default()
         };
         self.inner

--- a/laurus-python/src/schema.rs
+++ b/laurus-python/src/schema.rs
@@ -316,7 +316,13 @@ impl PySchema {
     ///         in a `*.hnsw.f32` sidecar for exact rerank distances.
     ///     embedder: Optional embedder name registered via `add_embedder`.
     ///         When set, text payloads are automatically embedded by the Rust engine.
-    #[pyo3(signature = (name, dimension, *, distance="cosine", m=16, ef_construction=200, default_ef_search=None, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None))]
+    ///     pq_codebook_path: Storage-relative file name of a shared PQ
+    ///         codebook (Issue #631), trained once via the
+    ///         `laurus train pq-codebook` CLI command. Only meaningful with
+    ///         `quantizer="product_quantization"`; commits then encode
+    ///         against the pre-trained codebook instead of re-training
+    ///         k-means per segment. None (default) keeps per-segment training.
+    #[pyo3(signature = (name, dimension, *, distance="cosine", m=16, ef_construction=200, default_ef_search=None, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
         &mut self,
@@ -330,6 +336,7 @@ impl PySchema {
         subvector_count: Option<usize>,
         rerank_storage: Option<String>,
         embedder: Option<String>,
+        pq_codebook_path: Option<String>,
     ) -> PyResult<()> {
         let opt = HnswOption {
             dimension,
@@ -340,6 +347,7 @@ impl PySchema {
             quantizer: parse_quantizer(quantizer.as_deref(), subvector_count)?,
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
+            pq_codebook_path,
             ..Default::default()
         };
         self.inner

--- a/laurus-ruby/src/schema.rs
+++ b/laurus-ruby/src/schema.rs
@@ -373,6 +373,12 @@ impl RbSchema {
     ///   - `rerank_storage:` (String, optional): Stage-2 rerank sidecar —
     ///     omitted (default) keeps the int8-only segment, "f32" stores
     ///     full-precision vectors in a `*.hnsw.f32` sidecar for exact rerank.
+    ///   - `pq_codebook_path:` (String, optional): Storage-relative file
+    ///     name of a shared PQ codebook (Issue #631), trained once via the
+    ///     `laurus train pq-codebook` CLI command. Only meaningful with
+    ///     `quantizer:` "product_quantization"; commits then encode against
+    ///     the pre-trained codebook instead of re-training k-means per
+    ///     segment. Omitted (default) keeps per-segment training.
     fn add_hnsw_field(&self, args: &[Value]) -> Result<(), Error> {
         let args = scan_args::<(String, usize), (), (), (), RHash, ()>(args)?;
         let (name, dimension) = args.required;
@@ -388,6 +394,7 @@ impl RbSchema {
                 Option<String>,
                 Option<usize>,
                 Option<String>,
+                Option<String>,
             ),
             (),
         >(
@@ -402,6 +409,7 @@ impl RbSchema {
                 "quantizer",
                 "subvector_count",
                 "rerank_storage",
+                "pq_codebook_path",
             ],
         )?;
         let (
@@ -413,6 +421,7 @@ impl RbSchema {
             quantizer,
             subvector_count,
             rerank_storage,
+            pq_codebook_path,
         ) = kwargs.optional;
         let distance_str = distance.as_deref().unwrap_or("cosine");
         let opt = HnswOption {
@@ -424,6 +433,7 @@ impl RbSchema {
             quantizer: parse_quantizer(quantizer.as_deref(), subvector_count)?,
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder: embedder.flatten(),
+            pq_codebook_path,
             ..Default::default()
         };
         self.inner

--- a/laurus-wasm/src/schema.rs
+++ b/laurus-wasm/src/schema.rs
@@ -288,6 +288,12 @@ impl WasmSchema {
     /// * `rerankStorage` - Stage-2 rerank sidecar — omitted (default) keeps
     ///   the int8-only segment, "f32" stores full-precision vectors in a
     ///   `*.hnsw.f32` sidecar for exact rerank distances.
+    /// * `pqCodebookPath` - Storage-relative file name of a shared PQ
+    ///   codebook (Issue #631), trained once via the
+    ///   `laurus train pq-codebook` CLI command. Only meaningful when
+    ///   `quantizer` is "product_quantization"; commits then encode against
+    ///   the pre-trained codebook instead of re-training k-means per
+    ///   segment. Omitted (default) keeps per-segment training.
     #[wasm_bindgen(js_name = "addHnswField")]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
@@ -302,6 +308,7 @@ impl WasmSchema {
         quantizer: Option<String>,
         subvector_count: Option<u32>,
         rerank_storage: Option<String>,
+        pq_codebook_path: Option<String>,
     ) -> Result<(), JsValue> {
         let opt = HnswOption {
             dimension: dimension as usize,
@@ -312,6 +319,7 @@ impl WasmSchema {
             quantizer: parse_quantizer(quantizer.as_deref(), subvector_count.map(|v| v as usize))?,
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
+            pq_codebook_path,
             ..Default::default()
         };
         self.inner.fields.insert(name, FieldOption::Hnsw(opt));


### PR DESCRIPTION
## Summary

PR-3 of the #631 shared-PQ-codebook campaign: exposes PR-2's (#918) schema-level `pq_codebook_path` across all five Tier-2 language bindings.

Each binding's `add_hnsw_field` gains a trailing optional `pq_codebook_path` parameter following the exact `rerank_storage` idiom, passed straight into `HnswOption` — no binding-side validation (the core validates geometry and the missing-file failure policy at commit time, per PR-2). All bindings already used `..Default::default()`, so the change is purely additive: existing call sites and test suites work unchanged.

- **Python**: `pq_codebook_path=None` kwarg + docstring.
- **Node.js**: trailing `Option<String>` + doc. `index.d.ts` is gitignored and regenerated by `napi build` from the Rust signature/doc comments, so the `pqCodebookPath?` typing ships automatically with the next build.
- **WASM** (`addHnswField`): trailing `Option<String>` + doc.
- **Ruby**: `pq_codebook_path` appended to the `get_kwargs` name list + tuple + doc.
- **PHP**: trailing nullable + doc.
- **Docs**: all five bindings' API references updated, English and Japanese (10 files).

Out of scope (per the plan comment on #919): no `train_pq_codebook` binding exposure (the issue scopes the schema knob only; training runs via the CLI / Rust `Engine` API against the same index directory), and no new tests (the acceptance criteria require existing suites to stay green *unchanged*; a binding e2e of the knob would need a training path bindings intentionally lack).

## Verification

- `cargo check` + `cargo clippy --all-targets -- -D warnings` clean for laurus-python / laurus-nodejs / laurus-ruby on stable **and** 1.97.0
- laurus-wasm checked + clippy-clean on the real `wasm32-unknown-unknown` target
- laurus-php (workspace-excluded) checked + fmt + clippy-clean standalone
- `cargo fmt --check` clean on stable and 1.97.0
- `markdownlint-cli2`: 154 files, 0 errors; both mdBooks build
- CI's binding matrix (pytest / Node / WASM / minitest / PHPUnit) validates the purely-additive claim

Closes #919. Refs #631. Depends on #918 (merged as #923).
