### PR TITLE
feat(cli): train pq-codebook --from-index samples committed vectors (#920 sub-item 1)

### DIFF
--- a/docs/ja/src/concepts/indexing/vector_indexing.md
+++ b/docs/ja/src/concepts/indexing/vector_indexing.md
@@ -485,11 +485,14 @@ subvector_count = 32
 laurus train pq-codebook --field embedding --input vectors.jsonl --update-schema
 ```
 
-またはプログラムから
+（`--input` の代わりに `--from-index` でインデックスにコミット済みの
+ベクトルを直接サンプリングすることもできます、Issue #920）、または
+プログラムから
 [`Engine::train_pq_codebook`](https://docs.rs/laurus/latest/laurus/struct.Engine.html)
-（`engine.train_pq_codebook("embedding", &vectors, None)`）を使い
-ます。学習は同期・CPU-bound で、代表的なベクトル数千件で十分です
-（全コーパスは不要）。
+（`engine.train_pq_codebook("embedding", &vectors, None)`。from-index
+フローには `engine.sample_committed_vectors("embedding", Some(n))` を
+組み合わせます）を使います。学習は同期・CPU-bound で、代表的な
+ベクトル数千件で十分です（全コーパスは不要）。
 
 セマンティクス:
 

--- a/docs/ja/src/laurus-cli/commands.md
+++ b/docs/ja/src/laurus-cli/commands.md
@@ -404,15 +404,16 @@ commit と merge のすべてで再利用します — segment ごとの k-means
 小さな per-commit segment も PQ を維持します。
 
 ```bash
-laurus train pq-codebook --field <FIELD> --input <JSONL> \
+laurus train pq-codebook --field <FIELD> (--input <JSONL> | --from-index) \
     [--sample-size <N>] [--output <NAME>] [--update-schema]
 ```
 
 | 引数 | 説明 |
 | :--- | :--- |
 | `--field` | 学習対象の HNSW ベクトルフィールド。`ProductQuantization` quantizer が設定されている必要があります。 |
-| `--input` | JSONL 学習ファイル — `put docs` / `add docs` と同じ `{"id": "...", "document": {"fields": {...}}}` 形式。フィールド値は事前計算済み `Vector` である必要があります（embedder 生成の入力は未対応）。 |
-| `--sample-size` | ファイルの先頭 N 件のみを使用（決定的）。省略時は全件を使用。代表的なベクトル数千件で十分です。 |
+| `--input` | JSONL 学習ファイル — `put docs` / `add docs` と同じ `{"id": "...", "document": {"fields": {...}}}` 形式。フィールド値は事前計算済み `Vector` である必要があります（embedder 生成の入力は未対応）。`--input` と `--from-index` はどちらか一方のみ指定できます。 |
+| `--from-index` | ファイルの代わりに、このインデックスにコミット済みのベクトルを直接サンプリングします（Issue #920）— JSONL エクスポート不要。`--input` と `--from-index` はどちらか一方のみ指定できます。注意: 既に PQ エンコード済みのフィールドではサンプルは有損の再構成ベクトルになります。想定フローはフィールドの PQ 有効化**前**にコミットしたベクトルからの学習です。 |
+| `--sample-size` | 先頭 N 件のみを使用（決定的: `--input` はファイル順、`--from-index` は doc_id 昇順）。省略時は全件を使用。代表的なベクトル数千件で十分です。 |
 | `--output` | ストレージ相対の codebook ファイル名。デフォルトはフィールドの `pq_codebook_path`、未設定なら `{field}.pqcb`。稼働中の codebook の横に v2 を学習する場合に使用。 |
 | `--update-schema` | フィールドの `pq_codebook_path` が学習済みファイルを指すよう `schema.toml` を書き換えます。 |
 
@@ -437,6 +438,13 @@ laurus train pq-codebook --field embedding --input train.jsonl --update-schema
 # Training PQ codebook for field 'embedding' on 2 vectors...
 # Trained codebook 'embedding.pqcb' (m = 2, k = 256, sub_dim = 2, dimension = 4) from 2 vectors.
 # Updated schema.toml: embedding.pq_codebook_path = "embedding.pqcb".
+```
+
+または、インデックスにコミット済みのベクトルから直接サンプリングします
+— JSONL エクスポートは不要です:
+
+```bash
+laurus train pq-codebook --field embedding --from-index --sample-size 5000 --update-schema
 ```
 
 ---

--- a/docs/src/concepts/indexing/vector_indexing.md
+++ b/docs/src/concepts/indexing/vector_indexing.md
@@ -508,11 +508,13 @@ subvector_count = 32
 laurus train pq-codebook --field embedding --input vectors.jsonl --update-schema
 ```
 
-or programmatically via
+(or `--from-index` in place of `--input` to sample vectors already
+committed to the index, Issue #920), or programmatically via
 [`Engine::train_pq_codebook`](https://docs.rs/laurus/latest/laurus/struct.Engine.html)
-(`engine.train_pq_codebook("embedding", &vectors, None)`). Training is
-CPU-bound and synchronous; thousands of representative vectors are
-enough — the full corpus is not required.
+(`engine.train_pq_codebook("embedding", &vectors, None)`; pair with
+`engine.sample_committed_vectors("embedding", Some(n))` for the
+from-index flow). Training is CPU-bound and synchronous; thousands of
+representative vectors are enough — the full corpus is not required.
 
 Semantics:
 

--- a/docs/src/laurus-cli/commands.md
+++ b/docs/src/laurus-cli/commands.md
@@ -408,15 +408,16 @@ per segment — commits on PQ fields get dramatically faster, and even
 tiny per-commit segments stay on PQ.
 
 ```bash
-laurus train pq-codebook --field <FIELD> --input <JSONL> \
+laurus train pq-codebook --field <FIELD> (--input <JSONL> | --from-index) \
     [--sample-size <N>] [--output <NAME>] [--update-schema]
 ```
 
 | Argument | Description |
 | :--- | :--- |
 | `--field` | The HNSW vector field to train for. Must be configured with a `ProductQuantization` quantizer. |
-| `--input` | JSONL training file — the same `{"id": "...", "document": {"fields": {...}}}` shape as `put docs` / `add docs`. The field value must be a pre-computed `Vector` (embedder-generated input is not supported). |
-| `--sample-size` | Use only the first N vectors of the file (deterministic). Omit to use all of them; thousands of representative vectors are enough. |
+| `--input` | JSONL training file — the same `{"id": "...", "document": {"fields": {...}}}` shape as `put docs` / `add docs`. The field value must be a pre-computed `Vector` (embedder-generated input is not supported). Exactly one of `--input` and `--from-index` must be given. |
+| `--from-index` | Sample the vectors already committed to this index instead of reading a file (Issue #920) — no JSONL export needed. Exactly one of `--input` and `--from-index` must be given. Note: on a field that is already PQ-encoded, the sampled vectors are lossy reconstructions; the intended flow is to train from vectors committed **before** enabling PQ on the field. |
+| `--sample-size` | Use only the first N vectors (deterministic: file order for `--input`, ascending doc_id for `--from-index`). Omit to use all of them; thousands of representative vectors are enough. |
 | `--output` | Storage-relative codebook file name. Defaults to the field's configured `pq_codebook_path`, else `{field}.pqcb`. Use to train a v2 codebook alongside a live one. |
 | `--update-schema` | Rewrite `schema.toml` so the field's `pq_codebook_path` names the trained file. |
 
@@ -441,6 +442,13 @@ laurus train pq-codebook --field embedding --input train.jsonl --update-schema
 # Training PQ codebook for field 'embedding' on 2 vectors...
 # Trained codebook 'embedding.pqcb' (m = 2, k = 256, sub_dim = 2, dimension = 4) from 2 vectors.
 # Updated schema.toml: embedding.pq_codebook_path = "embedding.pqcb".
+```
+
+Or sample directly from the vectors already committed to the index —
+no JSONL export needed:
+
+```bash
+laurus train pq-codebook --field embedding --from-index --sample-size 5000 --update-schema
 ```
 
 ---

--- a/laurus-cli/src/cli.rs
+++ b/laurus-cli/src/cli.rs
@@ -250,23 +250,30 @@ pub struct TrainCommand {
 pub enum TrainResource {
     /// Train a shared PQ codebook for an HNSW vector field (Issue #631).
     ///
-    /// Reads training vectors from a JSONL file (the same
+    /// Reads training vectors either from a JSONL file (--input, the same
     /// `{"id": "...", "document": {"fields": {...}}}` shape as `put docs` /
-    /// `add docs`; the field value must be a pre-computed `Vector`) and
-    /// persists the codebook into the index's vector storage. Subsequent
-    /// commits encode segments against it instead of re-training k-means
-    /// per segment — provided the schema's `pq_codebook_path` names the
-    /// trained file (pass --update-schema to set it automatically).
+    /// `add docs`; the field value must be a pre-computed `Vector`) or from
+    /// the vectors already committed to this index (--from-index, Issue
+    /// #920), and persists the codebook into the index's vector storage.
+    /// Subsequent commits encode segments against it instead of re-training
+    /// k-means per segment — provided the schema's `pq_codebook_path` names
+    /// the trained file (pass --update-schema to set it automatically).
     PqCodebook {
         /// The HNSW vector field to train for. Must be configured with
         /// ProductQuantization.
         #[arg(long)]
         field: String,
-        /// Path to the JSONL training file.
+        /// Path to the JSONL training file. Exactly one of --input and
+        /// --from-index must be given.
         #[arg(long)]
-        input: std::path::PathBuf,
-        /// Use only the first N vectors of the file (deterministic;
-        /// omit to use all of them).
+        input: Option<std::path::PathBuf>,
+        /// Sample the vectors already committed to this index instead of
+        /// reading a JSONL file (Issue #920). Exactly one of --input and
+        /// --from-index must be given.
+        #[arg(long, default_value_t = false)]
+        from_index: bool,
+        /// Use only the first N vectors (deterministic: file order for
+        /// --input, ascending doc_id for --from-index; omit to use all).
         #[arg(long)]
         sample_size: Option<usize>,
         /// Storage-relative codebook file name (defaults to the field's

--- a/laurus-cli/src/commands/train.rs
+++ b/laurus-cli/src/commands/train.rs
@@ -1,9 +1,10 @@
 //! Implementation for the `train pq-codebook` subcommand (Issue #631).
 //!
-//! Trains a shared PQ codebook for one HNSW vector field from a JSONL
-//! file — the same `{"id": "...", "document": {"fields": {...}}}` shape
-//! the bulk-ingest commands read — and persists it into the index's
-//! vector storage namespace via
+//! Trains a shared PQ codebook for one HNSW vector field — from a JSONL
+//! file (the same `{"id": "...", "document": {"fields": {...}}}` shape
+//! the bulk-ingest commands read), or with `--from-index` (Issue #920)
+//! from the vectors already committed to the index itself — and persists
+//! it into the index's vector storage namespace via
 //! [`Engine::train_pq_codebook`](laurus::Engine::train_pq_codebook).
 //! Subsequent engine opens (the next `add` / `put` / `commit` CLI
 //! invocation) pick the codebook up through the field's
@@ -22,18 +23,24 @@ use crate::context;
 
 /// Execute the `train pq-codebook` command.
 ///
-/// Reads `input` line by line (blank lines are skipped), extracts the
-/// pre-computed vector value of `field` from each entry, and trains the
-/// codebook on the collected vectors (all of them, or the first
-/// `sample_size` when set — deterministic, no random sampling). With
-/// `update_schema`, the index's `schema.toml` is rewritten afterwards so
-/// the field's `pq_codebook_path` names the trained file.
+/// Collects training vectors from exactly one of two sources — a JSONL
+/// file (`input`: read line by line, blank lines skipped, each entry's
+/// pre-computed vector value for `field` extracted) or the index itself
+/// (`from_index`: the vectors already committed for `field`, in
+/// ascending doc_id order, Issue #920) — and trains the codebook on the
+/// collected vectors (all of them, or the first `sample_size` when set
+/// — deterministic, no random sampling). With `update_schema`, the
+/// index's `schema.toml` is rewritten afterwards so the field's
+/// `pq_codebook_path` names the trained file.
 ///
 /// # Arguments
 ///
 /// * `field` - The HNSW vector field to train for. Must be configured
 ///   with `ProductQuantization`.
 /// * `input` - Path to the JSONL training file (bulk-ingest shape).
+///   Mutually exclusive with `from_index`.
+/// * `from_index` - Sample the vectors already committed to the index
+///   instead of reading a file. Mutually exclusive with `input`.
 /// * `sample_size` - Optional cap: only the first N vectors are used.
 /// * `output` - Optional storage-relative codebook file name override
 ///   (defaults to the field's configured `pq_codebook_path`, else
@@ -44,14 +51,16 @@ use crate::context;
 ///
 /// # Errors
 ///
-/// Returns an error if the index cannot be opened, the file cannot be
-/// read, an entry fails to parse, an entry lacks a pre-computed vector
-/// for `field` (the message names the line; embedder-generated training
-/// input is not supported), training fails (wrong field type, empty
-/// sample, dimension mismatch), or the schema rewrite fails.
+/// Returns an error if neither or both of `input` / `from_index` are
+/// given, the index cannot be opened, the file cannot be read, an entry
+/// fails to parse, an entry lacks a pre-computed vector for `field` (the
+/// message names the line; embedder-generated training input is not
+/// supported), no vectors are found, training fails (wrong field type,
+/// empty sample, dimension mismatch), or the schema rewrite fails.
 pub async fn run_pq_codebook(
     field: &str,
-    input: &Path,
+    input: Option<&Path>,
+    from_index: bool,
     sample_size: Option<usize>,
     output: Option<&str>,
     update_schema: bool,
@@ -60,43 +69,64 @@ pub async fn run_pq_codebook(
     if sample_size == Some(0) {
         bail!("--sample-size must be greater than 0");
     }
+    match (input.is_some(), from_index) {
+        (true, true) => bail!("--input and --from-index are mutually exclusive"),
+        (false, false) => bail!("either --input or --from-index must be given"),
+        _ => {}
+    }
 
     let engine = context::open_index(index_dir).await?;
 
-    let reader = std::io::BufReader::new(
-        std::fs::File::open(input)
-            .with_context(|| format!("failed to open JSONL file '{}'", input.display()))?,
-    );
+    let vectors: Vec<Vector> = if from_index {
+        engine.sample_committed_vectors(field, sample_size)?
+    } else {
+        // Checked above: when `from_index` is false, `input` is Some.
+        let input = input.expect("validated: --input given when --from-index is not");
+        let reader = std::io::BufReader::new(
+            std::fs::File::open(input)
+                .with_context(|| format!("failed to open JSONL file '{}'", input.display()))?,
+        );
 
-    let mut vectors: Vec<Vector> = Vec::new();
-    for (index, line) in reader.lines().enumerate() {
-        let line_no = index + 1;
-        let line = line.with_context(|| format!("line {line_no}: failed to read"))?;
-        if line.trim().is_empty() {
-            continue;
+        let mut vectors: Vec<Vector> = Vec::new();
+        for (index, line) in reader.lines().enumerate() {
+            let line_no = index + 1;
+            let line = line.with_context(|| format!("line {line_no}: failed to read"))?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let (_, doc) = parse_entry(&line, line_no)?;
+            let Some(value) = doc.fields.get(field) else {
+                bail!("line {line_no}: entry has no '{field}' field");
+            };
+            let Some(data) = value.as_vector() else {
+                bail!(
+                    "line {line_no}: field '{field}' is not a pre-computed vector \
+                     (embedder-generated training input is not supported; provide \
+                     `{{\"{field}\": {{\"Vector\": [..]}}}}` values)"
+                );
+            };
+            vectors.push(Vector::new(data.clone()));
+            if let Some(cap) = sample_size
+                && vectors.len() >= cap
+            {
+                break;
+            }
         }
-        let (_, doc) = parse_entry(&line, line_no)?;
-        let Some(value) = doc.fields.get(field) else {
-            bail!("line {line_no}: entry has no '{field}' field");
-        };
-        let Some(data) = value.as_vector() else {
-            bail!(
-                "line {line_no}: field '{field}' is not a pre-computed vector \
-                 (embedder-generated training input is not supported; provide \
-                 `{{\"{field}\": {{\"Vector\": [..]}}}}` values)"
-            );
-        };
-        vectors.push(Vector::new(data.clone()));
-        if let Some(cap) = sample_size
-            && vectors.len() >= cap
-        {
-            break;
-        }
-    }
+        vectors
+    };
     if vectors.is_empty() {
+        if from_index {
+            bail!(
+                "no committed vectors found in the index at '{}' for field '{field}' \
+                 (commit some documents first, or train from a JSONL file via --input)",
+                index_dir.display()
+            );
+        }
         bail!(
             "no training vectors found in '{}' for field '{field}'",
-            input.display()
+            input
+                .expect("validated: --input given when --from-index is not")
+                .display()
         );
     }
 
@@ -199,9 +229,17 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let jsonl = setup(dir.path(), 300, None);
 
-        run_pq_codebook("embedding", &jsonl, None, None, true, dir.path())
-            .await
-            .unwrap();
+        run_pq_codebook(
+            "embedding",
+            Some(&jsonl),
+            false,
+            None,
+            None,
+            true,
+            dir.path(),
+        )
+        .await
+        .unwrap();
 
         // schema.toml now names the codebook.
         let schema = context::read_schema(dir.path()).unwrap();
@@ -241,7 +279,8 @@ mod tests {
 
         run_pq_codebook(
             "embedding",
-            &jsonl,
+            Some(&jsonl),
+            false,
             Some(280),
             Some("embedding.v2.pqcb"),
             false,
@@ -253,6 +292,134 @@ mod tests {
         assert!(dir.path().join("store/vector/embedding.v2.pqcb").exists());
         let after = std::fs::read_to_string(dir.path().join("schema.toml")).unwrap();
         assert_eq!(before, after, "schema.toml must stay untouched");
+    }
+
+    /// Write the schema and ingest+commit `count` deterministic vectors so
+    /// `--from-index` has committed data to sample (Issue #920). Returns
+    /// after the commit; the engine is dropped so the training run reopens
+    /// the index fresh.
+    async fn setup_committed_index(dir: &Path, count: usize) {
+        setup(dir, 0, None); // schema.toml only; the JSONL is empty/unused.
+        let engine = context::open_index(dir).await.unwrap();
+        let mut state = 0x9876_5432_u64;
+        for i in 0..count {
+            let data: Vec<f32> = (0..DIM)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                })
+                .collect();
+            let doc = Document::builder()
+                .add_field("embedding", DataValue::Vector(data))
+                .build();
+            engine.put_document(&format!("doc{i}"), doc).await.unwrap();
+        }
+        engine.commit().await.unwrap();
+    }
+
+    /// Issue #920: `--from-index` trains from the committed vectors —
+    /// no JSONL file involved — and `--update-schema` still rewrites
+    /// `pq_codebook_path`. A subsequent tiny commit must encode against
+    /// the shared codebook (it would hard-error without one).
+    #[tokio::test]
+    async fn train_from_index_uses_committed_vectors_and_updates_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_committed_index(dir.path(), 300).await;
+
+        run_pq_codebook("embedding", None, true, None, None, true, dir.path())
+            .await
+            .unwrap();
+
+        let schema = context::read_schema(dir.path()).unwrap();
+        let Some(FieldOption::Hnsw(opt)) = schema.fields.get("embedding") else {
+            panic!("embedding field must survive the schema rewrite");
+        };
+        assert_eq!(opt.pq_codebook_path.as_deref(), Some("embedding.pqcb"));
+        assert!(dir.path().join("store/vector/embedding.pqcb").exists());
+
+        // A reopened engine commits a tiny batch on the shared codebook.
+        let engine = context::open_index(dir.path()).await.unwrap();
+        let doc = Document::builder()
+            .add_field(
+                "embedding",
+                DataValue::Vector((0..DIM).map(|j| j as f32 * 0.01).collect()),
+            )
+            .build();
+        engine.put_document("extra", doc).await.unwrap();
+        engine.commit().await.unwrap();
+    }
+
+    /// Issue #920: `--sample-size` caps the committed vectors used under
+    /// `--from-index` too (first N by ascending doc_id).
+    #[tokio::test]
+    async fn train_from_index_honors_sample_size() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_committed_index(dir.path(), 300).await;
+
+        run_pq_codebook(
+            "embedding",
+            None,
+            true,
+            Some(280),
+            Some("embedding.v2.pqcb"),
+            false,
+            dir.path(),
+        )
+        .await
+        .unwrap();
+
+        assert!(dir.path().join("store/vector/embedding.v2.pqcb").exists());
+    }
+
+    /// Issue #920: exactly one of `--input` / `--from-index` must be
+    /// given — both and neither are rejected up front.
+    #[tokio::test]
+    async fn train_rejects_conflicting_or_missing_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl = setup(dir.path(), 1, None);
+
+        let err = run_pq_codebook(
+            "embedding",
+            Some(&jsonl),
+            true,
+            None,
+            None,
+            false,
+            dir.path(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "both sources must be rejected: {err}"
+        );
+
+        let err = run_pq_codebook("embedding", None, false, None, None, false, dir.path())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("either --input or --from-index must be given"),
+            "no source must be rejected: {err}"
+        );
+    }
+
+    /// Issue #920: `--from-index` on an index with no committed vectors
+    /// for the field errors with a message pointing at both remedies.
+    #[tokio::test]
+    async fn train_from_index_errors_on_empty_index() {
+        let dir = tempfile::tempdir().unwrap();
+        setup(dir.path(), 0, None); // schema only, nothing committed.
+
+        let err = run_pq_codebook("embedding", None, true, None, None, false, dir.path())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no committed vectors"),
+            "empty index must be named: {err}"
+        );
     }
 
     /// A non-vector value for the field names the failing line.
@@ -267,9 +434,17 @@ mod tests {
         )
         .unwrap();
 
-        let err = run_pq_codebook("embedding", &jsonl, None, None, false, dir.path())
-            .await
-            .unwrap_err();
+        let err = run_pq_codebook(
+            "embedding",
+            Some(&jsonl),
+            false,
+            None,
+            None,
+            false,
+            dir.path(),
+        )
+        .await
+        .unwrap_err();
         assert!(
             err.to_string().contains("line 1"),
             "error must name the line: {err}"

--- a/laurus-cli/src/main.rs
+++ b/laurus-cli/src/main.rs
@@ -95,13 +95,15 @@ async fn main() -> Result<()> {
             TrainResource::PqCodebook {
                 field,
                 input,
+                from_index,
                 sample_size,
                 output,
                 update_schema,
             } => {
                 train::run_pq_codebook(
                     &field,
-                    &input,
+                    input.as_deref(),
+                    from_index,
                     sample_size,
                     output.as_deref(),
                     update_schema,

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -1770,6 +1770,40 @@ impl Engine {
         self.vector.warmup()
     }
 
+    /// Sample up to `sample_size` vectors already committed for `field`,
+    /// suitable as [`Self::train_pq_codebook`] input without a separate
+    /// JSONL export (Issue #920).
+    ///
+    /// Ordered by ascending doc_id for determinism — the same "first N"
+    /// semantics `laurus train pq-codebook`'s JSONL path already uses,
+    /// just drawn from committed segments instead of a training file. See
+    /// [`VectorStore::sample_field_vectors`](crate::vector::store::VectorStore::sample_field_vectors)
+    /// for the full ordering/emptiness contract.
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Vector field to sample. An unknown or vector-less
+    ///   field yields an empty `Vec`, not an error.
+    /// * `sample_size` - Maximum number of vectors to return. `None`
+    ///   returns every committed vector for the field.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if obtaining the reader or reading the field's
+    /// vectors fails.
+    pub fn sample_committed_vectors(
+        &self,
+        field: &str,
+        sample_size: Option<usize>,
+    ) -> Result<Vec<Vector>> {
+        Ok(self
+            .vector
+            .sample_field_vectors(field, sample_size)?
+            .into_iter()
+            .map(|(_, v)| v)
+            .collect())
+    }
+
     /// Train a shared PQ codebook for `field` and persist it into the
     /// engine's vector storage namespace (Issue #631).
     ///

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -937,6 +937,43 @@ impl VectorStore {
         })
     }
 
+    /// Sample up to `limit` `(doc_id, vector)` pairs already committed for
+    /// `field`.
+    ///
+    /// Ordered by ascending doc_id for determinism —
+    /// [`get_vectors_by_field`](crate::vector::reader::VectorIndexReader::get_vectors_by_field)
+    /// returns vectors in sealed-segment (newest-generation-first) order,
+    /// not doc_id order, so this sorts before truncating (Issue #920:
+    /// mirrors the `laurus train pq-codebook` JSONL path's "first N,
+    /// deterministic" sampling semantics, just drawn from committed
+    /// segments instead of a training file).
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Vector field to sample. An unknown or vector-less
+    ///   field yields an empty `Vec`, not an error (matches
+    ///   `get_vectors_by_field`'s own convention).
+    /// * `limit` - Maximum number of pairs to return. `None` returns
+    ///   every committed vector for the field.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if obtaining the reader or reading the field's
+    /// vectors fails.
+    pub fn sample_field_vectors(
+        &self,
+        field: &str,
+        limit: Option<usize>,
+    ) -> Result<Vec<(u64, Vector)>> {
+        let reader = self.index.reader()?;
+        let mut vectors = reader.get_vectors_by_field(field)?;
+        vectors.sort_unstable_by_key(|(doc_id, _)| *doc_id);
+        if let Some(limit) = limit {
+            vectors.truncate(limit);
+        }
+        Ok(vectors)
+    }
+
     /// Get the storage backend.
     pub fn storage(&self) -> &Arc<dyn Storage> {
         self.index.storage()
@@ -1083,6 +1120,70 @@ mod tests {
         assert!(!store.is_closed());
         store.close().await.unwrap();
         assert!(store.is_closed());
+    }
+
+    /// Build a `VectorStore` (Flat, Euclidean — no normalization, so the
+    /// dequantized round-trip is easy to bound) and commit `n` vectors
+    /// under `field`, one dimension of value `doc_id as f32` (so exact
+    /// identity is trivially checkable modulo int8 quantization error).
+    async fn store_with_committed_vectors(field: &str, doc_ids: &[u64]) -> VectorStore {
+        use crate::vector::index::config::FlatIndexConfig;
+
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let config = VectorIndexTypeConfig::Flat(FlatIndexConfig {
+            dimension: 4,
+            distance_metric: crate::vector::core::distance::DistanceMetric::Euclidean,
+            ..Default::default()
+        });
+        let store = VectorStore::with_index_type_config(storage, config).unwrap();
+
+        for &doc_id in doc_ids {
+            let doc = Document::builder()
+                .add_field(field, DataValue::Vector(vec![doc_id as f32; 4]))
+                .build();
+            store
+                .upsert_document_by_internal_id(doc_id, doc)
+                .await
+                .unwrap();
+        }
+        store.commit().await.unwrap();
+        store
+    }
+
+    /// Issue #920: `sample_field_vectors` must return committed vectors
+    /// sorted by ascending doc_id, regardless of commit/insertion order —
+    /// `get_vectors_by_field`'s underlying sealed-segment order is
+    /// newest-generation-first, not doc_id order.
+    #[tokio::test]
+    async fn sample_field_vectors_orders_by_ascending_doc_id() {
+        let store = store_with_committed_vectors("embedding", &[30, 10, 20]).await;
+
+        let sampled = store.sample_field_vectors("embedding", None).unwrap();
+        let ids: Vec<u64> = sampled.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![10, 20, 30]);
+    }
+
+    /// `limit` truncates to the first N by doc_id; `None` returns all.
+    #[tokio::test]
+    async fn sample_field_vectors_respects_limit() {
+        let store = store_with_committed_vectors("embedding", &[5, 1, 3, 2, 4]).await;
+
+        let limited = store.sample_field_vectors("embedding", Some(2)).unwrap();
+        let ids: Vec<u64> = limited.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![1, 2]);
+
+        let all = store.sample_field_vectors("embedding", None).unwrap();
+        assert_eq!(all.len(), 5);
+    }
+
+    /// An unknown field yields an empty `Vec`, not an error — matches
+    /// `get_vectors_by_field`'s own convention.
+    #[tokio::test]
+    async fn sample_field_vectors_returns_empty_for_unknown_field() {
+        let store = store_with_committed_vectors("embedding", &[1, 2]).await;
+
+        let sampled = store.sample_field_vectors("no_such_field", None).unwrap();
+        assert!(sampled.is_empty());
     }
 
     /// Issue #790: the store-level config conversion must carry


### PR DESCRIPTION
## Summary

- First of three independent sub-items of #920 (PQ shared-codebook follow-ups from the #631 campaign). Refs #920 — does not close it; sub-items 2 (FastScan shared-codebook) and 3 (`create index --train-pq-codebook`) remain open.
- Adds a `--from-index` flag to `laurus train pq-codebook`: sample the vectors already committed to the index instead of requiring a separate JSONL export. Modeled as a boolean (not a path) because the CLI has exactly one open index per invocation via the global `index_dir`.

## Changes

- `VectorStore::sample_field_vectors(field, limit) -> Result<Vec<(u64, Vector)>>` (new): reader → `get_vectors_by_field` → **sort by ascending doc_id** → truncate. The fan-out's underlying order is newest-segment-first, so sorting is what makes the "first N, deterministic" semantics (shared with the JSONL path) meaningful rather than biased toward the latest commits. Unknown field yields `Ok(vec![])`, matching `get_vectors_by_field`'s convention.
- `Engine::sample_committed_vectors(field, sample_size) -> Result<Vec<Vector>>` (new): thin delegation.
- CLI: `--input` became optional, new `--from-index` flag; exactly-one-source validation up front; only the vector-collection step branches — the train call and `--update-schema` handling stay shared. The empty-index case errors with a message naming both remedies.
- Docs (EN+JA): `laurus-cli/commands.md` usage/argument table/example (including the lossy-reconstruction caveat for already-PQ-encoded fields); `vector_indexing.md` shared-codebook section.

## Tests

- Unit ×3 (`vector/store.rs`): doc_id-ascending ordering, `limit` truncation / `None` returns all, unknown field → empty not error.
- Integration ×4 (`laurus-cli/src/commands/train.rs`): from-index e2e (ingest+commit 300 → train → `--update-schema` → reopened tiny commit encodes against the shared codebook, which would hard-error without one); `--sample-size` under from-index; both-sources / no-source rejection; empty-index error.
- RED proof: reversibly stubbing `sample_committed_vectors` to return `vec![]` fails both from-index e2e tests; restored to green.

## Verification

- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`: clean on stable and 1.97.0.
- `cargo test -p laurus --lib`: 1273 passed (+3). `-p laurus-cli --bin laurus`: 13 passed (+4). Full `-p laurus --tests`: green.
- wasm32 `cargo check -p laurus-wasm`: clean. `cargo doc`: 73 warnings (unchanged baseline). markdownlint EN+JA: 0 errors; both mdBooks build.