### PR TITLE
fix(deps): make laurus's HF/tokenizers dependencies musl-friendly

### DIFF
--- a/.github/workflows/index-interop.yml
+++ b/.github/workflows/index-interop.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.HF_HOME }}
-          key: hf-cache-${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2
+          key: hf-cache-${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2-rustls
 
       - name: Build laurus CLI
         run: |
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.HF_HOME }}
-          key: hf-cache-${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2
+          key: hf-cache-${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2-rustls
 
       - name: Build laurus CLI
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -216,6 +216,24 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --features embeddings-all -- -D warnings
 
+      - name: Assert laurus-cli links no OpenSSL
+        run: |
+          set -euo pipefail
+          # Guards the musl release binaries: openssl-sys cannot cross-compile
+          # to *-unknown-linux-musl. Historically it entered the graph via
+          # hf-hub's default features (default-tls -> native-tls -> openssl-sys).
+          #
+          # NOTE: grepping Cargo.lock is NOT a valid guard here -- the
+          # workspace lock legitimately contains openssl-sys via
+          # laurus-php -> ext-php-rs. Only the laurus-cli sub-graph matters.
+          if cargo tree -p laurus-cli --features embeddings-all \
+               --target x86_64-unknown-linux-musl -i openssl-sys >/dev/null 2>&1; then
+            echo "ERROR: openssl-sys reappeared in the laurus-cli dependency graph:" >&2
+            cargo tree -p laurus-cli --features embeddings-all \
+              --target x86_64-unknown-linux-musl -i openssl-sys >&2
+            exit 1
+          fi
+
   # ============================================================
   # Test laurus (core library)
   # ============================================================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,9 +1419,6 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "exr"
@@ -2020,19 +2017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
- "futures",
  "http",
  "indicatif",
  "libc",
  "log",
- "native-tls",
- "num_cpus",
  "rand 0.9.2",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
  "ureq",
  "windows-sys 0.61.2",
 ]
@@ -2137,6 +2130,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2149,22 +2143,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4385,30 +4363,27 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4418,6 +4393,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5411,7 +5387,6 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "indicatif",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
@@ -5458,16 +5433,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/docs/ja/src/development/feature_flags.md
+++ b/docs/ja/src/development/feature_flags.md
@@ -49,6 +49,30 @@ laurus = { version = "0.9", features = ["embeddings-multimodal"] }
 laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
+## TLS とネットワークの挙動
+
+Embedding Feature は、信頼するルート証明書のソースが異なる 2 系統の TLS
+スタックを使用します。
+
+| Feature | HTTP クライアント | TLS backend | 信頼するルート証明書のソース |
+| :--- | :--- | :--- | :--- |
+| `embeddings-candle`, `embeddings-multimodal` | `hf-hub`（`ureq`） | rustls | バイナリに埋め込まれた Mozilla ルート証明書（`webpki-roots`） |
+| `embeddings-openai` | `reqwest` | rustls | OS の信頼ストア（`rustls-platform-verifier` 経由） |
+
+Hugging Face Hub からのモデルダウンロード（`embeddings-candle` /
+`embeddings-multimodal`）は、OS の信頼ストアではなくバイナリに埋め込まれた
+証明書を使用します。これは意図的な設計です。`ca-certificates` パッケージが
+入っていない `scratch` や distroless コンテナ内でも、完全静的リンクの musl
+バイナリがモデルをダウンロードできるようにするためです。トレードオフとして、
+このパスでは `SSL_CERT_FILE` / `SSL_CERT_DIR` は尊重されず、OS の信頼ストア
+にのみ導入された独自 CA（例: 社内の TLS インスペクションプロキシ配下）は
+信頼されません。そのようなプロキシ経由で Hugging Face へのダウンロードを
+行う必要がある場合は、キャッシュを事前に用意して `HF_HOME` でそれを指すか、
+信頼された内部ミラーを `HF_ENDPOINT` で指定してください。
+
+`embeddings-openai` は OS の信頼ストアを参照するため、これを使用する
+コンテナには引き続き `ca-certificates` のインストールが必要です。
+
 ## Feature Flag がバイナリサイズに与える影響
 
 Embedding Feature を有効にすると、コンパイル時間とバイナリサイズが増加する依存クレートが追加されます。

--- a/docs/src/development/feature_flags.md
+++ b/docs/src/development/feature_flags.md
@@ -49,6 +49,30 @@ Convenience flag that enables all embedding features.
 laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
+## TLS and Network Behavior
+
+The embedding features use two independent TLS stacks with different trust
+sources:
+
+| Feature | HTTP client | TLS backend | Trust source |
+| :--- | :--- | :--- | :--- |
+| `embeddings-candle`, `embeddings-multimodal` | `hf-hub` (`ureq`) | rustls | Bundled Mozilla root certificates (`webpki-roots`) |
+| `embeddings-openai` | `reqwest` | rustls | OS trust store (via `rustls-platform-verifier`) |
+
+Model downloads from Hugging Face Hub (`embeddings-candle` /
+`embeddings-multimodal`) use certificates bundled into the binary rather than
+the operating system's trust store. This is deliberate: it lets a fully
+static musl binary download models inside a `scratch` or distroless
+container with no `ca-certificates` package installed. The tradeoff is that
+`SSL_CERT_FILE` / `SSL_CERT_DIR` are not honored on this path, and a custom
+CA installed only in the OS trust store (for example behind a corporate
+TLS-inspecting proxy) will not be trusted. If you need to route Hugging Face
+downloads through such a proxy, pre-populate the cache and point `HF_HOME` at
+it, or set `HF_ENDPOINT` to an internally trusted mirror.
+
+`embeddings-openai` reads the OS trust store, so containers using it still
+need `ca-certificates` installed.
+
 ## Feature Flag Impact on Binary Size
 
 Enabling embedding features adds dependencies that increase compile time and binary size:

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -64,8 +64,34 @@ tempfile = { workspace = true, optional = true }
 candle-core = { version = "0.10.2", optional = true }
 candle-nn = { version = "0.10.2", optional = true }
 candle-transformers = { version = "0.10.2", optional = true }
-hf-hub = { version = "0.5.0", optional = true }
-tokenizers = { version = "0.23.1", optional = true }
+# hf-hub's default features are ["default-tls", "tokio", "ureq"], and
+# `default-tls = ["native-tls"]` pulls reqwest 0.12 + native-tls + openssl-sys
+# -- the only openssl-sys entry point in the laurus-cli dependency graph
+# (laurus's own reqwest 0.13 already defaults to rustls). openssl-sys cannot
+# cross-compile to *-unknown-linux-musl, which is what this pins away.
+#
+# `ureq` is mandatory, not optional: laurus uses `hf_hub::api::sync::ApiBuilder`
+# (candle_bert_embedder.rs, candle_clip_embedder.rs) and hf-hub gates the whole
+# `api::sync` module behind `#[cfg(feature = "ureq")]`. `ureq` itself defaults
+# to a rustls TLS backend, so `rustls-tls` here only guards the (currently
+# unused) `tokio`/reqwest path in case some future dependency turns it on via
+# feature unification.
+hf-hub = { version = "0.5.0", default-features = false, features = [
+    "ureq",
+    "rustls-tls",
+], optional = true }
+# Default features include `esaxx_fast` (-> esaxx-rs/cpp), which compiles a
+# C++ source file (esaxx.cpp) purely to accelerate Unigram tokenizer
+# *training* (tokenizers::models::unigram::trainer). laurus only loads
+# pretrained tokenizers via `Tokenizer::from_file` + `encode` and never
+# trains one, so this buys nothing here while forcing every build (not just
+# musl) to carry a C++ toolchain. Disabling it falls back to the pure-Rust
+# `suffix_rs` implementation with no functional change. `candle-core`
+# already builds tokenizers this way (`default-features = false,
+# features = ["onig"]`).
+tokenizers = { version = "0.23.1", default-features = false, features = [
+    "onig",
+], optional = true }
 reqwest = { version = "0.13.3", features = ["json"], optional = true }
 image = { version = "0.25.10", optional = true }
 


### PR DESCRIPTION
## Summary

- Switch `hf-hub` to a rustls/ureq feature set (`default-features = false`,
  `["ureq", "rustls-tls"]`), dropping `native-tls` -> `openssl-sys`. This was
  the only `openssl-sys` entry point in the `laurus-cli` dependency graph and
  it cannot cross-compile to `*-unknown-linux-musl`.
- Disable `tokenizers`' default `esaxx_fast` feature, which compiles a C++
  source file solely to accelerate Unigram tokenizer *training* -- a code
  path laurus never exercises (it only loads pretrained tokenizers via
  `Tokenizer::from_file` + `encode`). Falls back to the pure-Rust `suffix_rs`
  implementation with no functional change, and removes an unnecessary C++
  toolchain requirement from every build target, not just musl.
- Add a CI guard (`regression.yml`) asserting `openssl-sys` never reappears in
  `laurus-cli`'s dependency graph for the musl target.
- Bump the Hugging Face model cache key in `index-interop.yml` to force a
  real download on this PR (proving the new TLS stack actually works, not
  just compiles).
- Document the resulting TLS/trust-store behavior split in
  `feature_flags.md` (English + Japanese): `embeddings-candle` /
  `embeddings-multimodal` now use bundled Mozilla root certificates via
  `ureq`+rustls, while `embeddings-openai` continues to use the OS trust
  store via `reqwest`+`rustls-platform-verifier`.

These are prerequisites for #951 (static musl release binaries); the CI
matrix changes and documentation for the actual musl binaries will follow in
a separate PR based on this branch.

## Behavior change

Hugging Face model downloads (`embeddings-candle` / `embeddings-multimodal`)
no longer honor `SSL_CERT_FILE` / `SSL_CERT_DIR` and no longer trust CAs
installed only in the OS trust store (e.g. behind a corporate TLS-inspecting
proxy) -- they now verify against certificates bundled into the binary. This
is what makes those downloads work inside a `scratch`/distroless container
with no `ca-certificates` package installed, which is the whole point of the
musl binaries this unblocks. Workaround for corporate-CA environments:
pre-populate `HF_HOME`, or point `HF_ENDPOINT` at an internally trusted
mirror. Documented in `feature_flags.md`.

`embeddings-openai` is unaffected (already used rustls with the OS trust
store before this change).

## Test plan

- [x] `cargo tree -p laurus-cli --features embeddings-all --target x86_64-unknown-linux-musl -i openssl-sys` exits non-zero (not found)
- [x] `cargo tree -p laurus --features embeddings-all -e features -i esaxx-rs` shows the `cpp`/`esaxx_fast` feature is not activated by any path
- [x] `cargo check -p laurus --features embeddings-all` (native gnu target) -- no regression
- [x] `cargo clippy -p laurus --all-targets --features embeddings-all -- -D warnings` -- clean
- [x] `cargo test -p laurus --lib --features embeddings-all` -- 1305 passed, 0 failed
- [x] Cold-cache real download: `HF_HOME=$(mktemp -d) cargo run --release -p laurus --example search_with_candle --features embeddings-candle` -- model downloaded and search completed successfully
- [x] Cold-cache real download: same with `--example multimodal_search --features embeddings-multimodal` -- CLIP model downloaded and loaded successfully
- [x] `markdownlint-cli2` on the two changed doc files -- zero errors
- [ ] CI: `index-interop` job re-downloads (cache key bumped) and passes on this PR

Closes part of #951 (dependency prerequisite; CI/docs for the musl binaries themselves ship in a follow-up PR)
