### PR TITLE
feat(vector/index): FastScan shared PQ codebook support (#920 sub-item 2)

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -246,10 +246,14 @@ jobs:
       - name: Run test
         shell: bash
         run: |
+          # pq-fastscan rides along on every platform (Issue #920): its
+          # feature-gated tests would otherwise never run in CI, and the
+          # 3-platform matrix exercises the AVX2 / NEON / scalar kernel
+          # dispatch paths.
           if [ "${{ matrix.platform.skip_embedding_features }}" == "true" ]; then
-            FEATURES=""
+            FEATURES="--features pq-fastscan"
           else
-            FEATURES="--features embeddings-all"
+            FEATURES="--features embeddings-all,pq-fastscan"
           fi
 
           cargo test --package laurus --target "${{ matrix.platform.target }}" $FEATURES

--- a/docs/ja/src/concepts/indexing/vector_indexing.md
+++ b/docs/ja/src/concepts/indexing/vector_indexing.md
@@ -518,6 +518,13 @@ train-before-first-commit の順序ハザードを完全に解消することも
 - Cosine メトリックのフィールドでは、 writer がインデックス時に行う
   L2 正規化と同じ正規化を学習サンプルにも適用し、 codebook の基底を
   常に一致させます（#794 の罠への対処）。
+- **FastScan フィールドにも対応**（Issue #920、`pq-fastscan` feature）:
+  `ProductQuantizationFastScan` フィールドは同じコマンド・同じファイル
+  フォーマットで k=16 の共有 codebook を学習・エンコードします —
+  `.pqcb` header は `k` をそのまま保存するため 2 つの variant は
+  保存された値で区別され、k 不一致の codebook（例: k=256 のファイルを
+  FastScan フィールドに設定）は両方の値を明示するエラーで commit が
+  失敗します。
 
 #### on-disk format
 

--- a/docs/ja/src/laurus-cli/commands.md
+++ b/docs/ja/src/laurus-cli/commands.md
@@ -31,7 +31,7 @@ laurus create index [--schema <FILE>] [--train-pq-codebook <JSONL>]
 | フラグ | 必須 | 説明 |
 | :--- | :--- | :--- |
 | `--schema <FILE>` | いいえ | インデックススキーマを定義する TOML ファイルのパス。省略時はインデックスディレクトリに既存の `schema.toml` があればそれを使用し、なければ対話型ウィザードが起動します。 |
-| `--train-pq-codebook <JSONL>` | いいえ | インデックス作成の一部として共有 PQ codebook を学習します（Issue #920）。`ProductQuantization` + `pq_codebook_path` を設定したすべての HNSW フィールドを、作成直後にこの JSONL ファイル（`put docs` / `add docs` と同じ形式、事前計算済み `Vector` 値）から学習します。最初の commit がすぐに codebook でエンコードできるため、create → `train pq-codebook` → ingest の順序を手動で守る必要がなくなります。ファイル不在または対象フィールドなしの場合は、何も作成する前にエラーになります。 |
+| `--train-pq-codebook <JSONL>` | いいえ | インデックス作成の一部として共有 PQ codebook を学習します（Issue #920）。`ProductQuantization`（または `pq-fastscan` feature 有効時は `ProductQuantizationFastScan`）+ `pq_codebook_path` を設定したすべての HNSW フィールドを、作成直後にこの JSONL ファイル（`put docs` / `add docs` と同じ形式、事前計算済み `Vector` 値）から学習します。最初の commit がすぐに codebook でエンコードできるため、create → `train pq-codebook` → ingest の順序を手動で守る必要がなくなります。ファイル不在または対象フィールドなしの場合は、何も作成する前にエラーになります。 |
 
 **スキーマファイルの形式:**
 
@@ -418,7 +418,7 @@ laurus train pq-codebook --field <FIELD> (--input <JSONL> | --from-index) \
 
 | 引数 | 説明 |
 | :--- | :--- |
-| `--field` | 学習対象の HNSW ベクトルフィールド。`ProductQuantization` quantizer が設定されている必要があります。 |
+| `--field` | 学習対象の HNSW ベクトルフィールド。`ProductQuantization` quantizer（または `pq-fastscan` feature 有効時は `ProductQuantizationFastScan` — その場合 codebook は k=16 で学習されます、Issue #920）が設定されている必要があります。 |
 | `--input` | JSONL 学習ファイル — `put docs` / `add docs` と同じ `{"id": "...", "document": {"fields": {...}}}` 形式。フィールド値は事前計算済み `Vector` である必要があります（embedder 生成の入力は未対応）。`--input` と `--from-index` はどちらか一方のみ指定できます。 |
 | `--from-index` | ファイルの代わりに、このインデックスにコミット済みのベクトルを直接サンプリングします（Issue #920）— JSONL エクスポート不要。`--input` と `--from-index` はどちらか一方のみ指定できます。注意: 既に PQ エンコード済みのフィールドではサンプルは有損の再構成ベクトルになります。想定フローはフィールドの PQ 有効化**前**にコミットしたベクトルからの学習です。 |
 | `--sample-size` | 先頭 N 件のみを使用（決定的: `--input` はファイル順、`--from-index` は doc_id 昇順）。省略時は全件を使用。代表的なベクトル数千件で十分です。 |

--- a/docs/src/concepts/indexing/vector_indexing.md
+++ b/docs/src/concepts/indexing/vector_indexing.md
@@ -541,6 +541,13 @@ Semantics:
 - Cosine-metric fields L2-normalize the training sample the same way
   the writer normalizes indexed vectors, so the codebook basis always
   matches (the #794 trap).
+- **FastScan fields are supported too** (Issue #920, `pq-fastscan`
+  feature): a `ProductQuantizationFastScan` field trains and encodes
+  against a k=16 shared codebook through the exact same commands and
+  file format — the `.pqcb` header stores `k` verbatim, so the two
+  variants are distinguished by the stored value, and a k-mismatched
+  codebook (e.g. a k=256 file configured on a FastScan field) fails
+  the commit loudly with both values named.
 
 #### On-disk format
 

--- a/docs/src/laurus-cli/commands.md
+++ b/docs/src/laurus-cli/commands.md
@@ -31,7 +31,7 @@ laurus create index [--schema <FILE>] [--train-pq-codebook <JSONL>]
 | Flag | Required | Description |
 | :--- | :--- | :--- |
 | `--schema <FILE>` | No | Path to a TOML file defining the index schema. When omitted, the command checks if a `schema.toml` already exists in the index directory and uses it; otherwise the interactive wizard is launched. |
-| `--train-pq-codebook <JSONL>` | No | Train shared PQ codebooks as part of creation (Issue #920). Every HNSW field configuring `ProductQuantization` + `pq_codebook_path` is trained from this JSONL file (the `put docs` / `add docs` shape with pre-computed `Vector` values) immediately after the index is created, so the very first commit can already encode against the codebook — removing the create → `train pq-codebook` → ingest ordering the failure policy otherwise requires you to manage manually. Errors before creating anything if the file is missing or no field is eligible. |
+| `--train-pq-codebook <JSONL>` | No | Train shared PQ codebooks as part of creation (Issue #920). Every HNSW field configuring `ProductQuantization` (or, with the `pq-fastscan` feature, `ProductQuantizationFastScan`) + `pq_codebook_path` is trained from this JSONL file (the `put docs` / `add docs` shape with pre-computed `Vector` values) immediately after the index is created, so the very first commit can already encode against the codebook — removing the create → `train pq-codebook` → ingest ordering the failure policy otherwise requires you to manage manually. Errors before creating anything if the file is missing or no field is eligible. |
 
 **Schema file format:**
 
@@ -422,7 +422,7 @@ laurus train pq-codebook --field <FIELD> (--input <JSONL> | --from-index) \
 
 | Argument | Description |
 | :--- | :--- |
-| `--field` | The HNSW vector field to train for. Must be configured with a `ProductQuantization` quantizer. |
+| `--field` | The HNSW vector field to train for. Must be configured with a `ProductQuantization` quantizer (or `ProductQuantizationFastScan` when the `pq-fastscan` feature is enabled — the codebook is then trained with k=16, Issue #920). |
 | `--input` | JSONL training file — the same `{"id": "...", "document": {"fields": {...}}}` shape as `put docs` / `add docs`. The field value must be a pre-computed `Vector` (embedder-generated input is not supported). Exactly one of `--input` and `--from-index` must be given. |
 | `--from-index` | Sample the vectors already committed to this index instead of reading a file (Issue #920) — no JSONL export needed. Exactly one of `--input` and `--from-index` must be given. Note: on a field that is already PQ-encoded, the sampled vectors are lossy reconstructions; the intended flow is to train from vectors committed **before** enabling PQ on the field. |
 | `--sample-size` | Use only the first N vectors (deterministic: file order for `--input`, ascending doc_id for `--from-index`). Omit to use all of them; thousands of representative vectors are enough. |

--- a/laurus-cli/Cargo.toml
+++ b/laurus-cli/Cargo.toml
@@ -54,3 +54,7 @@ embeddings-all = [
     "embeddings-multimodal",
     "embeddings-openai",
 ]
+# Passthrough for laurus's experimental PQ FastScan variant (k=16 4-bit
+# codes) so FastScan schemas parse and `create index --train-pq-codebook`
+# can target FastScan fields (Issue #920). Mirrors laurus-server's flag.
+pq-fastscan = ["laurus/pq-fastscan", "laurus-server/pq-fastscan"]

--- a/laurus-cli/src/commands/create.rs
+++ b/laurus-cli/src/commands/create.rs
@@ -135,19 +135,25 @@ pub async fn run_index(
 }
 
 /// Collect the fields eligible for create-time codebook training: HNSW
-/// fields configuring `ProductQuantization` with a `pq_codebook_path`,
-/// sorted by field name (`Schema::fields` is a HashMap, so iteration
-/// order alone would be nondeterministic).
+/// fields configuring `ProductQuantization` (or, with the `pq-fastscan`
+/// feature, `ProductQuantizationFastScan` — Issue #920) with a
+/// `pq_codebook_path`, sorted by field name (`Schema::fields` is a
+/// HashMap, so iteration order alone would be nondeterministic).
 fn eligible_pq_fields(schema: &Schema) -> Vec<String> {
     use laurus::vector::core::quantization::QuantizationMethod;
+    fn is_pq_variant(quantizer: &QuantizationMethod) -> bool {
+        match quantizer {
+            QuantizationMethod::ProductQuantization { .. } => true,
+            #[cfg(feature = "pq-fastscan")]
+            QuantizationMethod::ProductQuantizationFastScan { .. } => true,
+            _ => false,
+        }
+    }
     let mut fields: Vec<String> = schema
         .fields
         .iter()
         .filter_map(|(name, option)| match option {
-            FieldOption::Hnsw(o)
-                if matches!(o.quantizer, QuantizationMethod::ProductQuantization { .. })
-                    && o.pq_codebook_path.is_some() =>
-            {
+            FieldOption::Hnsw(o) if is_pq_variant(&o.quantizer) && o.pq_codebook_path.is_some() => {
                 Some(name.clone())
             }
             _ => None,

--- a/laurus/benches/pq_train_bench.rs
+++ b/laurus/benches/pq_train_bench.rs
@@ -112,6 +112,7 @@ fn bench_pq_encode_shared_codebook(c: &mut Criterion) {
             &codebook_name,
             DIM,
             16,
+            256,
             true,
             &training_sample,
         )

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -111,7 +111,8 @@ pub struct PqCodebookInfo {
     pub path: String,
     /// Number of sub-vectors (`m`) the codebook was trained for.
     pub subvector_count: usize,
-    /// Centroids per sub-vector (`k`, currently always `256`).
+    /// Centroids per sub-vector (`k`): `256` for standard 8-bit PQ
+    /// fields, `16` for FastScan fields (Issue #920).
     pub centroids: usize,
     /// Sub-vector dimension (`dimension / subvector_count`).
     pub sub_dimension: usize,
@@ -1859,7 +1860,7 @@ impl Engine {
             default_codebook_name, train_and_write_pq_codebook,
         };
 
-        let (dimension, subvector_count, normalize, configured_path) = {
+        let (dimension, subvector_count, k, normalize, configured_path) = {
             let schema = self.schema.read();
             let Some(option) = schema.fields.get(field) else {
                 return Err(crate::error::LaurusError::invalid_argument(format!(
@@ -1872,16 +1873,28 @@ impl Engine {
                      (shared PQ codebooks are HNSW-only)"
                 )));
             };
-            let QuantizationMethod::ProductQuantization { subvector_count } = o.quantizer else {
-                return Err(crate::error::LaurusError::invalid_argument(format!(
-                    "cannot train a PQ codebook: field '{field}' does not use \
-                     ProductQuantization (quantizer is {:?})",
-                    o.quantizer
-                )));
+            // The quantizer variant fixes the centroid count the segments
+            // will encode against: k=256 for standard 8-bit PQ, k=16 for
+            // the FastScan 4-bit variant (Issue #920).
+            let (subvector_count, k): (usize, u16) = match o.quantizer {
+                QuantizationMethod::ProductQuantization { subvector_count } => {
+                    (subvector_count, 256)
+                }
+                #[cfg(feature = "pq-fastscan")]
+                QuantizationMethod::ProductQuantizationFastScan { subvector_count } => {
+                    (subvector_count, 16)
+                }
+                other => {
+                    return Err(crate::error::LaurusError::invalid_argument(format!(
+                        "cannot train a PQ codebook: field '{field}' does not use \
+                         ProductQuantization (quantizer is {other:?})"
+                    )));
+                }
             };
             (
                 o.dimension,
                 subvector_count,
+                k,
                 o.distance == DistanceMetric::Cosine,
                 o.pq_codebook_path.clone(),
             )
@@ -1897,6 +1910,7 @@ impl Engine {
             &name,
             dimension,
             subvector_count,
+            k,
             normalize,
             vectors,
         )?;

--- a/laurus/src/vector/core/field.rs
+++ b/laurus/src/vector/core/field.rs
@@ -202,9 +202,12 @@ pub struct HnswOption {
     /// Storage-relative file name of a shared PQ codebook (Issue #631).
     ///
     /// Only meaningful when [`Self::quantizer`] is
-    /// [`quantization::QuantizationMethod::ProductQuantization`]. When set,
-    /// segment writes encode against the named pre-trained codebook
-    /// (trained once via `Engine::train_pq_codebook` / the
+    /// [`quantization::QuantizationMethod::ProductQuantization`] (k=256)
+    /// or, with the `pq-fastscan` feature, `ProductQuantizationFastScan`
+    /// (k=16 — Issue #920; the same `.pqcb` file format carries either
+    /// variant, distinguished by the stored `k`). When set, segment
+    /// writes encode against the named pre-trained codebook (trained
+    /// once via `Engine::train_pq_codebook` / the
     /// `laurus train pq-codebook` CLI command) instead of re-running
     /// k-means from scratch on every commit and merge. The segment
     /// format is unchanged: the shared codebook is still embedded

--- a/laurus/src/vector/core/quantization.rs
+++ b/laurus/src/vector/core/quantization.rs
@@ -570,13 +570,27 @@ impl PqParams {
         Ok(Self { m, k, sub_dim })
     }
 
-    /// Derive params from `dim` and `m`. `sub_dim` is `dim / m`.
+    /// Derive params from `dim` and `m` for the standard 8-bit PQ
+    /// variant (`k = 256`). `sub_dim` is `dim / m`.
     ///
     /// # Errors
     ///
     /// Returns [`LaurusError::InvalidOperation`] if `m == 0` or
     /// `dim % m != 0`.
     pub fn from_dim_and_m(dim: usize, m: usize) -> Result<Self> {
+        Self::from_dim_and_m_k(dim, m, 256)
+    }
+
+    /// Derive params from `dim`, `m`, and an explicit centroid count
+    /// `k` (`256` for standard 8-bit PQ, `16` for the FastScan 4-bit
+    /// variant — Issue #920). `sub_dim` is `dim / m`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LaurusError::InvalidOperation`] if `m == 0`,
+    /// `dim % m != 0`, or `k` is not one of `{16, 256}` (via
+    /// [`Self::new`]'s validation).
+    pub fn from_dim_and_m_k(dim: usize, m: usize, k: u16) -> Result<Self> {
         if m == 0 {
             return Err(LaurusError::InvalidOperation(
                 "Product quantization subvector_count must be > 0".to_string(),
@@ -596,7 +610,7 @@ impl PqParams {
                     "Product quantization subvector_count {m} exceeds u16::MAX"
                 ))
             })?,
-            256,
+            k,
             u16::try_from(sub_dim).map_err(|_| {
                 LaurusError::InvalidOperation(format!(
                     "Product quantization sub_dim {sub_dim} exceeds u16::MAX"
@@ -820,11 +834,10 @@ impl VectorQuantizer {
             }
             #[cfg(feature = "pq-fastscan")]
             QuantizationMethod::ProductQuantizationFastScan { subvector_count } => {
-                // FastScan uses K=16; reuse `from_dim_and_m` which validates
-                // divisibility and propagate via the standard PQ codebook
-                // training (k-means on each sub-vector).
-                let mut params = PqParams::from_dim_and_m(self.dimension, subvector_count)?;
-                params.k = 16;
+                // FastScan uses K=16; `from_dim_and_m_k` validates both the
+                // divisibility and the k value, then the codebook trains via
+                // the standard PQ path (k-means on each sub-vector).
+                let params = PqParams::from_dim_and_m_k(self.dimension, subvector_count, 16)?;
                 let codebook = pq_train_codebook(self.dimension, params, vectors)?;
                 self.state = QuantizerState::ProductQuantization { params, codebook };
                 Ok(())

--- a/laurus/src/vector/index/hnsw/tests.rs
+++ b/laurus/src/vector/index/hnsw/tests.rs
@@ -633,6 +633,7 @@ fn shared_pq_codebook_keeps_small_segment_on_pq() -> Result<()> {
         "shared.pqcb",
         4,
         2,
+        256,
         false,
         &training_sample,
     )?;
@@ -731,6 +732,209 @@ fn missing_shared_pq_codebook_is_lenient_at_open_but_errors_at_write() -> Result
     assert!(
         message.contains("not-yet-trained.pqcb"),
         "error must name the configured path, got: {message}"
+    );
+    Ok(())
+}
+
+/// Issue #920 (FastScan mirror of `shared_pq_codebook_keeps_small_segment_on_pq`):
+/// a segment below `PQ_FASTSCAN_MIN_TRAIN_VECTORS` (16) normally
+/// degrades to Scalar8Bit, but with a shared k=16 codebook configured
+/// nothing is trained, so the segment must stay FastScan and encode
+/// against the shared codebook.
+#[cfg(feature = "pq-fastscan")]
+#[test]
+fn shared_pq_codebook_keeps_small_segment_on_fastscan() -> Result<()> {
+    use crate::vector::core::quantization::QuantizationMethod;
+    use crate::vector::index::pq_codebook::train_and_write_pq_codebook;
+    use crate::vector::index::storage::VectorStorage;
+
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+
+    let mut state: u64 = 0xABCD_EF01_2345_6789;
+    let training_sample: Vec<Vector> = (0..300)
+        .map(|_| {
+            let data: Vec<f32> = (0..4)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                })
+                .collect();
+            Vector::new(data)
+        })
+        .collect();
+    train_and_write_pq_codebook(
+        storage.as_ref(),
+        "shared-fs.pqcb",
+        4,
+        2,
+        16,
+        false,
+        &training_sample,
+    )?;
+
+    let mut config = HnswIndexConfig {
+        dimension: 4,
+        m: 8,
+        ef_construction: 50,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantizationFastScan { subvector_count: 2 },
+        pq_codebook_path: Some("shared-fs.pqcb".to_string()),
+        ..Default::default()
+    };
+    config.resolve_pq_codebook(storage.as_ref())?;
+    assert!(
+        config.pq_codebook.is_some(),
+        "the shared k=16 codebook must resolve from the file just written"
+    );
+
+    let index = HnswIndex::create(storage.clone(), "small_fs_segment", config)?;
+    let mut writer = index.writer()?;
+    // Only 10 vectors -- below PQ_FASTSCAN_MIN_TRAIN_VECTORS (16).
+    let vectors: Vec<_> = (0..10u64)
+        .map(|i| {
+            (
+                i + 1,
+                "embedding".to_string(),
+                Vector::new(vec![i as f32, i as f32, i as f32 * 2.0, i as f32 * 2.0]),
+            )
+        })
+        .collect();
+    writer.build(vectors)?;
+    writer.finalize()?;
+    writer.commit()?;
+
+    let reader = index.reader()?;
+    let hnsw_reader = reader
+        .as_any()
+        .downcast_ref::<HnswIndexReader>()
+        .expect("HnswIndex::reader() always returns an HnswIndexReader");
+    assert!(
+        matches!(hnsw_reader.vectors(), VectorStorage::OwnedPqFastScan(_)),
+        "a 10-vector segment with a shared k=16 codebook configured must stay \
+         FastScan, not degrade to Scalar8Bit"
+    );
+    Ok(())
+}
+
+/// Issue #920 (FastScan mirror of
+/// `missing_shared_pq_codebook_is_lenient_at_open_but_errors_at_write`):
+/// a configured-but-untrained `pq_codebook_path` on a FastScan field
+/// must fail loudly at write — before this fix it was silently ignored
+/// and every segment retrained k-means.
+#[cfg(feature = "pq-fastscan")]
+#[test]
+fn missing_shared_pq_codebook_errors_at_write_for_fastscan() -> Result<()> {
+    use crate::vector::core::quantization::QuantizationMethod;
+
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+    let mut config = HnswIndexConfig {
+        dimension: 4,
+        m: 8,
+        ef_construction: 50,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantizationFastScan { subvector_count: 2 },
+        pq_codebook_path: Some("not-yet-trained-fs.pqcb".to_string()),
+        ..Default::default()
+    };
+    config.resolve_pq_codebook(storage.as_ref())?;
+    assert!(config.pq_codebook.is_none());
+
+    let index = HnswIndex::create(storage.clone(), "no_fs_codebook_yet", config)?;
+    let mut writer = index.writer()?;
+    let vectors: Vec<_> = (0..300u64)
+        .map(|i| {
+            (
+                i + 1,
+                "embedding".to_string(),
+                Vector::new(vec![i as f32, i as f32, i as f32 * 2.0, i as f32 * 2.0]),
+            )
+        })
+        .collect();
+    writer.build(vectors)?;
+    writer.finalize()?;
+
+    let err = writer.write().expect_err(
+        "write() must reject a configured-but-unresolved pq_codebook_path on a \
+         FastScan field instead of silently training a fresh codebook",
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("not-yet-trained-fs.pqcb"),
+        "error must name the configured path, got: {message}"
+    );
+    Ok(())
+}
+
+/// Issue #920: a k=256 (standard PQ) codebook configured on a FastScan
+/// field must be rejected loudly at write with the k mismatch named.
+#[cfg(feature = "pq-fastscan")]
+#[test]
+fn k256_codebook_on_fastscan_field_errors_at_write() -> Result<()> {
+    use crate::vector::core::quantization::QuantizationMethod;
+    use crate::vector::index::pq_codebook::train_and_write_pq_codebook;
+
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+
+    let mut state: u64 = 0xABCD_EF01_2345_6789;
+    let training_sample: Vec<Vector> = (0..300)
+        .map(|_| {
+            let data: Vec<f32> = (0..4)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                })
+                .collect();
+            Vector::new(data)
+        })
+        .collect();
+    // Standard-PQ (k=256) codebook...
+    train_and_write_pq_codebook(
+        storage.as_ref(),
+        "wrong-k.pqcb",
+        4,
+        2,
+        256,
+        false,
+        &training_sample,
+    )?;
+
+    // ...configured on a FastScan (k=16) field.
+    let mut config = HnswIndexConfig {
+        dimension: 4,
+        m: 8,
+        ef_construction: 50,
+        distance_metric: DistanceMetric::Euclidean,
+        quantization_method: QuantizationMethod::ProductQuantizationFastScan { subvector_count: 2 },
+        pq_codebook_path: Some("wrong-k.pqcb".to_string()),
+        ..Default::default()
+    };
+    config.resolve_pq_codebook(storage.as_ref())?;
+
+    let index = HnswIndex::create(storage.clone(), "wrong_k_fs", config)?;
+    let mut writer = index.writer()?;
+    let vectors: Vec<_> = (0..300u64)
+        .map(|i| {
+            (
+                i + 1,
+                "embedding".to_string(),
+                Vector::new(vec![i as f32, i as f32, i as f32 * 2.0, i as f32 * 2.0]),
+            )
+        })
+        .collect();
+    writer.build(vectors)?;
+    writer.finalize()?;
+
+    let err = writer
+        .write()
+        .expect_err("a k=256 codebook must not encode a FastScan field");
+    let message = err.to_string();
+    assert!(
+        message.contains("k = 256") && message.contains("k = 16"),
+        "error must name both the stored and required k, got: {message}"
     );
     Ok(())
 }

--- a/laurus/src/vector/index/hnsw/writer.rs
+++ b/laurus/src/vector/index/hnsw/writer.rs
@@ -1788,9 +1788,14 @@ impl VectorIndexWriter for HnswIndexWriter {
                 }
                 #[cfg(feature = "pq-fastscan")]
                 Qm::ProductQuantizationFastScan { subvector_count }
-                    if n > 0 && n < PQ_FASTSCAN_MIN_TRAIN_VECTORS =>
+                    if n > 0 && n < PQ_FASTSCAN_MIN_TRAIN_VECTORS && !has_shared_pq_codebook =>
                 {
-                    // Same geometry validation as the PQ arm above.
+                    // Same geometry validation as the PQ arm above; the
+                    // shared-codebook exemption also mirrors it (Issue
+                    // #920): with a shared codebook nothing is trained, so
+                    // small flushes stay FastScan, and a configured-but-
+                    // untrained path must reach the loud error in the
+                    // FastScan arm below instead of degrading silently.
                     crate::vector::core::quantization::PqParams::from_dim_and_m(
                         self.index_config.dimension,
                         subvector_count.max(1),
@@ -1915,11 +1920,27 @@ impl VectorIndexWriter for HnswIndexWriter {
                         .with_field_dict(field_dict.clone())
                         .write_to(&mut output)?;
                 } else {
+                    // Issue #920: same failure policy as the standard PQ
+                    // arm above — a configured-but-unresolved shared
+                    // codebook must fail loudly here, not silently fall
+                    // through to per-segment training.
+                    if self.index_config.pq_codebook_path.is_some()
+                        && self.index_config.pq_codebook.is_none()
+                    {
+                        return Err(LaurusError::InvalidOperation(format!(
+                            "HNSW field configures pq_codebook_path = {:?} but no codebook \
+                             has been trained there yet; train one first (e.g. `laurus train \
+                             pq-codebook`) before committing, or clear pq_codebook_path to use \
+                             per-segment training",
+                            self.index_config.pq_codebook_path.as_deref().unwrap_or_default()
+                        )));
+                    }
                     let (params, codebook, codes) =
                         crate::vector::index::pq_fastscan_io::quantize_segment_pq_fastscan(
                             &f32_vectors,
                             self.index_config.dimension,
                             subvector_count,
+                            self.index_config.pq_codebook.as_deref(),
                         )?;
                     VectorSegmentHeader::product_quantization_fastscan(params, codebook)
                         .with_version(VERSION_FIELD_DICT)

--- a/laurus/src/vector/index/pq_codebook.rs
+++ b/laurus/src/vector/index/pq_codebook.rs
@@ -58,12 +58,19 @@ pub struct SharedPqCodebook {
 
 impl SharedPqCodebook {
     /// Confirm this codebook can be used to encode `dimension`-d
-    /// vectors split into `subvector_count` sub-vectors.
+    /// vectors split into `subvector_count` sub-vectors with
+    /// `expected_k` centroids per sub-quantizer.
     ///
     /// # Arguments
     ///
     /// * `dimension` - The caller's configured vector dimension.
     /// * `subvector_count` - The caller's configured PQ `m`.
+    /// * `expected_k` - The centroid count the caller's quantizer
+    ///   variant encodes against: `256` for standard 8-bit PQ, `16`
+    ///   for FastScan (Issue #920). A k-mismatched codebook (e.g. a
+    ///   k=256 file configured on a FastScan field) must fail loudly
+    ///   here — at the writer, before any segment is encoded — per the
+    ///   #918 failure policy.
     ///
     /// # Errors
     ///
@@ -71,7 +78,12 @@ impl SharedPqCodebook {
     /// geometry does not match the caller's expectations, or if its
     /// stored length is inconsistent with its own params (defensive;
     /// [`read_pq_codebook`] already guarantees this on the load path).
-    pub fn validate_for(&self, dimension: usize, subvector_count: usize) -> Result<()> {
+    pub fn validate_for(
+        &self,
+        dimension: usize,
+        subvector_count: usize,
+        expected_k: u16,
+    ) -> Result<()> {
         if self.params.original_dim() != dimension {
             return Err(LaurusError::InvalidOperation(format!(
                 "shared PQ codebook dimension {} does not match the configured \
@@ -84,6 +96,14 @@ impl SharedPqCodebook {
                 "shared PQ codebook subvector_count {} does not match the configured \
                  subvector_count {subvector_count}",
                 self.params.m
+            )));
+        }
+        if self.params.k != expected_k {
+            return Err(LaurusError::InvalidOperation(format!(
+                "shared PQ codebook has k = {} centroids per sub-quantizer but the \
+                 field's quantizer variant requires k = {expected_k} (16 = FastScan, \
+                 256 = standard PQ); retrain the codebook for this variant",
+                self.params.k
             )));
         }
         if self.codebook.len() != self.params.codebook_len() {
@@ -193,6 +213,10 @@ pub fn read_pq_codebook(storage: &dyn Storage, name: &str) -> Result<SharedPqCod
 /// * `name` - Storage-relative file name (see [`default_codebook_name`]).
 /// * `dimension` - Original vector dimension.
 /// * `subvector_count` - PQ `m` (must divide `dimension`).
+/// * `k` - Centroids per sub-quantizer: `256` for standard 8-bit PQ,
+///   `16` for the FastScan 4-bit variant (Issue #920). The on-disk
+///   `.pqcb` format stores `k` verbatim, so both variants share the
+///   same file format; readers dispatch on the stored value.
 /// * `normalize` - Must match the field's `HnswIndexConfig::normalize_vectors`
 ///   (i.e. `true` for Cosine distance). Training on a different scale
 ///   than the segments that will later encode against this codebook
@@ -203,17 +227,19 @@ pub fn read_pq_codebook(storage: &dyn Storage, name: &str) -> Result<SharedPqCod
 /// # Errors
 ///
 /// * [`LaurusError::InvalidOperation`] if `vectors` is empty, has
-///   mixed dimensions, or `subvector_count` does not divide `dimension`.
+///   mixed dimensions, `subvector_count` does not divide `dimension`,
+///   or `k` is not one of `{16, 256}`.
 /// * Any error from [`write_pq_codebook`].
 pub fn train_and_write_pq_codebook(
     storage: &dyn Storage,
     name: &str,
     dimension: usize,
     subvector_count: usize,
+    k: u16,
     normalize: bool,
     vectors: &[Vector],
 ) -> Result<SharedPqCodebook> {
-    let params = PqParams::from_dim_and_m(dimension, subvector_count)?;
+    let params = PqParams::from_dim_and_m_k(dimension, subvector_count, k)?;
 
     let normalized;
     let training_set: &[Vector] = if normalize {
@@ -263,7 +289,8 @@ mod tests {
         let storage = storage();
         let vectors = sample_vectors(300, 32);
         let trained =
-            train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, false, &vectors).unwrap();
+            train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, 256, false, &vectors)
+                .unwrap();
 
         let loaded = read_pq_codebook(&storage, "field.pqcb").unwrap();
         assert_eq!(loaded.params, trained.params);
@@ -274,7 +301,7 @@ mod tests {
     fn corrupted_payload_byte_fails_checksum() {
         let storage = storage();
         let vectors = sample_vectors(300, 32);
-        train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, false, &vectors).unwrap();
+        train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, 256, false, &vectors).unwrap();
 
         // Flip one byte inside the codebook payload (after the 24-byte
         // prefix) and confirm the CRC catches it.
@@ -297,7 +324,7 @@ mod tests {
     fn truncated_file_is_rejected_before_allocating() {
         let storage = storage();
         let vectors = sample_vectors(300, 32);
-        train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, false, &vectors).unwrap();
+        train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, 256, false, &vectors).unwrap();
 
         // Truncate to just past the fixed prefix -- the declared
         // codebook (m=4, k=256, sub_dim=8 -> 8192 floats = 32768 bytes)
@@ -322,17 +349,43 @@ mod tests {
     fn validate_for_rejects_dimension_and_subvector_mismatch() {
         let storage = storage();
         let vectors = sample_vectors(300, 32);
-        let cb =
-            train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, false, &vectors).unwrap();
+        let cb = train_and_write_pq_codebook(&storage, "field.pqcb", 32, 4, 256, false, &vectors)
+            .unwrap();
 
-        assert!(cb.validate_for(32, 4).is_ok());
+        assert!(cb.validate_for(32, 4, 256).is_ok());
         assert!(
-            cb.validate_for(64, 4).is_err(),
+            cb.validate_for(64, 4, 256).is_err(),
             "dimension mismatch must be rejected"
         );
         assert!(
-            cb.validate_for(32, 8).is_err(),
+            cb.validate_for(32, 8, 256).is_err(),
             "subvector_count mismatch must be rejected"
+        );
+        assert!(
+            cb.validate_for(32, 4, 16).is_err(),
+            "k mismatch must be rejected (Issue #920: a k=256 codebook must not \
+             encode a FastScan field)"
+        );
+    }
+
+    /// Issue #920: a k=16 (FastScan) codebook round-trips through the
+    /// same `.pqcb` file format — the header stores `k` verbatim, so no
+    /// format change is needed for the FastScan variant.
+    #[test]
+    fn k16_codebook_round_trips_through_the_same_format() {
+        let storage = storage();
+        let vectors = sample_vectors(300, 32);
+        let trained =
+            train_and_write_pq_codebook(&storage, "fs.pqcb", 32, 4, 16, false, &vectors).unwrap();
+        assert_eq!(trained.params.k, 16);
+
+        let loaded = read_pq_codebook(&storage, "fs.pqcb").unwrap();
+        assert_eq!(loaded.params, trained.params);
+        assert_eq!(loaded.codebook, trained.codebook);
+        assert!(loaded.validate_for(32, 4, 16).is_ok());
+        assert!(
+            loaded.validate_for(32, 4, 256).is_err(),
+            "a k=16 codebook must not validate for the standard-PQ variant"
         );
     }
 
@@ -342,9 +395,9 @@ mod tests {
         let vectors = sample_vectors(300, 32);
 
         let cb_raw =
-            train_and_write_pq_codebook(&storage, "raw.pqcb", 32, 4, false, &vectors).unwrap();
+            train_and_write_pq_codebook(&storage, "raw.pqcb", 32, 4, 256, false, &vectors).unwrap();
         let cb_normalized =
-            train_and_write_pq_codebook(&storage, "norm.pqcb", 32, 4, true, &vectors).unwrap();
+            train_and_write_pq_codebook(&storage, "norm.pqcb", 32, 4, 256, true, &vectors).unwrap();
 
         // Same input, different `normalize` flag: the trained codebooks
         // must differ (proves normalization actually ran, rather than

--- a/laurus/src/vector/index/pq_fastscan_io.rs
+++ b/laurus/src/vector/index/pq_fastscan_io.rs
@@ -30,6 +30,7 @@ use std::io::{Read, Write};
 use crate::error::{LaurusError, Result};
 use crate::vector::core::quantization::{PqParams, QuantizationMethod, VectorQuantizer, pq_decode};
 use crate::vector::core::vector::Vector;
+use crate::vector::index::pq_codebook::SharedPqCodebook;
 
 /// Bytes consumed by the per-vector codes section (everything after
 /// the field_name string ends), i.e. `ceil(m / 2)`.
@@ -43,19 +44,33 @@ pub(super) const fn pq_fastscan_record_payload_size(m: u16) -> usize {
     (m as usize).div_ceil(2)
 }
 
-/// Train a K=16 PQ codebook on the given vectors and encode each one
-/// into 4-bit codes.
+/// Encode each vector into 4-bit codes against a K=16 PQ codebook —
+/// either the `shared` one (Issue #920: trained once via
+/// `laurus train pq-codebook` and reused by every segment) or a fresh
+/// per-segment codebook trained here.
 ///
 /// Returns `(params, codebook, codes)` where `codes[i]` is a `Vec<u8>`
 /// of length `params.m`, each entry in `[0, 15]`. The caller pairs
 /// each entry back with its `(doc_id, field_name)` triple before
 /// writing through [`write_pq_fastscan_record`].
 ///
+/// # Arguments
+///
+/// * `vectors` - The segment's vectors to encode (and, without
+///   `shared`, to train on).
+/// * `dim` - Configured vector dimension.
+/// * `subvector_count` - PQ `m` (must divide `dim`).
+/// * `shared` - Optional shared codebook. Must have been trained with
+///   `k = 16` for this FastScan variant — a k-mismatched codebook
+///   (e.g. a standard-PQ k=256 file) is rejected loudly by
+///   `validate_for` before anything is encoded.
+///
 /// # Errors
 ///
 /// Forwards any error from [`VectorQuantizer::train`] /
 /// [`VectorQuantizer::quantize`] (e.g. empty input, dimension
-/// mismatch, `dim % m != 0`). Returns
+/// mismatch, `dim % m != 0`) and
+/// [`SharedPqCodebook::validate_for`]'s geometry/k mismatches. Returns
 /// [`LaurusError::InvalidOperation`] if a sub-quantiser code ends up
 /// outside `[0, 15]` (should never happen with `K = 16` but we
 /// validate to fail loudly rather than silently truncating during
@@ -64,12 +79,22 @@ pub(super) fn quantize_segment_pq_fastscan(
     vectors: &[Vector],
     dim: usize,
     subvector_count: usize,
+    shared: Option<&SharedPqCodebook>,
 ) -> Result<(PqParams, Vec<f32>, Vec<Vec<u8>>)> {
-    let mut quantizer = VectorQuantizer::new(
-        QuantizationMethod::ProductQuantizationFastScan { subvector_count },
-        dim,
-    );
-    quantizer.train(vectors)?;
+    let quantizer = match shared {
+        Some(cb) => {
+            cb.validate_for(dim, subvector_count, 16)?;
+            VectorQuantizer::from_pq_codebook(dim, cb.params, cb.codebook.clone())?
+        }
+        None => {
+            let mut quantizer = VectorQuantizer::new(
+                QuantizationMethod::ProductQuantizationFastScan { subvector_count },
+                dim,
+            );
+            quantizer.train(vectors)?;
+            quantizer
+        }
+    };
     let (params, codebook_slice) = quantizer
         .pq_state()
         .expect("PQ FastScan quantizer trained successfully implies pq_state is set");
@@ -216,7 +241,7 @@ mod tests {
             vec_of(&[-10.0, -10.0, -20.0, -20.0]),
             vec_of(&[10.1, 10.1, 20.1, 20.1]),
         ];
-        let (params, codebook, codes) = quantize_segment_pq_fastscan(&vectors, 4, 2).unwrap();
+        let (params, codebook, codes) = quantize_segment_pq_fastscan(&vectors, 4, 2, None).unwrap();
         assert_eq!(params.m, 2);
         assert_eq!(params.k, 16);
         assert_eq!(params.sub_dim, 2);
@@ -228,6 +253,64 @@ mod tests {
                 assert!(code < 16, "code {code} exceeds 4-bit range");
             }
         }
+    }
+
+    /// Issue #920 (mirror of the standard-PQ test in `pq_io.rs`):
+    /// encoding against a pre-trained [`SharedPqCodebook`] must produce
+    /// byte-identical output to training a fresh codebook on the exact
+    /// same corpus — `pq_train_codebook` is deterministic (seeded
+    /// k-means), so any divergence means the shared path diverged.
+    #[test]
+    fn shared_codebook_produces_byte_identical_fastscan_codes_to_fresh_training() {
+        let mut state: u64 = 0x1234_5678_9ABC_DEF0;
+        let vectors: Vec<Vector> = (0..300)
+            .map(|_| {
+                let data: Vec<f32> = (0..32)
+                    .map(|_| {
+                        state = state
+                            .wrapping_mul(6_364_136_223_846_793_005)
+                            .wrapping_add(1_442_695_040_888_963_407);
+                        ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                    })
+                    .collect();
+                Vector::new(data)
+            })
+            .collect();
+
+        let (trained_params, trained_codebook, trained_codes) =
+            quantize_segment_pq_fastscan(&vectors, 32, 4, None).unwrap();
+        assert_eq!(trained_params.k, 16);
+
+        let shared = SharedPqCodebook {
+            params: trained_params,
+            codebook: trained_codebook.clone(),
+        };
+        let (shared_params, shared_codebook, shared_codes) =
+            quantize_segment_pq_fastscan(&vectors, 32, 4, Some(&shared)).unwrap();
+
+        assert_eq!(shared_params, trained_params);
+        assert_eq!(shared_codebook, trained_codebook);
+        assert_eq!(shared_codes, trained_codes);
+    }
+
+    /// Issue #920: a k=256 (standard PQ) codebook must be rejected
+    /// loudly when handed to the FastScan encode path.
+    #[test]
+    fn k256_codebook_is_rejected_by_the_fastscan_encode_path() {
+        let vectors = vec![
+            vec_of(&[10.0, 10.0, 20.0, 20.0]),
+            vec_of(&[-10.0, -10.0, -20.0, -20.0]),
+        ];
+        let params = PqParams::new(2, 256, 2).unwrap();
+        let shared = SharedPqCodebook {
+            codebook: vec![0.0; params.codebook_len()],
+            params,
+        };
+        let err = quantize_segment_pq_fastscan(&vectors, 4, 2, Some(&shared)).unwrap_err();
+        assert!(
+            err.to_string().contains("k = 256"),
+            "the k mismatch must be named: {err}"
+        );
     }
 
     #[test]

--- a/laurus/src/vector/index/pq_io.rs
+++ b/laurus/src/vector/index/pq_io.rs
@@ -71,7 +71,7 @@ pub(super) fn quantize_segment_pq(
 ) -> Result<(PqParams, Vec<f32>, Vec<Vec<u8>>)> {
     let quantizer = match shared {
         Some(cb) => {
-            cb.validate_for(dim, subvector_count)?;
+            cb.validate_for(dim, subvector_count, 256)?;
             VectorQuantizer::from_pq_codebook(dim, cb.params, cb.codebook.clone())?
         }
         None => {

--- a/laurus/tests/pq_fastscan_shared_codebook_test.rs
+++ b/laurus/tests/pq_fastscan_shared_codebook_test.rs
@@ -1,0 +1,184 @@
+//! End-to-end engine tests for the FastScan shared PQ codebook (Issue
+//! #920 sub-item 2).
+//!
+//! FastScan mirror of `engine_pq_codebook_test.rs`: with a
+//! `ProductQuantizationFastScan` quantizer and a `pq_codebook_path` on
+//! the schema, `Engine::train_pq_codebook` must train a k=16 codebook,
+//! a commit before training must hard-error (before this fix the path
+//! was silently ignored and every segment retrained k-means), and a
+//! reopened engine must encode against the shared codebook.
+
+#![cfg(feature = "pq-fastscan")]
+
+use laurus::storage::file::FileStorageConfig;
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::vector::HnswOption;
+use laurus::vector::Vector;
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::quantization::QuantizationMethod;
+use laurus::vector::index::pq_codebook::read_pq_codebook;
+use laurus::{DataValue, Document, Engine, FieldOption, Schema};
+use tempfile::TempDir;
+
+const DIM: usize = 32;
+const M: usize = 4;
+
+/// Deterministic pseudo-random vectors (same LCG as
+/// `engine_pq_codebook_test.rs`); distinct seeds give distinct corpora.
+fn make_vectors(count: usize, seed: u64) -> Vec<Vector> {
+    let mut state = seed;
+    (0..count)
+        .map(|_| {
+            let data: Vec<f32> = (0..DIM)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    ((state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+                })
+                .collect();
+            Vector::new(data)
+        })
+        .collect()
+}
+
+/// Schema with one HNSW + FastScan field pointing at a shared codebook.
+fn fastscan_schema(pq_codebook_path: Option<&str>) -> Schema {
+    Schema::builder()
+        .add_field(
+            "embedding",
+            FieldOption::Hnsw(HnswOption {
+                dimension: DIM,
+                distance: DistanceMetric::Euclidean,
+                m: 8,
+                ef_construction: 32,
+                quantizer: QuantizationMethod::ProductQuantizationFastScan { subvector_count: M },
+                pq_codebook_path: pq_codebook_path.map(str::to_string),
+                ..HnswOption::default()
+            }),
+        )
+        .build()
+}
+
+/// The full schema-level loop for FastScan: (1) a commit before training
+/// hard-errors naming the training step, (2) `train_pq_codebook` trains
+/// a k=16 codebook into the vector namespace, (3) a reopened engine
+/// commits a tiny batch successfully — far below the FastScan min-train
+/// threshold, so a silent fallback (the pre-#920 behavior of ignoring
+/// the path, or the demotion guard firing) would produce a different
+/// outcome.
+#[tokio::test(flavor = "multi_thread")]
+async fn fastscan_train_then_reopen_commits_with_the_shared_codebook() -> laurus::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let storage = StorageFactory::create(StorageConfig::File(FileStorageConfig::new(dir.path())))?;
+
+    // (1) Before training: the configured-but-missing codebook must fail
+    // the commit loudly (pre-#920 this was silently ignored for FastScan).
+    {
+        let engine = Engine::new(storage.clone(), fastscan_schema(Some("embedding.pqcb"))).await?;
+        let doc = Document::builder()
+            .add_field(
+                "embedding",
+                DataValue::Vector(make_vectors(1, 7)[0].data.to_vec()),
+            )
+            .build();
+        engine.put_document("doc-early", doc).await?;
+        let err = engine.commit().await.unwrap_err();
+        assert!(
+            err.to_string().contains("train"),
+            "an untrained configured codebook must point at the training step: {err}"
+        );
+    }
+
+    // (2) Train — the FastScan quantizer variant must yield k=16.
+    let fresh_dir = TempDir::new().unwrap();
+    let fresh_storage = StorageFactory::create(StorageConfig::File(FileStorageConfig::new(
+        fresh_dir.path(),
+    )))?;
+    let trainer = Engine::new(
+        fresh_storage.clone(),
+        fastscan_schema(Some("embedding.pqcb")),
+    )
+    .await?;
+    let info = trainer.train_pq_codebook("embedding", &make_vectors(400, 0x0F0F), None)?;
+    assert_eq!(info.path, "embedding.pqcb");
+    assert_eq!(info.subvector_count, M);
+    assert_eq!(
+        info.centroids, 16,
+        "a FastScan field must train a k=16 codebook, not the standard 256"
+    );
+    assert_eq!(info.sub_dimension, DIM / M);
+    assert!(fresh_storage.file_exists("vector/embedding.pqcb"));
+    drop(trainer);
+
+    // The persisted file itself carries k=16.
+    let vector_ns =
+        laurus::storage::prefixed::PrefixedStorage::new("vector", fresh_storage.clone());
+    let loaded = read_pq_codebook(&vector_ns, "embedding.pqcb")?;
+    assert_eq!(loaded.params.k, 16);
+
+    // (3) A reopened engine picks the codebook up at open and commits a
+    // tiny batch — 5 docs, far below PQ_FASTSCAN_MIN_TRAIN_VECTORS (16),
+    // so this only succeeds because the shared codebook exempts the
+    // segment from both the demotion guard and per-segment training.
+    let engine = Engine::new(
+        fresh_storage.clone(),
+        fastscan_schema(Some("embedding.pqcb")),
+    )
+    .await?;
+    for (i, v) in make_vectors(5, 0xBEEF).into_iter().enumerate() {
+        let doc = Document::builder()
+            .add_field("embedding", DataValue::Vector(v.data.to_vec()))
+            .build();
+        engine.put_document(&format!("d{i}"), doc).await?;
+    }
+    engine.commit().await?;
+
+    Ok(())
+}
+
+/// A k=256 (standard PQ) codebook configured on a FastScan field must
+/// fail the commit loudly with the k mismatch named — not encode
+/// garbage or silently retrain.
+#[tokio::test(flavor = "multi_thread")]
+async fn k256_codebook_on_fastscan_field_fails_the_commit() -> laurus::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let storage = StorageFactory::create(StorageConfig::File(FileStorageConfig::new(dir.path())))?;
+
+    // Train a k=256 codebook by declaring the field as standard PQ first.
+    let pq_schema = Schema::builder()
+        .add_field(
+            "embedding",
+            FieldOption::Hnsw(HnswOption {
+                dimension: DIM,
+                distance: DistanceMetric::Euclidean,
+                m: 8,
+                ef_construction: 32,
+                quantizer: QuantizationMethod::ProductQuantization { subvector_count: M },
+                pq_codebook_path: Some("embedding.pqcb".to_string()),
+                ..HnswOption::default()
+            }),
+        )
+        .build();
+    let trainer = Engine::new(storage.clone(), pq_schema).await?;
+    let info = trainer.train_pq_codebook("embedding", &make_vectors(400, 0x0F0F), None)?;
+    assert_eq!(info.centroids, 256);
+    drop(trainer);
+
+    // Reopen with the SAME codebook file but a FastScan quantizer.
+    let engine = Engine::new(storage.clone(), fastscan_schema(Some("embedding.pqcb"))).await?;
+    for (i, v) in make_vectors(20, 0xBEEF).into_iter().enumerate() {
+        let doc = Document::builder()
+            .add_field("embedding", DataValue::Vector(v.data.to_vec()))
+            .build();
+        engine.put_document(&format!("d{i}"), doc).await?;
+    }
+    let err = engine.commit().await.unwrap_err();
+    let message = err.to_string();
+    assert!(
+        message.contains("k = 256") && message.contains("k = 16"),
+        "the k mismatch must be named: {message}"
+    );
+
+    Ok(())
+}

--- a/laurus/tests/pq_shared_codebook_test.rs
+++ b/laurus/tests/pq_shared_codebook_test.rs
@@ -118,6 +118,7 @@ fn shared_codebook_search_results_match_fresh_training() {
         &codebook_name,
         DIM,
         M,
+        256,
         false,
         &training_sample,
     )
@@ -180,6 +181,7 @@ fn shared_codebook_survives_a_forced_merge() {
         &codebook_name,
         DIM,
         M,
+        256,
         false,
         &training_sample,
     )


### PR DESCRIPTION
## Summary

- Final sub-item of #920 (sub-items 1 `--from-index` / 3 `create --train-pq-codebook` merged as PRs #938 / #939). **Closes #920.**
- Wires the shared PQ codebook (#631) into the FastScan k=16 variant (`pq-fastscan` feature, HNSW-only). Previously a `pq_codebook_path` configured on a `ProductQuantizationFastScan` field was **silently ignored** — every segment retrained k-means — and `Engine::train_pq_codebook` rejected the quantizer outright, so there was no way to even produce a k=16 codebook.
- **No `.pqcb` format change**: the header already stores `k` as a u16, so both variants share the file format, distinguished by the stored value under the same `quant_kind` (a FastScan-specific kind would make the same file unreadable on feature-off builds).

## Changes

- `quantization.rs`: `PqParams::from_dim_and_m_k(dim, m, k)` (existing `from_dim_and_m` delegates with 256); the FastScan train arm's direct `params.k = 16` assignment now goes through `PqParams::new`'s validation.
- `pq_codebook.rs` — two public API signature changes (in-crate callers only; bindings/proto/server go through `Engine::train_pq_codebook`, whose signature is unchanged):
  - `train_and_write_pq_codebook(..., k: u16, ...)`
  - `SharedPqCodebook::validate_for(dim, m, expected_k: u16)` — a k-mismatched codebook (e.g. a k=256 file on a FastScan field) now fails the commit loudly with **both values named**.
- `pq_fastscan_io.rs`: `quantize_segment_pq_fastscan` gains `shared: Option<&SharedPqCodebook>`, mirroring the standard-PQ path; the `k != 16` backstop stays.
- `hnsw/writer.rs`: the FastScan arm gains the configured-but-untrained hard-error and the shared-codebook demotion-guard exemption **together** (policy and guard changing in lockstep prevents "configured but nothing happens" states), matching the standard arm's #918 failure policy.
- `engine.rs`: feature-gated FastScan arm in `train_pq_codebook` (k=16); `PqCodebookInfo::centroids` doc updated.
- `laurus-cli`: `pq-fastscan` passthrough feature (FastScan schemas cannot even deserialize without it) + `eligible_pq_fields` covers FastScan so `create index --train-pq-codebook` works there too.
- **CI**: `regression.yml`'s `test-laurus` job enables `pq-fastscan` on all three platforms — these feature-gated tests had **never run in CI**; the matrix also exercises AVX2/NEON/scalar kernel dispatch.
- Docs (EN+JA): `vector_indexing.md` shared-codebook semantics, `HnswOption::pq_codebook_path` doc comment, CLI `commands.md` wording.

## Tests

- Unit: byte-identical shared-vs-fresh FastScan codes (mirror of the standard-PQ test); k=256 rejected by the encode path; k=16 `.pqcb` roundtrip; `validate_for` k-mismatch.
- Writer (feature-gated ×3): a 10-vector segment stays `OwnedPqFastScan` with a shared codebook (no Scalar8Bit demotion); configured-but-untrained hard-errors at write naming the path; k=256-on-FastScan errors with both k values named.
- E2e (`pq_fastscan_shared_codebook_test.rs`, new, feature-gated ×2): commit-before-training errors → train (`centroids == 16`, persisted file verified) → reopened engine commits 5 docs (below the min-train threshold of 16, only possible via the shared codebook); a k=256 codebook on a FastScan schema fails the commit with the mismatch named.
- RED proof: reversibly forcing the writer's shared argument to `None` makes the k256-on-FastScan test fail (the commit wrongly succeeds); restored to green.

## Verification

- `cargo fmt --check`: clean (stable + 1.97.0). `cargo clippy -- -D warnings`: 0 errors across 4 configs (workspace stable / workspace 1.97.0 / laurus+pq-fastscan / laurus-cli+pq-fastscan).
- `cargo test -p laurus --lib`: 1274 passed; `--lib --features pq-fastscan`: 1286 passed. Full `--tests`: green in both feature configs.
- wasm32 `cargo check -p laurus-wasm`: clean. `cargo doc`: 73 warnings (unchanged baseline). markdownlint EN+JA: 0 errors; both mdBooks build.