### PR TITLE
fix(vector/search): rescore multi-segment hits on a shared basis (#927)

### DIFF
--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -1048,6 +1048,13 @@ impl HnswSearcher {
                 _ => found.into_iter().collect(),
             };
 
+        // Issue #927: when the rerank arm above actually ran, the scores
+        // are `distance(raw_query, true_f32_vector)` — an exact,
+        // cross-segment-comparable basis the multi-segment fan-out must
+        // not overwrite with its (approximate) dequantized rescore.
+        let rerank_applied =
+            request.params.rerank_factor.is_some() && reader.rerank_storage().is_some();
+
         // Convert candidate set to results.
         let field_name_owned = field_name.to_string();
         let mut final_results = Vec::new();
@@ -1093,11 +1100,18 @@ impl HnswSearcher {
         let top_k = request.params.top_k.min(final_results.len());
         final_results.truncate(top_k);
 
+        let mut query_metadata = std::collections::HashMap::new();
+        if rerank_applied {
+            query_metadata.insert(
+                crate::vector::search::searcher::SCORE_BASIS_METADATA_KEY.to_string(),
+                crate::vector::search::searcher::SCORE_BASIS_F32_RERANK.to_string(),
+            );
+        }
         Ok(VectorIndexQueryResults {
             results: final_results,
             candidates_examined,
             search_time_ms: 0.0, // Set by caller
-            query_metadata: std::collections::HashMap::new(),
+            query_metadata,
         })
     }
 

--- a/laurus/src/vector/index/segment/fanout.rs
+++ b/laurus/src/vector/index/segment/fanout.rs
@@ -327,6 +327,60 @@ impl SegmentFanoutSearcher {
     }
 }
 
