### PR TITLE
fix(wasm-demo): pass addHnswField embedder at its current argument position

### DIFF
--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -202,7 +202,7 @@ class Schema {
 | `addGeoField(name, stored?, indexed?)` | 地理座標フィールド。 |
 | `addGeo3dField(name, stored?, indexed?)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `addDatetimeField(name, stored?, indexed?)` | UTC 日時フィールド。 |
-| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)` | HNSW ベクトルフィールド。 |
+| `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)` | HNSW ベクトルフィールド。 |
 | `addFlatField(name, dimension, distance?, embedder?)` | Flat（全探索）ベクトルフィールド。 |
 | `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)` | IVF ベクトルフィールド。 |
 | `addEmbedder(name, config)` | 名前付き Embedder を登録。 |

--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -169,7 +169,7 @@ new \Laurus\Schema()
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | 地理座標フィールド（緯度/経度）。 |
 | `addGeo3dField(string $name, bool $stored = true, bool $indexed = true): void` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `addDatetimeField(string $name, bool $stored = true, bool $indexed = true): void` | UTC 日時フィールド。 |
-| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null): void` | HNSW 近似最近傍ベクトルフィールド。 |
+| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?int $defaultEfSearch = null, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null): void` | HNSW 近似最近傍ベクトルフィールド。 |
 | `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null): void` | Flat（総当たり）ベクトルフィールド。 |
 | `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null): void` | IVF 近似最近傍ベクトルフィールド。 |
 

--- a/docs/ja/src/laurus-wasm.md
+++ b/docs/ja/src/laurus-wasm.md
@@ -113,7 +113,7 @@ schema.addEmbedder("transformers", {
     return Array.from(output.data);
   },
 });
-schema.addHnswField("embedding", 384, "cosine", undefined, undefined, "transformers");
+schema.addHnswField("embedding", 384, "cosine", undefined, undefined, undefined, "transformers");
 const index = await Index.create(schema);
 
 await index.putDocument("doc1", { title: "Rust 入門" });

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -385,13 +385,14 @@ WASM バインディングは `Geo3dDistanceQuery` / `Geo3dBoundingBoxQuery` /
 
 バイナリデータフィールドを追加します。
 
-#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)`
+#### `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)`
 
 HNSW ベクトルインデックスフィールドを追加します。
 
 - `distance`: `"cosine"`（デフォルト）、`"euclidean"`、`"dot_product"`、`"manhattan"`、`"angular"`
 - `m`: 分岐係数（デフォルト 16）
 - `efConstruction`: 構築時の探索幅（デフォルト 200）
+- `defaultEfSearch`: クエリ時の `ef_search`（候補リストサイズ）のスキーマレベルデフォルト。省略時は内部フォールバックの 50 を使用します
 - `quantizer`: `"scalar_8bit"`（デフォルト）または `"product_quantization"`（`subvectorCount` が必須）
 - `subvectorCount`: PQ サブベクトル数。`dimension` を割り切れる値を指定します
 - `rerankStorage`: 省略（デフォルト）するか、`"f32"` を指定して完全精度のリランクサイドカーを保存します

--- a/docs/ja/src/laurus-wasm/development.md
+++ b/docs/ja/src/laurus-wasm/development.md
@@ -120,7 +120,7 @@ schema.addEmbedder("minilm", {
 
 schema.addHnswField(
   "embedding", 384, "cosine",
-  undefined, undefined, "minilm",
+  undefined, undefined, undefined, "minilm",
 );
 ```
 

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -200,7 +200,7 @@ class Schema {
 | `addGeoField(name, stored?, indexed?)` | Geographic coordinate field. |
 | `addGeo3dField(name, stored?, indexed?)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `addDatetimeField(name, stored?, indexed?)` | UTC datetime field. |
-| `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)` | HNSW vector field. |
+| `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)` | HNSW vector field. |
 | `addFlatField(name, dimension, distance?, embedder?)` | Flat (brute-force) vector field. |
 | `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)` | IVF vector field. |
 | `addEmbedder(name, config)` | Register a named embedder. |

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -167,7 +167,7 @@ new \Laurus\Schema()
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | Geographic coordinate field (lat/lon). |
 | `addGeo3dField(string $name, bool $stored = true, bool $indexed = true): void` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `addDatetimeField(string $name, bool $stored = true, bool $indexed = true): void` | UTC datetime field. |
-| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null): void` | HNSW approximate nearest-neighbor vector field. |
+| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?int $defaultEfSearch = null, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null): void` | HNSW approximate nearest-neighbor vector field. |
 | `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null): void` | Flat (brute-force) vector field. |
 | `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null): void` | IVF approximate nearest-neighbor vector field. |
 

--- a/docs/src/laurus-wasm.md
+++ b/docs/src/laurus-wasm.md
@@ -120,7 +120,7 @@ schema.addEmbedder("transformers", {
     return Array.from(output.data);
   },
 });
