### PR TITLE
fix(wasm): invalidate OPFS dictionary cache when the Lindera version changes

### DIFF
--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -561,6 +561,7 @@ Private File System にダウンロード・保存・読込するヘルパを提
 ```javascript
 import {
   downloadDictionary,
+  getDictionaryVersion,
   loadDictionaryFiles,
   hasDictionary,
   listDictionaries,
@@ -570,11 +571,21 @@ import {
 
 | 関数 | 説明 |
 | ---- | ---- |
-| `downloadDictionary(url, name, options?)` | `.zip` を fetch し、Web の `DecompressionStream` API で展開して、Lindera 8 ファイルを OPFS の `laurus/dictionaries/<name>/` 配下に保存します。`options.onProgress({ phase, loaded?, total? })` で進捗通知を受け取れます。 |
+| `downloadDictionary(url, name, options?)` | `.zip` を fetch し、Web の `DecompressionStream` API で展開して、Lindera 8 ファイルを OPFS の `laurus/dictionaries/<name>/` 配下に保存します。`options.onProgress({ phase, loaded?, total? })` で進捗通知を受け取れます。`options.version` を渡すとファイルと並べてバージョンスタンプを保存します（下記参照）。 |
+| `getDictionaryVersion(name)` | `downloadDictionary` が保存したバージョンスタンプを返します。辞書またはスタンプが存在しない場合は `null` を返します。 |
 | `loadDictionaryFiles(name)` | 8 ファイルを `{ metadata, dictDa, dictVals, dictWordsIdx, dictWords, matrixMtx, charDef, unk }` オブジェクトとして読み出し、`JapaneseAnalyzer.fromBytes` にそのまま渡せる形にします。 |
 | `hasDictionary(name)` | 辞書ディレクトリが OPFS にあれば `true`。 |
 | `listDictionaries()` | 保存済み辞書名の配列を返します。 |
 | `removeDictionary(name)` | 辞書ディレクトリを削除します。 |
+
+辞書のバイナリ形式は WASM バイナリにコンパイルされた Lindera
+（およびその依存 daachorse）のバージョンに紐づいており、アプリが
+Lindera を更新すると OPFS にキャッシュ済みの辞書は読めなくなります
+（`InvalidAutomatonError` でデシリアライズに失敗します）。ダウンロード時に
+zip の対象 Lindera バージョンを `options.version` として渡し、起動時に
+`getDictionaryVersion(name)` を現在のビルドが期待するバージョンと比較して、
+不一致なら再ダウンロードしてください。スタンプが `null` の場合も
+不一致として扱います。
 
 ブラウザ CORS の制約により GitHub Releases から直接 fetch できないため、
 zip はアプリと同一オリジンで配信してください（Laurus デモではデプロイ

--- a/docs/ja/src/laurus-wasm/development.md
+++ b/docs/ja/src/laurus-wasm/development.md
@@ -96,7 +96,7 @@ schema.addAnalyzer("ja-ipadic", ja);
 schema.addTextField("body", undefined, undefined, undefined, "ja-ipadic");
 ```
 
