### PR TITLE
ci: exclude napi platform binary packages from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,13 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      # The napi-rs per-platform binary packages in optionalDependencies
+      # (laurus-nodejs-darwin-x64 etc.) are placeholders pinned at "0.0.0";
+      # release.yml's publish-npm job overwrites them with the real version
+      # at publish time. Dependabot must not "update" them to whatever is
+      # currently published on npm.
+      - dependency-name: "laurus-nodejs-*"
 
   # WASM binding package metadata. No dependencies today, but keeping this
   # entry means Dependabot picks them up automatically if any are added.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "laurus"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-mcp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-nodejs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "laurus",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-php"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "ext-php-rs",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-python"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "laurus",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-ruby"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "laurus",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-wasm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Unified search library for lexical, vector, and semantic retrieval"
@@ -32,9 +32,9 @@ axum = "0.8.9"
 base64 = "0.23.1"
 chrono = { version = "0.4.45", features = ["serde"] }
 dialoguer = "0.12.0"
-laurus = { version = "0.11.0", path = "laurus", default-features = false }
-laurus-mcp = { version = "0.11.0", path = "laurus-mcp" }
-laurus-server = { version = "0.11.0", path = "laurus-server" }
+laurus = { version = "0.12.0", path = "laurus", default-features = false }
+laurus-mcp = { version = "0.12.0", path = "laurus-mcp" }
+laurus-server = { version = "0.12.0", path = "laurus-server" }
 prost = "0.14.4"
 rmcp = { version = "3.1.2", features = ["server", "transport-io"] }
 rustyline = "18.0.1"

--- a/docs/ja/src/development/feature_flags.md
+++ b/docs/ja/src/development/feature_flags.md
@@ -19,7 +19,7 @@
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-candle"] }
+laurus = { version = "0.12", features = ["embeddings-candle"] }
 ```
 
 ### `embeddings-openai`
@@ -28,7 +28,7 @@ laurus = { version = "0.11", features = ["embeddings-candle"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-openai"] }
+laurus = { version = "0.12", features = ["embeddings-openai"] }
 ```
 
 ### `embeddings-multimodal`