-schema.addHnswField("embedding", 384, "cosine", undefined, undefined, "transformers");
+schema.addHnswField("embedding", 384, "cosine", undefined, undefined, undefined, "transformers");
 const index = await Index.create(schema);
 
 await index.putDocument("doc1", { title: "Introduction to Rust" });

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -384,7 +384,7 @@ above.
 
 Add a binary data field.
 
-#### `addHnswField(name, dimension, distance?, m?, efConstruction?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)`
+#### `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)`
 
 Add an HNSW vector index field.
 
@@ -392,6 +392,8 @@ Add an HNSW vector index field.
   `"manhattan"`, `"angular"`
 - `m`: Branching factor (default 16)
 - `efConstruction`: Build-time expansion (default 200)
+- `defaultEfSearch`: Schema-level default for the query-time `ef_search`
+  candidate-list size; omit to use the internal fallback of 50
 - `quantizer`: `"scalar_8bit"` (default) or `"product_quantization"`
   (requires `subvectorCount`)
 - `subvectorCount`: number of PQ sub-vectors; must divide `dimension`

--- a/docs/src/laurus-wasm/development.md
+++ b/docs/src/laurus-wasm/development.md
@@ -120,7 +120,7 @@ schema.addEmbedder("minilm", {
 
 schema.addHnswField(
   "embedding", 384, "cosine",
-  undefined, undefined, "minilm",
+  undefined, undefined, undefined, "minilm",
 );
 ```
 

--- a/laurus-nodejs/README.md
+++ b/laurus-nodejs/README.md
@@ -116,7 +116,7 @@ schema.addBooleanField("active");
 schema.addDatetimeField("created_at");
 schema.addGeoField("location");
 schema.addBytesField("thumbnail");
-schema.addHnswField("embedding", 384, "cosine", 16, 200, "bert");
+schema.addHnswField("embedding", 384, "cosine", 16, 200, undefined, "bert");
 schema.addFlatField("embedding", 384);
 schema.addIvfField("embedding", 384, "cosine", 100, 1);
 schema.addEmbedder("bert", {

--- a/laurus-nodejs/README_ja.md
+++ b/laurus-nodejs/README_ja.md
@@ -115,7 +115,7 @@ schema.addBooleanField("active");
 schema.addDatetimeField("created_at");
 schema.addGeoField("location");
 schema.addBytesField("thumbnail");
-schema.addHnswField("embedding", 384, "cosine", 16, 200, "bert");
+schema.addHnswField("embedding", 384, "cosine", 16, 200, undefined, "bert");
 schema.addFlatField("embedding", 384);
 schema.addIvfField("embedding", 384, "cosine", 100, 1);
 schema.addEmbedder("bert", {

--- a/laurus-php/README.md
+++ b/laurus-php/README.md
@@ -108,7 +108,7 @@ The `Schema` class defines the structure of your index. Use the following method
 | `addDatetimeField(name, stored, indexed)` | Date/time field |
 | `addGeoField(name, stored, indexed)` | Geographic coordinate field (lat/lon) |
 | `addBytesField(name, stored)` | Binary data field |
-| `addHnswField(name, dimension, distance, m, efConstruction)` | HNSW vector index field |
+| `addHnswField(name, dimension, distance, m, efConstruction, defaultEfSearch, embedder, ...)` | HNSW vector index field |
 | `addFlatField(name, dimension, distance)` | Flat (brute-force) vector index field |
 | `addIvfField(name, dimension, distance, nClusters, nProbe)` | IVF vector index field |
 | `addEmbedder(name, config)` | Register a named embedder |

--- a/laurus-php/README_ja.md
+++ b/laurus-php/README_ja.md
@@ -108,7 +108,7 @@ $index = new Index("./myindex", $schema);
 | `addDatetimeField(name, stored, indexed)` | 日時フィールド |
 | `addGeoField(name, stored, indexed)` | 地理座標フィールド（緯度/経度） |
 | `addBytesField(name, stored)` | バイナリデータフィールド |
-| `addHnswField(name, dimension, distance, m, efConstruction)` | HNSW ベクトルインデックスフィールド |
+| `addHnswField(name, dimension, distance, m, efConstruction, defaultEfSearch, embedder, ...)` | HNSW ベクトルインデックスフィールド |
 | `addFlatField(name, dimension, distance)` | Flat（総当たり）ベクトルインデックスフィールド |
 | `addIvfField(name, dimension, distance, nClusters, nProbe)` | IVF ベクトルインデックスフィールド |
 | `addEmbedder(name, config)` | 名前付きエンベダーの登録 |

--- a/laurus-wasm/README.md
+++ b/laurus-wasm/README.md
@@ -116,7 +116,7 @@ schema.addBooleanField("active");
 schema.addDatetimeField("created_at");
 schema.addGeoField("location");
 schema.addBytesField("thumbnail");
-schema.addHnswField("embedding", 384, "cosine", 16, 200, "minilm");
+schema.addHnswField("embedding", 384, "cosine", 16, 200, undefined, "minilm");
 schema.addFlatField("embedding", 384);
 schema.addIvfField("embedding", 384, "cosine", 100, 1);
 schema.addEmbedder("minilm", {

--- a/laurus-wasm/README_ja.md
+++ b/laurus-wasm/README_ja.md
@@ -118,7 +118,7 @@ schema.addBooleanField("active");
 schema.addDatetimeField("created_at");
 schema.addGeoField("location");
 schema.addBytesField("thumbnail");
-schema.addHnswField("embedding", 384, "cosine", 16, 200, "minilm");
+schema.addHnswField("embedding", 384, "cosine", 16, 200, undefined, "minilm");
 schema.addFlatField("embedding", 384);
 schema.addIvfField("embedding", 384, "cosine", 100, 1);
 schema.addEmbedder("minilm", {

--- a/laurus-wasm/examples/basic/index.html
+++ b/laurus-wasm/examples/basic/index.html
@@ -152,9 +152,10 @@
         schema.addHnswField(
           EMBED_FIELD,
           EMBED_DIM,
-          undefined,
-          undefined,
-          undefined,
+          undefined, // distance (default: cosine)
+          undefined, // m
+          undefined, // efConstruction
+          undefined, // defaultEfSearch
           EMBEDDER_NAME,
         );
         schema.setDefaultFields(['title', 'body']);

--- a/laurus-wasm/examples/geo/index.html
+++ b/laurus-wasm/examples/geo/index.html
@@ -624,9 +624,10 @@
         schema.addHnswField(
           EMBED_FIELD,
           EMBED_DIM,
-          undefined,
-          undefined,
-          undefined,
+          undefined, // distance (default: cosine)
+          undefined, // m
+          undefined, // efConstruction
+          undefined, // defaultEfSearch
           EMBEDDER_NAME,
         );
         schema.setDefaultFields(['title', 'description', 'category']);


### PR DESCRIPTION
## Summary

Fixes the WASM demo failure `Error: Invalid argument: Embedder 'PerFieldEmbedder' does not support text input` when indexing sample documents on a fresh OPFS index.

#644 (PR #689) inserted `defaultEfSearch` into `addHnswField` at position 6, shifting `embedder` to position 7 in the WASM / Node.js / PHP bindings. The demos, docs snippets, READMEs, and API references kept passing the embedder name at the old slot. JS silently coerces the string to `0` for `defaultEfSearch` (ToUint32), so the schema builds without error, the field carries no embedder, and indexing later fails with the confusing message above. The bug stayed hidden since 2026-05-23 because sample indexing is skipped when a persisted index exists; the OPFS resets from #975 surfaced it.

Docs/examples only — the engine wiring was verified correct with a native repro test during investigation (see the issue comments on #978).

## Changes

- **Demos** (`laurus-wasm/examples/basic/index.html`, `geo/index.html`): pass `undefined` for `defaultEfSearch`; every positional placeholder now carries an argument-name comment so future signature drift is visible at the call site
- **Broken snippets**: `docs/{src,ja/src}/laurus-wasm.md`, `docs/{src,ja/src}/laurus-wasm/development.md`, `laurus-wasm/README{,_ja}.md`, `laurus-nodejs/README{,_ja}.md`
- **Stale signatures**: `addHnswField` listings in `docs/{src,ja/src}/laurus-{wasm,nodejs,php}/api_reference.md` (+ parameter bullet in the wasm reference) and the `laurus-php/README{,_ja}.md` summary table now include `defaultEfSearch`

## Verification

- `markdownlint-cli2` clean on `docs/src` (77 files), `docs/ja/src` (77 files), and all 6 touched READMEs
- Native repro test of the identical wiring passes on main (not committed: it passes with and without this fix, so it cannot guard the JS-side defect)
- Browser verification on the deployed demo follows the next docs deploy after merge ("Reset everything" required where an OPFS index already exists)

Closes #978
Refs #979 (follow-up: boot-time warning when a registered embedder is referenced by no field)