-OPFS ヘルパー（`downloadDictionary` / `loadDictionaryFiles` / `hasDictionary` / `listDictionaries` / `removeDictionary`）は [`js/opfs.js`](https://github.com/mosuka/laurus/blob/main/laurus-wasm/js/opfs.js) にあり、`package.json` で `laurus-wasm/opfs` サブパスとして再公開されています。引数表は [API リファレンス → JapaneseAnalyzer](api_reference.md#japaneseanalyzer) を参照してください。
+OPFS ヘルパー（`downloadDictionary` / `getDictionaryVersion` / `loadDictionaryFiles` / `hasDictionary` / `listDictionaries` / `removeDictionary`）は [`js/opfs.js`](https://github.com/mosuka/laurus/blob/main/laurus-wasm/js/opfs.js) にあり、`package.json` で `laurus-wasm/opfs` サブパスとして再公開されています。引数表は [API リファレンス → JapaneseAnalyzer](api_reference.md#japaneseanalyzer) を参照してください。
 
 ### コールバック Embedder
 

--- a/docs/ja/src/laurus-wasm/quickstart.md
+++ b/docs/ja/src/laurus-wasm/quickstart.md
@@ -71,6 +71,7 @@ OPFS にロードした IPADIC のバイト列から analyzer を構築します
 import init, { Index, Schema, JapaneseAnalyzer } from 'laurus-wasm';
 import {
   downloadDictionary,
+  getDictionaryVersion,
   loadDictionaryFiles,
   hasDictionary,
 } from 'laurus-wasm/opfs';
@@ -80,8 +81,16 @@ await init();
 // 1. 初回訪問時に IPADIC アーカイブを OPFS にキャッシュする。zip は
 //    アプリと同一オリジンで配信する必要がある（GitHub Releases は CORS
 //    でブロックされる）。圧縮 ~16 MB / 展開後 ~58 MB。
-if (!(await hasDictionary("ipadic"))) {
+//    バイナリ形式は WASM にコンパイルされた Lindera バージョンに紐づく
+//    ため、`version` でキャッシュにスタンプを付け、ビルドが期待する
+//    バージョンと一致しなくなったら再ダウンロードする。
+const LINDERA_VERSION = "5.0.2"; // Cargo.lock の lindera バージョンと揃える
+if (
+  !(await hasDictionary("ipadic"))
+  || (await getDictionaryVersion("ipadic")) !== LINDERA_VERSION
+) {
   await downloadDictionary("./dict/lindera-ipadic.zip", "ipadic", {
+    version: LINDERA_VERSION,
     onProgress: ({ phase, loaded, total }) => console.log(phase, loaded, total),
   });
 }

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -572,6 +572,7 @@ Private File System. Used together with `JapaneseAnalyzer.fromBytes`.
 ```javascript
 import {
   downloadDictionary,
+  getDictionaryVersion,
   loadDictionaryFiles,
   hasDictionary,
   listDictionaries,
@@ -581,11 +582,21 @@ import {
 
 | Function | Description |
 | ---- | ---- |
-| `downloadDictionary(url, name, options?)` | Fetch a `.zip`, decompress with the Web `DecompressionStream` API, and store the eight Lindera files under `laurus/dictionaries/<name>/` in OPFS. `options.onProgress({ phase, loaded?, total? })` reports progress. |
+| `downloadDictionary(url, name, options?)` | Fetch a `.zip`, decompress with the Web `DecompressionStream` API, and store the eight Lindera files under `laurus/dictionaries/<name>/` in OPFS. `options.onProgress({ phase, loaded?, total? })` reports progress. `options.version` stores a version stamp next to the files (see below). |
+| `getDictionaryVersion(name)` | Return the version stamp stored by `downloadDictionary`, or `null` if the dictionary or its stamp does not exist. |
 | `loadDictionaryFiles(name)` | Read the eight files back as a `{ metadata, dictDa, dictVals, dictWordsIdx, dictWords, matrixMtx, charDef, unk }` object suitable for `JapaneseAnalyzer.fromBytes`. |
 | `hasDictionary(name)` | `true` if the dictionary directory exists in OPFS. |
 | `listDictionaries()` | Return an array of stored dictionary names. |
 | `removeDictionary(name)` | Delete the dictionary directory. |
+
+The binary dictionary format is tied to the Lindera (and daachorse)
+version compiled into the WASM binary, so a dictionary cached in OPFS
+becomes unreadable after your app updates its Lindera version
+(deserialization fails with an `InvalidAutomatonError`). Pass the
+Lindera version your zip was built for as `options.version` when
+downloading, then compare `getDictionaryVersion(name)` against the
+version your current build expects on startup and re-download on
+mismatch. A `null` stamp should be treated as a mismatch.
 
 Browser CORS prevents fetching directly from GitHub Releases, so host
 the zip on the same origin as your app (the Laurus demo bundles

--- a/docs/src/laurus-wasm/development.md
+++ b/docs/src/laurus-wasm/development.md
@@ -96,7 +96,7 @@ schema.addAnalyzer("ja-ipadic", ja);
 schema.addTextField("body", undefined, undefined, undefined, "ja-ipadic");
 ```
 
-The OPFS helpers (`downloadDictionary`, `loadDictionaryFiles`, `hasDictionary`, `listDictionaries`, `removeDictionary`) live in [`js/opfs.js`](https://github.com/mosuka/laurus/blob/main/laurus-wasm/js/opfs.js) and are re-exported as the `laurus-wasm/opfs` subpath in `package.json`. See [API Reference → JapaneseAnalyzer](api_reference.md#japaneseanalyzer) for the argument table.
+The OPFS helpers (`downloadDictionary`, `getDictionaryVersion`, `loadDictionaryFiles`, `hasDictionary`, `listDictionaries`, `removeDictionary`) live in [`js/opfs.js`](https://github.com/mosuka/laurus/blob/main/laurus-wasm/js/opfs.js) and are re-exported as the `laurus-wasm/opfs` subpath in `package.json`. See [API Reference → JapaneseAnalyzer](api_reference.md#japaneseanalyzer) for the argument table.
 
 ### Callback Embedder
 

--- a/docs/src/laurus-wasm/quickstart.md
+++ b/docs/src/laurus-wasm/quickstart.md
@@ -71,6 +71,7 @@ so build the analyzer from raw IPADIC bytes loaded from OPFS.
 import init, { Index, Schema, JapaneseAnalyzer } from 'laurus-wasm';
 import {
   downloadDictionary,
+  getDictionaryVersion,
   loadDictionaryFiles,
   hasDictionary,
 } from 'laurus-wasm/opfs';
@@ -80,8 +81,16 @@ await init();
 // 1. Cache the IPADIC archive in OPFS on first visit. The zip must be
 //    served from the same origin as the page — GitHub Releases assets
 //    are blocked by CORS. (~16 MB compressed, ~58 MB extracted.)
-if (!(await hasDictionary("ipadic"))) {
+//    The binary format is tied to the Lindera version compiled into
+//    the WASM, so stamp the cache with `version` and re-download when
+//    it no longer matches the version your build expects.
+const LINDERA_VERSION = "5.0.2"; // keep in sync with your Cargo.lock
+if (
+  !(await hasDictionary("ipadic"))
+  || (await getDictionaryVersion("ipadic")) !== LINDERA_VERSION
+) {
   await downloadDictionary("./dict/lindera-ipadic.zip", "ipadic", {
+    version: LINDERA_VERSION,
     onProgress: ({ phase, loaded, total }) => console.log(phase, loaded, total),
   });
 }

--- a/laurus-wasm/examples/README.md
+++ b/laurus-wasm/examples/README.md
@@ -32,11 +32,35 @@ automatically; for local development, download a matching version
 from the [Lindera releases][lindera-releases] and drop it under
 `examples/dict/`.
 
+`<version>` must be the `lindera` version pinned in the workspace
+`Cargo.lock` — the binary dictionary format is not stable across
+Lindera versions, and a mismatched (or stale, previously downloaded)
+zip fails at load time with an `InvalidAutomatonError`. Re-download
+the zip whenever the workspace updates Lindera.
+
 ```bash
 # from the repository root
+LINDERA_VERSION=$(cargo metadata --format-version 1 \
+  | python3 -c "import json,sys; m=json.load(sys.stdin); print(next(p['version'] for p in m['packages'] if p['name']=='lindera'))")
 mkdir -p laurus-wasm/examples/dict
 curl -fsSL -o laurus-wasm/examples/dict/lindera-unidic.zip \
-  "https://github.com/lindera/lindera/releases/download/v<version>/lindera-unidic-<version>.zip"
+  "https://github.com/lindera/lindera/releases/download/v${LINDERA_VERSION}/lindera-unidic-${LINDERA_VERSION}.zip"
+```
+
+Optionally, also generate `examples/dict/manifest.json` (the deploy
+workflow always does). With a manifest present, the sample dictionary
+loader stamps the OPFS cache with the version and re-downloads it
+automatically when the version changes; without one, it trusts
+whatever is cached and you must clear stale caches by hand via each
+sample's "Reset everything" button.
+
+```bash
+cat > laurus-wasm/examples/dict/manifest.json <<EOF
+{
+  "unidic": "lindera-unidic.zip",
+  "lindera_version": "${LINDERA_VERSION}"
+}
+EOF
 ```
 
 Then start any HTTP server (WASM cannot be loaded over `file://`):

--- a/laurus-wasm/examples/README_ja.md
+++ b/laurus-wasm/examples/README_ja.md
@@ -31,11 +31,37 @@ UniDic を読み込みます。デプロイワークフローでは自動取得�
 バージョンの合う zip をダウンロードして `examples/dict/` に置いて
 ください。
 
+`<version>` は workspace の `Cargo.lock` に固定されている `lindera`
+のバージョンと一致させる必要があります。辞書のバイナリ形式は
+Lindera のバージョン間で互換性がなく、バージョン違い（過去に
+ダウンロードした古い zip を含む）はロード時に
+`InvalidAutomatonError` で失敗します。workspace の Lindera を
+更新したら zip も再ダウンロードしてください。
+
 ```bash
 # リポジトリのルートから実行
+LINDERA_VERSION=$(cargo metadata --format-version 1 \
+  | python3 -c "import json,sys; m=json.load(sys.stdin); print(next(p['version'] for p in m['packages'] if p['name']=='lindera'))")
 mkdir -p laurus-wasm/examples/dict
 curl -fsSL -o laurus-wasm/examples/dict/lindera-unidic.zip \
-  "https://github.com/lindera/lindera/releases/download/v<version>/lindera-unidic-<version>.zip"
+  "https://github.com/lindera/lindera/releases/download/v${LINDERA_VERSION}/lindera-unidic-${LINDERA_VERSION}.zip"
+```
+
+必要に応じて `examples/dict/manifest.json` も生成してください
+（デプロイワークフローは常に生成します）。manifest があると、
+サンプルの辞書ローダーは OPFS キャッシュにバージョンスタンプを
+付与し、バージョンが変わったときに自動で再ダウンロードします。
+manifest がない場合はキャッシュをそのまま信頼するため、古い
+キャッシュは各サンプルの「Reset everything」ボタンで手動削除する
+必要があります。
+
+```bash
+cat > laurus-wasm/examples/dict/manifest.json <<EOF
+{
+  "unidic": "lindera-unidic.zip",
+  "lindera_version": "${LINDERA_VERSION}"
+}
+EOF
 ```
 
 その後、任意の HTTP サーバーを起動します（WASM は `file://` では

--- a/laurus-wasm/examples/basic/index.html
+++ b/laurus-wasm/examples/basic/index.html
@@ -211,6 +211,15 @@
         statusEl.textContent = 'error';
         statusEl.className = 'badge badge-error';
         console.error(e);
+        // Keep the recovery path reachable: stale persisted state is a
+        // likely cause of boot failures, so the Reset buttons must be
+        // usable even though the rest of the UI stays disabled.
+        document.getElementById('reset-index-btn').disabled = false;
+        document.getElementById('reset-all-btn').disabled = false;
+        logger.log(
+          'If this persists, use "Reset everything (index + dictionary)" '
+          + 'below to clear persisted state and reload.',
+        );
       }
     }
 

--- a/laurus-wasm/examples/geo/index.html
+++ b/laurus-wasm/examples/geo/index.html
@@ -677,6 +677,15 @@
         statusEl.textContent = 'error';
         statusEl.className = 'badge badge-error';
         console.error(e);
+        // Keep the recovery path reachable: stale persisted state is a
+        // likely cause of boot failures, so the Reset buttons must be
+        // usable even though the rest of the UI stays disabled.
+        document.getElementById('reset-index-btn').disabled = false;
+        document.getElementById('reset-all-btn').disabled = false;
+        logger.log(
+          'If this persists, use "Reset everything (index + dictionary)" '
+          + 'below to clear persisted state and reload.',
+        );
       }
     }
 

--- a/laurus-wasm/examples/geo3d/index.html
+++ b/laurus-wasm/examples/geo3d/index.html
@@ -1189,6 +1189,14 @@
         statusEl.textContent = 'error';
         statusEl.className = 'badge badge-error';
         console.error(e);
+        // Keep the recovery path reachable: stale persisted state is a
+        // likely cause of boot failures, so the Reset button must be
+        // usable even though the rest of the UI stays disabled.
+        document.getElementById('reset-all-btn').disabled = false;
+        logger.log(
+          'If this persists, use "Reset everything (index + dictionary)" '
+          + 'below to clear persisted state and reload.',
+        );
       }
     }
 

