### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,7 +600,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          # github.ref_name is the tag name on a tag push (e.g. "v0.10.0",
+          # github.ref_name is the tag name on a tag push (e.g. "v0.11.0",
           # never contains '/') but is the branch name on a workflow_dispatch
           # run (e.g. "ci/musl-release-binaries"). A literal '/' breaks the
           # tar/zip filenames below, since tar/Compress-Archive interpret it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "laurus"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-mcp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-nodejs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "laurus",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-php"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "ext-php-rs",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-python"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "laurus",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-ruby"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "laurus",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-server"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Unified search library for lexical, vector, and semantic retrieval"
@@ -31,9 +31,9 @@ async-trait = "0.1.89"
 axum = "0.8.9"
 chrono = { version = "0.4.44", features = ["serde"] }
 dialoguer = "0.12.0"
-laurus = { version = "0.10.0", path = "laurus", default-features = false }
-laurus-mcp = { version = "0.10.0", path = "laurus-mcp" }
-laurus-server = { version = "0.10.0", path = "laurus-server" }
+laurus = { version = "0.11.0", path = "laurus", default-features = false }
+laurus-mcp = { version = "0.11.0", path = "laurus-mcp" }
+laurus-server = { version = "0.11.0", path = "laurus-server" }
 prost = "0.14.3"
 rmcp = { version = "1.6.0", features = ["server", "transport-io"] }
 rustyline = "18.0.0"

--- a/docs/ja/src/development/feature_flags.md
+++ b/docs/ja/src/development/feature_flags.md
@@ -19,7 +19,7 @@
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-candle"] }
+laurus = { version = "0.11", features = ["embeddings-candle"] }
 ```
 
 ### `embeddings-openai`
@@ -28,7 +28,7 @@ laurus = { version = "0.9", features = ["embeddings-candle"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-openai"] }
+laurus = { version = "0.11", features = ["embeddings-openai"] }
 ```
 
 ### `embeddings-multimodal`
