### PR TITLE
refactor(vector/search): extract RerankStage/RerankPipeline, port HNSW Stage-2 (#650 PR-1)

### DIFF
--- a/laurus/src/vector/index/hnsw/searcher.rs
+++ b/laurus/src/vector/index/hnsw/searcher.rs
@@ -1023,45 +1023,56 @@ impl HnswSearcher {
         found: BinaryHeap<ResultCandidate>,
         candidates_examined: usize,
     ) -> Result<VectorIndexQueryResults> {
-        // Stage 2 (Issue #481): if the query asks for rerank
-        // (`rerank_factor`) and the reader has the LRS1 sidecar loaded
-        // (`reader.rerank_storage()`), widen the int8 candidate set to
-        // `top_k * rerank_factor`, recompute distances against the
-        // original f32 vectors, and use the new distances for the
-        // ranking that the existing convert-to-results pipeline below
-        // operates on. When either prerequisite is missing we silently
-        // fall through to Stage 1 ranking — Stage 1 segments cannot
-        // recover the f32 information that was discarded at index
+        // Stage 2 (Issue #481, refactored by #650 PR-1 / #931): when the
+        // query asks for rerank (`rerank_factor`) and the reader has the
+        // LRS1 sidecar loaded, run the shared `RerankPipeline` — for this
+        // searcher a single `F32SidecarStage` that widens the int8
+        // candidate set to `top_k * rerank_factor` and rescores against
+        // the original f32 vectors. When either prerequisite is missing
+        // we silently fall through to Stage 1 ranking — Stage 1 segments
+        // cannot recover the f32 information that was discarded at index
         // time, so there's nothing better to do.
-        let candidates_for_results: Vec<ResultCandidate> =
-            match (request.params.rerank_factor, reader.rerank_storage()) {
-                (Some(factor), Some(pool)) => {
-                    let widened = request.params.top_k.saturating_mul(factor);
-                    let int8_sorted: Vec<ResultCandidate> = found.into_sorted_vec();
-                    let metric = reader.distance_metric();
-                    let prepared_query = metric.prepare_query(&query.data);
-                    let field_idx = pool.field_position_index(field_name);
-                    let mut rescored: Vec<ResultCandidate> = Vec::with_capacity(widened);
-                    for c in int8_sorted.into_iter().take(widened) {
-                        let pos = match field_idx.as_ref().and_then(|idx| idx.get(&c.id).copied()) {
-                            Some(p) => p,
-                            None => continue,
-                        };
-                        let f32_slice = pool.f32_slice_at(pos);
-                        let distance = metric.distance_with_prepared(&prepared_query, f32_slice)?;
-                        rescored.push(ResultCandidate { id: c.id, distance });
-                    }
-                    rescored
-                }
-                _ => found.into_iter().collect(),
-            };
+        use crate::vector::search::rerank::{F32SidecarStage, RerankCandidates, RerankPipeline};
+        let pipeline = match (request.params.rerank_factor, reader.rerank_storage()) {
+            (Some(factor), Some(pool)) => Some((
+                RerankPipeline::new(
+                    vec![Box::new(F32SidecarStage::new(
+                        Arc::clone(pool),
+                        field_name,
+                        reader.distance_metric(),
+                    ))],
+                    vec![factor],
+                ),
+                factor,
+            )),
+            _ => None,
+        };
 
-        // Issue #927: when the rerank arm above actually ran, the scores
-        // are `distance(raw_query, true_f32_vector)` — an exact,
-        // cross-segment-comparable basis the multi-segment fan-out must
-        // not overwrite with its (approximate) dequantized rescore.
-        let rerank_applied =
-            request.params.rerank_factor.is_some() && reader.rerank_storage().is_some();
+        // Issue #927: when the pipeline's final stage actually applies,
+        // the scores are `distance(raw_query, true_f32_vector)` — an
+        // exact, cross-segment-comparable basis the multi-segment
+        // fan-out must not overwrite with its (approximate) dequantized
+        // rescore.
+        let mut rerank_applied = false;
+        let candidates_for_results: Vec<ResultCandidate> = match pipeline {
+            Some((pipeline, _factor)) => {
+                // Ascending int8 order so the pipeline's widening prefix
+                // matches the pre-refactor `into_sorted_vec().take(..)`.
+                let int8_sorted: Vec<ResultCandidate> = found.into_sorted_vec();
+                let mut candidates = RerankCandidates::with_capacity(int8_sorted.len());
+                for c in &int8_sorted {
+                    candidates.push(c.id, c.distance);
+                }
+                rerank_applied = pipeline.run(query, &mut candidates, request.params.top_k)?;
+                candidates
+                    .doc_ids
+                    .iter()
+                    .zip(&candidates.distances)
+                    .map(|(&id, &distance)| ResultCandidate { id, distance })
+                    .collect()
+            }
+            None => found.into_iter().collect(),
+        };
 
         // Convert candidate set to results.
         let field_name_owned = field_name.to_string();

--- a/laurus/src/vector/search.rs
+++ b/laurus/src/vector/search.rs
@@ -9,4 +9,5 @@
 //! similarity-metric / ranking API that no production caller invoked.
 
 pub mod filter_set;
+pub(crate) mod rerank;
 pub mod searcher;

--- a/laurus/src/vector/search/rerank.rs
+++ b/laurus/src/vector/search/rerank.rs
@@ -1,0 +1,296 @@
+//! Composable rerank pipeline (Issue #650 PR-1 / #931).
+//!
+//! Stage-2 rerank (Issue #481) was an inline match arm in the HNSW
+//! searcher, unusable by Flat/IVF and inexpressible as a multi-stage
+//! chain. This module hosts the index-type-agnostic pieces: an
+//! object-safe [`RerankStage`], the SoA [`RerankCandidates`] buffer the
+//! stages narrow, and the [`RerankPipeline`] driver. A per-segment
+//! searcher builds the pipeline once per query from whatever backing
+//! data its reader exposes and runs it over the quantized candidate
+//! set before result conversion.
+//!
+//! A stage's per-query preparation (prepared query, LUTs) coincides
+//! with its single per-query invocation, so preparation happens inside
+//! [`RerankStage::rescore`] rather than through an associated
+//! `Prepared` type — keeping the trait object-safe (the deviation from
+//! the #650 sketch is recorded on #931).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::vector::core::distance::DistanceMetric;
+use crate::vector::core::vector::Vector;
+use crate::vector::index::rerank_storage::RerankStoragePool;
+
+/// SoA candidate buffer flowing through the pipeline: parallel
+/// `doc_ids` / `distances` columns (the #650 data-structure note — no
+/// tuple-of-structs).
+#[derive(Debug, Default)]
+pub(crate) struct RerankCandidates {
+    /// Candidate doc ids, parallel to [`Self::distances`].
+    pub doc_ids: Vec<u64>,
+    /// Current-basis distance per candidate (lower is more similar).
+    pub distances: Vec<f32>,
+}
+
+impl RerankCandidates {
+    /// Create an empty buffer sized for `capacity` candidates.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            doc_ids: Vec::with_capacity(capacity),
+            distances: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Append one candidate.
+    #[inline]
+    pub fn push(&mut self, doc_id: u64, distance: f32) {
+        self.doc_ids.push(doc_id);
+        self.distances.push(distance);
+    }
+
+    /// Number of candidates currently held.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.doc_ids.len()
+    }
+
+    /// Sort both columns ascending by distance with a doc-id tiebreak —
+    /// the crate-wide ordering convention (#927/#933: similarity's
+    /// `exp(-d)` underflows at long range; distance stays precise).
+    pub fn sort_by_distance(&mut self) {
+        let mut order: Vec<u32> = (0..self.len() as u32).collect();
+        order.sort_unstable_by(|&a, &b| {
+            self.distances[a as usize]
+                .total_cmp(&self.distances[b as usize])
+                .then(self.doc_ids[a as usize].cmp(&self.doc_ids[b as usize]))
+        });
+        self.doc_ids = order.iter().map(|&i| self.doc_ids[i as usize]).collect();
+        self.distances = order.iter().map(|&i| self.distances[i as usize]).collect();
+    }
+}
+
+/// One rerank stage: rescores (a prefix of) the incoming candidates
+/// against a more precise representation and re-sorts them on the new
+/// basis.
+///
+/// Implementations must be cheap to construct per query — any per-query
+/// preparation (prepared query, LUT) happens inside
+/// [`Self::rescore`], which is called exactly once per query.
+pub(crate) trait RerankStage: Send + Sync {
+    /// Rescore the top `take_n` incoming candidates (the buffer arrives
+    /// sorted ascending on the previous basis), replace the buffer with
+    /// the rescored survivors sorted ascending on the new basis, and
+    /// report `true`. A candidate absent from this stage's backing data
+    /// is dropped (it cannot be scored on the new basis). Return
+    /// `Ok(false)` — leaving the buffer untouched — when the stage's
+    /// backing data is unavailable.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The raw query vector.
+    /// * `candidates` - The SoA candidate buffer, sorted ascending by
+    ///   the previous stage's distances.
+    /// * `take_n` - How many leading candidates to rescore (the
+    ///   caller-computed widening budget for this stage).
+    fn rescore(
+        &self,
+        query: &Vector,
+        candidates: &mut RerankCandidates,
+        take_n: usize,
+    ) -> Result<bool>;
+}
+
+/// Rescore against the exact f32 vectors in the LRS1 rerank sidecar
+/// (Issue #481 Stage 2) — the final, exact stage of every pipeline.
+pub(crate) struct F32SidecarStage {
+    pool: Arc<RerankStoragePool>,
+    /// `doc_id -> pool position` for the searched field, resolved once
+    /// at stage construction.
+    positions: Option<Arc<HashMap<u64, u32>>>,
+    metric: DistanceMetric,
+}
+
+impl F32SidecarStage {
+    /// Build the stage for one query against `field_name`.
+    ///
+    /// # Arguments
+    ///
+    /// * `pool` - The reader's loaded sidecar pool.
+    /// * `field_name` - The searched field (position index key).
+    /// * `metric` - The index's distance metric.
+    pub fn new(pool: Arc<RerankStoragePool>, field_name: &str, metric: DistanceMetric) -> Self {
+        let positions = pool.field_position_index(field_name);
+        Self {
+            pool,
+            positions,
+            metric,
+        }
+    }
+}
+
+impl RerankStage for F32SidecarStage {
+    fn rescore(
+        &self,
+        query: &Vector,
+        candidates: &mut RerankCandidates,
+        take_n: usize,
+    ) -> Result<bool> {
+        let prepared = self.metric.prepare_query(&query.data);
+        let take_n = take_n.min(candidates.len());
+        let mut rescored = RerankCandidates::with_capacity(take_n);
+        for i in 0..take_n {
+            let doc_id = candidates.doc_ids[i];
+            // A doc without a sidecar record for this field cannot be
+            // scored on the exact basis — drop it (pre-refactor
+            // behavior: the inline arm `continue`d on a missing
+            // position).
+            let Some(pos) = self
+                .positions
+                .as_ref()
+                .and_then(|idx| idx.get(&doc_id).copied())
+            else {
+                continue;
+            };
+            let distance = self
+                .metric
+                .distance_with_prepared(&prepared, self.pool.f32_slice_at(pos))?;
+            rescored.push(doc_id, distance);
+        }
+        rescored.sort_by_distance();
+        *candidates = rescored;
+        Ok(true)
+    }
+}
+
+/// Multi-stage rerank driver: stage `i` rescores the top
+/// `top_k * factors[i]` candidates of the previous basis.
+pub(crate) struct RerankPipeline {
+    stages: Vec<Box<dyn RerankStage>>,
+    /// Per-stage widening factors, parallel to `stages`.
+    factors: Vec<usize>,
+}
+
+impl RerankPipeline {
+    /// Build a pipeline from parallel `stages` / `factors`.
+    ///
+    /// # Panics
+    ///
+    /// Debug-asserts the two are the same length and non-empty.
+    pub fn new(stages: Vec<Box<dyn RerankStage>>, factors: Vec<usize>) -> Self {
+        debug_assert_eq!(stages.len(), factors.len());
+        debug_assert!(!stages.is_empty());
+        Self { stages, factors }
+    }
+
+    /// Run every stage over `candidates` (which must arrive sorted
+    /// ascending on the generation basis).
+    ///
+    /// # Returns
+    ///
+    /// Whether the FINAL stage applied — i.e. whether the surviving
+    /// scores sit on that stage's basis. For a pipeline ending in
+    /// [`F32SidecarStage`] this is exactly the
+    /// `score_basis = "f32-rerank"` condition the multi-segment fan-out
+    /// keys on (#927).
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The raw query vector.
+    /// * `candidates` - The generation-stage candidates, sorted
+    ///   ascending by distance.
+    /// * `top_k` - The caller-requested result count; stage `i`
+    ///   consumes at most `top_k * factors[i]` candidates.
+    pub fn run(
+        &self,
+        query: &Vector,
+        candidates: &mut RerankCandidates,
+        top_k: usize,
+    ) -> Result<bool> {
+        let mut last_applied = false;
+        for (stage, &factor) in self.stages.iter().zip(&self.factors) {
+            let take_n = top_k.saturating_mul(factor.max(1));
+            last_applied = stage.rescore(query, candidates, take_n)?;
+        }
+        Ok(last_applied)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A test stage that halves each distance and reverses nothing —
+    /// used to check narrowing and ordering mechanics without storage.
+    struct HalveStage;
+    impl RerankStage for HalveStage {
+        fn rescore(
+            &self,
+            _query: &Vector,
+            candidates: &mut RerankCandidates,
+            take_n: usize,
+        ) -> Result<bool> {
+            let take_n = take_n.min(candidates.len());
+            let mut out = RerankCandidates::with_capacity(take_n);
+            for i in 0..take_n {
+                out.push(candidates.doc_ids[i], candidates.distances[i] / 2.0);
+            }
+            out.sort_by_distance();
+            *candidates = out;
+            Ok(true)
+        }
+    }
+
+    /// A stage whose backing data is absent: must leave the buffer
+    /// untouched and report `false`.
+    struct AbsentStage;
+    impl RerankStage for AbsentStage {
+        fn rescore(
+            &self,
+            _query: &Vector,
+            _candidates: &mut RerankCandidates,
+            _take_n: usize,
+        ) -> Result<bool> {
+            Ok(false)
+        }
+    }
+
+    fn buffer(pairs: &[(u64, f32)]) -> RerankCandidates {
+        let mut c = RerankCandidates::with_capacity(pairs.len());
+        for &(id, d) in pairs {
+            c.push(id, d);
+        }
+        c
+    }
+
+    #[test]
+    fn sort_by_distance_breaks_ties_by_doc_id() {
+        let mut c = buffer(&[(9, 1.0), (2, 0.5), (7, 0.5)]);
+        c.sort_by_distance();
+        assert_eq!(c.doc_ids, vec![2, 7, 9]);
+        assert_eq!(c.distances, vec![0.5, 0.5, 1.0]);
+    }
+
+    #[test]
+    fn pipeline_narrows_by_per_stage_factor_and_reports_last_stage() {
+        let pipeline =
+            RerankPipeline::new(vec![Box::new(HalveStage), Box::new(HalveStage)], vec![3, 1]);
+        // top_k = 2: stage 1 takes 6 (all), stage 2 takes 2.
+        let mut c = buffer(&[(1, 1.0), (2, 2.0), (3, 3.0), (4, 4.0), (5, 5.0), (6, 6.0)]);
+        let applied = pipeline.run(&Vector::new(vec![0.0]), &mut c, 2).unwrap();
+        assert!(applied);
+        assert_eq!(c.doc_ids, vec![1, 2]);
+        assert_eq!(c.distances, vec![0.25, 0.5]);
+    }
+
+    #[test]
+    fn absent_final_stage_reports_not_applied_and_preserves_buffer() {
+        let pipeline = RerankPipeline::new(vec![Box::new(AbsentStage)], vec![4]);
+        let mut c = buffer(&[(1, 1.0), (2, 2.0)]);
+        let applied = pipeline.run(&Vector::new(vec![0.0]), &mut c, 1).unwrap();
+        assert!(!applied);
+        assert_eq!(c.doc_ids, vec![1, 2]);
+        assert_eq!(c.distances, vec![1.0, 2.0]);
+    }
+}

--- a/laurus/tests/rerank_pipeline_oracle_test.rs
+++ b/laurus/tests/rerank_pipeline_oracle_test.rs
@@ -1,0 +1,173 @@
+//! Frozen behavior oracle for the #650 PR-1 rerank refactor (#931).
+//!
+//! Captured against the pre-refactor inline HNSW Stage-2 implementation,
+//! this pins the observable rerank contract — result ordering AND exact
+//! score bits — across the rerank-on/off × single/multi-segment matrix,
+//! so porting the logic onto `RerankPipeline` must not change a bit.
+//!
+//! The expectations are computed independently (brute force over the raw
+//! f32 vectors + the public `DistanceMetric` conversion), not recorded as
+//! goldens: Stage-2 rescoring is exact-f32 against the sidecar, so the
+//! reranked results must equal the exact computation regardless of which
+//! implementation produced them. Grid-spaced vectors keep every ordering
+//! decision far outside int8 quantization error.
+
+use std::sync::Arc;
+
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::core::rerank::RerankStorageKind;
+use laurus::vector::index::VectorIndex;
+use laurus::vector::index::config::HnswIndexConfig;
+use laurus::vector::index::hnsw::segmented::SegmentedHnswIndex;
+use laurus::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryParams};
+use laurus::vector::{DistanceMetric, Vector};
+
+const DIM: usize = 8;
+const TOP_K: usize = 5;
+const RERANK_FACTOR: usize = 4;
+
+fn config() -> HnswIndexConfig {
+    HnswIndexConfig {
+        dimension: DIM,
+        m: 8,
+        ef_construction: 64,
+        normalize_vectors: false,
+        distance_metric: DistanceMetric::Euclidean,
+        rerank_storage: Some(RerankStorageKind::F32),
+        segmented: true,
+        ..Default::default()
+    }
+}
+
+/// Grid vector: all components `level * 10.0` — inter-doc distances dwarf
+/// quantization error, so orderings are deterministic.
+fn grid(level: f32) -> Vector {
+    Vector::new(vec![level * 10.0; DIM])
+}
+
+fn query(vector: &Vector, rerank: Option<usize>) -> VectorIndexQuery {
+    VectorIndexQuery {
+        query: vector.clone(),
+        params: VectorIndexQueryParams {
+            top_k: TOP_K,
+            ef_search: Some(256),
+            rerank_factor: rerank,
+            ..Default::default()
+        },
+        field_name: Some("v".to_string()),
+        filter: None,
+    }
+}
+
+/// Build an index from `batches` (one commit per batch). Returns the index
+/// and the live `(doc_id, level)` state (newest copy wins).
+fn build(batches: &[Vec<(u64, f32)>]) -> (SegmentedHnswIndex, Vec<(u64, f32)>) {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index =
+        SegmentedHnswIndex::open_or_create(storage as Arc<dyn Storage>, "vi", config()).unwrap();
+    let mut live: Vec<(u64, f32)> = Vec::new();
+    for batch in batches {
+        let docs: Vec<(u64, String, Vector)> = batch
+            .iter()
+            .map(|&(id, level)| (id, "v".to_string(), grid(level)))
+            .collect();
+        let mut w = index.writer().unwrap();
+        w.add_vectors(docs).unwrap();
+        w.commit().unwrap();
+        for &(id, level) in batch {
+            if let Some(entry) = live.iter_mut().find(|(d, _)| *d == id) {
+                entry.1 = level;
+            } else {
+                live.push((id, level));
+            }
+        }
+    }
+    (index, live)
+}
+
+/// Exact expected `(doc_id, similarity_bits)` top-k for a query at
+/// `q_level`, computed from raw f32 vectors through the public metric API —
+/// the same arithmetic the exact-f32 sidecar rescoring performs.
+fn expected(live: &[(u64, f32)], q_level: f32) -> Vec<(u64, u32)> {
+    let metric = DistanceMetric::Euclidean;
+    let q = grid(q_level);
+    let mut d: Vec<(f32, u64)> = live
+        .iter()
+        .map(|&(id, level)| (metric.distance(&q.data, &grid(level).data).unwrap(), id))
+        .collect();
+    d.sort_by(|a, b| a.0.total_cmp(&b.0).then(a.1.cmp(&b.1)));
+    d.truncate(TOP_K);
+    d.into_iter()
+        .map(|(dist, id)| (id, metric.distance_to_similarity(dist).to_bits()))
+        .collect()
+}
+
+fn run_case(batches: &[Vec<(u64, f32)>], q_levels: &[f32]) {
+    let (index, live) = build(batches);
+    let searcher = index.searcher().unwrap();
+
+    for &q_level in q_levels {
+        // Rerank ON: order and score bits must equal the exact-f32
+        // computation (the sidecar holds the raw vectors).
+        let reranked = searcher
+            .search(&query(&grid(q_level), Some(RERANK_FACTOR)))
+            .unwrap();
+        let got: Vec<(u64, u32)> = reranked
+            .results
+            .iter()
+            .map(|r| (r.doc_id, r.similarity.to_bits()))
+            .collect();
+        assert_eq!(
+            got,
+            expected(&live, q_level),
+            "rerank-on at q={q_level} must match the exact f32 oracle bit-for-bit"
+        );
+
+        // Rerank OFF: same doc set (grid separation makes int8 ordering
+        // agree with exact ordering), and the call must succeed — the
+        // scores travel the quantized/shared-basis path, which the
+        // refactor must leave untouched. Deterministic across runs.
+        let plain = searcher.search(&query(&grid(q_level), None)).unwrap();
+        let plain_ids: Vec<u64> = plain.results.iter().map(|r| r.doc_id).collect();
+        let expected_ids: Vec<u64> = expected(&live, q_level).iter().map(|&(id, _)| id).collect();
+        assert_eq!(
+            plain_ids, expected_ids,
+            "rerank-off at q={q_level}: grid separation must keep the quantized order exact"
+        );
+        let plain2 = searcher.search(&query(&grid(q_level), None)).unwrap();
+        let bits1: Vec<u32> = plain
+            .results
+            .iter()
+            .map(|r| r.similarity.to_bits())
+            .collect();
+        let bits2: Vec<u32> = plain2
+            .results
+            .iter()
+            .map(|r| r.similarity.to_bits())
+            .collect();
+        assert_eq!(bits1, bits2, "rerank-off must be bit-deterministic");
+    }
+}
+
+/// Single sealed segment: the per-segment searcher's Stage-2 arm runs with
+/// the fan-out's serial single-reader branch.
+#[test]
+fn oracle_single_segment() {
+    let batches = vec![(0..20u64).map(|i| (i, i as f32)).collect::<Vec<_>>()];
+    run_case(&batches, &[0.2, 7.3, 13.6, 19.0]);
+}
+
+/// Three sealed segments with a cross-segment stale duplicate: exercises
+/// the fan-out's newest-wins masking together with the exact-basis skip
+/// (#927) under rerank.
+#[test]
+fn oracle_multi_segment_with_stale_duplicate() {
+    let batches = vec![
+        (0..10u64).map(|i| (i, i as f32)).collect::<Vec<_>>(),
+        (10..20u64).map(|i| (i, i as f32)).collect::<Vec<_>>(),
+        // Newer copy of doc 3 far from its stale position.
+        vec![(20u64, 20.0), (21u64, 21.0), (3u64, 15.5)],
+    ];
+    run_case(&batches, &[0.2, 3.1, 15.4, 20.6]);
+}


### PR DESCRIPTION
## Summary

PR-1 of the #650 rerank-pipeline campaign: extracts Stage-2 rerank (Issue #481) from its inline match arm in the HNSW searcher into a shared, composable abstraction — with **zero behavior change**, proven bit-for-bit by a frozen oracle.

- **New `vector/search/rerank.rs`** (crate-private): the object-safe `RerankStage` trait (a stage's per-query preparation coincides with its single per-query invocation, so it folds into `rescore` — the object-safety deviation from the #650 sketch, recorded on #931), the SoA `RerankCandidates` buffer (parallel `doc_ids`/`distances`, crate-wide distance-ascending + doc-id-tiebreak sort per #927/#933), and the `RerankPipeline` driver: stage `i` consumes the top `top_k * factors[i]` of the previous basis, and `run` reports whether the FINAL stage applied — exactly the `score_basis = "f32-rerank"` condition the multi-segment fan-out keys on (#927).
- **`F32SidecarStage`**: the former inline arm as a stage — field position index resolved at construction, query prepared once, rescoring against `pool.f32_slice_at`, docs absent from the sidecar dropped (pre-refactor `continue` semantics).
- **HNSW port**: `finalize_graph_results` builds a one-stage pipeline from `(rerank_factor, reader.rerank_storage())`, feeds it the ascending int8 candidates (matching the pre-refactor `into_sorted_vec().take(widened)` prefix), takes `rerank_applied` from the pipeline's return, and the inline arm is deleted. No public API change.

## Zero-behavior-change evidence

- **Frozen oracle** (`rerank_pipeline_oracle_test.rs`, captured against the pre-refactor implementation on the post-#933 baseline): rerank-on results equal an independently-computed exact-f32 expectation **bit-for-bit** (doc ids + similarity bits); rerank-off stays exact-ordered and bit-deterministic; single-segment and multi-segment-with-stale-duplicate fixtures. Green after the port. (Writing this oracle is what exposed #933, fixed first in PR #934.)
- Existing `vector_rerank_engine_test` (Stage-2 applied + silent Stage-1 fallback), the #927 comparability suite, and the #933 distance-sort suite: green unchanged.
- 3 unit tests for pipeline mechanics (tiebreak sort, per-stage narrowing + last-stage reporting, absent-stage pass-through).

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean on stable and 1.97.0
- `cargo test -p laurus --lib`: 1261 passed; `--tests`: all 66 binaries ok
- wasm32 `cargo check -p laurus-wasm`: clean; `cargo doc --no-deps -p laurus`: 73 warnings (baseline)

Closes #931. Part of #650; unblocks #932 (Flat/IVF adoption) and keeps #673's 3-stage chain expressible.
