### PR TITLE
fix(vector/index): bound PQ codebook allocation against file size (#921)

### DIFF
--- a/laurus/src/vector/index/flat/reader.rs
+++ b/laurus/src/vector/index/flat/reader.rs
@@ -109,7 +109,11 @@ impl FlatVectorIndexReader {
         // Pre-Stage-1 segments are rejected with IncompatibleFormat.
         // Matched by reference so `header` (version + field dictionary,
         // Issue #633) stays alive for the record parse below.
-        let header = VectorSegmentHeader::read_from(&mut input)?;
+        // Issue #921: pass the bytes physically left in the file so the
+        // header's PQ codebook allocation is bounded before it reserves.
+        let header_available =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let header = VectorSegmentHeader::read_from(&mut input, header_available)?;
         let params = match &header.quant {
             QuantHeader::Scalar8Bit(p) => *p,
             QuantHeader::ProductQuantization { .. } => {

--- a/laurus/src/vector/index/flat/writer.rs
+++ b/laurus/src/vector/index/flat/writer.rs
@@ -126,7 +126,11 @@ impl FlatIndexWriter {
         // Pre-Stage-1 segments are rejected with IncompatibleFormat.
         // Matched by reference so `header` (version + field dictionary,
         // Issue #633) stays alive for the record parse below.
-        let header = VectorSegmentHeader::read_from(&mut input)?;
+        // Issue #921: pass the bytes physically left in the file so the
+        // header's PQ codebook allocation is bounded before it reserves.
+        let header_available =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let header = VectorSegmentHeader::read_from(&mut input, header_available)?;
         let params = match &header.quant {
             QuantHeader::Scalar8Bit(p) => *p,
             QuantHeader::ProductQuantization { .. } => {

--- a/laurus/src/vector/index/format.rs
+++ b/laurus/src/vector/index/format.rs
@@ -75,6 +75,13 @@ use crate::vector::core::quantization::{PqParams, ScalarQuantParams};
 /// 4-byte ASCII magic at offset 0 of every quantized vector segment.
 pub const VECTOR_SEGMENT_MAGIC: [u8; 4] = *b"LVS1";
 
+/// Bytes [`VectorSegmentHeader::read_from`] has consumed by the time a PQ
+/// branch sizes its codebook: the 16-byte fixed header (magic + version +
+/// quant_kind + reserved) plus the 8-byte `m`/`k`/`sub_dim`/padding block.
+/// Subtracted from the caller-supplied `available` budget so the codebook
+/// allocation bound (Issue #921) compares against the bytes truly left.
+const PQ_PREFIX_SIZE: u64 = 24;
+
 /// Lowest header format version this build can read (and the version
 /// legacy Flat/IVF segments were written with).
 ///
@@ -123,7 +130,8 @@ pub mod quant_kind {
     pub const NONE: u16 = 0;
     /// Per-segment global affine 8-bit scalar quantization. Stage 1.
     pub const SCALAR_8BIT: u16 = 1;
-    /// Product quantization. Stage 3 — reader returns NotImplemented.
+    /// Product quantization (Issue #481 Stage 3). The metadata block
+    /// carries `m`/`k`/`sub_dim` plus the inline codebook.
     pub const PRODUCT_QUANTIZATION: u16 = 2;
     /// FastScan Product Quantization (K=16 4-bit codes + SIMD LUT
     /// distance). Issue [#695](https://github.com/mosuka/laurus/issues/695)
@@ -419,6 +427,17 @@ impl VectorSegmentHeader {
 
     /// Read and validate the header (fixed portion + quant metadata).
     ///
+    /// # Arguments
+    ///
+    /// * `reader` - Stream positioned at the start of the `LVS1` header.
+    /// * `available` - Bytes the file can still supply from the current
+    ///   position (typically `file_size - stream_position`), used to
+    ///   bound the PQ codebook allocation against ground truth before
+    ///   `Vec::with_capacity` (Issue #921, generalizing #806): the
+    ///   header's `m`/`sub_dim` are unverified `u16`s, and a flipped
+    ///   byte could otherwise request a ~4 TB allocation that aborts
+    ///   the process via `handle_alloc_error`.
+    ///
     /// # Errors
     ///
     /// * [`LaurusError::IncompatibleFormat`] if the magic does not
@@ -428,10 +447,11 @@ impl VectorSegmentHeader {
     /// * [`LaurusError::IncompatibleFormat`] if the version is outside
     ///   the supported `CURRENT_VERSION..=MAX_SUPPORTED_VERSION` range
     ///   or if `quant_kind` is the reserved value 0.
-    /// * [`LaurusError::NotImplemented`] if `quant_kind` is the
-    ///   Product-Quantization value (2) — reserved for Stage 3.
+    /// * [`LaurusError::Index`] if a PQ / PQ FastScan codebook declares
+    ///   more entries than `available` bytes can physically hold — the
+    ///   segment is corrupted (Issue #921).
     /// * [`LaurusError::Io`] for any underlying read failure.
-    pub fn read_from<R: Read>(reader: &mut R) -> Result<Self> {
+    pub fn read_from<R: Read>(reader: &mut R, available: u64) -> Result<Self> {
         let mut magic = [0u8; 4];
         reader.read_exact(&mut magic)?;
         if magic != VECTOR_SEGMENT_MAGIC {
@@ -485,6 +505,17 @@ impl VectorSegmentHeader {
                     LaurusError::IncompatibleFormat(format!("invalid PQ params: {e}"))
                 })?;
                 let codebook_len = params.codebook_len();
+                // Issue #921: `m`/`sub_dim` are unverified u16s straight
+                // off disk; bound the codebook allocation against the
+                // bytes the file actually has left (the fixed prefix +
+                // PQ params block consumed so far is PQ_PREFIX_SIZE)
+                // before reserving anything.
+                crate::vector::index::alloc_bounds::checked_capacity(
+                    codebook_len,
+                    4,
+                    available.saturating_sub(PQ_PREFIX_SIZE),
+                    "vector segment PQ codebook length",
+                )?;
                 let mut codebook = Vec::with_capacity(codebook_len);
                 let mut fbuf = [0u8; 4];
                 for _ in 0..codebook_len {
@@ -513,6 +544,13 @@ impl VectorSegmentHeader {
                     )));
                 }
                 let codebook_len = params.codebook_len();
+                // Issue #921: same allocation bound as the PQ branch above.
+                crate::vector::index::alloc_bounds::checked_capacity(
+                    codebook_len,
+                    4,
+                    available.saturating_sub(PQ_PREFIX_SIZE),
+                    "vector segment PQ FastScan codebook length",
+                )?;
                 let mut codebook = Vec::with_capacity(codebook_len);
                 let mut fbuf = [0u8; 4];
                 for _ in 0..codebook_len {
@@ -834,7 +872,7 @@ mod tests {
         assert_eq!(buf.len(), FIXED_HEADER_SIZE + SCALAR_8BIT_METADATA_SIZE);
 
         let mut cursor = Cursor::new(&buf);
-        let parsed = VectorSegmentHeader::read_from(&mut cursor).unwrap();
+        let parsed = VectorSegmentHeader::read_from(&mut cursor, buf.len() as u64).unwrap();
         assert_eq!(parsed, header);
     }
 
@@ -851,7 +889,7 @@ mod tests {
         );
 
         let mut cursor = Cursor::new(&buf);
-        let parsed = VectorSegmentHeader::read_from(&mut cursor).unwrap();
+        let parsed = VectorSegmentHeader::read_from(&mut cursor, buf.len() as u64).unwrap();
         assert_eq!(parsed.version, VERSION_ORDINAL_GRAPH);
         assert_eq!(parsed, header);
     }
@@ -864,7 +902,7 @@ mod tests {
         header.write_to(&mut buf).unwrap();
 
         let mut cursor = Cursor::new(&buf);
-        let err = VectorSegmentHeader::read_from(&mut cursor).unwrap_err();
+        let err = VectorSegmentHeader::read_from(&mut cursor, buf.len() as u64).unwrap_err();
         assert!(
             err.to_string().contains("unsupported vector segment"),
             "unexpected error: {err}"
@@ -894,7 +932,7 @@ mod tests {
             );
 
             let mut cursor = Cursor::new(&buf);
-            let parsed = VectorSegmentHeader::read_from(&mut cursor).unwrap();
+            let parsed = VectorSegmentHeader::read_from(&mut cursor, buf.len() as u64).unwrap();
             assert_eq!(parsed.field_dict, dict);
             assert_eq!(parsed, header);
         }
@@ -907,7 +945,8 @@ mod tests {
         header.write_to(&mut buf).unwrap();
         assert_eq!(buf.len(), 24, "v1 SQ header must stay 24 bytes");
         assert_eq!(header.serialized_size(), 24);
-        let parsed = VectorSegmentHeader::read_from(&mut Cursor::new(&buf)).unwrap();
+        let parsed =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap();
         assert!(parsed.field_dict.is_empty());
     }
 
@@ -920,7 +959,8 @@ mod tests {
         header.write_to(&mut buf).unwrap();
         buf.truncate(buf.len() - 3); // cut into the dict entry
 
-        let err = VectorSegmentHeader::read_from(&mut Cursor::new(&buf)).unwrap_err();
+        let err =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap_err();
         assert!(matches!(err, LaurusError::Io(_)), "got: {err:?}");
     }
 
@@ -1060,7 +1100,7 @@ mod tests {
             0x00, 0x00, 0x40, 0x40, // 3.0
         ];
         let mut cursor = Cursor::new(&f32_bytes[..]);
-        let err = VectorSegmentHeader::read_from(&mut cursor).unwrap_err();
+        let err = VectorSegmentHeader::read_from(&mut cursor, f32_bytes.len() as u64).unwrap_err();
         match err {
             LaurusError::IncompatibleFormat(msg) => {
                 assert!(msg.contains("LVS1"), "message should mention LVS1");
@@ -1084,7 +1124,8 @@ mod tests {
         buf.extend_from_slice(&0.0_f32.to_le_bytes());
         buf.extend_from_slice(&1.0_f32.to_le_bytes());
 
-        let err = VectorSegmentHeader::read_from(&mut Cursor::new(&buf)).unwrap_err();
+        let err =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap_err();
         match err {
             LaurusError::IncompatibleFormat(msg) => {
                 assert!(msg.contains("99"), "message should mention the version");
@@ -1101,8 +1142,65 @@ mod tests {
         buf.extend_from_slice(&quant_kind::NONE.to_le_bytes());
         buf.extend_from_slice(&[0u8; 8]);
 
-        let err = VectorSegmentHeader::read_from(&mut Cursor::new(&buf)).unwrap_err();
+        let err =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap_err();
         assert!(matches!(err, LaurusError::IncompatibleFormat(_)));
+    }
+
+    /// Issue #921: a corrupted PQ header whose `m`/`sub_dim` declare a
+    /// codebook far larger than the file must be rejected as corruption
+    /// *before* the codebook `Vec` is reserved — previously this
+    /// requested a ~4 TB allocation and aborted the process via
+    /// `handle_alloc_error` instead of returning a clean error.
+    #[test]
+    fn oversized_pq_codebook_declaration_is_rejected_cleanly() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"LVS1");
+        buf.extend_from_slice(&CURRENT_VERSION.to_le_bytes());
+        buf.extend_from_slice(&quant_kind::PRODUCT_QUANTIZATION.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 8]);
+        // m = 65535, k = 256, sub_dim = 65535 → ~1.1e12 codebook f32s
+        // (~4 TB) declared by a 24-byte file.
+        buf.extend_from_slice(&u16::MAX.to_le_bytes());
+        buf.extend_from_slice(&256u16.to_le_bytes());
+        buf.extend_from_slice(&u16::MAX.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes());
+
+        let err =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap_err();
+        match err {
+            LaurusError::Index(msg) => {
+                assert!(msg.contains("corrupted"), "corruption must be named: {msg}");
+            }
+            other => panic!("expected LaurusError::Index, got {other:?}"),
+        }
+    }
+
+    /// Issue #921: the FastScan PQ branch shares the same codebook
+    /// allocation bound as the 8-bit PQ branch above.
+    #[cfg(feature = "pq-fastscan")]
+    #[test]
+    fn oversized_pq_fastscan_codebook_declaration_is_rejected_cleanly() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"LVS1");
+        buf.extend_from_slice(&CURRENT_VERSION.to_le_bytes());
+        buf.extend_from_slice(&quant_kind::PRODUCT_QUANTIZATION_FASTSCAN.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 8]);
+        // k must be 16 for FastScan; m/sub_dim maxed out still declare
+        // a ~256 GB codebook this 24-byte file cannot hold.
+        buf.extend_from_slice(&u16::MAX.to_le_bytes());
+        buf.extend_from_slice(&16u16.to_le_bytes());
+        buf.extend_from_slice(&u16::MAX.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes());
+
+        let err =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap_err();
+        match err {
+            LaurusError::Index(msg) => {
+                assert!(msg.contains("corrupted"), "corruption must be named: {msg}");
+            }
+            other => panic!("expected LaurusError::Index, got {other:?}"),
+        }
     }
 
     fn sample_pq_params() -> PqParams {
@@ -1141,7 +1239,8 @@ mod tests {
             FIXED_HEADER_SIZE + PQ_FIXED_METADATA_SIZE + 4 * 256 * 2 * 4
         );
 
-        let parsed = VectorSegmentHeader::read_from(&mut Cursor::new(&buf)).unwrap();
+        let parsed =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap();
         assert_eq!(parsed, header);
     }
 
@@ -1191,7 +1290,8 @@ mod tests {
         buf.extend_from_slice(&256u16.to_le_bytes());
         buf.extend_from_slice(&2u16.to_le_bytes());
         buf.extend_from_slice(&0u16.to_le_bytes());
-        let err = VectorSegmentHeader::read_from(&mut Cursor::new(&buf)).unwrap_err();
+        let err =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap_err();
         assert!(matches!(err, LaurusError::IncompatibleFormat(_)));
     }
 
@@ -1203,7 +1303,8 @@ mod tests {
         buf.extend_from_slice(&999u16.to_le_bytes()); // unknown
         buf.extend_from_slice(&[0u8; 8]);
 
-        let err = VectorSegmentHeader::read_from(&mut Cursor::new(&buf)).unwrap_err();
+        let err =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap_err();
         match err {
             LaurusError::IncompatibleFormat(msg) => {
                 assert!(msg.contains("999"));
@@ -1216,7 +1317,8 @@ mod tests {
     fn truncated_header_returns_io_error() {
         // Magic only, no version → reader hits EOF on the version read.
         let buf = b"LVS1".to_vec();
-        let err = VectorSegmentHeader::read_from(&mut Cursor::new(&buf)).unwrap_err();
+        let err =
+            VectorSegmentHeader::read_from(&mut Cursor::new(&buf), buf.len() as u64).unwrap_err();
         assert!(matches!(err, LaurusError::Io(_)));
     }
 

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -545,7 +545,11 @@ impl HnswIndexReader {
         // handled here; Lazy mode silently degrades PQ to "not
         // supported" because the OnDemand path's offsets table only
         // carries Scalar8Bit params today.
-        let header = VectorSegmentHeader::read_from(&mut input)?;
+        // Issue #921: pass the bytes physically left in the file so the
+        // header's PQ codebook allocation is bounded before it reserves.
+        let header_available =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let header = VectorSegmentHeader::read_from(&mut input, header_available)?;
 
         // Graph-block parser, version-dispatched (Issue #686). The graph
         // physically trails the records, so by the time each quant branch

--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -599,7 +599,11 @@ impl HnswIndexWriter {
         // back to f32 for the writer's in-memory state — the on-disk
         // form is rebuilt from scratch in `write()` once add_vector /
         // delete_document calls have replayed.
-        let header = VectorSegmentHeader::read_from(&mut input)?;
+        // Issue #921: pass the bytes physically left in the file so the
+        // header's PQ codebook allocation is bounded before it reserves.
+        let header_available =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let header = VectorSegmentHeader::read_from(&mut input, header_available)?;
 
         // Read quantized vectors and dequantize back to f32 for the
         // in-memory writer state. The dequantized values are a lossy

--- a/laurus/src/vector/index/ivf/reader.rs
+++ b/laurus/src/vector/index/ivf/reader.rs
@@ -149,7 +149,11 @@ impl IvfIndexReader {
         // rejected with IncompatibleFormat.
         // Matched by reference so `header` (version + field dictionary,
         // Issue #633) stays alive for the record parse below.
-        let header = VectorSegmentHeader::read_from(&mut input)?;
+        // Issue #921: pass the bytes physically left in the file so the
+        // header's PQ codebook allocation is bounded before it reserves.
+        let header_available =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let header = VectorSegmentHeader::read_from(&mut input, header_available)?;
         let params = match &header.quant {
             QuantHeader::Scalar8Bit(p) => *p,
             QuantHeader::ProductQuantization { .. } => {

--- a/laurus/src/vector/index/ivf/writer.rs
+++ b/laurus/src/vector/index/ivf/writer.rs
@@ -196,7 +196,11 @@ impl IvfIndexWriter {
         // Pre-Stage-1 segments are rejected with IncompatibleFormat.
         // Matched by reference so `header` (version + field dictionary,
         // Issue #633) stays alive for the record parse below.
-        let header = VectorSegmentHeader::read_from(&mut input)?;
+        // Issue #921: pass the bytes physically left in the file so the
+        // header's PQ codebook allocation is bounded before it reserves.
+        let header_available =
+            file_size.saturating_sub(input.stream_position().map_err(LaurusError::Io)?);
+        let header = VectorSegmentHeader::read_from(&mut input, header_available)?;
         let params = match &header.quant {
             QuantHeader::Scalar8Bit(p) => *p,
             QuantHeader::ProductQuantization { .. } => {

--- a/laurus/src/vector/index/pq_codebook.rs
+++ b/laurus/src/vector/index/pq_codebook.rs
@@ -37,9 +37,12 @@ const PQ_CODEBOOK_FOOTER_MAGIC: u32 = 0x5051_4342;
 /// Footer size in bytes: magic (`u32`) + CRC-32 (`u32`).
 const FOOTER_SIZE: usize = 8;
 
-/// Byte length of the fixed PQ header prefix this module reads before
-/// trusting any length it declares: the 16-byte [`VectorSegmentHeader`]
-/// fixed header plus the 8-byte `m`/`k`/`sub_dim`/padding block.
+/// Byte length of the fixed PQ header prefix (the 16-byte
+/// [`VectorSegmentHeader`] fixed header plus the 8-byte
+/// `m`/`k`/`sub_dim`/padding block). The truncation test uses it to cut
+/// a file mid-codebook; the allocation bound itself lives inside
+/// [`VectorSegmentHeader::read_from`] since Issue #921.
+#[cfg(test)]
 const PQ_HEADER_PREFIX_SIZE: usize = 24;
 
 /// A trained PQ codebook loaded from (or about to be persisted to) a
@@ -132,14 +135,14 @@ pub fn write_pq_codebook(
 ///
 /// # Allocation safety
 ///
-/// The full header parse (which allocates the `codebook: Vec<f32>`
-/// buffer internally) trusts its own `m`/`k`/`sub_dim` fields, which
-/// are not yet integrity-checked at that point — mirroring the
-/// `rerank_sidecar` module's Issue #791 guard, this function first
-/// reads only the small fixed prefix, computes the codebook's declared
-/// byte size from it, and rejects the file as corrupted *before*
-/// calling into the real parse if that declared size cannot fit in the
-/// file's actual on-disk length.
+/// The codebook allocation inside the header parse is bounded against
+/// `file_size` by [`VectorSegmentHeader::read_from`] itself (Issue
+/// #921) — a header whose `m`/`sub_dim` declare more codebook entries
+/// than the file can physically hold is rejected as corrupted before
+/// anything is reserved. (This function originally carried its own
+/// prefix-peek pre-check because `read_from` had no budget parameter;
+/// #921 moved the bound inside, protecting every `.hnsw` PQ segment
+/// too, so the bespoke guard is gone.)
 ///
 /// # Errors
 ///
@@ -149,40 +152,8 @@ pub fn write_pq_codebook(
 /// * Any I/O error from `storage`.
 pub fn read_pq_codebook(storage: &dyn Storage, name: &str) -> Result<SharedPqCodebook> {
     let file_size = storage.file_size(name)?;
-
-    let declared = {
-        let mut input = storage.open_input(name)?;
-        let mut prefix = [0u8; PQ_HEADER_PREFIX_SIZE];
-        input.read_exact(&mut prefix)?;
-        let m = u16::from_le_bytes([prefix[16], prefix[17]]);
-        let k = u16::from_le_bytes([prefix[18], prefix[19]]);
-        let sub_dim = u16::from_le_bytes([prefix[20], prefix[21]]);
-        PqParams::new(m, k, sub_dim).map_err(|e| {
-            LaurusError::index(format!(
-                "shared PQ codebook '{name}' has invalid params: {e}"
-            ))
-        })?
-    };
-    let min_total = (PQ_HEADER_PREFIX_SIZE as u64)
-        .checked_add(declared.codebook_byte_size() as u64)
-        .and_then(|n| n.checked_add(FOOTER_SIZE as u64))
-        .ok_or_else(|| {
-            LaurusError::index(format!(
-                "shared PQ codebook '{name}' declared size overflows u64: file is corrupted"
-            ))
-        })?;
-    if min_total > file_size {
-        return Err(LaurusError::index(format!(
-            "shared PQ codebook '{name}' declares a {}-byte codebook but the file is \
-             only {file_size} bytes: file is corrupted",
-            declared.codebook_byte_size()
-        )));
-    }
-
-    // Bounded: re-parse for real now that `file_size` has confirmed the
-    // declared codebook fits.
     let mut crc_reader = CrcReader::new(storage.open_input(name)?);
-    let header = VectorSegmentHeader::read_from(&mut crc_reader)
+    let header = VectorSegmentHeader::read_from(&mut crc_reader, file_size)
         .map_err(|e| LaurusError::index(format!("shared PQ codebook '{name}': {e}")))?;
     let (params, codebook) = match header.quant {
         QuantHeader::ProductQuantization { params, codebook } => (params, codebook),

--- a/laurus/src/vector/index/quantized_segment.rs
+++ b/laurus/src/vector/index/quantized_segment.rs
@@ -151,14 +151,24 @@ impl QuantizedSegmentVectors {
     /// Read a segment from `reader`. Self-describing: `dim` and
     /// `vector_count` are recovered from the on-disk prefix.
     ///
+    /// # Arguments
+    ///
+    /// * `reader` - Stream positioned at the start of the segment.
+    /// * `available` - Bytes the source can still supply (the file or
+    ///   buffer length), bounding the header's PQ codebook allocation
+    ///   and this segment's record-data allocation against ground truth
+    ///   (Issue #921 / #806).
+    ///
     /// # Errors
     ///
     /// * Forwards any error from [`VectorSegmentHeader::read_from`]
-    ///   (incompatible magic / version / quant_kind).
+    ///   (incompatible magic / version / quant_kind, oversized codebook).
+    /// * [`crate::error::LaurusError::Index`] if the declared record
+    ///   data cannot fit in `available` bytes (corruption).
     /// * Returns [`crate::error::LaurusError::Io`] for any underlying
     ///   read failure (EOF, etc.).
-    pub fn read_from<R: Read>(reader: &mut R) -> Result<Self> {
-        let header = VectorSegmentHeader::read_from(reader)?;
+    pub fn read_from<R: Read>(reader: &mut R, available: u64) -> Result<Self> {
+        let header = VectorSegmentHeader::read_from(reader, available)?;
         // Stage 3 (PQ) segments are handled by a separate code path
         // (see `crate::vector::index::pq_segment`); this Stage 1
         // helper only reads Scalar8Bit segments.
@@ -188,7 +198,16 @@ impl QuantizedSegmentVectors {
         let dim = u32::from_le_bytes(dim_bytes) as usize;
         let vector_count = u32::from_le_bytes(count_bytes) as usize;
 
+        // Issue #921: `dim`/`vector_count` are unverified u32s; bound the
+        // data buffer against the source's real length before allocating
+        // (the header + prefix already consumed can only make the true
+        // remainder smaller, so `available` is a safe upper bound).
         let total = vector_count.saturating_mul(Self::record_size(dim));
+        crate::vector::index::alloc_bounds::checked_len(
+            total,
+            available,
+            "quantized segment data size",
+        )?;
         let mut data = vec![0u8; total];
         reader.read_exact(&mut data)?;
 
@@ -273,7 +292,7 @@ mod tests {
         assert_eq!(buf.len(), original.serialized_size());
 
         let mut cursor = Cursor::new(&buf);
-        let recovered = QuantizedSegmentVectors::read_from(&mut cursor).unwrap();
+        let recovered = QuantizedSegmentVectors::read_from(&mut cursor, buf.len() as u64).unwrap();
         assert_eq!(recovered.dim, original.dim);
         assert_eq!(recovered.vector_count, original.vector_count);
         assert_eq!(recovered.params, original.params);
@@ -285,7 +304,7 @@ mod tests {
         // Build a buffer that LOOKS like raw f32 vectors (no LVS1 header).
         let raw: Vec<u8> = (0..16).flat_map(|i: u8| [i, 0, 0, 0]).collect();
         let mut cursor = Cursor::new(&raw);
-        let err = QuantizedSegmentVectors::read_from(&mut cursor).unwrap_err();
+        let err = QuantizedSegmentVectors::read_from(&mut cursor, raw.len() as u64).unwrap_err();
         match err {
             crate::error::LaurusError::IncompatibleFormat(msg) => {
                 assert!(msg.contains("LVS1"), "msg: {msg}");
@@ -305,7 +324,8 @@ mod tests {
         // Truncate the last vector record.
         let truncated_len = buf.len() - QuantizedSegmentVectors::record_size(dim) / 2;
         buf.truncate(truncated_len);
-        let err = QuantizedSegmentVectors::read_from(&mut Cursor::new(&buf)).unwrap_err();
+        let err = QuantizedSegmentVectors::read_from(&mut Cursor::new(&buf), buf.len() as u64)
+            .unwrap_err();
         assert!(matches!(err, crate::error::LaurusError::Io(_)));
     }
 
@@ -334,7 +354,7 @@ mod tests {
         assert_eq!(buf.len(), 32);
 
         let mut cursor = Cursor::new(&buf);
-        let recovered = QuantizedSegmentVectors::read_from(&mut cursor).unwrap();
+        let recovered = QuantizedSegmentVectors::read_from(&mut cursor, buf.len() as u64).unwrap();
         assert_eq!(recovered.vector_count, 0);
         assert_eq!(recovered.dim, dim);
         assert_eq!(recovered.data, Vec::<u8>::new());
@@ -352,7 +372,7 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         seg.write_to(&mut buf).unwrap();
         let mut cursor = Cursor::new(&buf);
-        let recovered = QuantizedSegmentVectors::read_from(&mut cursor).unwrap();
+        let recovered = QuantizedSegmentVectors::read_from(&mut cursor, buf.len() as u64).unwrap();
 
         // Pick query = vectors[0] (so cosine distance to vectors[0]
         // should be ~ 0, modulo quantization noise).

--- a/laurus/tests/vector_segment_test.rs
+++ b/laurus/tests/vector_segment_test.rs
@@ -250,7 +250,8 @@ async fn test_pq_quantizer_honored_through_engine_commit() {
     // 4. The header must report ProductQuantization (quant_kind = 2). The
     //    default Scalar8Bit would report quant_kind = 1 and fail here, so this
     //    catches a regression that drops `quantizer` from `from_hnsw_option`.
-    let header = VectorSegmentHeader::read_from(&mut input).unwrap();
+    let available = input.size().unwrap() - input.stream_position().unwrap();
+    let header = VectorSegmentHeader::read_from(&mut input, available).unwrap();
     match header.quant {
         QuantHeader::ProductQuantization { params, .. } => {
             assert_eq!(


### PR DESCRIPTION
## Summary

Closes the #806 scope gap this issue describes: `VectorSegmentHeader::read_from`'s `ProductQuantization` / `ProductQuantizationFastScan` branches allocated the codebook `Vec` from unverified on-disk `m`/`k`/`sub_dim` with no check against the file's real size. A single flipped byte could request a ~4 TB allocation and abort the process via `handle_alloc_error` instead of returning a clean "corrupted segment" error.

**The bug is proven real**: with the bound temporarily neutralized, the new unit test reproduces `memory allocation of 4397912294400 bytes failed` (process abort) from a crafted 24-byte file. With the bound in place the same input returns a clean `LaurusError::Index` corruption error.

## Changes

- `VectorSegmentHeader::read_from` gains an `available: u64` parameter (approved API change — no unbounded entry point remains) and both PQ branches call `alloc_bounds::checked_capacity(codebook_len, 4, available - PQ_PREFIX_SIZE, ..)` before `Vec::with_capacity`.
- All 8 production call sites pass `file_size.saturating_sub(stream_position)` computed immediately before the call (every caller already had `file_size` in scope from #806): `hnsw`/`flat`/`ivf` readers + writer reload paths, plus:
  - `pq_codebook.rs::read_pq_codebook`: the bespoke prefix-peek pre-guard (#631's workaround for exactly this gap) is deleted — single open, budget passed straight through; footer/CRC checks unchanged.
  - `quantized_segment.rs::read_from`: same parameter threaded; its own unbounded record-data allocation (same defect class, unverified u32 `dim`/`vector_count`) got a `checked_len` bound while passing through.
- ~19 test call sites updated to pass their real buffer length, so the bound is exercised rather than bypassed.
- Stale-doc fix in passing: `quant_kind::PRODUCT_QUANTIZATION` still claimed "reader returns NotImplemented".

## Tests

- `oversized_pq_codebook_declaration_is_rejected_cleanly` (RED-proved as above) and, under the `pq-fastscan` feature, `oversized_pq_fastscan_codebook_declaration_is_rejected_cleanly`.
- All existing round-trip / truncation / corruption tests green with real budgets.

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean on stable and 1.97.0
- `cargo test -p laurus --lib`: 1258 passed; `--tests`: all 62 binaries ok
- `cargo check -p laurus --features pq-fastscan --all-targets`: clean, feature-gated test green
- `cargo doc --no-deps -p laurus`: 73 warnings (baseline)

Closes #921. Generalizes #806 (which generalized #791); found during #631 PR-1 (#917).