@@ -37,7 +37,7 @@ laurus = { version = "0.9", features = ["embeddings-openai"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-multimodal"] }
+laurus = { version = "0.11", features = ["embeddings-multimodal"] }
 ```
 
 ### `embeddings-all`
@@ -46,7 +46,7 @@ laurus = { version = "0.9", features = ["embeddings-multimodal"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-all"] }
+laurus = { version = "0.11", features = ["embeddings-all"] }
 ```
 
 ## TLS とネットワークの挙動

--- a/docs/ja/src/getting_started/installation.md
+++ b/docs/ja/src/getting_started/installation.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-laurus = "0.9"
+laurus = "0.11"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -28,28 +28,28 @@ Laurus はデフォルトで最小限の機能セットで提供されます。�
 
 ```toml
 [dependencies]
-laurus = "0.9"
+laurus = "0.11"
 ```
 
 **ローカルモデルによる Vector 検索**（API キー不要）:
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-candle"] }
+laurus = { version = "0.11", features = ["embeddings-candle"] }
 ```
 
 **OpenAI による Vector 検索**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-openai"] }
+laurus = { version = "0.11", features = ["embeddings-openai"] }
 ```
 
 **すべての機能**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-all"] }
+laurus = { version = "0.11", features = ["embeddings-all"] }
 ```
 
 ## インストールの確認

--- a/docs/ja/src/laurus-cli/installation.md
+++ b/docs/ja/src/laurus-cli/installation.md
@@ -18,7 +18,7 @@
 | `aarch64-pc-windows-msvc` | Windows arm64 | MSVC | 動的 | `.zip` |
 
 ```bash
-VERSION=v0.10.0
+VERSION=v0.11.0
 TARGET=x86_64-unknown-linux-musl
 curl -fsSL -O "https://github.com/mosuka/laurus/releases/download/${VERSION}/laurus-${VERSION}-${TARGET}.tar.gz"
 tar -xzf "laurus-${VERSION}-${TARGET}.tar.gz"

--- a/docs/ja/src/laurus.md
+++ b/docs/ja/src/laurus.md
@@ -48,15 +48,15 @@ graph TB
 ```toml
 # Lexical検索のみ（Embeddingなし）
 [dependencies]
-laurus = "0.9"
+laurus = "0.11"
 
 # ローカルBERT Embeddingを使用
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-candle"] }
+laurus = { version = "0.11", features = ["embeddings-candle"] }
 
 # すべてのFeatureを有効化
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-all"] }
+laurus = { version = "0.11", features = ["embeddings-all"] }
 ```
 
 ## セクション

--- a/docs/src/development/feature_flags.md
+++ b/docs/src/development/feature_flags.md
@@ -19,7 +19,7 @@ Enables `CandleBertEmbedder` for running BERT models locally on the CPU. Models 
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-candle"] }
+laurus = { version = "0.11", features = ["embeddings-candle"] }
 ```
 
 ### `embeddings-openai`
@@ -28,7 +28,7 @@ Enables `OpenAIEmbedder` for calling the OpenAI Embeddings API. Requires an `OPE
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-openai"] }
+laurus = { version = "0.11", features = ["embeddings-openai"] }
 ```
 
 ### `embeddings-multimodal`
@@ -37,7 +37,7 @@ Enables `CandleClipEmbedder` for CLIP-based text and image embeddings. Implies `
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-multimodal"] }
+laurus = { version = "0.11", features = ["embeddings-multimodal"] }
 ```
 
 ### `embeddings-all`
@@ -46,7 +46,7 @@ Convenience flag that enables all embedding features.
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-all"] }
+laurus = { version = "0.11", features = ["embeddings-all"] }
 ```
 
 ## TLS and Network Behavior

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -6,7 +6,7 @@ Add `laurus` and `tokio` (async runtime) to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-laurus = "0.9"
+laurus = "0.11"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -28,28 +28,28 @@ Laurus ships with a minimal default feature set. Enable additional features as n
 
 ```toml
 [dependencies]
-laurus = "0.9"
+laurus = "0.11"
 ```
 
 **Vector search with local model** (no API key required):
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-candle"] }
+laurus = { version = "0.11", features = ["embeddings-candle"] }
 ```
 
 **Vector search with OpenAI**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-openai"] }
+laurus = { version = "0.11", features = ["embeddings-openai"] }
 ```
 
 **Everything**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-all"] }
+laurus = { version = "0.11", features = ["embeddings-all"] }
 ```
 
 ## Verify Installation

--- a/docs/src/laurus-cli/installation.md
+++ b/docs/src/laurus-cli/installation.md
@@ -18,7 +18,7 @@ prebuilt `laurus` binaries for the following targets, all built with
 | `aarch64-pc-windows-msvc` | Windows arm64 | MSVC | dynamic | `.zip` |
 
 ```bash
-VERSION=v0.10.0
+VERSION=v0.11.0
 TARGET=x86_64-unknown-linux-musl
 curl -fsSL -O "https://github.com/mosuka/laurus/releases/download/${VERSION}/laurus-${VERSION}-${TARGET}.tar.gz"
 tar -xzf "laurus-${VERSION}-${TARGET}.tar.gz"

--- a/docs/src/laurus.md
+++ b/docs/src/laurus.md
@@ -48,15 +48,15 @@ The `laurus` crate has no default features enabled. Enable embedding support as 
 ```toml
 # Lexical search only (no embedding)
 [dependencies]
-laurus = "0.9"
+laurus = "0.11"
 
 # With local BERT embeddings
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-candle"] }
+laurus = { version = "0.11", features = ["embeddings-candle"] }
 
 # All features
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-all"] }
+laurus = { version = "0.11", features = ["embeddings-all"] }
 ```
 
 ## Sections

--- a/laurus/README.md
+++ b/laurus/README.md
@@ -23,15 +23,15 @@ Core search engine library for the [Laurus](https://github.com/mosuka/laurus) pr
 ```toml
 # Lexical search only (no embedding)
 [dependencies]
-laurus = "0.9"
+laurus = "0.11"
 
 # With local BERT embeddings
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-candle"] }
+laurus = { version = "0.11", features = ["embeddings-candle"] }
 
 # All embedding backends
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-all"] }
+laurus = { version = "0.11", features = ["embeddings-all"] }
 ```
 
 ## Feature Flags

--- a/laurus/README_ja.md
+++ b/laurus/README_ja.md
@@ -23,15 +23,15 @@
 ```toml
 # Lexical 検索のみ（エンベディングなし）
 [dependencies]
-laurus = "0.9"
+laurus = "0.11"
 
 # ローカル BERT エンベディング付き
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-candle"] }
+laurus = { version = "0.11", features = ["embeddings-candle"] }
 
 # 全エンベディングバックエンド
 [dependencies]
-laurus = { version = "0.9", features = ["embeddings-all"] }
+laurus = { version = "0.11", features = ["embeddings-all"] }
 ```
 
 ## フィーチャーフラグ

--- a/scripts/bump-up-version.sh
+++ b/scripts/bump-up-version.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Bump the laurus workspace version across every file that needs it by hand.
+#
+# What it does:
+#   1. Reads the current version from the root Cargo.toml's
+#      [workspace.package].version.
+#   2. Updates that version and the internal laurus / laurus-mcp /
+#      laurus-server dependency pins in [workspace.dependencies].
+#   3. Regenerates Cargo.lock. Every other workspace member crate
+#      (laurus-cli, laurus-python, laurus-nodejs, laurus-wasm, laurus-ruby,
+#      laurus-php) inherits the version via `version = { workspace = true }`,
+#      so they update automatically — no per-crate edits needed.
+#   4. Updates the documented `laurus = "X.Y"` (major.minor, no patch)
+#      install examples in the root/laurus READMEs and the mdBook docs.
+#   5. Updates the `VERSION=vX.Y.Z` release-binary download example in the
+#      laurus-cli installation docs.
+#
+# What it does NOT do:
+#   * Commit, tag, or push anything — review the diff yourself
+#     (`git diff`), then commit and open a PR by hand.
+#   * Touch language-binding manifests (pyproject.toml, package.json,
+#     *.gemspec, composer.json) — release.yml's publish jobs inject the
+#     version dynamically from `cargo metadata` at publish time, so those
+#     files intentionally stay at their placeholder values.
+#   * Create the release tag — tagging `vX.Y.Z` triggers the release build
+#     and crates.io/PyPI/npm/RubyGems publishing, and should only happen
+#     after this bump has been reviewed and merged.
+#
+# Usage:
+#   ./scripts/bump-up-version.sh <new-version>
+#
+# Example:
+#   ./scripts/bump-up-version.sh 0.11.0
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <new-version>" >&2
+  echo "Example: $0 0.11.0" >&2
+  exit 1
+fi
+
+NEW_VERSION="$1"
+
+# This project's releases are plain major.minor.patch — no pre-release or
+# build-metadata suffixes — so a strict X.Y.Z check is enough.
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: '$NEW_VERSION' does not look like a version (expected X.Y.Z)" >&2
+  exit 1
+fi
+NEW_MAJOR_MINOR="${NEW_VERSION%.*}"
+
+CURRENT_VERSION=$(awk -F'"' '/^version = "/{print $2; exit}' Cargo.toml)
+if [ -z "$CURRENT_VERSION" ]; then
+  echo "Error: could not find [workspace.package].version in Cargo.toml" >&2
+  exit 1
+fi
+if [ "$CURRENT_VERSION" = "$NEW_VERSION" ]; then
+  echo "Error: current version is already $NEW_VERSION" >&2
+  exit 1
+fi
+CURRENT_MAJOR_MINOR="${CURRENT_VERSION%.*}"
+
+echo "==> Bumping version: $CURRENT_VERSION -> $NEW_VERSION"
+
+# Portable in-place sed: `-i.bak` (suffix glued directly to `-i`, no space)
+# is the one form both GNU sed (Linux) and BSD sed (macOS) accept
+# identically; the backup is removed right after.
+sed_inplace() {
+  sed -i.bak "$@"
+}
+
+# --- 1. Cargo.toml: workspace version + internal dependency pins ---
+echo "==> Updating Cargo.toml"
+sed_inplace \
+  -e "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" \
+  -e "s/{ version = \"${CURRENT_VERSION}\", path = /{ version = \"${NEW_VERSION}\", path = /g" \
+  Cargo.toml
+rm -f Cargo.toml.bak
+
+# --- 2. Cargo.lock: regenerate so every workspace member reflects it ---
+echo "==> Regenerating Cargo.lock (cargo build --workspace, this takes a while)"
+cargo build --workspace --no-default-features >/dev/null
+
+# --- 3. Documented install examples (major.minor only, no patch) ---
+DOC_FILES=(
+  laurus/README.md
+  laurus/README_ja.md
+  docs/src/laurus.md
+  docs/ja/src/laurus.md
+  docs/src/getting_started/installation.md
+  docs/ja/src/getting_started/installation.md
+  docs/src/development/feature_flags.md
+  docs/ja/src/development/feature_flags.md
+)
+echo "==> Updating documented install examples (laurus = \"${CURRENT_MAJOR_MINOR}\" -> \"${NEW_MAJOR_MINOR}\")"
+for f in "${DOC_FILES[@]}"; do
+  if [ ! -f "$f" ]; then
+    echo "Warning: $f not found, skipping" >&2
+    continue
+  fi
+  sed_inplace \
+    -e "s/laurus = \"${CURRENT_MAJOR_MINOR}\"/laurus = \"${NEW_MAJOR_MINOR}\"/g" \
+    -e "s/laurus = { version = \"${CURRENT_MAJOR_MINOR}\"/laurus = { version = \"${NEW_MAJOR_MINOR}\"/g" \
+    "$f"
+  rm -f "${f}.bak"
+done
+
+# --- 4. CLI release-binary download example (full version, with patch) ---
+CLI_INSTALL_FILES=(
+  docs/src/laurus-cli/installation.md
+  docs/ja/src/laurus-cli/installation.md
+)
+echo "==> Updating CLI install examples (VERSION=v${CURRENT_VERSION} -> v${NEW_VERSION})"
+for f in "${CLI_INSTALL_FILES[@]}"; do
+  if [ ! -f "$f" ]; then
+    echo "Warning: $f not found, skipping" >&2
+    continue
+  fi
+  sed_inplace "s/VERSION=v${CURRENT_VERSION}/VERSION=v${NEW_VERSION}/g" "$f"
+  rm -f "${f}.bak"
+done
+
+echo "==> Done."
+echo "    Review with 'git diff', then commit and open a PR by hand."
+echo "    Not touched (by design): language-binding manifests, release tag."


### PR DESCRIPTION
## Summary

- Bumps the workspace version (`[workspace.package].version`) and the
  internal `laurus`/`laurus-mcp`/`laurus-server` dependency pins in the
  root `Cargo.toml` from `0.10.0` to `0.11.0`. All other workspace member
  crates (`laurus-cli`, `laurus-python`, `laurus-nodejs`, `laurus-wasm`,
  `laurus-ruby`, `laurus-php`) inherit automatically via
  `version = { workspace = true }`.
- Regenerated `Cargo.lock` accordingly.
- Language-binding manifests (`pyproject.toml`, `package.json`, `*.gemspec`,
  `composer.json`) are intentionally left untouched — `release.yml`'s
  publish jobs inject the version dynamically from `cargo metadata` at
  publish time.
- Catches up documented `laurus = "0.9"` install examples (root/laurus
  READMEs, `docs/src/laurus.md`, `docs/src/getting_started/installation.md`,
  `docs/src/development/feature_flags.md`, and their `docs/ja/src`
  counterparts) that were missed during the previous 0.9 → 0.10 bump, plus
  the `VERSION=v0.10.0` binary-download example in
  `docs/*/laurus-cli/installation.md`.
- Updates a version example in a `release.yml` comment (cosmetic, no
  behavior change).
- Adds `scripts/bump-up-version.sh`, which automates all of the above steps
  for future releases (`./scripts/bump-up-version.sh <new-version>`).

## Test plan

- [x] `cargo build --workspace` succeeds; all 9 workspace member crates
      show `0.11.0` in `Cargo.lock`
- [x] `markdownlint-cli2` clean on every touched doc (English + Japanese)
- [x] Repo-wide grep confirms no remaining `0.10.0` / `laurus = "0.9"`
      references outside `Cargo.lock` history and the unrelated vendored
      `patches/ext-php-rs-clang-sys/CHANGELOG.md`
- [x] `scripts/bump-up-version.sh` dry-run tested against a throwaway
      `0.11.0` -> `0.11.1` bump (verified the diff matched expectations,
      then reverted before committing)

Tagging `v0.11.0` (which triggers the release build and crates.io/PyPI/npm/
RubyGems publishing) will be done separately after this merges.