--- a/laurus-wasm/examples/shared/dictionary.js
+++ b/laurus-wasm/examples/shared/dictionary.js
@@ -11,6 +11,7 @@
 
 import {
   downloadDictionary,
+  getDictionaryVersion,
   hasDictionary,
   loadDictionaryFiles,
   removeDictionary,
@@ -32,27 +33,91 @@ export const ANALYZER_NAME = 'ja-unidic';
 export const DEFAULT_DICT_URL = '../dict/lindera-unidic.zip';
 
 /**
+ * Default location of the dictionary manifest written by the deploy
+ * workflow next to the zip. Its `lindera_version` field identifies
+ * which Lindera version the zip was built for, letting the loader
+ * invalidate an OPFS cache left over from an older deployment (the
+ * binary dictionary format is not stable across Lindera versions).
+ */
+export const DEFAULT_MANIFEST_URL = '../dict/manifest.json';
+
+/**
+ * Fetch the expected dictionary version from the deploy manifest.
+ * Returns null when the manifest is unavailable or malformed (e.g.,
+ * a local development server without a generated manifest), in which
+ * case the caller falls back to trusting any cached dictionary.
+ *
+ * @param {string} url - URL of the manifest JSON.
+ * @returns {Promise<string | null>} The expected version, or null.
+ */
+async function fetchExpectedVersion(url) {
+  try {
+    // The manifest is tiny; skip stale HTTP caches so a fresh deploy
+    // is picked up promptly.
+    const response = await fetch(url, { cache: 'no-cache' });
+    if (!response.ok) {
+      return null;
+    }
+    const manifest = await response.json();
+    const version = manifest?.lindera_version;
+    return typeof version === 'string' && version.length > 0 ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Make sure the UniDic dictionary is present in OPFS, downloading
  * the bundled zip on first visit. Reports progress through the
  * supplied logger and an optional status DOM hook.
  *
+ * A cached dictionary is reused only if its stored version stamp
+ * matches the `lindera_version` in the deploy manifest; on mismatch
+ * (including caches stored before version stamping existed) the
+ * cache is discarded and the zip is re-downloaded. When no manifest
+ * is available the cache is trusted as-is.
+ *
  * @param {object} options
  * @param {string} [options.url] - URL of the dictionary zip.
+ * @param {string} [options.manifestUrl] - URL of the manifest JSON.
  * @param {{log: Function, ok: Function, err: Function}} options.logger
  * @param {(text: string) => void} [options.setStatus] - Optional status hook.
  */
 export async function ensureDictionary({
   url = DEFAULT_DICT_URL,
+  manifestUrl = DEFAULT_MANIFEST_URL,
   logger,
   setStatus,
 } = {}) {
+  const expected = await fetchExpectedVersion(manifestUrl);
+
   if (await hasDictionary(DICT_NAME)) {
-    logger?.ok?.(`Dictionary "${DICT_NAME}" found in OPFS cache.`);
-    return;
+    if (expected === null) {
+      logger?.ok?.(
+        `Dictionary "${DICT_NAME}" found in OPFS cache `
+        + '(no manifest to verify against).',
+      );
+      return;
+    }
+    const cached = await getDictionaryVersion(DICT_NAME);
+    if (cached === expected) {
+      logger?.ok?.(
+        `Dictionary "${DICT_NAME}" (Lindera ${cached}) found in OPFS cache.`,
+      );
+      return;
+    }
+    logger?.log?.(
+      `Cached dictionary "${DICT_NAME}" is for Lindera `
+      + `${cached ?? 'unknown'} but this build needs ${expected}; `
+      + 're-downloading...',
+    );
+    await removeDictionary(DICT_NAME);
   }
+
   logger?.log?.(`Downloading dictionary "${DICT_NAME}" from ${url}...`);
   const t0 = performance.now();
   await downloadDictionary(url, DICT_NAME, {
+    version: expected ?? undefined,
     onProgress: ({ phase, loaded, total }) => {
       if (phase === 'downloading' && total) {
         const pct = ((loaded / total) * 100).toFixed(0);

--- a/laurus-wasm/js/opfs.d.ts
+++ b/laurus-wasm/js/opfs.d.ts
@@ -44,6 +44,13 @@ export interface DownloadDictionaryOptions {
   onProgress?: (progress: DownloadProgress) => void;
   /** Additional options forwarded to the underlying `fetch()` call. */
   fetchInit?: RequestInit;
+  /**
+   * Version string identifying the archive contents (e.g., the
+   * Lindera version the dictionary was built for). Stored alongside
+   * the dictionary files and readable via `getDictionaryVersion()`.
+   * When omitted, any previous version stamp is removed.
+   */
+  version?: string;
 }
 
 /**
@@ -69,6 +76,20 @@ export function downloadDictionary(
  * @returns Object containing the dictionary file data.
  */
 export function loadDictionaryFiles(name: string): Promise<DictionaryFiles>;
+
+/**
+ * Reads the version stamp stored with a dictionary, if any.
+ *
+ * The stamp is written by `downloadDictionary()` when it is called
+ * with a `version` option. Dictionaries stored without a version
+ * (including ones cached before version stamping existed) yield
+ * `null`.
+ *
+ * @param name - The dictionary name (e.g., "ipadic").
+ * @returns The stored version string, or `null` if the dictionary or
+ *   its version stamp does not exist.
+ */
+export function getDictionaryVersion(name: string): Promise<string | null>;
 
 /**
  * Removes a dictionary from OPFS.

--- a/laurus-wasm/js/opfs.js
+++ b/laurus-wasm/js/opfs.js
@@ -13,6 +13,13 @@
  * `dict.words`, `matrix.mtx`, `char_def.bin`, `unk.bin`. Files are
  * placed under `laurus/dictionaries/<name>/` within OPFS.
  *
+ * The binary dictionary format is tied to the Lindera (and its
+ * daachorse dependency) version compiled into the WASM binary, so a
+ * cached dictionary can become unreadable after the site updates its
+ * Lindera version. To let callers detect this, `downloadDictionary()`
+ * accepts a `version` string that is stored alongside the dictionary
+ * files and can be read back with `getDictionaryVersion()`.
+ *
  * @module opfs
  */
 
@@ -27,6 +34,12 @@ const DICTIONARY_FILES = [
   "char_def.bin",
   "unk.bin",
 ];
+
+/**
+ * Name of the OPFS stamp file recording which dictionary version the
+ * stored files came from. Not part of the Lindera archive itself.
+ */
+const VERSION_FILE = ".dict_version";
 
 /** Base directory path within OPFS for storing dictionaries. */
 const OPFS_BASE_PATH = ["laurus", "dictionaries"];
@@ -174,11 +187,16 @@ async function extractZip(zipBuffer) {
  * @param {function} [options.onProgress] - Progress callback receiving
  *   `{ phase: string, loaded?: number, total?: number }`.
  * @param {RequestInit} [options.fetchInit] - Additional options passed to `fetch()`.
+ * @param {string} [options.version] - Version string identifying the
+ *   archive contents (e.g., the Lindera version the dictionary was
+ *   built for). Stored alongside the dictionary files and readable
+ *   via `getDictionaryVersion()`. When omitted, any previous version
+ *   stamp is removed.
  * @returns {Promise<void>}
  * @throws {Error} If download fails, archive is invalid, or required files are missing.
  */
 export async function downloadDictionary(url, name, options = {}) {
-  const { onProgress, fetchInit = {} } = options;
+  const { onProgress, fetchInit = {}, version } = options;
 
   if (onProgress) onProgress({ phase: "downloading" });
   const response = await fetch(url, fetchInit);
@@ -234,6 +252,15 @@ export async function downloadDictionary(url, name, options = {}) {
 
   if (onProgress) onProgress({ phase: "storing" });
   const dir = await getDictionaryDir(name);
+
+  // Drop any stale version stamp first so a failure while storing the
+  // files below never leaves an old stamp next to new (or partial) data.
+  try {
+    await dir.removeEntry(VERSION_FILE);
+  } catch {
+    // Missing stamp is the normal case; nothing to remove.
+  }
+
   for (const [fileName, data] of fileMap) {
     const fileHandle = await dir.getFileHandle(fileName, { create: true });
     const writable = await fileHandle.createWritable();
@@ -241,7 +268,45 @@ export async function downloadDictionary(url, name, options = {}) {
     await writable.close();
   }
 
+  if (version !== undefined) {
+    const stampHandle = await dir.getFileHandle(VERSION_FILE, {
+      create: true,
+    });
+    const writable = await stampHandle.createWritable();
+    await writable.write(new TextEncoder().encode(String(version)));
+    await writable.close();
+  }
+
   if (onProgress) onProgress({ phase: "complete" });
+}
+
+/**
+ * Reads the version stamp stored with a dictionary, if any.
+ *
+ * The stamp is written by `downloadDictionary()` when it is called
+ * with a `version` option. Dictionaries stored without a version
+ * (including ones cached before version stamping existed) yield
+ * `null`, which callers should treat as "version unknown" and, when
+ * an expected version is available, as a mismatch.
+ *
+ * @param {string} name - The dictionary name (e.g., "ipadic").
+ * @returns {Promise<string | null>} The stored version string, or
+ *   `null` if the dictionary or its version stamp does not exist.
+ */
+export async function getDictionaryVersion(name) {
+  try {
+    const root = await navigator.storage.getDirectory();
+    let current = root;
+    for (const segment of [...OPFS_BASE_PATH, name]) {
+      current = await current.getDirectoryHandle(segment);
+    }
+    const stampHandle = await current.getFileHandle(VERSION_FILE);
+    const file = await stampHandle.getFile();
+    const text = (await file.text()).trim();
+    return text.length > 0 ? text : null;
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #975

## Problem

The published demo (<https://mosuka.github.io/laurus/demo/basic/>) fails to boot for returning visitors with:

```text
Analysis error: Failed to load prefix dictionary: LinderaError(kind=Deserialize, source=InvalidAutomatonError: invalid serialized automaton)
```

#957 moved `lindera` 3.0.7 → 5.0.2, which changed the daachorse serialization format of `dict.da` incompatibly (2.1.0 → 4.0.0). The deployed WASM, zip, and manifest are all consistent at 5.0.2 (fresh visitors work), but the demo caches the ~52 MB UniDic dictionary in OPFS and reused it unconditionally — the CI-generated `dict/manifest.json` with its `lindera_version` field was never read. Returning visitors therefore feed an old-format `dict.da` to the new WASM. On top of that, the Reset buttons are disabled until boot succeeds, so the manual recovery path was unreachable exactly when needed.

## Changes

- **`laurus-wasm/js/opfs.js` / `opfs.d.ts`**: `downloadDictionary()` gains a `version` option that writes a `.dict_version` stamp next to the eight dictionary files (any stale stamp is removed before storing so a mid-store failure can't pair an old stamp with new data); new `getDictionaryVersion()` reads it back (`null` when absent).
- **`laurus-wasm/examples/shared/dictionary.js`**: `ensureDictionary()` fetches `../dict/manifest.json` (`cache: 'no-cache'`) and reuses the cache only when the stamp matches `lindera_version`. A missing stamp — i.e. every cache stored by the pre-fix loader — counts as a mismatch, so currently-broken visitors heal automatically on next load. When no manifest is available (local dev), the loader falls back to trusting the cache.
- **`examples/{basic,geo,geo3d}/index.html`**: enable the Reset buttons in the boot `catch` block and log a recovery hint.
- **Docs (EN/JA)**: opfs API reference (new option/function + binary-format compatibility caveat), development helper list, quickstart sample (version-checked pattern), examples README (pin the local zip download to the `Cargo.lock` lindera version; optional local `manifest.json` for auto-invalidation).

No Rust changes; the demo fix reaches production via the `deploy-docs.yml` Pages redeploy on merge.

## Verification

- `node --check` on all edited JS (helpers + inline module scripts extracted from the three sample pages): pass.
- `markdownlint-cli2` on `docs/src` (77 files), `docs/ja/src` (77 files), and the edited READMEs: 0 errors.
- Headless-Chrome (CDP) E2E against a locally served rebuild of the current lockfile (lindera-dictionary 5.0.2 / daachorse 4.0.0 confirmed via `strings`), using the real 3.0.7-era zip and the real v5.0.2 release zip:

```text
STEP1 old-format dict stored, stamp=null
STEP2 expected failure: Analysis error: Failed to load prefix dictionary:
      LinderaError(kind=Deserialize, source=InvalidAutomatonError: ...)   <- reproduces the bug (RED)
[log] Cached dictionary "unidic" is for Lindera unknown but this build
      needs 5.0.2; re-downloading...
STEP3 ensureDictionary done, stamp=5.0.2                                  <- automatic heal
STEP4 analyzer built: ok                                                  <- fix confirmed (GREEN)
[ok] Dictionary "unidic" (Lindera 5.0.2) found in OPFS cache.
STEP5 second ensureDictionary done                                        <- revisit is a cache hit
```

## Notes

- No unit tests added: the changed code is demo/helper JS tightly coupled to browser-only APIs (OPFS, `DecompressionStream`, `fetch`) and the repository has no JS test harness; the RED/GREEN E2E above covers the load-bearing path in a real browser instead.