@@ -37,7 +37,7 @@ laurus = { version = "0.11", features = ["embeddings-openai"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-multimodal"] }
+laurus = { version = "0.12", features = ["embeddings-multimodal"] }
 ```
 
 ### `embeddings-all`
@@ -46,7 +46,7 @@ laurus = { version = "0.11", features = ["embeddings-multimodal"] }
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-all"] }
+laurus = { version = "0.12", features = ["embeddings-all"] }
 ```
 
 ## TLS とネットワークの挙動

--- a/docs/ja/src/getting_started/installation.md
+++ b/docs/ja/src/getting_started/installation.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-laurus = "0.11"
+laurus = "0.12"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -28,28 +28,28 @@ Laurus はデフォルトで最小限の機能セットで提供されます。�
 
 ```toml
 [dependencies]
-laurus = "0.11"
+laurus = "0.12"
 ```
 
 **ローカルモデルによる Vector 検索**（API キー不要）:
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-candle"] }
+laurus = { version = "0.12", features = ["embeddings-candle"] }
 ```
 
 **OpenAI による Vector 検索**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-openai"] }
+laurus = { version = "0.12", features = ["embeddings-openai"] }
 ```
 
 **すべての機能**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-all"] }
+laurus = { version = "0.12", features = ["embeddings-all"] }
 ```
 
 ## インストールの確認

--- a/docs/ja/src/laurus-cli/installation.md
+++ b/docs/ja/src/laurus-cli/installation.md
@@ -18,7 +18,7 @@
 | `aarch64-pc-windows-msvc` | Windows arm64 | MSVC | 動的 | `.zip` |
 
 ```bash
-VERSION=v0.11.0
+VERSION=v0.12.0
 TARGET=x86_64-unknown-linux-musl
 curl -fsSL -O "https://github.com/mosuka/laurus/releases/download/${VERSION}/laurus-${VERSION}-${TARGET}.tar.gz"
 tar -xzf "laurus-${VERSION}-${TARGET}.tar.gz"

--- a/docs/ja/src/laurus.md
+++ b/docs/ja/src/laurus.md
@@ -48,15 +48,15 @@ graph TB
 ```toml
 # Lexical検索のみ（Embeddingなし）
 [dependencies]
-laurus = "0.11"
+laurus = "0.12"
 
 # ローカルBERT Embeddingを使用
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-candle"] }
+laurus = { version = "0.12", features = ["embeddings-candle"] }
 
 # すべてのFeatureを有効化
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-all"] }
+laurus = { version = "0.12", features = ["embeddings-all"] }
 ```
 
 ## セクション

--- a/docs/src/development/feature_flags.md
+++ b/docs/src/development/feature_flags.md
@@ -19,7 +19,7 @@ Enables `CandleBertEmbedder` for running BERT models locally on the CPU. Models 
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-candle"] }
+laurus = { version = "0.12", features = ["embeddings-candle"] }
 ```
 
 ### `embeddings-openai`
@@ -28,7 +28,7 @@ Enables `OpenAIEmbedder` for calling the OpenAI Embeddings API. Requires an `OPE
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-openai"] }
+laurus = { version = "0.12", features = ["embeddings-openai"] }
 ```
 
 ### `embeddings-multimodal`
@@ -37,7 +37,7 @@ Enables `CandleClipEmbedder` for CLIP-based text and image embeddings. Implies `
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-multimodal"] }
+laurus = { version = "0.12", features = ["embeddings-multimodal"] }
 ```
 
 ### `embeddings-all`
@@ -46,7 +46,7 @@ Convenience flag that enables all embedding features.
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-all"] }
+laurus = { version = "0.12", features = ["embeddings-all"] }
 ```
 
 ## TLS and Network Behavior

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -6,7 +6,7 @@ Add `laurus` and `tokio` (async runtime) to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-laurus = "0.11"
+laurus = "0.12"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -28,28 +28,28 @@ Laurus ships with a minimal default feature set. Enable additional features as n
 
 ```toml
 [dependencies]
-laurus = "0.11"
+laurus = "0.12"
 ```
 
 **Vector search with local model** (no API key required):
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-candle"] }
+laurus = { version = "0.12", features = ["embeddings-candle"] }
 ```
 
 **Vector search with OpenAI**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-openai"] }
+laurus = { version = "0.12", features = ["embeddings-openai"] }
 ```
 
 **Everything**:
 
 ```toml
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-all"] }
+laurus = { version = "0.12", features = ["embeddings-all"] }
 ```
 
 ## Verify Installation

--- a/docs/src/laurus-cli/installation.md
+++ b/docs/src/laurus-cli/installation.md
@@ -18,7 +18,7 @@ prebuilt `laurus` binaries for the following targets, all built with
 | `aarch64-pc-windows-msvc` | Windows arm64 | MSVC | dynamic | `.zip` |
 
 ```bash
-VERSION=v0.11.0
+VERSION=v0.12.0
 TARGET=x86_64-unknown-linux-musl
 curl -fsSL -O "https://github.com/mosuka/laurus/releases/download/${VERSION}/laurus-${VERSION}-${TARGET}.tar.gz"
 tar -xzf "laurus-${VERSION}-${TARGET}.tar.gz"

--- a/docs/src/laurus.md
+++ b/docs/src/laurus.md
@@ -48,15 +48,15 @@ The `laurus` crate has no default features enabled. Enable embedding support as 
 ```toml
 # Lexical search only (no embedding)
 [dependencies]
-laurus = "0.11"
+laurus = "0.12"
 
 # With local BERT embeddings
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-candle"] }
+laurus = { version = "0.12", features = ["embeddings-candle"] }
 
 # All features
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-all"] }
+laurus = { version = "0.12", features = ["embeddings-all"] }
 ```
 
 ## Sections

--- a/laurus/README.md
+++ b/laurus/README.md
@@ -23,15 +23,15 @@ Core search engine library for the [Laurus](https://github.com/mosuka/laurus) pr
 ```toml
 # Lexical search only (no embedding)
 [dependencies]
-laurus = "0.11"
+laurus = "0.12"
 
 # With local BERT embeddings
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-candle"] }
+laurus = { version = "0.12", features = ["embeddings-candle"] }
 
 # All embedding backends
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-all"] }
+laurus = { version = "0.12", features = ["embeddings-all"] }
 ```
 
 ## Feature Flags

--- a/laurus/README_ja.md
+++ b/laurus/README_ja.md
@@ -23,15 +23,15 @@
 ```toml
 # Lexical 検索のみ（エンベディングなし）
 [dependencies]
-laurus = "0.11"
+laurus = "0.12"
 
 # ローカル BERT エンベディング付き
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-candle"] }
+laurus = { version = "0.12", features = ["embeddings-candle"] }
 
 # 全エンベディングバックエンド
 [dependencies]
-laurus = { version = "0.11", features = ["embeddings-all"] }
+laurus = { version = "0.12", features = ["embeddings-all"] }
 ```
 
 ## フィーチャーフラグ


### PR DESCRIPTION
## Summary

The per-platform binary packages in `laurus-nodejs`'s
`optionalDependencies` (`laurus-nodejs-darwin-x64`,
`laurus-nodejs-linux-x64-gnu`, etc.) are placeholders pinned at `"0.0.0"`
— `release.yml`'s `publish-npm` job overwrites them with the real version
at publish time. Dependabot must not "update" them to whatever is
currently published on npm, so this adds an `ignore` rule with a
`dependency-name: "laurus-nodejs-*"` wildcard to the npm entry for
`/laurus-nodejs`.

## Test plan

- [x] `dependabot.yml` parses as valid YAML; the ignore rule lands on the
      `/laurus-nodejs` npm entry and the wildcard covers all six platform
      packages