### PR TITLE
fix(vector/search): select per-searcher top-k by distance, not underflow-prone similarity (#933)

### DIFF
--- a/laurus/src/vector/index/flat/searcher.rs
+++ b/laurus/src/vector/index/flat/searcher.rs
@@ -131,7 +131,11 @@ impl VectorIndexSearcher for FlatVectorSearcher {
                 results.candidates_examined = candidates.len();
             }
 
-            candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
+            // Sort ascending by distance with a doc-id tiebreak (#933):
+            // similarity's `exp(-d)` underflows to 0.0 at long range,
+            // collapsing distant candidates into ties whose unstable order
+            // would make top-k membership arbitrary; distance stays precise.
+            candidates.sort_unstable_by(|a, b| a.2.total_cmp(&b.2).then(a.0.cmp(&b.0)));
 
             let top_k = request.params.top_k.min(candidates.len());
             for (doc_id, similarity, distance, vector) in candidates.into_iter().take(top_k) {
@@ -198,7 +202,11 @@ impl VectorIndexSearcher for FlatVectorSearcher {
                 results.candidates_examined = candidates.len();
             }
 
-            candidates.sort_unstable_by(|a, b| b.2.total_cmp(&a.2));
+            // Sort ascending by distance with a doc-id tiebreak (#933):
+            // similarity's `exp(-d)` underflows to 0.0 at long range,
+            // collapsing distant candidates into ties whose unstable order
+            // would make top-k membership arbitrary; distance stays precise.
+            candidates.sort_unstable_by(|a, b| a.3.total_cmp(&b.3).then(a.0.cmp(&b.0)));
 
             let top_k = request.params.top_k.min(candidates.len());
             for (doc_id, field_name, similarity, distance, vector) in

--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -360,7 +360,11 @@ impl VectorIndexSearcher for HnswSearcher {
                 }
             }
 
-            candidates.sort_by(|a, b| b.1.total_cmp(&a.1));
+            // Sort ascending by distance with a doc-id tiebreak (#933):
+            // similarity's `exp(-d)` underflows to 0.0 at long range,
+            // collapsing distant candidates into ties whose unstable order
+            // would make top-k membership arbitrary; distance stays precise.
+            candidates.sort_by(|a, b| a.2.total_cmp(&b.2).then(a.0.cmp(&b.0)));
 
             let top_k = request.params.top_k.min(candidates.len());
             for (doc_id, similarity, distance, vector) in candidates.into_iter().take(top_k) {
@@ -1097,8 +1101,15 @@ impl HnswSearcher {
             });
         }
 
-        // Sort results (similarity descending)
-        final_results.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
+        // Sort ascending by distance with a doc-id tiebreak (#933):
+        // similarity's `exp(-d)` underflows to 0.0 at long range, collapsing
+        // distant candidates into ties whose unstable order would make top-k
+        // membership arbitrary; distance stays precise at any range.
+        final_results.sort_by(|a, b| {
+            a.distance
+                .total_cmp(&b.distance)
+                .then(a.doc_id.cmp(&b.doc_id))
+        });
 
         // Top K
         let top_k = request.params.top_k.min(final_results.len());

--- a/laurus/src/vector/index/ivf/searcher.rs
+++ b/laurus/src/vector/index/ivf/searcher.rs
@@ -288,8 +288,11 @@ impl VectorIndexSearcher for IvfSearcher {
                 Ok(None)
             })?;
 
-        // Sort by similarity (descending)
-        candidates.sort_unstable_by(|a, b| b.2.total_cmp(&a.2));
+        // Sort ascending by distance with a doc-id tiebreak (#933):
+        // similarity's `exp(-d)` underflows to 0.0 at long range, collapsing
+        // distant candidates into ties whose unstable order would make top-k
+        // membership arbitrary; distance stays precise at any range.
+        candidates.sort_unstable_by(|a, b| a.3.total_cmp(&b.3).then(a.0.cmp(&b.0)));
 
         // Take top_k results
         let candidates_len = candidates.len();