+impl SegmentFanoutSearcher {
+    /// Rescore `hits` against the raw query in the shared
+    /// dequantized-f32 space (Issue #927).
+    ///
+    /// Per-segment similarities are computed by the quantized kernels
+    /// against **per-segment** affine params, with the query clamped into
+    /// each segment's value range — so they are comparable only within a
+    /// segment. A segment whose range excludes the query reports its
+    /// boundary doc as an exact match (`similarity = 1.0`), outranking
+    /// truly closer docs from other segments. Clamping shifts every
+    /// distance in a segment by the same offset (`|doc − clamp(q)| =
+    /// |doc − q| − |q − edge|` for out-of-range queries), so the
+    /// segment-internal candidate ordering the graph search produced is
+    /// correct — only the absolute scores must be recomputed on a shared
+    /// basis before the cross-segment sort (the Stage-2 rerank
+    /// precedent).
+    ///
+    /// # Arguments
+    ///
+    /// * `hits` - One segment's surviving hits; `distance`/`similarity`
+    ///   are overwritten in place.
+    /// * `idx` - The segment's reader index (fallback vector source when
+    ///   a hit does not carry its dequantized vector).
+    /// * `metric` - The index's distance metric.
+    /// * `prepared_query` - The raw query prepared once per search.
+    ///
+    /// # Errors
+    ///
+    /// Forwards reader / distance-kernel errors.
+    fn rescore_on_shared_basis(
+        &self,
+        hits: &mut [crate::vector::search::searcher::VectorIndexQueryResult],
+        idx: usize,
+        metric: DistanceMetric,
+        prepared_query: &crate::vector::core::distance::PreparedQuery,
+    ) -> Result<()> {
+        for hit in hits.iter_mut() {
+            let distance = if let Some(v) = &hit.vector {
+                metric.distance_with_prepared(prepared_query, &v.data)?
+            } else if let Some(v) = self.readers[idx].get_vector(hit.doc_id, &hit.field_name)? {
+                metric.distance_with_prepared(prepared_query, &v.data)?
+            } else {
+                // The hit was just returned by this segment, so a missing
+                // vector is unreachable in practice; keep the local score
+                // rather than dropping the hit.
+                continue;
+            };
+            hit.distance = distance;
+            hit.similarity = metric.distance_to_similarity(distance);
+        }
+        Ok(())
+    }
+}
+
 impl VectorIndexSearcher for SegmentFanoutSearcher {
     fn search(&self, request: &VectorIndexQuery) -> Result<VectorIndexQueryResults> {
         let started = crate::util::time::Timer::now();
@@ -335,6 +389,11 @@ impl VectorIndexSearcher for SegmentFanoutSearcher {
         if limit == 0 || self.readers.is_empty() {
             return Ok(merged);
         }
+
+        // Issue #927: shared scoring basis for the cross-segment merge —
+        // see `rescore_on_shared_basis`.
+        let metric = self.readers[0].distance_metric();
+        let prepared_query = metric.prepare_query(&request.query.data);
 
         // Over-fetch per segment: containment masking drops shadowed hits
         // AFTER the per-segment top-k, so stale copies would otherwise
@@ -354,9 +413,20 @@ impl VectorIndexSearcher for SegmentFanoutSearcher {
             let mut probe = request.clone();
             probe.params.top_k = limit.saturating_mul(2);
             let mut kept: Vec<crate::vector::search::searcher::VectorIndexQueryResult>;
+            // Whether this segment's scores are already on the exact f32
+            // rerank basis (Issue #481 Stage 2) — comparable across
+            // segments and MORE precise than the dequantized rescore, so
+            // the #927 rescore below must not overwrite them. Stamped by
+            // the per-segment searcher; constant across refill rounds
+            // (same segment, same sidecar).
+            let mut exact_basis = false;
             loop {
                 let results = searcher.search(&probe)?;
                 merged.candidates_examined += results.candidates_examined;
+                exact_basis |= results
+                    .query_metadata
+                    .get(crate::vector::search::searcher::SCORE_BASIS_METADATA_KEY)
+                    .is_some_and(|v| v == crate::vector::search::searcher::SCORE_BASIS_F32_RERANK);
                 let returned = results.results.len();
                 kept = results
                     .results
@@ -376,12 +446,35 @@ impl VectorIndexSearcher for SegmentFanoutSearcher {
                 probe.params.top_k = next;
             }
 
+            // Issue #927: overwrite the segment-local scores with the
+            // shared-basis ones, then re-apply `min_similarity` on the
+            // final scores — the per-segment filter ran on local scores,
+            // which clamping can only inflate (clamped distance ≤ true
+            // distance), so it never dropped a hit the shared basis would
+            // keep; the inverse (an inflated score sneaking past the
+            // threshold) is corrected here. Skipped when the segment's
+            // scores already sit on the exact f32 rerank basis — a MORE
+            // precise shared basis the dequantized rescore would degrade.
+            if !exact_basis {
+                self.rescore_on_shared_basis(&mut kept, idx, metric, &prepared_query)?;
+                kept.retain(|hit| hit.similarity >= request.params.min_similarity);
+            }
+
             merged.results.append(&mut kept);
         }
 
-        merged
-            .results
-            .sort_unstable_by(|a, b| b.similarity.total_cmp(&a.similarity));
+        // Sort by ascending distance rather than descending similarity
+        // (#927): every metric's `distance` is lower-is-more-similar and
+        // stays precise at long range, while `distance_to_similarity`'s
+        // `exp(-d)` (Euclidean/Manhattan) underflows to 0.0 far from the
+        // query — collapsing distant hits into ties whose unstable-sort
+        // order would leak segment order into the results. Doc id breaks
+        // exact-tie ordering deterministically.
+        merged.results.sort_unstable_by(|a, b| {
+            a.distance
+                .total_cmp(&b.distance)
+                .then(a.doc_id.cmp(&b.doc_id))
+        });
         merged.results.truncate(limit);
         merged.search_time_ms = started.elapsed_ms() as f64;
         Ok(merged)

--- a/laurus/src/vector/search/searcher.rs
+++ b/laurus/src/vector/search/searcher.rs
@@ -276,6 +276,19 @@ pub struct VectorIndexQueryResult {
     pub vector: Option<Vector>,
 }
 
+/// `query_metadata` key a per-segment searcher sets when its scores were
+/// computed against the exact f32 rerank sidecar (Issue #481 Stage 2) —
+/// i.e. `distance(raw_query, true_f32_vector)`, a basis that is already
+/// comparable across segments AND more precise than the dequantized
+/// reconstruction. The multi-segment fan-out (Issue #927) skips its
+/// shared-basis rescore for such results so the sidecar's precision is
+/// not overwritten.
+pub(crate) const SCORE_BASIS_METADATA_KEY: &str = "score_basis";
+
+/// `query_metadata` value for [`SCORE_BASIS_METADATA_KEY`]: exact f32
+/// sidecar rerank basis.
+pub(crate) const SCORE_BASIS_F32_RERANK: &str = "f32-rerank";
+
 /// Collection of results from a low-level vector index query.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VectorIndexQueryResults {

--- a/laurus/tests/segment_score_comparability_test.rs
+++ b/laurus/tests/segment_score_comparability_test.rs
@@ -1,0 +1,181 @@
+//! Regression test for Issue #927: cross-segment score comparability.
+//!
+//! Per-segment similarities come from quantized kernels running against
+//! per-segment affine params, with the query clamped into each segment's
+//! value range. Before #927 the fan-out compared those segment-local
+//! scores globally, so any segment whose value range excluded the query
+//! reported its boundary doc as an exact match (`similarity = 1.0`) and
+//! outranked truly closer docs from other segments — a single-doc
+//! segment (one upsert commit) topped every out-of-range query.
+//!
+//! The fixture places vectors on a coarse grid (steps of 10.0 per
+//! component) so the expected ordering is far outside quantization error,
+//! and the per-segment `ef_search` exceeds every segment's size — making
+//! per-segment search exact and the brute-force expectation
+//! deterministic.
+
+use std::sync::Arc;
+
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::index::VectorIndex;
+use laurus::vector::index::config::HnswIndexConfig;
+use laurus::vector::index::hnsw::segmented::SegmentedHnswIndex;
+use laurus::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryParams};
+use laurus::vector::{DistanceMetric, Vector};
+
+const DIM: usize = 8;
+const TOP_K: usize = 5;
+
+fn config() -> HnswIndexConfig {
+    HnswIndexConfig {
+        dimension: DIM,
+        m: 8,
+        ef_construction: 64,
+        normalize_vectors: false,
+        distance_metric: DistanceMetric::Euclidean,
+        segmented: true,
+        ..Default::default()
+    }
+}
+
+/// A vector whose components all equal `level * 10.0` — grid spacing keeps
+/// every pairwise distance far outside quantization error.
+fn grid(level: f32) -> Vector {
+    Vector::new(vec![level * 10.0; DIM])
+}
+
+fn query(vector: &Vector, ef: usize) -> VectorIndexQuery {
+    VectorIndexQuery {
+        query: vector.clone(),
+        params: VectorIndexQueryParams {
+            top_k: TOP_K,
+            ef_search: Some(ef),
+            ..Default::default()
+        },
+        field_name: Some("v".to_string()),
+        filter: None,
+    }
+}
+
+/// Build a 4-segment index whose segments cover disjoint value ranges,
+/// with cross-segment stale duplicates and one deletion. Returns the
+/// index and the live `(doc_id, level)` state (newest copy wins, deleted
+/// doc excluded).
+fn build_fixture() -> (SegmentedHnswIndex, Vec<(u64, f32)>) {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index =
+        SegmentedHnswIndex::open_or_create(storage as Arc<dyn Storage>, "vi", config()).unwrap();
+
+    // 4 commits = 4 sealed segments (no merge trigger in this test).
+    // Segment 1: docs 0..10 at levels 0..10.
+    // Segment 2: docs 10..20 at levels 10..20 (disjoint range).
+    // Segment 3: docs 20..30 at levels 20..30, PLUS doc 3 re-added at
+    //            level 25.5 (stale copy of doc 3 remains in segment 1).
+    // Segment 4: doc 7 alone at level 12.5 — the degenerate-range,
+    //            single-doc segment that used to top every query.
+    let batches: Vec<Vec<(u64, String, Vector)>> = vec![
+        (0..10u64)
+            .map(|i| (i, "v".to_string(), grid(i as f32)))
+            .collect(),
+        (10..20u64)
+            .map(|i| (i, "v".to_string(), grid(i as f32)))
+            .collect(),
+        (20..30u64)
+            .map(|i| (i, "v".to_string(), grid(i as f32)))
+            .chain(std::iter::once((3u64, "v".to_string(), grid(25.5))))
+            .collect(),
+        vec![(7u64, "v".to_string(), grid(12.5))],
+    ];
+    for batch in batches {
+        let mut w = index.writer().unwrap();
+        w.add_vectors(batch).unwrap();
+        w.commit().unwrap();
+    }
+
+    // Delete doc 15 (level 15) — must never appear in results.
+    index.soft_delete_document(15).unwrap();
+
+    let mut live: Vec<(u64, f32)> = (0..30u64)
+        .map(|i| (i, i as f32))
+        .filter(|(i, _)| *i != 15)
+        .collect();
+    for (id, level) in live.iter_mut() {
+        if *id == 3 {
+            *level = 25.5; // newest copy (segment 3)
+        }
+        if *id == 7 {
+            *level = 12.5; // newest copy (segment 4)
+        }
+    }
+    (index, live)
+}
+
+/// Expected top-k doc ids for a query at `q_level`, by exact distance over
+/// the live state.
+fn expected_top_k(live: &[(u64, f32)], q_level: f32) -> Vec<u64> {
+    let mut d: Vec<(f32, u64)> = live
+        .iter()
+        .map(|(id, level)| ((level - q_level).abs(), *id))
+        .collect();
+    d.sort_by(|a, b| a.0.total_cmp(&b.0).then(a.1.cmp(&b.1)));
+    d.truncate(TOP_K);
+    d.into_iter().map(|(_, id)| id).collect()
+}
+
+/// The #927 repro: queries inside, outside, and between the segments'
+/// value ranges must return the brute-force expected top-k. Before the
+/// fix, the query at level 0.2 returned `[7, 20, 10, 0, 1]` — the
+/// out-of-range segments' boundary docs at similarity 1.0 — instead of
+/// `[0, 1, 2, 4, 5]`. Newest-wins masking (stale docs 3 / 7) and the
+/// deletion (doc 15) must survive the rescore unchanged.
+#[test]
+fn cross_segment_scores_match_bruteforce_on_disjoint_ranges() {
+    let (index, live) = build_fixture();
+    let searcher = index.searcher().unwrap();
+
+    // Query levels chosen so no two live docs are equidistant: an exact
+    // tie's rescored order would depend on each segment's reconstruction
+    // error (dequantized basis), which is not what this test pins. The
+    // smallest inter-hit distance gap (0.1 level = 2.8 raw L2) still
+    // exceeds the worst-case reconstruction perturbation (~1.0 raw L2).
+    for q_level in [0.2, 3.1, 7.1, 12.4, 15.3, 22.7, 25.4, 29.0] {
+        let res = searcher.search(&query(&grid(q_level), 256)).unwrap();
+        let got: Vec<u64> = res.results.iter().map(|r| r.doc_id).collect();
+        let want = expected_top_k(&live, q_level);
+        assert_eq!(
+            got, want,
+            "query at level {q_level}: cross-segment order must match brute force"
+        );
+    }
+}
+
+/// After the shared-basis rescore, `min_similarity` must filter on the
+/// comparable score: a threshold that the degenerate segment's inflated
+/// local score (1.0) would have passed must drop it once rescored.
+#[test]
+fn min_similarity_applies_to_the_shared_basis_score() {
+    let (index, _) = build_fixture();
+    let searcher = index.searcher().unwrap();
+
+    // Query far outside segment 4's point range: doc 7's local score
+    // used to saturate at 1.0. With Euclidean similarity = exp(-d), any
+    // positive threshold excludes every far-away doc once rescored.
+    let mut q = query(&grid(0.2), 256);
+    q.params.min_similarity = 0.5;
+    let res = searcher.search(&q).unwrap();
+    for hit in &res.results {
+        assert!(
+            hit.similarity >= 0.5,
+            "hit {} at similarity {} must respect min_similarity on the \
+             shared basis",
+            hit.doc_id,
+            hit.similarity
+        );
+        assert_ne!(
+            hit.doc_id, 7,
+            "the degenerate segment's doc must not pass min_similarity \
+             via its inflated local score"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the cross-segment score comparability bug: per-segment similarities come from quantized kernels running against **per-segment** affine params, with the query clamped into each segment's value range, so the fan-out's global sort compared meaningless numbers. Any segment whose value range excluded the query reported its boundary doc as an exact match (`similarity = 1.0`) — a single-doc segment (one upsert commit, routine under segment-per-commit) topped **every** out-of-range query. Repro: `[7, 20, 10, 0, 1]` where brute force says `[0, 1, 2, 4, 5]`, with the top three at `sim = 1.0`.

## Changes (`segment/fanout.rs` + one stamp in `hnsw/searcher.rs`)

1. **Shared-basis rescore**: after each segment's newest-wins masking, every surviving hit's `distance`/`similarity` is recomputed as `distance(prepared_raw_query, dequantized_vector)` (hit-carried vector, else `get_vector`). Candidate *generation* stays on the quantized kernels — clamping shifts a segment's distances by a per-segment constant, so segment-internal ordering was always correct; only the absolute scores needed a shared basis. `min_similarity` re-applies on final scores (the local filter can only be lenient, never over-strict, so no hit is lost).
2. **Sort by distance, not similarity** (second defect found while testing): `exp(-d)` similarity underflows to 0.0 at long range (and DotProduct similarity saturates via `clamp(0,1)`), collapsing distant hits into ties whose unstable-sort order leaked segment order into results. The merged sort now uses ascending `distance` (lower-is-more-similar for every metric, precise at long range) with a doc-id tiebreak.
3. **Stage-2 rerank scores preserved** (third defect, caught by the existing rerank e2e test): sidecar-reranked scores are `distance(raw_query, true_f32_vector)` — already cross-segment-comparable and *more* precise than the dequantized basis; the first version of the rescore overwrote them, silently discarding the sidecar's benefit. The searcher now stamps `query_metadata["score_basis"] = "f32-rerank"` when the rerank arm actually ran and the fan-out skips its rescore for such segments (per-segment decision, so mixed sidecar/non-sidecar indexes still get clamp-corrected scores where needed).

Flat/IVF segmented indexes share the fan-out and get all three for free. No public API changes.

## Tests

- New `segment_score_comparability_test.rs`: the discovery repro as a regression test (4 disjoint-range segments incl. the degenerate single-doc one, cross-segment stale duplicates, a deletion; queries inside/outside/between ranges must match brute force exactly; a second test pins `min_similarity` on the shared basis). Query positions are tie-free by construction — an exact tie's rescored order would depend on per-segment reconstruction error, which is not what the test pins.
- **RED-proved** via reversible sed: disabling the rescore reproduces the original `[7, 20, 10, ...]` corruption.
- The Stage-2 interaction is pinned by the existing `vector_rerank_engine_test.rs` (it caught defect 3 during development).

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean on stable and 1.97.0
- `cargo test -p laurus --lib`: 1258 passed; `--tests`: all 63 binaries ok
- wasm32 `cargo check -p laurus-wasm`: clean; `cargo doc --no-deps -p laurus`: 73 warnings (baseline)
- **Overhead** (#683 probe fixture, 10 segments / 20k vectors / 100 queries, release, best of 3): ef=50 40.1→60.6ms (+51%, ≈ +0.2ms/query), ef=100 67.3→88.0ms (+31%), ef=200 105.3→129.8ms (+23%); recall unchanged within build-RNG noise. Cost is the `get_vector` fallback, bounded by `2·top_k·N_segments` hits/query; #926's parallel fan-out (staged, rebases on this) offsets it in wall-clock, and populating `hit.vector` from the searcher's resident pool is a further optimization if the budget ever matters.

Closes #927. Found while implementing #926; blocks #926's correctness test.
