### PR TITLE
ci: publish static musl release binaries

### DIFF
--- a/.github/workflows/index-interop.yml
+++ b/.github/workflows/index-interop.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.HF_HOME }}
-          key: hf-cache-${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2
+          key: hf-cache-${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2-rustls
 
       - name: Build laurus CLI
         run: |
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.HF_HOME }}
-          key: hf-cache-${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2
+          key: hf-cache-${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2-rustls
 
       - name: Build laurus CLI
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -216,6 +216,24 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --features embeddings-all -- -D warnings
 
+      - name: Assert laurus-cli links no OpenSSL
+        run: |
+          set -euo pipefail
+          # Guards the musl release binaries: openssl-sys cannot cross-compile
+          # to *-unknown-linux-musl. Historically it entered the graph via
+          # hf-hub's default features (default-tls -> native-tls -> openssl-sys).
+          #
+          # NOTE: grepping Cargo.lock is NOT a valid guard here -- the
+          # workspace lock legitimately contains openssl-sys via
+          # laurus-php -> ext-php-rs. Only the laurus-cli sub-graph matters.
+          if cargo tree -p laurus-cli --features embeddings-all \
+               --target x86_64-unknown-linux-musl -i openssl-sys >/dev/null 2>&1; then
+            echo "ERROR: openssl-sys reappeared in the laurus-cli dependency graph:" >&2
+            cargo tree -p laurus-cli --features embeddings-all \
+              --target x86_64-unknown-linux-musl -i openssl-sys >&2
+            exit 1
+          fi
+
   # ============================================================
   # Test laurus (core library)
   # ============================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -539,7 +539,12 @@ jobs:
   # ============================================================
   build-binary:
     name: Build Binary
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Also allow workflow_dispatch: release.yml has no PR-time coverage
+    # (it isn't referenced by any regression.yml path filter), so this is
+    # the only way to exercise the musl legs before tagging a release.
+    # create-release and every publish-* job below stay tag-gated, so a
+    # dispatch run never publishes anything.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     needs: [test-all]
     strategy:
       matrix:
@@ -552,6 +557,24 @@ jobs:
             target: aarch64-unknown-linux-gnu
             binary: laurus
             archive: tar.gz
+          # Fully static musl builds for Alpine / distroless / scratch.
+          # The --features embeddings-all graph builds native C crates
+          # (aws-lc-sys, onig_sys) via cargo-zigbuild, which bundles a musl
+          # C/C++ cross-toolchain -- Ubuntu's musl-tools package ships only
+          # musl-gcc, no C++ support (needed historically for tokenizers'
+          # esaxx-rs; laurus now builds tokenizers without it, but zigbuild
+          # is kept since it's already verified end-to-end for this
+          # dependency set with no Docker requirement).
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            binary: laurus
+            archive: tar.gz
+            build_cmd: zigbuild
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            binary: laurus
+            archive: tar.gz
+            build_cmd: zigbuild
           - runner: macos-latest
             target: aarch64-apple-darwin
             binary: laurus
@@ -573,6 +596,10 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/free-disk-space
+
       - name: Install protoc
         uses: ./.github/actions/install-protoc
         with:
@@ -584,8 +611,45 @@ jobs:
           toolchain: stable
           target: ${{ matrix.platform.target }}
 
+      - name: Set up Python
+        if: matrix.platform.build_cmd == 'zigbuild'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install zig and cargo-zigbuild
+        if: matrix.platform.build_cmd == 'zigbuild'
+        run: |
+          set -euo pipefail
+          # cargo-zigbuild falls back to `python3 -m ziglang` when `zig` is
+          # not on PATH, so the PyPI distribution is sufficient. Both
+          # versions are pinned so a zig or cargo-zigbuild release cannot
+          # break a tag build.
+          pip install "ziglang==0.16.0"
+          cargo install cargo-zigbuild --version 0.23.0 --locked
+
       - name: Build binary
-        run: cargo build --release --target ${{ matrix.platform.target }} -p laurus-cli --features embeddings-all
+        run: cargo ${{ matrix.platform.build_cmd || 'build' }} --release --target ${{ matrix.platform.target }} -p laurus-cli --features embeddings-all
+
+      - name: Verify static linking
+        if: matrix.platform.build_cmd == 'zigbuild'
+        run: |
+          set -euo pipefail
+          BIN="target/${{ matrix.platform.target }}/release/${{ matrix.platform.binary }}"
+          file "$BIN"
+          file "$BIN" | grep -Eq 'statically linked|static-pie linked' || {
+            echo "ERROR: $BIN is not statically linked" >&2
+            exit 1
+          }
+          # A truly static executable has no DT_NEEDED entries.
+          if readelf -d "$BIN" 2>/dev/null | grep -q 'NEEDED'; then
+            echo "ERROR: $BIN has dynamic library dependencies:" >&2
+            readelf -d "$BIN" >&2
+            exit 1
+          fi
+          if [ "${{ matrix.platform.target }}" = "x86_64-unknown-linux-musl" ]; then
+            "$BIN" --version
+          fi
 
       - name: Package binary (Unix)
         if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -596,6 +596,17 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v6
 
+      - name: Compute release version string
+        id: version
+        shell: bash
+        run: |
+          # github.ref_name is the tag name on a tag push (e.g. "v0.10.0",
+          # never contains '/') but is the branch name on a workflow_dispatch
+          # run (e.g. "ci/musl-release-binaries"). A literal '/' breaks the
+          # tar/zip filenames below, since tar/Compress-Archive interpret it
+          # as a path separator. Sanitizing is a no-op for real tag builds.
+          echo "value=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
       - name: Free disk space
         if: runner.os == 'Linux'
         uses: ./.github/actions/free-disk-space
@@ -655,7 +666,7 @@ jobs:
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
           tar \
-            -czf "laurus-${{ github.ref_name }}-${{ matrix.platform.target }}.tar.gz" \
+            -czf "laurus-${{ steps.version.outputs.value }}-${{ matrix.platform.target }}.tar.gz" \
             -C "target/${{ matrix.platform.target }}/release" "${{ matrix.platform.binary }}"
 
       - name: Package binary (Windows)
@@ -664,13 +675,13 @@ jobs:
         run: |
           Compress-Archive `
             -Path "target/${{ matrix.platform.target }}/release/${{ matrix.platform.binary }}" `
-            -DestinationPath "laurus-${{ github.ref_name }}-${{ matrix.platform.target }}.zip"
+            -DestinationPath "laurus-${{ steps.version.outputs.value }}-${{ matrix.platform.target }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: laurus-${{ matrix.platform.target }}
-          path: laurus-${{ github.ref_name }}-${{ matrix.platform.target }}.${{ matrix.platform.archive }}
+          path: laurus-${{ steps.version.outputs.value }}-${{ matrix.platform.target }}.${{ matrix.platform.archive }}
 
   # ============================================================
   # Build Python source distribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,12 @@ Pull requests automatically run:
    `test-laurus-wasm`, `test-laurus-ruby`, `test-laurus-php`) run when their
    respective crate or shared sources change.
 
+   Release tags additionally build binaries for macOS (x86_64, aarch64) and
+   static Linux musl (`x86_64-unknown-linux-musl`,
+   `aarch64-unknown-linux-musl`) in `build-binary` -- these are build-only
+   and not part of the PR test matrix above; see
+   [Prebuilt binaries](https://mosuka.github.io/laurus/laurus-cli/installation.html#prebuilt-binaries).
+
 All checks must pass before a PR can be merged.
 
 ## License

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,9 +1419,6 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "exr"
@@ -2020,19 +2017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
- "futures",
  "http",
  "indicatif",
  "libc",
  "log",
- "native-tls",
- "num_cpus",
  "rand 0.9.2",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
  "ureq",
  "windows-sys 0.61.2",
 ]
@@ -2137,6 +2130,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2149,22 +2143,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4385,30 +4363,27 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4418,6 +4393,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5411,7 +5387,6 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "indicatif",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
@@ -5458,16 +5433,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ build-laurus: ## Build laurus (release)
 build-laurus-cli: ## Build laurus-cli (release)
 	cargo build -p laurus-cli --release
 
+build-laurus-cli-musl: ## Build laurus-cli for x86_64-unknown-linux-musl (static, requires cargo-zigbuild)
+	cargo zigbuild --release -p laurus-cli --features embeddings-all \
+	  --target x86_64-unknown-linux-musl
+
 build-laurus-server: ## Build laurus-server (release)
 	cargo build -p laurus-server --release
 

--- a/docs/ja/src/development/build_and_test.md
+++ b/docs/ja/src/development/build_and_test.md
@@ -5,6 +5,9 @@
 - **Rust** 1.85 以降（edition 2024）
 - **Cargo**（Rust に付属）
 - **protobuf コンパイラ**（`protoc`）-- `laurus-server` のビルドに必要
+- **[cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild)** --
+  任意。静的リンクの musl バイナリをローカルでクロスビルドする場合のみ必要
+  （[静的リンクの musl バイナリをクロスビルドする](#静的リンクの-musl-バイナリをクロスビルドする)を参照）
 
 ## ビルド
 
@@ -18,6 +21,53 @@ cargo build --features embeddings-candle
 # リリースモードでビルド
 cargo build --release
 ```
+
+## 静的リンクの musl バイナリをクロスビルドする
+
+`laurus-cli` のリリースワークフローは、動的リンクの glibc バイナリに加えて、
+完全に静的リンクされた `x86_64-unknown-linux-musl` /
+`aarch64-unknown-linux-musl` バイナリもビルドします
+（[ビルド済みバイナリ](../laurus-cli/installation.md#ビルド済みバイナリ)を参照）。
+
+前提条件:
+
+```bash
+rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+pip install cargo-zigbuild
+```
+
+`cargo build` の代わりに `cargo zigbuild` でビルドします:
+
+```bash
+cargo zigbuild --release --target x86_64-unknown-linux-musl \
+  -p laurus-cli --features embeddings-all
+```
+
+（`x86_64` ターゲットについては `make build-laurus-cli-musl` と同等です）
+
+**なぜ `apt install musl-tools` ではなく `cargo-zigbuild` を使うのか？**
+Ubuntu の `musl-tools` パッケージは `musl-gcc`（C）を提供しますが
+`musl-g++`（C++）は提供しません。laurus の `--features embeddings-all` の
+依存関係の大部分は C のみか純 Rust です（`aws-lc-sys`、`onig_sys`）が、
+`musl-tools` だけの構成は依存 Feature を 1 つ切り替えるだけで再び C++ を
+要求しかねません（`tokenizers` の `esaxx_fast`。laurus では意図的に無効化
+しています。[Feature Flags](feature_flags.md) を参照）。`cargo-zigbuild` は
+クロス C/C++ ツールチェーンとして [Zig](https://ziglang.org/) を使用し、
+各ターゲット向けの musl ヘッダとライブラリを同梱しているため、Docker が
+不要です。
+
+ビルド結果が本当に静的であることを確認する:
+
+```bash
+file target/x86_64-unknown-linux-musl/release/laurus
+# -> ELF 64-bit LSB executable, ..., statically linked
+readelf -d target/x86_64-unknown-linux-musl/release/laurus | grep NEEDED
+# -> (出力なし)
+```
+
+この手順が対応する CI 設定については
+[`.github/workflows/release.yml`](../../../.github/workflows/release.yml)
+の `build-binary` を参照してください。
 
 ## テスト
 

--- a/docs/ja/src/development/feature_flags.md
+++ b/docs/ja/src/development/feature_flags.md
@@ -49,6 +49,30 @@ laurus = { version = "0.9", features = ["embeddings-multimodal"] }
 laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
+## TLS とネットワークの挙動
+
+Embedding Feature は、信頼するルート証明書のソースが異なる 2 系統の TLS
+スタックを使用します。
+
+| Feature | HTTP クライアント | TLS backend | 信頼するルート証明書のソース |
+| :--- | :--- | :--- | :--- |
+| `embeddings-candle`, `embeddings-multimodal` | `hf-hub`（`ureq`） | rustls | バイナリに埋め込まれた Mozilla ルート証明書（`webpki-roots`） |
+| `embeddings-openai` | `reqwest` | rustls | OS の信頼ストア（`rustls-platform-verifier` 経由） |
+
+Hugging Face Hub からのモデルダウンロード（`embeddings-candle` /
+`embeddings-multimodal`）は、OS の信頼ストアではなくバイナリに埋め込まれた
+証明書を使用します。これは意図的な設計です。`ca-certificates` パッケージが
+入っていない `scratch` や distroless コンテナ内でも、完全静的リンクの musl
+バイナリがモデルをダウンロードできるようにするためです。トレードオフとして、
+このパスでは `SSL_CERT_FILE` / `SSL_CERT_DIR` は尊重されず、OS の信頼ストア
+にのみ導入された独自 CA（例: 社内の TLS インスペクションプロキシ配下）は
+信頼されません。そのようなプロキシ経由で Hugging Face へのダウンロードを
+行う必要がある場合は、キャッシュを事前に用意して `HF_HOME` でそれを指すか、
+信頼された内部ミラーを `HF_ENDPOINT` で指定してください。
+
+`embeddings-openai` は OS の信頼ストアを参照するため、これを使用する
+コンテナには引き続き `ca-certificates` のインストールが必要です。
+
 ## Feature Flag がバイナリサイズに与える影響
 
 Embedding Feature を有効にすると、コンパイル時間とバイナリサイズが増加する依存クレートが追加されます。

--- a/docs/ja/src/laurus-cli/installation.md
+++ b/docs/ja/src/laurus-cli/installation.md
@@ -1,5 +1,71 @@
 # インストール
 
+## ビルド済みバイナリ
+
+[GitHub のリリースページ](https://github.com/mosuka/laurus/releases)では、
+以下のターゲット向けにビルド済みの `laurus` バイナリを配布しています。
+いずれも `--features embeddings-all` でビルドされています。
+
+| ターゲットトリプル | プラットフォーム | libc | リンク方式 | アーカイブ |
+| :--- | :--- | :--- | :--- | :--- |
+| `x86_64-unknown-linux-gnu` | Linux x86_64 | glibc | 動的 | `.tar.gz` |
+| `aarch64-unknown-linux-gnu` | Linux aarch64 | glibc | 動的 | `.tar.gz` |
+| `x86_64-unknown-linux-musl` | Linux x86_64 | musl | 静的 | `.tar.gz` |
+| `aarch64-unknown-linux-musl` | Linux aarch64 | musl | 静的 | `.tar.gz` |
+| `x86_64-apple-darwin` | macOS Intel | -- | 動的 | `.tar.gz` |
+| `aarch64-apple-darwin` | macOS Apple Silicon | -- | 動的 | `.tar.gz` |
+| `x86_64-pc-windows-msvc` | Windows x86_64 | MSVC | 動的 | `.zip` |
+| `aarch64-pc-windows-msvc` | Windows arm64 | MSVC | 動的 | `.zip` |
+
+```bash
+VERSION=v0.10.0
+TARGET=x86_64-unknown-linux-musl
+curl -fsSL -O "https://github.com/mosuka/laurus/releases/download/${VERSION}/laurus-${VERSION}-${TARGET}.tar.gz"
+tar -xzf "laurus-${VERSION}-${TARGET}.tar.gz"
+./laurus --version
+```
+
+### どのビルドを使うべきか
+
+- 一般的な Linux ディストリビューションでは **gnu** ビルドを使ってください。
+  musl のアロケータ（`mallocng`）は、laurus の索引処理のようなマルチスレッド・
+  allocation-heavy なワークロードでは glibc のアロケータより明確に遅くなります。
+- Alpine、distroless、`scratch`、あるいはビルドランナーより古い glibc しか
+  持たないホストでは **musl** ビルドを使ってください。musl バイナリは
+  完全に静的リンクされており、動的ライブラリへの依存が一切ありません。
+
+### コンテナで musl バイナリを使う
+
+```dockerfile
+FROM alpine:3.22
+# embeddings-openai を使う場合のみ必要: reqwest の rustls backend は
+# OS の信頼ストアを参照します。Hugging Face からのモデルダウンロード
+# （embeddings-candle / embeddings-multimodal）はバイナリに埋め込まれた
+# ルート証明書を使うため、これがなくても動作します。詳細は開発ガイドの
+# 「Feature Flags」を参照してください。
+RUN apk add --no-cache ca-certificates
+COPY laurus /usr/local/bin/laurus
+ENTRYPOINT ["laurus"]
+```
+
+パッケージマネージャすら無い環境でも動作します:
+
+```dockerfile
+FROM scratch
+COPY laurus /laurus
+ENTRYPOINT ["/laurus"]
+```
+
+musl / `scratch` での運用における注意点:
+
+- DNS 解決には musl 内蔵のリゾルバが使われ、`/etc/resolv.conf` を読み込み、
+  NSS プラグインは無視されます。コンテナランタイムは常に `/etc/resolv.conf`
+  を提供するため通常は問題になりませんが、手動で `scratch` イメージを
+  構築する場合はこれを省略しないよう注意してください。
+- Rust の標準ライブラリは生成するスレッドに独自の既定スタックサイズ
+  （2 MiB）を使用するため、musl のより小さい `pthread` の既定値は
+  実質的に問題になりません。
+
 ## crates.io からインストール
 
 ```bash

--- a/docs/src/development/build_and_test.md
+++ b/docs/src/development/build_and_test.md
@@ -5,6 +5,9 @@
 - **Rust** 1.85 or later (edition 2024)
 - **Cargo** (included with Rust)
 - **protobuf compiler** (`protoc`) -- required for building `laurus-server`
+- **[cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild)** --
+  optional, only needed to cross-compile static musl binaries locally (see
+  [Cross-compiling static musl binaries](#cross-compiling-static-musl-binaries))
 
 ## Building
 
@@ -18,6 +21,52 @@ cargo build --features embeddings-candle
 # Build in release mode
 cargo build --release
 ```
+
+## Cross-compiling static musl binaries
+
+`laurus-cli`'s release workflow builds fully static
+`x86_64-unknown-linux-musl` / `aarch64-unknown-linux-musl` binaries in
+addition to the dynamically-linked glibc ones (see
+[Prebuilt binaries](../laurus-cli/installation.md#prebuilt-binaries)).
+
+Prerequisites:
+
+```bash
+rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+pip install cargo-zigbuild
+```
+
+Then build with `cargo zigbuild` in place of `cargo build`:
+
+```bash
+cargo zigbuild --release --target x86_64-unknown-linux-musl \
+  -p laurus-cli --features embeddings-all
+```
+
+(equivalent to `make build-laurus-cli-musl` for the `x86_64` target).
+
+**Why `cargo-zigbuild` and not `apt install musl-tools`?** Ubuntu's
+`musl-tools` package provides `musl-gcc` (C) but no `musl-g++` (C++). Most of
+laurus's `--features embeddings-all` dependency graph is C-only or pure Rust
+(`aws-lc-sys`, `onig_sys`), but a plain `musl-tools` setup is one dependency
+feature flip away from needing C++ again (`tokenizers`' `esaxx_fast`, which
+laurus deliberately disables -- see [Feature Flags](feature_flags.md)).
+`cargo-zigbuild` uses [Zig](https://ziglang.org/) as the cross C/C++
+toolchain, which bundles musl headers and libraries for every target and
+needs no Docker.
+
+Verify a build is genuinely static:
+
+```bash
+file target/x86_64-unknown-linux-musl/release/laurus
+# -> ELF 64-bit LSB executable, ..., statically linked
+readelf -d target/x86_64-unknown-linux-musl/release/laurus | grep NEEDED
+# -> (no output)
+```
+
+See `build-binary` in
+[`.github/workflows/release.yml`](../../../.github/workflows/release.yml)
+for the CI configuration this mirrors.
 
 ## Testing
 

--- a/docs/src/development/feature_flags.md
+++ b/docs/src/development/feature_flags.md
@@ -49,6 +49,30 @@ Convenience flag that enables all embedding features.
 laurus = { version = "0.9", features = ["embeddings-all"] }
 ```
 
+## TLS and Network Behavior
+
+The embedding features use two independent TLS stacks with different trust
+sources:
+
+| Feature | HTTP client | TLS backend | Trust source |
+| :--- | :--- | :--- | :--- |
+| `embeddings-candle`, `embeddings-multimodal` | `hf-hub` (`ureq`) | rustls | Bundled Mozilla root certificates (`webpki-roots`) |
+| `embeddings-openai` | `reqwest` | rustls | OS trust store (via `rustls-platform-verifier`) |
+
+Model downloads from Hugging Face Hub (`embeddings-candle` /
+`embeddings-multimodal`) use certificates bundled into the binary rather than
+the operating system's trust store. This is deliberate: it lets a fully
+static musl binary download models inside a `scratch` or distroless
+container with no `ca-certificates` package installed. The tradeoff is that
+`SSL_CERT_FILE` / `SSL_CERT_DIR` are not honored on this path, and a custom
+CA installed only in the OS trust store (for example behind a corporate
+TLS-inspecting proxy) will not be trusted. If you need to route Hugging Face
+downloads through such a proxy, pre-populate the cache and point `HF_HOME` at
+it, or set `HF_ENDPOINT` to an internally trusted mirror.
+
+`embeddings-openai` reads the OS trust store, so containers using it still
+need `ca-certificates` installed.
+
 ## Feature Flag Impact on Binary Size
 
 Enabling embedding features adds dependencies that increase compile time and binary size:

--- a/docs/src/laurus-cli/installation.md
+++ b/docs/src/laurus-cli/installation.md
@@ -1,5 +1,71 @@
 # Installation
 
+## Prebuilt binaries
+
+Each [GitHub release](https://github.com/mosuka/laurus/releases) ships
+prebuilt `laurus` binaries for the following targets, all built with
+`--features embeddings-all`:
+
+| Target triple | Platform | libc | Linking | Archive |
+| :--- | :--- | :--- | :--- | :--- |
+| `x86_64-unknown-linux-gnu` | Linux x86_64 | glibc | dynamic | `.tar.gz` |
+| `aarch64-unknown-linux-gnu` | Linux aarch64 | glibc | dynamic | `.tar.gz` |
+| `x86_64-unknown-linux-musl` | Linux x86_64 | musl | static | `.tar.gz` |
+| `aarch64-unknown-linux-musl` | Linux aarch64 | musl | static | `.tar.gz` |
+| `x86_64-apple-darwin` | macOS Intel | -- | dynamic | `.tar.gz` |
+| `aarch64-apple-darwin` | macOS Apple Silicon | -- | dynamic | `.tar.gz` |
+| `x86_64-pc-windows-msvc` | Windows x86_64 | MSVC | dynamic | `.zip` |
+| `aarch64-pc-windows-msvc` | Windows arm64 | MSVC | dynamic | `.zip` |
+
+```bash
+VERSION=v0.10.0
+TARGET=x86_64-unknown-linux-musl
+curl -fsSL -O "https://github.com/mosuka/laurus/releases/download/${VERSION}/laurus-${VERSION}-${TARGET}.tar.gz"
+tar -xzf "laurus-${VERSION}-${TARGET}.tar.gz"
+./laurus --version
+```
+
+### Which build should I use?
+
+- Use a **gnu** build on an ordinary Linux distribution. musl's allocator
+  (`mallocng`) is measurably slower than glibc's under multi-threaded,
+  allocation-heavy workloads, which describes laurus's indexing path.
+- Use a **musl** build for Alpine, distroless, `scratch`, or any host whose
+  glibc is older than the build runner's -- the musl binaries are fully
+  statically linked and have no dynamic library dependencies at all.
+
+### Using the musl binary in a container
+
+```dockerfile
+FROM alpine:3.22
+# Only needed if you use `embeddings-openai`: reqwest's rustls backend
+# verifies against the OS trust store. Hugging Face model downloads
+# (`embeddings-candle` / `embeddings-multimodal`) use root certificates
+# bundled into the binary and work without this. See "Feature Flags" in
+# the development guide for details.
+RUN apk add --no-cache ca-certificates
+COPY laurus /usr/local/bin/laurus
+ENTRYPOINT ["laurus"]
+```
+
+or, with no package manager at all:
+
+```dockerfile
+FROM scratch
+COPY laurus /laurus
+ENTRYPOINT ["/laurus"]
+```
+
+A couple of runtime notes for musl/`scratch` deployments:
+
+- DNS resolution uses musl's built-in resolver, which reads
+  `/etc/resolv.conf` and ignores NSS plugins. Container runtimes always
+  provide `/etc/resolv.conf`, so this works out of the box; a hand-built
+  `scratch` image must not omit it.
+- Rust's standard library uses its own default stack size for spawned
+  threads (2 MiB), not musl's smaller `pthread` default, so this is not
+  usually a concern in practice.
+
 ## From crates.io
 
 ```bash

--- a/laurus-cli/README.md
+++ b/laurus-cli/README.md
@@ -16,6 +16,11 @@ Command-line interface for the [Laurus](https://github.com/mosuka/laurus) search
 
 ## Installation
 
+Prebuilt binaries (including fully static musl builds for Alpine/scratch)
+are attached to each [GitHub release](https://github.com/mosuka/laurus/releases);
+see [Installation](https://mosuka.github.io/laurus/laurus-cli/installation.html)
+for the full target list and a download example.
+
 ```bash
 cargo install laurus-cli
 ```

--- a/laurus-cli/README_ja.md
+++ b/laurus-cli/README_ja.md
@@ -16,6 +16,12 @@
 
 ## インストール
 
+ビルド済みバイナリ（Alpine/scratch 向けの完全静的リンク musl ビルドを含む）は
+各 [GitHub リリース](https://github.com/mosuka/laurus/releases)に添付されています。
+全ターゲットの一覧とダウンロード例は
+[インストール](https://mosuka.github.io/laurus/ja/laurus-cli/installation.html)
+を参照してください。
+
 ```bash
 cargo install laurus-cli
 ```

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -64,8 +64,34 @@ tempfile = { workspace = true, optional = true }
 candle-core = { version = "0.10.2", optional = true }
 candle-nn = { version = "0.10.2", optional = true }
 candle-transformers = { version = "0.10.2", optional = true }
-hf-hub = { version = "0.5.0", optional = true }
-tokenizers = { version = "0.23.1", optional = true }
+# hf-hub's default features are ["default-tls", "tokio", "ureq"], and
+# `default-tls = ["native-tls"]` pulls reqwest 0.12 + native-tls + openssl-sys
+# -- the only openssl-sys entry point in the laurus-cli dependency graph
+# (laurus's own reqwest 0.13 already defaults to rustls). openssl-sys cannot
+# cross-compile to *-unknown-linux-musl, which is what this pins away.
+#
+# `ureq` is mandatory, not optional: laurus uses `hf_hub::api::sync::ApiBuilder`
+# (candle_bert_embedder.rs, candle_clip_embedder.rs) and hf-hub gates the whole
+# `api::sync` module behind `#[cfg(feature = "ureq")]`. `ureq` itself defaults
+# to a rustls TLS backend, so `rustls-tls` here only guards the (currently
+# unused) `tokio`/reqwest path in case some future dependency turns it on via
+# feature unification.
+hf-hub = { version = "0.5.0", default-features = false, features = [
+    "ureq",
+    "rustls-tls",
+], optional = true }
+# Default features include `esaxx_fast` (-> esaxx-rs/cpp), which compiles a
+# C++ source file (esaxx.cpp) purely to accelerate Unigram tokenizer
+# *training* (tokenizers::models::unigram::trainer). laurus only loads
+# pretrained tokenizers via `Tokenizer::from_file` + `encode` and never
+# trains one, so this buys nothing here while forcing every build (not just
+# musl) to carry a C++ toolchain. Disabling it falls back to the pure-Rust
+# `suffix_rs` implementation with no functional change. `candle-core`
+# already builds tokenizers this way (`default-features = false,
+# features = ["onig"]`).
+tokenizers = { version = "0.23.1", default-features = false, features = [
+    "onig",
+], optional = true }
 reqwest = { version = "0.13.3", features = ["json"], optional = true }
 image = { version = "0.25.10", optional = true }
 


### PR DESCRIPTION
## Summary

- Add `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to
  `build-binary`'s release matrix, built via `cargo-zigbuild` (zig bundles a
  musl C/C++ cross-toolchain; Ubuntu's `musl-tools` package ships C support
  only, which used to matter for `tokenizers`' `esaxx-rs` C++ dependency
  before #952 disabled it -- zigbuild is kept regardless since it's already
  verified end-to-end for this dependency set with no Docker requirement).
- A `build_cmd` matrix key lets the existing six legs keep using plain
  `cargo build` unchanged.
- A "Verify static linking" step (`file` + `readelf -d` check for no
  `NEEDED` entries) gates packaging so a non-static artifact can never reach
  a release.
- `Free disk space` added to all Linux legs (musl adds a second full
  `--features embeddings-all` LTO build tree).
- `build-binary` now also accepts `workflow_dispatch` (every `publish-*` job
  and `create-release` stay tag-gated) so the musl legs -- and the whole
  matrix -- can be exercised before tagging a release. This is what actually
  caught the bug below.
- `Makefile`: `build-laurus-cli-musl` target for local reproduction.
- Documentation (English, then Japanese): a "Prebuilt binaries" section in
  `laurus-cli/installation.md` with the full 8-target table and an
  Alpine/scratch usage example, a "Cross-compiling static musl binaries"
  section in `build_and_test.md`, short pointers in the `laurus-cli`
  READMEs, and a refresh of `CONTRIBUTING.md`'s CI platform list (musl is
  build-only, not part of the PR test matrix).

Depends on #952 (musl-friendly `hf-hub`/`tokenizers` dependencies).

## Bug found and fixed during verification

Dispatching this workflow from a branch surfaced a real, pre-existing bug:
`github.ref_name` is the tag name on a tag push (never contains `/`) but is
the *branch name* on a `workflow_dispatch` run -- and this project's own
branch naming convention uses slashes (`feat/`, `fix/`, `ci/`, ...). The
release archive filenames interpolate `github.ref_name` directly, so `tar`
read the `/` as a path separator and failed with `Cannot open: No such file
or directory` the first time this ran
(`laurus-ci/musl-release-binaries-aarch64-unknown-linux-gnu.tar.gz`). This
never manifested on a real tag push (no slash), which is presumably why it
went unnoticed, but it would have broken on the very first
`workflow_dispatch` use. Fixed by sanitizing `/` to `-` for the archive
filename (no-op for tag pushes).

## Test plan

Local:

- [x] `cargo zigbuild --release --target x86_64-unknown-linux-musl -p laurus-cli --features embeddings-all` -- 27MB, `file` reports `statically linked`, `readelf -d` has no `NEEDED` entries, `./laurus --version` runs
- [x] `cargo zigbuild --release --target aarch64-unknown-linux-musl -p laurus-cli --features embeddings-all` -- 22MB, same static-linking checks pass, runs under `qemu-aarch64-static`
- [x] `markdownlint-cli2 "docs/src/**/*.md" "docs/ja/src/**/*.md"` -- 154 files, zero errors
- [x] `mdbook build docs` and `mdbook build docs/ja` -- both succeed; verified the new cross-reference links (`installation.md#prebuilt-binaries` / `#ビルド済みバイナリ`) resolve to real anchors in the generated HTML

CI, via `gh workflow run release.yml --ref ci/musl-release-binaries` (two dispatch runs -- the first caught the ref_name bug above, the second is clean):

- [x] Full regression suite (format, clippy, all `test-*` jobs across every platform/binding) passes unmodified
- [x] All 8 `build-binary` legs succeed, including both musl legs with "Verify static linking" passing
- [x] `create-release` and all `publish-*` jobs correctly skipped (tag-gated, dispatch run does not publish anything)
- [x] Downloaded the two musl artifacts produced by CI itself and independently re-verified: `file` reports `statically linked` / `readelf -d` has no `NEEDED` entries for both, `laurus-x86_64-unknown-linux-musl` runs natively, `laurus-aarch64-unknown-linux-musl` runs under `qemu-aarch64-static`

Closes #951