--- a/laurus/tests/searcher_distance_sort_test.rs
+++ b/laurus/tests/searcher_distance_sort_test.rs
@@ -1,0 +1,150 @@
+//! Regression tests for Issue #933: per-searcher top-k must be selected by
+//! distance, not by the underflow-prone similarity.
+//!
+//! `distance_to_similarity`'s `exp(-d)` (Euclidean/Manhattan) underflows to
+//! `0.0f32` once raw distances get large, collapsing every distant candidate
+//! into a tie — and the former similarity-descending sorts then decided
+//! top-k **membership** by unstable-sort accident (the #931 oracle caught
+//! `[0, 1, 2, 3, 10]` instead of `[0, 1, 2, 3, 4]`). The fan-out layer was
+//! fixed by #927; these tests pin the same contract inside each per-segment
+//! searcher (HNSW graph path, Flat scan, IVF probe).
+//!
+//! Grid vectors (components `level * 10.0`, dim 8) make raw distances large
+//! enough to underflow while keeping every ordering decision far outside
+//! int8 quantization error.
+
+use std::sync::Arc;
+
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::index::VectorIndex;
+use laurus::vector::index::config::{FlatIndexConfig, HnswIndexConfig, IvfIndexConfig};
+use laurus::vector::index::flat::segmented::SegmentedFlatIndex;
+use laurus::vector::index::hnsw::segmented::SegmentedHnswIndex;
+use laurus::vector::index::ivf::segmented::SegmentedIvfIndex;
+use laurus::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryParams};
+use laurus::vector::{DistanceMetric, Vector};
+
+const DIM: usize = 8;
+const N_DOCS: u64 = 20;
+const TOP_K: usize = 5;
+
+fn grid(level: f32) -> Vector {
+    Vector::new(vec![level * 10.0; DIM])
+}
+
+fn corpus() -> Vec<(u64, String, Vector)> {
+    (0..N_DOCS)
+        .map(|i| (i, "v".to_string(), grid(i as f32)))
+        .collect()
+}
+
+fn query(q_level: f32) -> VectorIndexQuery {
+    VectorIndexQuery {
+        query: grid(q_level),
+        params: VectorIndexQueryParams {
+            top_k: TOP_K,
+            ef_search: Some(256),
+            ..Default::default()
+        },
+        field_name: Some("v".to_string()),
+        filter: None,
+    }
+}
+
+/// Exact expected top-k for a query at `q_level` over the grid corpus.
+fn expected(q_level: f32) -> Vec<u64> {
+    let mut d: Vec<(f32, u64)> = (0..N_DOCS)
+        .map(|i| ((i as f32 - q_level).abs(), i))
+        .collect();
+    d.sort_by(|a, b| a.0.total_cmp(&b.0).then(a.1.cmp(&b.1)));
+    d.truncate(TOP_K);
+    d.into_iter().map(|(_, id)| id).collect()
+}
+
+fn assert_exact_order(index: &dyn VectorIndex, label: &str) {
+    let searcher = index.searcher().unwrap();
+    // Query levels at both ends and middle; 0.2 is the #931 discovery case
+    // (docs beyond ~level 4 underflow to similarity 0.0).
+    for q_level in [0.2, 9.4, 18.7] {
+        let res = searcher.search(&query(q_level)).unwrap();
+        let got: Vec<u64> = res.results.iter().map(|r| r.doc_id).collect();
+        assert_eq!(
+            got,
+            expected(q_level),
+            "{label}: top-k at q={q_level} must be selected by distance"
+        );
+    }
+}
+
+/// HNSW graph path (`final_results` sort): the #931 oracle's repro.
+#[test]
+fn hnsw_top_k_membership_is_distance_selected() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index = SegmentedHnswIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vi",
+        HnswIndexConfig {
+            dimension: DIM,
+            m: 8,
+            ef_construction: 64,
+            normalize_vectors: false,
+            distance_metric: DistanceMetric::Euclidean,
+            segmented: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let mut w = index.writer().unwrap();
+    w.add_vectors(corpus()).unwrap();
+    w.commit().unwrap();
+    assert_exact_order(&index, "hnsw");
+}
+
+/// Flat scan paths (field-filtered and unfiltered sorts).
+#[test]
+fn flat_top_k_membership_is_distance_selected() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index = SegmentedFlatIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vi",
+        FlatIndexConfig {
+            dimension: DIM,
+            normalize_vectors: false,
+            distance_metric: DistanceMetric::Euclidean,
+            segmented: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let mut w = index.writer().unwrap();
+    w.add_vectors(corpus()).unwrap();
+    w.commit().unwrap();
+    assert_exact_order(&index, "flat");
+}
+
+/// IVF probe path (candidate sort across probed clusters). `n_probe` covers
+/// every cluster so the candidate set is complete and the expected order
+/// exact.
+#[test]
+fn ivf_top_k_membership_is_distance_selected() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index = SegmentedIvfIndex::open_or_create(
+        storage as Arc<dyn Storage>,
+        "vi",
+        IvfIndexConfig {
+            dimension: DIM,
+            normalize_vectors: false,
+            distance_metric: DistanceMetric::Euclidean,
+            n_clusters: 4,
+            n_probe: 4,
+            segmented: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let mut w = index.writer().unwrap();
+    w.add_vectors(corpus()).unwrap();
+    w.commit().unwrap();
+    assert_exact_order(&index, "ivf");
+}


### PR DESCRIPTION
## Summary

Fixes the in-searcher sibling of #927's defect 2: per-segment searchers sorted and truncated their results by `similarity` descending, but `distance_to_similarity`'s `exp(-d)` (Euclidean/Manhattan) underflows to `0.0f32` at long range — collapsing every distant candidate into a tie whose unstable-sort order decided top-k **membership** arbitrarily (DotProduct similarly saturates via `clamp(0,1)`). Discovered by #931's frozen-behavior oracle: a 20-doc single-segment grid corpus returned `[0, 1, 2, 3, 10]` where brute force says `[0, 1, 2, 3, 4]`. The fan-out layer was fixed by #927/#928; the drop here happens earlier, at the per-segment truncate, where the fan-out cannot recover it.

## Changes

All five per-searcher sort sites (distance is already in the same tuple/struct at each) now order ascending by `distance` with a `doc_id` tiebreak, exactly matching the fan-out's #927 convention:

- `hnsw/searcher.rs`: graph-path `final_results` sort (the repro site) + linear-fallback candidate sort
- `flat/searcher.rs`: field-filtered + unfiltered scan sorts
- `ivf/searcher.rs`: probed-cluster candidate sort

`min_similarity` filtering and every reported similarity value are unchanged — only ordering/truncation stops flowing through the underflow-prone conversion.

## Tests

- New `searcher_distance_sort_test.rs`: HNSW / Flat / IVF pinned against exact brute-force top-k on the underflow-triggering grid fixture (discovery case `q = 0.2` + mid/far queries; IVF probes all clusters so the expectation is exact).
- **RED-proved** via reversible swap: restoring the similarity sort reproduces the original `[0, 1, 2, 3, 10]` corruption.

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean on stable and 1.97.0
- `cargo test -p laurus --lib`: 1258 passed; `--tests`: all 65 binaries ok — no order-dependent test affected (quantized and distance orders agree wherever similarity does not underflow)
- wasm32 `cargo check -p laurus-wasm --target wasm32-unknown-unknown`: clean

Closes #933. Same defect class as #927 defect 2 (fan-out layer, PR #928). Found by and unblocks #931 (#650 rerank-pipeline campaign PR-1).
